### PR TITLE
feat(style): add OSC 8 hyperlink support

### DIFF
--- a/.changeset/neat-points-care.md
+++ b/.changeset/neat-points-care.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/style": patch
+---
+
+Add OSC 8 hyperlink styling primitives to `@crustjs/style` via `linkCode()`, `link()`, and `style.link()`, so CLIs can emit clickable terminal links instead of only visually styled link text.
+
+Hyperlinks now follow the package's mode-aware runtime behaviour: they emit in `always` mode, emit in `auto` mode when stdout is a TTY, and return plain text in `never` mode. The package docs now also explain how OSC 8 link emission relates to the markdown theme's visual link slots.

--- a/apps/docs/content/docs/modules/style.mdx
+++ b/apps/docs/content/docs/modules/style.mdx
@@ -63,6 +63,13 @@ ANSI pair factories for composition:
 | `bgHexCode(hex)` | Create background `AnsiPair` from hex string |
 | `parseHex(hex)` | Parse a hex color string into `[r, g, b]` tuple |
 
+### Hyperlinks (OSC 8)
+
+| Export | Description |
+| --- | --- |
+| `link(text, url, options?)` | Wrap text in OSC 8 hyperlink escape sequences |
+| `linkCode(url, options?)` | Create an OSC 8 open/close pair for composition |
+
 ### Style Engine
 
 | Export | Description |
@@ -75,6 +82,7 @@ ANSI pair factories for composition:
 | Export | Description |
 | --- | --- |
 | `resolveColorCapability(mode, overrides?)` | Resolve whether colors should be emitted |
+| `resolveHyperlinkCapability(mode, overrides?)` | Resolve whether OSC 8 hyperlinks should be emitted |
 | `resolveModifierCapability(mode, overrides?)` | Resolve whether non-color modifiers (bold, italic, etc.) should be emitted |
 | `resolveTrueColorCapability(mode, overrides?)` | Resolve whether truecolor (24-bit) sequences should be emitted |
 
@@ -118,6 +126,7 @@ To strip ANSI escape sequences from a string, use Bun's built-in `Bun.stripANSI(
 | `StyleOptions` | Options for `createStyle` |
 | `CapabilityOverrides` | Injectable TTY/NO_COLOR overrides for testing |
 | `TrueColorOverrides` | Injectable COLORTERM/TERM overrides for truecolor testing |
+| `HyperlinkOptions` | Optional OSC 8 hyperlink parameters such as `id` |
 | `StyleFn` | `(text: string) => string` style function |
 | `StyleInstance` | Configured style object with all styling methods. Exposes `enabled`, `colorsEnabled`, and `trueColorEnabled` capability flags |
 | `WrapOptions` | Options for `wrapText` |
@@ -253,6 +262,26 @@ Invalid inputs throw immediately: `RangeError` for out-of-range RGB values, `Typ
 Dynamic colors use truecolor (24-bit) ANSI sequences with no automatic fallback to 256 or 16 colors. On unsupported terminals, colors may be approximated or silently ignored — no runtime errors will occur.
 </Callout>
 
+### Hyperlinks (OSC 8)
+
+```ts
+import { createStyle, linkCode, composeStyles, applyStyle, underlineCode } from "@crustjs/style";
+
+const s = createStyle({ mode: "always" });
+
+console.log(s.link("Crust docs", "https://crustjs.com"));
+console.log(s.link("API reference", "https://crustjs.com/docs", { id: "docs-link" }));
+
+const underlinedLink = composeStyles(linkCode("https://crustjs.com"), underlineCode);
+console.log(applyStyle("Visit Crust", underlinedLink));
+```
+
+In `"auto"` mode, hyperlinks are emitted when stdout is a TTY. They are not disabled by `NO_COLOR`, since OSC 8 links are not color sequences. In `"never"` mode, link helpers return plain text.
+
+<Callout type="info">
+Terminal support for OSC 8 varies by emulator. Many modern terminals support it, but there is no reliable cross-terminal capability probe yet, so unsupported terminals may simply show plain text without clickable behavior.
+</Callout>
+
 ### Text Layout
 
 ```ts
@@ -291,6 +320,8 @@ const custom = createMarkdownTheme({
   },
 });
 ```
+
+The markdown theme controls how links look, but it does not create OSC 8 hyperlinks by itself. When your renderer has both the link label and destination URL, use `style.link()` or `linkCode()` to emit a clickable link.
 
 ## Design
 

--- a/apps/docs/content/docs/modules/style.mdx
+++ b/apps/docs/content/docs/modules/style.mdx
@@ -82,7 +82,6 @@ ANSI pair factories for composition:
 | Export | Description |
 | --- | --- |
 | `resolveColorCapability(mode, overrides?)` | Resolve whether colors should be emitted |
-| `resolveHyperlinkCapability(mode, overrides?)` | Resolve whether OSC 8 hyperlinks should be emitted |
 | `resolveModifierCapability(mode, overrides?)` | Resolve whether non-color modifiers (bold, italic, etc.) should be emitted |
 | `resolveTrueColorCapability(mode, overrides?)` | Resolve whether truecolor (24-bit) sequences should be emitted |
 
@@ -190,7 +189,7 @@ import { getGlobalColorMode, setGlobalColorMode, style } from "@crustjs/style";
 setGlobalColorMode("always");
 console.log(style.red("always red"));
 
-// Disable colors but keep bold / italic / underline
+// Disable colors but keep bold / italic / underline / hyperlinks
 setGlobalColorMode("never");
 console.log(style.bold.red("bold, but no red"));
 

--- a/packages/style/README.md
+++ b/packages/style/README.md
@@ -22,6 +22,7 @@ console.log(style.bold("Build succeeded"));
 console.log(style.red("Error: missing argument"));
 console.log(style.dim("hint: use --help for usage"));
 console.log(style.bold.red("Critical failure"));
+console.log(style.link("Docs", "https://crustjs.com"));
 ```
 
 ## Primitive Styling
@@ -61,6 +62,26 @@ console.log(applyStyle("critical error", boldRed));
 ```
 
 Nested styles are handled safely — no style bleed across boundaries.
+
+## Hyperlinks (OSC 8)
+
+Wrap text in terminal hyperlink escape sequences:
+
+```ts
+import { createStyle, linkCode, composeStyles, applyStyle, underlineCode } from "@crustjs/style";
+
+const s = createStyle({ mode: "always" });
+
+console.log(s.link("Crust docs", "https://crustjs.com"));
+console.log(s.link("API reference", "https://crustjs.com/docs", { id: "docs-link" }));
+
+const underlinedLink = composeStyles(linkCode("https://crustjs.com"), underlineCode);
+console.log(applyStyle("Visit Crust", underlinedLink));
+```
+
+In `"auto"` mode, hyperlinks are emitted when stdout is a TTY. They are not disabled by `NO_COLOR`, since OSC 8 links are not color sequences. In `"never"` mode, link methods return plain text.
+
+Terminal support for OSC 8 varies. Many modern terminals support it, but there is no reliable cross-terminal feature probe yet, so unsupported terminals may simply render plain text without clickable behavior.
 
 ## Dynamic Colors (Truecolor)
 
@@ -287,6 +308,8 @@ console.log(defaultTheme.strong("important"));
 console.log(defaultTheme.inlineCode("npm install"));
 console.log(defaultTheme.linkText("docs") + " " + defaultTheme.linkUrl("https://crustjs.com"));
 ```
+
+The markdown theme styles how links look, but it does not create OSC 8 hyperlinks by itself. When your renderer has both the label and destination URL, use `style.link()` or `linkCode()` to emit a clickable link.
 
 ### Custom Themes
 

--- a/packages/style/README.md
+++ b/packages/style/README.md
@@ -185,7 +185,7 @@ import { getGlobalColorMode, setGlobalColorMode, style } from "@crustjs/style";
 setGlobalColorMode("always");
 console.log(style.red("always red"));
 
-// Turn colors off while keeping bold/italic/etc.
+// Turn colors off while keeping bold/italic/hyperlinks/etc.
 setGlobalColorMode("never");
 console.log(style.bold.red("bold, but no red"));
 

--- a/packages/style/src/capability.ts
+++ b/packages/style/src/capability.ts
@@ -92,6 +92,35 @@ export function resolveModifierCapability(
 }
 
 /**
+ * Resolve whether OSC 8 hyperlinks should be emitted.
+ *
+ * There is no reliable cross-terminal capability probe for hyperlinks today,
+ * so `"auto"` mode uses a conservative TTY check similar to non-color
+ * modifiers while still allowing explicit `"always"` / `"never"` overrides.
+ *
+ * @internal Exported for use by {@link createStyle}; not part of the stable
+ * public surface of `@crustjs/style`.
+ */
+export function resolveHyperlinkCapability(
+	mode: ColorMode,
+	overrides?: CapabilityOverrides,
+): boolean {
+	if (mode === "always") {
+		return true;
+	}
+
+	if (mode === "never") {
+		return false;
+	}
+
+	const hasIsTTYOverride = overrides !== undefined && "isTTY" in overrides;
+	const isTTY = hasIsTTYOverride
+		? (overrides.isTTY ?? false)
+		: (process.stdout?.isTTY ?? false);
+	return isTTY;
+}
+
+/**
  * Resolve whether the terminal supports truecolor (24-bit) ANSI sequences.
  *
  * Detection heuristics (checked in order):

--- a/packages/style/src/createStyle.ts
+++ b/packages/style/src/createStyle.ts
@@ -226,9 +226,9 @@ export function getGlobalColorMode(): ColorMode | undefined {
 
 // Runtime style cache keyed on `(globalMode, isTTY, NO_COLOR)`. The
 // `"never"` override intentionally maps to an `auto` instance with
-// `noColor: "1"` so that modifiers (bold, italic, etc.) remain enabled —
-// matching the no-color.org semantics for `--no-color` without also
-// suppressing non-color ANSI.
+// `noColor: "1"` so that modifiers (bold, italic, hyperlinks, etc.) remain
+// enabled while colors are suppressed — matching the no-color.org semantics
+// used by `--no-color`.
 const runtimeStyleCache = new Map<string, StyleInstance>();
 
 function buildRuntimeStyle(): StyleInstance {

--- a/packages/style/src/createStyle.ts
+++ b/packages/style/src/createStyle.ts
@@ -5,6 +5,7 @@
 import type { AnsiPair } from "./ansiCodes.ts";
 import {
 	resolveColorCapability,
+	resolveHyperlinkCapability,
 	resolveModifierCapability,
 	resolveTrueColorCapability,
 } from "./capability.ts";
@@ -14,6 +15,7 @@ import {
 	hex as hexDirect,
 	rgb as rgbDirect,
 } from "./dynamicColors.ts";
+import { link as linkDirect } from "./hyperlinks.ts";
 import { applyStyle } from "./styleEngine.ts";
 import {
 	isModifierName,
@@ -153,6 +155,10 @@ export function createStyle(options?: StyleOptions): StyleInstance {
 	const mode = options?.mode ?? "auto";
 	const modifiersEnabled = resolveModifierCapability(mode, options?.overrides);
 	const colorsEnabled = resolveColorCapability(mode, options?.overrides);
+	const hyperlinksEnabled = resolveHyperlinkCapability(
+		mode,
+		options?.overrides,
+	);
 	const enabled = modifiersEnabled || colorsEnabled;
 	const trueColorEnabled = resolveTrueColorCapability(mode, options?.overrides);
 	const createChainableStyle = buildChainableStyleFactory(
@@ -176,6 +182,11 @@ export function createStyle(options?: StyleOptions): StyleInstance {
 			const gate = isModifierPair(pair) ? modifiersEnabled : colorsEnabled;
 			return gate ? applyStyle(text, pair) : text;
 		},
+
+		link: hyperlinksEnabled
+			? (text: string, url: string, hyperlinkOptions) =>
+					linkDirect(text, url, hyperlinkOptions)
+			: (text: string, _url: string) => text,
 
 		// ── Dynamic colors (truecolor) ──────────────────────────────────────
 
@@ -246,7 +257,14 @@ export function getRuntimeStyle(): StyleInstance {
 
 // Members whose implementation is a function and must be forwarded as a
 // bound method so callers can invoke them like `style.apply(...)`.
-const FORWARDED_METHODS = ["apply", "rgb", "bgRgb", "hex", "bgHex"] as const;
+const FORWARDED_METHODS = [
+	"apply",
+	"link",
+	"rgb",
+	"bgRgb",
+	"hex",
+	"bgHex",
+] as const;
 
 // Members that read a value off the current runtime style on every access.
 const FORWARDED_GETTERS = [

--- a/packages/style/src/hyperlinks.test.ts
+++ b/packages/style/src/hyperlinks.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { createStyle, link, linkCode, setGlobalColorMode } from "./index.ts";
+
+describe("hyperlinks", () => {
+	it("creates OSC 8 link pairs", () => {
+		const pair = linkCode("https://crustjs.com");
+		expect(pair).toEqual({
+			open: "\x1b]8;;https://crustjs.com\x1b\\",
+			close: "\x1b]8;;\x1b\\",
+		});
+	});
+
+	it("supports the id parameter", () => {
+		const pair = linkCode("https://crustjs.com/docs", { id: "docs-link" });
+		expect(pair).toEqual({
+			open: "\x1b]8;id=docs-link;https://crustjs.com/docs\x1b\\",
+			close: "\x1b]8;;\x1b\\",
+		});
+	});
+
+	it("wraps text in OSC 8 sequences", () => {
+		const s = createStyle({ mode: "always" });
+		expect(s.link("Crust docs", "https://crustjs.com")).toBe(
+			"\x1b]8;;https://crustjs.com\x1b\\Crust docs\x1b]8;;\x1b\\",
+		);
+	});
+
+	it("returns empty text unchanged", () => {
+		expect(link("", "https://crustjs.com")).toBe("");
+	});
+
+	it("reopens the outer hyperlink after an inner hyperlink closes", () => {
+		const s = createStyle({ mode: "always" });
+		const nested = s.link(
+			`outer ${s.link("inner", "https://crustjs.com/inner")} outer`,
+			"https://crustjs.com/outer",
+		);
+		expect(nested).toBe(
+			"\x1b]8;;https://crustjs.com/outer\x1b\\outer \x1b]8;;https://crustjs.com/inner\x1b\\inner\x1b]8;;\x1b\\\x1b]8;;https://crustjs.com/outer\x1b\\ outer\x1b]8;;\x1b\\",
+		);
+	});
+
+	it("composes with ANSI styles", () => {
+		const s = createStyle({ mode: "always" });
+		expect(s.red(s.link("Crust", "https://crustjs.com"))).toBe(
+			"\x1b[31m\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\\x1b[39m",
+		);
+	});
+});
+
+describe("createStyle().link", () => {
+	it("emits hyperlinks in always mode", () => {
+		const s = createStyle({ mode: "always" });
+		expect(s.link("Crust", "https://crustjs.com")).toBe(
+			"\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\",
+		);
+	});
+
+	it("emits hyperlinks in auto mode even when NO_COLOR is set", () => {
+		const s = createStyle({
+			mode: "auto",
+			overrides: { isTTY: true, noColor: "1" },
+		});
+		expect(s.link("Crust", "https://crustjs.com")).toBe(
+			"\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\",
+		);
+	});
+
+	it("suppresses hyperlinks when auto mode is not a TTY", () => {
+		const s = createStyle({
+			mode: "auto",
+			overrides: { isTTY: false, noColor: undefined },
+		});
+		expect(s.link("Crust", "https://crustjs.com")).toBe("Crust");
+	});
+
+	it("suppresses hyperlinks in never mode", () => {
+		const s = createStyle({ mode: "never" });
+		expect(s.link("Crust", "https://crustjs.com")).toBe("Crust");
+	});
+});
+
+describe("runtime link export", () => {
+	it("delegates through the runtime style facade", () => {
+		setGlobalColorMode("always");
+		try {
+			expect(link("Crust", "https://crustjs.com")).toBe(
+				"\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\",
+			);
+		} finally {
+			setGlobalColorMode(undefined);
+		}
+	});
+});

--- a/packages/style/src/hyperlinks.test.ts
+++ b/packages/style/src/hyperlinks.test.ts
@@ -18,6 +18,12 @@ describe("hyperlinks", () => {
 		});
 	});
 
+	it("rejects URLs containing spaces", () => {
+		expect(() => linkCode("https://example.com/foo bar")).toThrow(
+			/Invalid hyperlink URL/,
+		);
+	});
+
 	it("wraps text in OSC 8 sequences", () => {
 		const s = createStyle({ mode: "always" });
 		expect(s.link("Crust docs", "https://crustjs.com")).toBe(
@@ -83,6 +89,17 @@ describe("createStyle().link", () => {
 describe("runtime link export", () => {
 	it("delegates through the runtime style facade", () => {
 		setGlobalColorMode("always");
+		try {
+			expect(link("Crust", "https://crustjs.com")).toBe(
+				"\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\",
+			);
+		} finally {
+			setGlobalColorMode(undefined);
+		}
+	});
+
+	it('still emits hyperlinks when global color mode is "never"', () => {
+		setGlobalColorMode("never");
 		try {
 			expect(link("Crust", "https://crustjs.com")).toBe(
 				"\x1b]8;;https://crustjs.com\x1b\\Crust\x1b]8;;\x1b\\",

--- a/packages/style/src/hyperlinks.ts
+++ b/packages/style/src/hyperlinks.ts
@@ -1,0 +1,65 @@
+import type { AnsiPair } from "./ansiCodes.ts";
+import { applyStyle } from "./styleEngine.ts";
+
+const OSC = "\x1b]";
+const ST = "\x1b\\";
+const HYPERLINK_CLOSE = `${OSC}8;;${ST}`;
+const PRINTABLE_ASCII = /^[\x20-\x7e]*$/;
+
+export interface HyperlinkOptions {
+	/**
+	 * Optional OSC 8 hyperlink id used by some terminals to keep visually
+	 * separated segments grouped as a single hovered link.
+	 */
+	readonly id?: string;
+}
+
+function assertPrintableAscii(value: string, label: string): void {
+	if (!PRINTABLE_ASCII.test(value)) {
+		throw new TypeError(
+			`Invalid ${label}: must contain only printable ASCII characters.`,
+		);
+	}
+}
+
+function serializeParams(options?: HyperlinkOptions): string {
+	const id = options?.id;
+	if (id === undefined || id === "") {
+		return "";
+	}
+
+	assertPrintableAscii(id, "hyperlink id");
+	if (id.includes(":") || id.includes(";")) {
+		throw new TypeError(
+			'Invalid hyperlink id: ":" and ";" are reserved by the OSC 8 format.',
+		);
+	}
+
+	return `id=${id}`;
+}
+
+/**
+ * Create an OSC 8 hyperlink escape pair for a target URL.
+ *
+ * The returned pair can be applied directly with {@link applyStyle} or used via
+ * {@link link} for convenience.
+ */
+export function linkCode(url: string, options?: HyperlinkOptions): AnsiPair {
+	assertPrintableAscii(url, "hyperlink URL");
+	const params = serializeParams(options);
+	return {
+		open: `${OSC}8;${params};${url}${ST}`,
+		close: HYPERLINK_CLOSE,
+	};
+}
+
+/**
+ * Wrap text in OSC 8 hyperlink escape sequences.
+ */
+export function link(
+	text: string,
+	url: string,
+	options?: HyperlinkOptions,
+): string {
+	return applyStyle(text, linkCode(url, options));
+}

--- a/packages/style/src/hyperlinks.ts
+++ b/packages/style/src/hyperlinks.ts
@@ -5,6 +5,7 @@ const OSC = "\x1b]";
 const ST = "\x1b\\";
 const HYPERLINK_CLOSE = `${OSC}8;;${ST}`;
 const PRINTABLE_ASCII = /^[\x20-\x7e]*$/;
+const PRINTABLE_ASCII_NO_SPACE = /^[\x21-\x7e]*$/;
 
 export interface HyperlinkOptions {
 	/**
@@ -18,6 +19,14 @@ function assertPrintableAscii(value: string, label: string): void {
 	if (!PRINTABLE_ASCII.test(value)) {
 		throw new TypeError(
 			`Invalid ${label}: must contain only printable ASCII characters.`,
+		);
+	}
+}
+
+function assertPrintableAsciiNoSpace(value: string, label: string): void {
+	if (!PRINTABLE_ASCII_NO_SPACE.test(value)) {
+		throw new TypeError(
+			`Invalid ${label}: must contain only printable ASCII characters without spaces.`,
 		);
 	}
 }
@@ -45,7 +54,7 @@ function serializeParams(options?: HyperlinkOptions): string {
  * {@link link} for convenience.
  */
 export function linkCode(url: string, options?: HyperlinkOptions): AnsiPair {
-	assertPrintableAscii(url, "hyperlink URL");
+	assertPrintableAsciiNoSpace(url, "hyperlink URL");
 	const params = serializeParams(options);
 	return {
 		open: `${OSC}8;${params};${url}${ST}`,

--- a/packages/style/src/index.test.ts
+++ b/packages/style/src/index.test.ts
@@ -5,4 +5,9 @@ describe("@crustjs/style", () => {
 		const mod = await import("./index.ts");
 		expect(mod).toBeDefined();
 	});
+
+	it("does not publicly export internal hyperlink capability helpers", async () => {
+		const mod = await import("./index.ts");
+		expect("resolveHyperlinkCapability" in mod).toBe(false);
+	});
 });

--- a/packages/style/src/index.ts
+++ b/packages/style/src/index.ts
@@ -61,6 +61,7 @@ export type { ColumnAlignment, TableOptions } from "./blocks/tables.ts";
 export { table } from "./blocks/tables.ts";
 export {
 	resolveColorCapability,
+	resolveHyperlinkCapability,
 	resolveTrueColorCapability,
 } from "./capability.ts";
 export {
@@ -77,6 +78,8 @@ export {
 	parseHex,
 	rgbCode,
 } from "./dynamicColors.ts";
+export type { HyperlinkOptions } from "./hyperlinks.ts";
+export { linkCode } from "./hyperlinks.ts";
 export {
 	// Background
 	bgBlack,
@@ -117,6 +120,7 @@ export {
 	hidden,
 	inverse,
 	italic,
+	link,
 	magenta,
 	red,
 	rgb,

--- a/packages/style/src/index.ts
+++ b/packages/style/src/index.ts
@@ -61,7 +61,6 @@ export type { ColumnAlignment, TableOptions } from "./blocks/tables.ts";
 export { table } from "./blocks/tables.ts";
 export {
 	resolveColorCapability,
-	resolveHyperlinkCapability,
 	resolveTrueColorCapability,
 } from "./capability.ts";
 export {

--- a/packages/style/src/runtimeExports.ts
+++ b/packages/style/src/runtimeExports.ts
@@ -8,6 +8,7 @@
 // import time.
 
 import { style } from "./createStyle.ts";
+import type { HyperlinkOptions } from "./hyperlinks.ts";
 import type { StyleFn } from "./types.ts";
 
 export const black: StyleFn = (text) => style.black(text);
@@ -49,6 +50,14 @@ export const underline: StyleFn = (text) => style.underline(text);
 export const inverse: StyleFn = (text) => style.inverse(text);
 export const hidden: StyleFn = (text) => style.hidden(text);
 export const strikethrough: StyleFn = (text) => style.strikethrough(text);
+
+export function link(
+	text: string,
+	url: string,
+	options?: HyperlinkOptions,
+): string {
+	return style.link(text, url, options);
+}
 
 export function rgb(text: string, r: number, g: number, b: number): string {
 	return style.rgb(text, r, g, b);

--- a/packages/style/src/types.ts
+++ b/packages/style/src/types.ts
@@ -3,6 +3,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { AnsiPair } from "./ansiCodes.ts";
+import type { HyperlinkOptions } from "./hyperlinks.ts";
 import type { StyleMethodName as RegisteredStyleMethodName } from "./styleMethodRegistry.ts";
 
 /**
@@ -116,6 +117,13 @@ export interface StyleInstance extends StyleMethodMap {
 
 	/** Apply an arbitrary ANSI pair to text, respecting the color mode. */
 	readonly apply: (text: string, pair: AnsiPair) => string;
+
+	/** Wrap text in an OSC 8 hyperlink when link styling is enabled. */
+	readonly link: (
+		text: string,
+		url: string,
+		options?: HyperlinkOptions,
+	) => string;
 
 	// ── Dynamic colors (truecolor) ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add OSC 8 hyperlink primitives to `@crustjs/style` via `linkCode()`, `link()`, and `style.link()`
- make hyperlink emission mode-aware so links emit on TTYs in `auto`, emit in `always`, and return plain text in `never`
- document how clickable hyperlinks relate to the markdown theme's visual link styling and cover the new behavior with tests
- Closes #101 

## Test plan
- [x] `cd packages/style && bun test`
- [x] `bun run check`
- [x] `bun run check:types`
