### PR TITLE
fix(validate): align zod/effect flag inherit support with core

### DIFF
--- a/.changeset/funny-yaks-admire.md
+++ b/.changeset/funny-yaks-admire.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/validate": patch
+---
+
+Align Zod and Effect flag definitions with core `FlagDefBase` by adding `inherit` support to the exported types and `flag()` helpers.
+
+This makes `flag(..., { inherit: true })` behave consistently across validate and core, preserving inherited flag metadata for subcommands.

--- a/apps/docs/content/docs/modules/validate.mdx
+++ b/apps/docs/content/docs/modules/validate.mdx
@@ -145,7 +145,7 @@ Use a scalar schema (not `z.array()`). The framework handles array collection. C
 | `flag`                          | function | Declare a flag with a Zod schema and optional short/aliases |
 | `commandValidator`              | function | Create a validated `run` handler via Zod schemas      |
 | `ZodArgDef<N, S, V, T>`         | type     | `ArgDef` with hidden Zod schema metadata              |
-| `ZodFlagDef<S, A, T>`           | type     | `FlagDef` with hidden Zod schema metadata             |
+| `ZodFlagDef<S, Short, Aliases, Inherit, T>` | type     | `FlagDef` with hidden Zod schema metadata             |
 | `CommandValidatorHandler<A, F>` | type     | Handler receiving `ValidatedContext`                  |
 | `InferValidatedArgs<A>`         | type     | Infer validated args from definitions                 |
 | `InferValidatedFlags<F>`        | type     | Infer validated flags from definitions                |
@@ -245,7 +245,7 @@ Use a scalar schema (not `Schema.Array()`). The framework handles array collecti
 | `flag`                          | function | Declare a flag with an Effect schema and optional short/aliases |
 | `commandValidator`              | function | Create a validated `run` handler via Effect schemas       |
 | `EffectArgDef<N, S, V, T>`      | type     | `ArgDef` with hidden Effect schema metadata               |
-| `EffectFlagDef<S, A, T>`        | type     | `FlagDef` with hidden Effect schema metadata              |
+| `EffectFlagDef<S, Short, Aliases, Inherit, T>` | type     | `FlagDef` with hidden Effect schema metadata              |
 | `CommandValidatorHandler<A, F>` | type     | Handler receiving `ValidatedContext`                      |
 | `InferValidatedArgs<A>`         | type     | Infer validated args from definitions                     |
 | `InferValidatedFlags<F>`        | type     | Infer validated flags from definitions                    |

--- a/packages/validate/src/effect/command.test.ts
+++ b/packages/validate/src/effect/command.test.ts
@@ -81,6 +81,11 @@ describe("flag() produces core-compatible FlagDef", () => {
 		expect(f.short).toBe("v");
 	});
 
+	it("passes through inherit", () => {
+		const f = flag(Schema.UndefinedOr(Schema.Boolean), { inherit: true });
+		expect(f.inherit).toBe(true);
+	});
+
 	it("extracts description from schema annotations", () => {
 		const f = flag(Schema.String.annotations({ description: "Output dir" }));
 		expect(f.description).toBe("Output dir");

--- a/packages/validate/src/effect/command.test.ts
+++ b/packages/validate/src/effect/command.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { InheritableFlags } from "@crustjs/core";
 import { Crust, CrustError, parseArgs } from "@crustjs/core";
 import * as Schema from "effect/Schema";
 import { commandValidator } from "./command.ts";
@@ -521,6 +522,15 @@ describe("arg() / flag() generic type narrowing", () => {
 		const f = flag(Schema.Boolean);
 		type _check = Expect<Equal<typeof f.aliases, undefined>>;
 		expect(f.aliases).toBeUndefined();
+	});
+
+	it("narrows inherit to true so core can detect inheritable flags", () => {
+		const inherited = flag(Schema.Boolean, { inherit: true });
+		type Flags = { verbose: typeof inherited };
+		type Result = InheritableFlags<Flags>;
+		type _checkInherit = Expect<Equal<typeof inherited.inherit, true>>;
+		type _checkResult = Expect<Equal<Result, Flags>>;
+		expect(inherited.inherit).toBe(true);
 	});
 });
 

--- a/packages/validate/src/effect/schema.ts
+++ b/packages/validate/src/effect/schema.ts
@@ -414,7 +414,7 @@ export function arg<
  * If both are available and conflict, a `DEFINITION` error is thrown.
  *
  * @param schema - Effect schema (source of truth for type/optionality/description)
- * @param options - Optional flag metadata (`short`, `aliases`, `type`, `description`, `required`)
+ * @param options - Optional flag metadata (`short`, `aliases`, `type`, `description`, `required`, `inherit`)
  *
  * @example
  * ```ts
@@ -473,6 +473,7 @@ export function flag<
 		aliases,
 		...(description !== undefined && { description }),
 		...(resolvedRequired && { required: true as const }),
+		...(options?.inherit && { inherit: true as const }),
 		[EFFECT_SCHEMA]: schema,
 	};
 

--- a/packages/validate/src/effect/schema.ts
+++ b/packages/validate/src/effect/schema.ts
@@ -427,10 +427,15 @@ export function flag<
 	SchemaType extends EffectSchemaLike,
 	const Short extends string | undefined = undefined,
 	const Aliases extends readonly string[] | undefined = undefined,
+	const Inherit extends true | undefined = undefined,
 >(
 	schema: SchemaType,
-	options?: FlagOptions & { short?: Short; aliases?: Aliases },
-): EffectFlagDef<SchemaType, Short, Aliases> {
+	options?: FlagOptions & {
+		short?: Short;
+		aliases?: Aliases;
+		inherit?: Inherit;
+	},
+): EffectFlagDef<SchemaType, Short, Aliases, Inherit> {
 	if (!isSchema(schema)) {
 		throw new CrustError(
 			"DEFINITION",
@@ -477,5 +482,5 @@ export function flag<
 		[EFFECT_SCHEMA]: schema,
 	};
 
-	return def as EffectFlagDef<SchemaType, Short, Aliases>;
+	return def as EffectFlagDef<SchemaType, Short, Aliases, Inherit>;
 }

--- a/packages/validate/src/effect/types.ts
+++ b/packages/validate/src/effect/types.ts
@@ -97,6 +97,7 @@ export interface EffectFlagDef<
 	readonly type: Type;
 	readonly description?: string;
 	readonly required?: true;
+	readonly inherit?: true;
 	/**
 	 * Non-optional so `ValidateFlagAliases` can extract narrow alias literals.
 	 * When `Short` is `undefined`, the runtime value is `undefined` (no short alias).
@@ -165,6 +166,8 @@ export interface FlagOptions extends ParserMeta {
 	readonly short?: string;
 	/** Additional long aliases (e.g. `["out"]` → `--out`). */
 	readonly aliases?: readonly string[];
+	/** When `true`, the flag is inherited by subcommands. */
+	readonly inherit?: true;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/validate/src/effect/types.ts
+++ b/packages/validate/src/effect/types.ts
@@ -92,12 +92,17 @@ export interface EffectFlagDef<
 	SchemaType extends EffectSchemaLike = EffectSchemaLike,
 	Short extends string | undefined = string | undefined,
 	Aliases extends readonly string[] | undefined = readonly string[] | undefined,
+	Inherit extends true | undefined = true | undefined,
 	Type extends ValueType = ResolveEffectValueType<SchemaType>,
 > {
 	readonly type: Type;
 	readonly description?: string;
 	readonly required?: true;
-	readonly inherit?: true;
+	/**
+	 * Non-optional so `InheritableFlags` can match `{ inherit: true }`.
+	 * When `Inherit` is `undefined`, the runtime value is `undefined`.
+	 */
+	readonly inherit: Inherit;
 	/**
 	 * Non-optional so `ValidateFlagAliases` can extract narrow alias literals.
 	 * When `Short` is `undefined`, the runtime value is `undefined` (no short alias).

--- a/packages/validate/src/zod/command.test.ts
+++ b/packages/validate/src/zod/command.test.ts
@@ -70,6 +70,11 @@ describe("flag() produces core-compatible FlagDef", () => {
 		expect(f.short).toBe("v");
 	});
 
+	it("passes through inherit", () => {
+		const f = flag(z.boolean().default(false), { inherit: true });
+		expect(f.inherit).toBe(true);
+	});
+
 	it("extracts description from schema", () => {
 		const f = flag(z.string().describe("Output dir"));
 		expect(f.description).toBe("Output dir");

--- a/packages/validate/src/zod/command.test.ts
+++ b/packages/validate/src/zod/command.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { InheritableFlags } from "@crustjs/core";
 import { Crust, CrustError, parseArgs } from "@crustjs/core";
 import { z } from "zod";
 import { commandValidator } from "./command.ts";
@@ -578,6 +579,15 @@ describe("arg() / flag() generic type narrowing", () => {
 		const f = flag(z.boolean());
 		type _check = Expect<Equal<typeof f.aliases, undefined>>;
 		expect(f.aliases).toBeUndefined();
+	});
+
+	it("narrows inherit to true so core can detect inheritable flags", () => {
+		const inherited = flag(z.boolean(), { inherit: true });
+		type Flags = { verbose: typeof inherited };
+		type Result = InheritableFlags<Flags>;
+		type _checkInherit = Expect<Equal<typeof inherited.inherit, true>>;
+		type _checkResult = Expect<Equal<Result, Flags>>;
+		expect(inherited.inherit).toBe(true);
 	});
 });
 

--- a/packages/validate/src/zod/schema.ts
+++ b/packages/validate/src/zod/schema.ts
@@ -397,7 +397,7 @@ export function arg<
  * If both are available and conflict, a `DEFINITION` error is thrown.
  *
  * @param schema - Zod schema (source of truth for type/optionality/description)
- * @param options - Optional flag metadata (`short`, `aliases`, `type`, `description`, `required`)
+ * @param options - Optional flag metadata (`short`, `aliases`, `type`, `description`, `required`, `inherit`)
  *
  * @example
  * ```ts
@@ -453,6 +453,7 @@ export function flag<
 		aliases,
 		...(description !== undefined && { description }),
 		...(resolvedRequired && { required: true as const }),
+		...(options?.inherit && { inherit: true as const }),
 		[ZOD_SCHEMA]: schema,
 	};
 

--- a/packages/validate/src/zod/schema.ts
+++ b/packages/validate/src/zod/schema.ts
@@ -410,10 +410,15 @@ export function flag<
 	Schema extends ZodSchemaLike,
 	const Short extends string | undefined = undefined,
 	const Aliases extends readonly string[] | undefined = undefined,
+	const Inherit extends true | undefined = undefined,
 >(
 	schema: Schema,
-	options?: FlagOptions & { short?: Short; aliases?: Aliases },
-): ZodFlagDef<Schema, Short, Aliases> {
+	options?: FlagOptions & {
+		short?: Short;
+		aliases?: Aliases;
+		inherit?: Inherit;
+	},
+): ZodFlagDef<Schema, Short, Aliases, Inherit> {
 	if (!isZodSchema(schema)) {
 		throw new CrustError("DEFINITION", "flag(): schema must be a Zod schema");
 	}
@@ -457,5 +462,5 @@ export function flag<
 		[ZOD_SCHEMA]: schema,
 	};
 
-	return def as ZodFlagDef<Schema, Short, Aliases>;
+	return def as ZodFlagDef<Schema, Short, Aliases, Inherit>;
 }

--- a/packages/validate/src/zod/types.ts
+++ b/packages/validate/src/zod/types.ts
@@ -128,6 +128,7 @@ export interface ZodFlagDef<
 	readonly type: Type;
 	readonly description?: string;
 	readonly required?: true;
+	readonly inherit?: true;
 	/**
 	 * Non-optional so `ValidateFlagAliases` can extract narrow alias literals.
 	 * When `Short` is `undefined`, the runtime value is `undefined` (no short alias).
@@ -196,6 +197,8 @@ export interface FlagOptions extends ParserMeta {
 	readonly short?: string;
 	/** Additional long aliases (e.g. `["out"]` → `--out`). */
 	readonly aliases?: readonly string[];
+	/** When `true`, the flag is inherited by subcommands. */
+	readonly inherit?: true;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/validate/src/zod/types.ts
+++ b/packages/validate/src/zod/types.ts
@@ -123,12 +123,17 @@ export interface ZodFlagDef<
 	Schema extends ZodSchemaLike = ZodSchemaLike,
 	Short extends string | undefined = string | undefined,
 	Aliases extends readonly string[] | undefined = readonly string[] | undefined,
+	Inherit extends true | undefined = true | undefined,
 	Type extends ValueType = ResolveZodValueType<Schema>,
 > {
 	readonly type: Type;
 	readonly description?: string;
 	readonly required?: true;
-	readonly inherit?: true;
+	/**
+	 * Non-optional so `InheritableFlags` can match `{ inherit: true }`.
+	 * When `Inherit` is `undefined`, the runtime value is `undefined`.
+	 */
+	readonly inherit: Inherit;
 	/**
 	 * Non-optional so `ValidateFlagAliases` can extract narrow alias literals.
 	 * When `Short` is `undefined`, the runtime value is `undefined` (no short alias).


### PR DESCRIPTION
## What changed

This PR aligns `@crustjs/validate` flag definitions with core `FlagDefBase` by adding `inherit` support
to both validate backends:

- add `inherit?: true` to `ZodFlagDef` and `EffectFlagDef`
- add `inherit?: true` to validate `FlagOptions`
- pass `inherit` through in both Zod and Effect `flag()` helpers
- add tests covering `inherit` passthrough for both implementations
- update inline `flag()` option docs to include `inherit`

## Why it changed

`packages/core/src/types.ts` includes `inherit?: true` on `FlagDefBase`, but the validate package types
and helpers did not expose that field consistently.

As a result, `flag(..., { inherit: true })` was not fully aligned with core when using `@crustjs/
validate/zod` or `@crustjs/validate/effect`. This change brings the validate package back in sync with
core behavior and typing.

## Packages and docs affected

- `@crustjs/validate`
- Zod validate types and schema helpers
- Effect validate types and schema helpers
- test coverage for both validate backends

No README changes were needed because this is an alignment fix rather than a new feature.

## Follow-up work / known limitations

- No follow-up work is currently required.
- This does not change the default behavior of `inherit`; it remains opt-in, consistent with core.
- `inherit: false` is still not supported, matching the existing core type shape.

## Verification

- `bun run check`
- `bun run check:types`
- `bun test packages/validate/src/zod/command.test.ts`
- `bun test packages/validate/src/effect/command.test.ts`