### PR TITLE
feat(skills): make `agents` optional on `generateSkill`/`uninstallSkill`/`skillStatus`

### DIFF
--- a/.changeset/skills-optional-agents-default.md
+++ b/.changeset/skills-optional-agents-default.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/skills": minor
+"@crustjs/skills": patch
 ---
 
 # Make `agents` optional on `generateSkill`, `uninstallSkill`, and `skillStatus`
@@ -9,7 +9,7 @@ The `agents` field on `GenerateOptions`, `UninstallOptions`, and
 to:
 
 ```ts
-[...getUniversalAgents(), ...await detectInstalledAgents()]
+[...getUniversalAgents(), ...(await detectInstalledAgents())];
 ```
 
 — the union of always-included universal agents and additional agents

--- a/.changeset/skills-optional-agents-default.md
+++ b/.changeset/skills-optional-agents-default.md
@@ -5,24 +5,30 @@
 # Make `agents` optional on `generateSkill`, `uninstallSkill`, and `skillStatus`
 
 The `agents` field on `GenerateOptions`, `UninstallOptions`, and
-`StatusOptions` is now optional. When omitted, all three entrypoints default
-to:
+`StatusOptions` is now optional. The default differs by entrypoint so
+install behavior tracks the current machine, while uninstall and status
+sweep every known path:
 
-```ts
-[...getUniversalAgents(), ...(await detectInstalledAgents())];
-```
+| Entrypoint                      | Default when `agents` is omitted                          | `PATH` I/O? |
+| ------------------------------- | --------------------------------------------------------- | ----------- |
+| `generateSkill`                 | `[...getUniversalAgents(), ...await detectInstalledAgents()]` | Yes      |
+| `uninstallSkill`, `skillStatus` | Every supported agent (exhaustive sweep of all known paths)   | No       |
 
-— the union of always-included universal agents and additional agents
-detected on the current machine.
+In all three, `agents: []` is treated as a no-op (no install, uninstall, or
+status entries). An explicit array always overrides the default.
 
-**Behavior change.** Omitting `agents` performs filesystem I/O via
-`detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
-Previously these functions did no I/O for agent resolution because the
-caller always supplied the list. Pass an explicit array (including the
-empty array, which still means “do nothing”) to skip the probe.
+**Behavior change.** Existing callers that pass an explicit `agents` array
+keep their current behavior. Callers that omit `agents` (or pass
+`agents: undefined`, which is common from object spread) now trigger the
+defaults above:
 
-**Migration.** Existing callers continue to work without modification — this
-is a purely additive change. New code can drop the manual composition:
+- `generateSkill` performs filesystem I/O via `detectInstalledAgents()` to
+  probe `PATH` for installed agent CLIs.
+- `uninstallSkill` and `skillStatus` do not probe `PATH`; they iterate the
+  full agent registry and stat each per-agent path, which can return a
+  larger result set than before (one entry per supported agent).
+
+**Migration.**
 
 ```ts
 // Before — manual composition of universals + detected agents
@@ -39,5 +45,11 @@ await generateSkill({
 await generateSkill({ command, meta, scope: "global" });
 ```
 
-`getUniversalAgents()` and `detectInstalledAgents()` remain exported for
-callers who want fine-grained control.
+`getUniversalAgents()`, `getAdditionalAgents()`, and
+`detectInstalledAgents()` remain exported for callers who want fine-grained
+control.
+
+**Bug fix.** `detectInstalledAgents()` no longer reports a command as
+installed when the matching `PATH` entry is an executable directory rather
+than a file. The probe now requires the entry to be a regular file (or
+symlink to one) before checking the `X_OK` bit.

--- a/.changeset/skills-optional-agents-default.md
+++ b/.changeset/skills-optional-agents-default.md
@@ -1,0 +1,43 @@
+---
+"@crustjs/skills": minor
+---
+
+# Make `agents` optional on `generateSkill`, `uninstallSkill`, and `skillStatus`
+
+The `agents` field on `GenerateOptions`, `UninstallOptions`, and
+`StatusOptions` is now optional. When omitted, all three entrypoints default
+to:
+
+```ts
+[...getUniversalAgents(), ...await detectInstalledAgents()]
+```
+
+— the union of always-included universal agents and additional agents
+detected on the current machine.
+
+**Behavior change.** Omitting `agents` performs filesystem I/O via
+`detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+Previously these functions did no I/O for agent resolution because the
+caller always supplied the list. Pass an explicit array (including the
+empty array, which still means “do nothing”) to skip the probe.
+
+**Migration.** Existing callers continue to work without modification — this
+is a purely additive change. New code can drop the manual composition:
+
+```ts
+// Before — manual composition of universals + detected agents
+const universal = getUniversalAgents();
+const additional = await detectInstalledAgents();
+await generateSkill({
+  command,
+  meta,
+  agents: [...universal, ...additional],
+  scope: "global",
+});
+
+// After — same result, no manual composition
+await generateSkill({ command, meta, scope: "global" });
+```
+
+`getUniversalAgents()` and `detectInstalledAgents()` remain exported for
+callers who want fine-grained control.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -215,51 +215,59 @@ isValidSkillName("My_CLI"); // false
 
 For custom workflows, the package also exports lower-level functions:
 
+### Default targets — omit `agents` for the common case
+
+`generateSkill`, `uninstallSkill`, and `skillStatus` accept an optional
+`agents` field. When omitted, all three default to the union of
+`getUniversalAgents()` and `await detectInstalledAgents()` — every universal
+agent plus every additional agent whose CLI is detected on `PATH`.
+
+> Omitting `agents` performs filesystem I/O via `detectInstalledAgents()` to
+> probe `PATH` for installed agent CLIs. Pass an explicit array (including
+> the empty array, which means “do nothing”) to override.
+
+```ts
+import { generateSkill, skillStatus, uninstallSkill } from "@crustjs/skills";
+
+// Install — defaults to universal + detected additional agents.
+const result = await generateSkill({
+  command: rootCommand,
+  meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
+  scope: "global", // or "project"
+});
+
+// Status uses the same default.
+const status = await skillStatus({ name: "my-cli" });
+
+// Uninstall uses the same default.
+const removed = await uninstallSkill({ name: "my-cli" });
+```
+
+### Explicit targets — override the default
+
+For full control, pass `agents` explicitly. `getUniversalAgents()` and
+`detectInstalledAgents()` remain exported so callers can compose the same
+list the default produces (or any subset of it):
+
 ```ts
 import {
   detectInstalledAgents,
   generateSkill,
-  uninstallSkill,
-  skillStatus,
+  getUniversalAgents,
   isValidSkillName,
 } from "@crustjs/skills";
 
-// Validate a skill name
+// Validate a skill name.
 isValidSkillName("my-cli"); // true
 
-// Detect which agents are installed
-const agents = await detectInstalledAgents();
-// Additional detected agents only (universal is handled separately)
+// Compose the same list the default would produce.
+const universal = getUniversalAgents();
+const additional = await detectInstalledAgents();
 
-const universalAgents = [
-  "amp",
-  "cline",
-  "codex",
-  "cursor",
-  "gemini-cli",
-  "github-copilot",
-  "kimi-cli",
-  "opencode",
-  "replit",
-] as const;
-
-// Install skills
-const result = await generateSkill({
+await generateSkill({
   command: rootCommand,
   meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
-  agents: [...universalAgents, ...agents],
-  scope: "global", // or "project"
-});
-
-// Check status
-const status = await skillStatus({
-  name: "my-cli",
-  agents,
-});
-
-// Uninstall
-const removed = await uninstallSkill({
-  name: "my-cli",
-  agents,
+  agents: [...universal, ...additional], // explicit form
+  scope: "global",
 });
 ```

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -218,36 +218,43 @@ For custom workflows, the package also exports lower-level functions:
 ### Default targets — omit `agents` for the common case
 
 `generateSkill`, `uninstallSkill`, and `skillStatus` accept an optional
-`agents` field. When omitted, all three default to the union of
-`getUniversalAgents()` and `await detectInstalledAgents()` — every universal
-agent plus every additional agent whose CLI is detected on `PATH`.
+`agents` field. The default differs by entrypoint so install behavior tracks
+what is actually on the current machine, while uninstall and status sweep
+every known path:
 
-> Omitting `agents` performs filesystem I/O via `detectInstalledAgents()` to
-> probe `PATH` for installed agent CLIs. Pass an explicit array (including
-> the empty array, which means “do nothing”) to override.
+| Entrypoint                    | Default when `agents` is omitted                                | `PATH` I/O? |
+| ----------------------------- | --------------------------------------------------------------- | ----------- |
+| `generateSkill`               | Universal agents + additional agents detected on `PATH`         | Yes         |
+| `uninstallSkill`, `skillStatus` | Every supported agent (exhaustive sweep of all known paths)   | No          |
+
+In all three, passing `agents: []` is treated as a no-op (no install,
+uninstall, or status entries). An explicit array always overrides the
+default.
 
 ```ts
 import { generateSkill, skillStatus, uninstallSkill } from "@crustjs/skills";
 
-// Install — defaults to universal + detected additional agents.
+// Install — universal + agents whose CLI is on PATH.
 const result = await generateSkill({
   command: rootCommand,
   meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
   scope: "global", // or "project"
 });
 
-// Status uses the same default.
+// Status — reports an entry for every supported agent. Most read
+// `installed: false` on a typical machine; that is expected.
 const status = await skillStatus({ name: "my-cli" });
 
-// Uninstall uses the same default.
+// Uninstall — sweeps every known agent path and removes any Crust-managed
+// install regardless of whether its CLI is currently on PATH.
 const removed = await uninstallSkill({ name: "my-cli" });
 ```
 
 ### Explicit targets — override the default
 
-For full control, pass `agents` explicitly. `getUniversalAgents()` and
-`detectInstalledAgents()` remain exported so callers can compose the same
-list the default produces (or any subset of it):
+For full control, pass `agents` explicitly. `getUniversalAgents()`,
+`getAdditionalAgents()`, and `detectInstalledAgents()` remain exported so
+callers can compose any subset:
 
 ```ts
 import {
@@ -260,7 +267,7 @@ import {
 // Validate a skill name.
 isValidSkillName("my-cli"); // true
 
-// Compose the same list the default would produce.
+// Compose the same list `generateSkill` would build by default.
 const universal = getUniversalAgents();
 const additional = await detectInstalledAgents();
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -82,18 +82,21 @@ Generated bundles are written once to a canonical store (`.crust/skills` for pro
 ### Programmatic Auto-Install
 
 For full control over first-time installation, use the exported primitives
-directly in your own setup logic:
+directly in your own setup logic. `generateSkill`, `skillStatus`, and
+`uninstallSkill` accept an optional `agents` field; when omitted, all three
+default to the union of `getUniversalAgents()` and
+`await detectInstalledAgents()`. Omitting `agents` performs filesystem I/O to
+probe `PATH` for installed agent CLIs.
 
 ```ts
 import { defineCommand, runMain } from "@crustjs/core";
-import { detectInstalledAgents, generateSkill, skillStatus } from "@crustjs/skills";
+import { generateSkill, skillStatus } from "@crustjs/skills";
 
 const app = defineCommand({
   meta: { name: "my-cli", description: "My CLI" },
   async run() {
-    // Detect agents and install skills if not yet present
-    const agents = await detectInstalledAgents();
-    const status = await skillStatus({ name: "my-cli", agents, scope: "global" });
+    // Status defaults to universal + detected additional agents.
+    const status = await skillStatus({ name: "my-cli", scope: "global" });
 
     const notInstalled = status.agents
       .filter((a) => !a.installed)
@@ -112,6 +115,10 @@ const app = defineCommand({
 
 runMain(app);
 ```
+
+For fine-grained control, `getUniversalAgents()` and
+`detectInstalledAgents()` remain exported so callers can compose the same
+list the default produces (or any subset of it).
 
 #### Troubleshooting
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -2,7 +2,7 @@
 
 Generate distributable AI agent skills from [Crust](https://crustjs.com) command definitions.
 
-Instead of hand-maintaining skill files for AI coding agents, generate them from your `defineCommand` metadata. The output is a portable skill bundle that developers can download and install into their own agent environments (OpenCode, Claude Code, etc.).
+Instead of hand-maintaining skill files for AI coding agents, generate them from your Crust command metadata. The output is a portable skill bundle that developers can download and install into their own agent environments (OpenCode, Claude Code, etc.).
 
 ## Install
 
@@ -41,22 +41,15 @@ for (const agent of result.agents) {
 
 ### Runtime Plugin (`autoUpdate`)
 
-`skillPlugin()` is a runtime plugin. Register it in `runMain(..., { plugins })`.
-Do not put a `plugins` field inside `defineCommand(...)`.
+Register `skillPlugin()` on your `Crust` builder with `.use()`:
 
 ```ts
-import { defineCommand, runMain } from "@crustjs/core";
+import { Crust } from "@crustjs/core";
 import { skillPlugin } from "@crustjs/skills";
 
-const app = defineCommand({
-  meta: { name: "my-cli", description: "My CLI" },
-  run() {
-    console.log("hello");
-  },
-});
-
-runMain(app, {
-  plugins: [
+const app = new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .use(
     skillPlugin({
       version: "1.0.0",
       instructions: `
@@ -71,8 +64,12 @@ Prefer readonly commands before mutating project state.
       // defaultScope: "global" | "project" — skip scope prompt when set
       // installMode: "auto" | "symlink" | "copy" (default: "auto")
     }),
-  ],
-});
+  )
+  .run(() => {
+    console.log("hello");
+  });
+
+await app.execute();
 ```
 
 The plugin automatically updates already-installed skills when the version changes, checking both project and global paths for the current working directory. If the current working directory is the home directory, `project` scope is normalized to `global` so installs, updates, and status checks use the global skill locations. First-time installation is done via the interactive `skill` subcommand (or `skill update` for update-only flows), or programmatically using the exported primitives.
@@ -81,50 +78,52 @@ Generated bundles are written once to a canonical store (`.crust/skills` for pro
 
 ### Programmatic Auto-Install
 
-For full control over first-time installation, use the exported primitives
-directly in your own setup logic. `generateSkill`, `skillStatus`, and
-`uninstallSkill` accept an optional `agents` field; when omitted, all three
-default to the union of `getUniversalAgents()` and
-`await detectInstalledAgents()`. Omitting `agents` performs filesystem I/O to
-probe `PATH` for installed agent CLIs.
+For full control over first-time installation, call `generateSkill()`
+directly from your handler. With `agents` omitted, it installs into every
+universal agent plus every additional agent whose CLI is on `PATH`, and
+returns `up-to-date` for targets that already match the current version —
+so the same call is safe to run on every invocation. Pass `agents: []` to
+opt out, or an explicit array to scope the install.
 
 ```ts
-import { defineCommand, runMain } from "@crustjs/core";
-import { generateSkill, skillStatus } from "@crustjs/skills";
+import { Crust } from "@crustjs/core";
+import { generateSkill } from "@crustjs/skills";
 
-const app = defineCommand({
-  meta: { name: "my-cli", description: "My CLI" },
-  async run() {
-    // Status defaults to universal + detected additional agents.
-    const status = await skillStatus({ name: "my-cli", scope: "global" });
+export const app = new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .run(async (ctx) => {
+    // Defaults to universal + agents detected on PATH. Idempotent: targets
+    // that already match the current version are returned as `up-to-date`.
+    const result = await generateSkill({
+      command: ctx.command,
+      meta: {
+        name: ctx.command.meta.name,
+        description: ctx.command.meta.description ?? "",
+        version: "1.0.0",
+      },
+      scope: "global",
+    });
 
-    const notInstalled = status.agents
-      .filter((a) => !a.installed)
-      .map((a) => a.agent);
-
-    if (notInstalled.length > 0) {
-      await generateSkill({
-        command: app,
-        meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
-        agents: notInstalled,
-        scope: "global",
-      });
+    const changed = result.agents.filter((a) => a.status !== "up-to-date");
+    if (changed.length > 0) {
+      console.log(`Installed or updated skills for ${changed.length} target(s).`);
     }
-  },
-});
+  });
 
-runMain(app);
+if (import.meta.main) {
+  await app.execute();
+}
 ```
 
-For fine-grained control, `getUniversalAgents()` and
-`detectInstalledAgents()` remain exported so callers can compose the same
-list the default produces (or any subset of it).
+`getUniversalAgents()`, `getAdditionalAgents()`, and
+`detectInstalledAgents()` remain exported for callers that want to compose
+their own agent list.
 
 #### Troubleshooting
 
 If auto-update does not appear to work:
 
-- Ensure plugin is passed to `runMain(..., { plugins: [...] })`.
+- Ensure `skillPlugin(...)` is registered on the `Crust` builder via `.use()`.
 - Ensure at least one supported agent is detected. Auto-update checks both project and global install paths, with home-directory `project` scope treated as `global`.
 - Check for existing conflicting skill directories without `crust.json`.
 
@@ -133,19 +132,18 @@ If auto-update does not appear to work:
 To avoid side effects when your command module is imported for generation, guard runtime code with `import.meta.main`:
 
 ```ts
-import { defineCommand, runMain } from "@crustjs/core";
+import { Crust } from "@crustjs/core";
 
-// Export the command object — used by skill generation
-export const rootCommand = defineCommand({
-  meta: { name: "my-cli", description: "My CLI tool" },
-  run({ args }) {
+// Export the command — used by skill generation.
+export const rootCommand = new Crust("my-cli")
+  .meta({ description: "My CLI tool" })
+  .run(({ args }) => {
     console.log("Hello from my-cli!");
-  },
-});
+  });
 
-// Only run when executed directly — not when imported for generation
+// Only execute when run directly — not when imported for generation.
 if (import.meta.main) {
-  runMain(rootCommand);
+  await rootCommand.execute();
 }
 ```
 
@@ -196,7 +194,7 @@ Read command docs before suggesting exact flags.
   .command(deploy);
 ```
 
-This pattern lets `crust skills generate` import the command definition without triggering `runMain`.
+This pattern lets `crust skills generate` import the command definition without triggering `app.execute()`.
 
 ## CLI Usage
 

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -152,6 +152,7 @@ describe("detectInstalledAgents", () => {
 describe("PATH-based detection (default commandChecker)", () => {
 	let tmpDir: string;
 	let originalPath: string | undefined;
+	let originalPathExt: string | undefined;
 
 	beforeEach(() => {
 		tmpDir = join(
@@ -160,11 +161,17 @@ describe("PATH-based detection (default commandChecker)", () => {
 		);
 		mkdirSync(tmpDir, { recursive: true });
 		originalPath = process.env.PATH;
+		originalPathExt = process.env.PATHEXT;
 	});
 
 	afterEach(() => {
 		if (originalPath !== undefined) {
 			process.env.PATH = originalPath;
+		}
+		if (originalPathExt === undefined) {
+			delete process.env.PATHEXT;
+		} else {
+			process.env.PATHEXT = originalPathExt;
 		}
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
@@ -197,6 +204,27 @@ describe("PATH-based detection (default commandChecker)", () => {
 		chmodSync(fakeBin, 0o644); // readable but not executable
 
 		process.env.PATH = tmpDir; // only our temp dir, so no real `claude` can be found
+
+		const result = await detectInstalledAgents();
+		expect(result).not.toContain("claude-code");
+	});
+
+	it("does not detect a directory named like a command", async () => {
+		// Regression: `accessSync(X_OK)` returns success for executable directories,
+		// so the probe must additionally check that the entry is a file. The
+		// platform shape of the entry name (`claude` vs `claude.CMD`) is chosen
+		// so the probe sees this directory at all.
+		const dirName = process.platform === "win32" ? "claude.CMD" : "claude";
+		const fakeDir = join(tmpDir, dirName);
+		mkdirSync(fakeDir, { recursive: true });
+		if (process.platform !== "win32") {
+			chmodSync(fakeDir, 0o755);
+		}
+		if (process.platform === "win32") {
+			process.env.PATHEXT = ".CMD";
+		}
+
+		process.env.PATH = tmpDir;
 
 		const result = await detectInstalledAgents();
 		expect(result).not.toContain("claude-code");

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -2,7 +2,7 @@
 // Agent path resolution and detection
 // ────────────────────────────────────────────────────────────────────────────
 
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import type { AgentClass, AgentTarget, Scope } from "./types.ts";
@@ -457,6 +457,11 @@ function isCommandOnPath(command: string): boolean {
 
 function isExecutable(filePath: string): boolean {
 	try {
+		// `accessSync(X_OK)` returns success for executable directories on POSIX,
+		// so verify the entry is a regular file (or symlink to one) before
+		// reporting the command as installed. `statSync` follows symlinks, so
+		// symlinked binaries are still detected.
+		if (!statSync(filePath).isFile()) return false;
 		accessSync(filePath, constants.X_OK);
 		return true;
 	} catch {

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -12,7 +12,7 @@ import { delimiter, join } from "node:path";
 import type { ArgDef, CommandNode, FlagDef } from "@crustjs/core";
 import { Crust } from "@crustjs/core";
 
-import { getUniversalAgents } from "./agents.ts";
+import { ALL_AGENTS, getUniversalAgents } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
 import {
 	generateSkill,
@@ -97,20 +97,30 @@ async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
 }
 
 /**
- * Overrides `process.env.PATH` for the duration of a callback.
+ * Overrides `process.env.PATH` for the duration of a callback. Also
+ * normalizes `process.env.PATHEXT` to `".CMD"` on Windows so the probe in
+ * `isCommandOnPath` looks for the same extension that
+ * {@link makeFakeExecutable} writes (`name.cmd`), regardless of the host's
+ * `PATHEXT` value.
  *
  * Used to deterministically control what `detectInstalledAgents()` returns
  * when the public entrypoints fall back to their default agent resolution.
  * Tests pass a directory that contains zero or more fake executables.
  */
 async function withPath<T>(dirs: string[], fn: () => Promise<T>): Promise<T> {
-	const original = process.env.PATH;
+	const originalPath = process.env.PATH;
+	const originalPathExt = process.env.PATHEXT;
 	process.env.PATH = dirs.join(delimiter);
+	if (process.platform === "win32") {
+		process.env.PATHEXT = ".CMD";
+	}
 	try {
 		return await fn();
 	} finally {
-		if (original === undefined) delete process.env.PATH;
-		else process.env.PATH = original;
+		if (originalPath === undefined) delete process.env.PATH;
+		else process.env.PATH = originalPath;
+		if (originalPathExt === undefined) delete process.env.PATHEXT;
+		else process.env.PATHEXT = originalPathExt;
 	}
 }
 
@@ -121,9 +131,10 @@ async function withPath<T>(dirs: string[], fn: () => Promise<T>): Promise<T> {
  *
  * - POSIX: checks `dir/name` with `X_OK`, so we write a shebang script
  *   and `chmod 0o755`.
- * - Windows: checks `dir/name + ext` for each `PATHEXT` entry (default
- *   `.EXE;.CMD;.BAT;.COM`), so we write `dir/name.cmd`. `X_OK` collapses
- *   to `R_OK` on Windows, so no `chmod` is needed.
+ * - Windows: checks `dir/name + ext` for each `PATHEXT` entry. Tests rely on
+ *   {@link withPath} forcing `PATHEXT=".CMD"`, so this helper writes
+ *   `dir/name.cmd`. `X_OK` collapses to `R_OK` on Windows, so no `chmod`
+ *   is needed.
  */
 async function makeFakeExecutable(dir: string, name: string): Promise<void> {
 	if (process.platform === "win32") {
@@ -1587,15 +1598,20 @@ describe("skillStatus", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Default agent resolution — omitted `agents` triggers universal + detected
+// Default agent resolution — omitted `agents` triggers per-entrypoint default
+//
+// `generateSkill`           → universal + PATH-detected additional agents
+// `uninstallSkill` / status → exhaustive sweep over ALL_AGENTS (no PATH I/O)
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("default agent resolution", () => {
 	/**
-	 * `getUniversalAgents()` is fixed at module-load time, so we capture it
-	 * once and reuse for assertions about the default-resolution shape.
+	 * `getUniversalAgents()` and `ALL_AGENTS` are fixed at module-load time, so
+	 * we capture them once and reuse for assertions about the default-resolution
+	 * shape.
 	 */
 	const universalAgents = getUniversalAgents();
+	const allAgentsCount = ALL_AGENTS.length;
 
 	describe("generateSkill", () => {
 		it("defaults to universal + detected when `agents` is omitted", async () => {
@@ -1704,57 +1720,59 @@ describe("default agent resolution", () => {
 	});
 
 	describe("uninstallSkill", () => {
-		it("defaults to universal + detected when `agents` is omitted", async () => {
-			const pathDir = join(tmpDir, "fake-bin");
-			await mkdir(pathDir, { recursive: true });
-			await makeFakeExecutable(pathDir, "claude");
-
-			// Install with explicit list, then uninstall using the default.
+		/**
+		 * Default uninstall now sweeps every supported agent path with no PATH
+		 * I/O, so the install side uses an explicit list and the uninstall side
+		 * does not need a controlled PATH.
+		 */
+		it("defaults to all supported agents when `agents` is omitted", async () => {
+			// Install only `claude-code` (additional) — universal agents share
+			// `.agents/skills/<name>`, so they are intentionally not in the install
+			// list to keep the universal path empty for the uninstall assertions.
 			await withCwd(tmpDir, () =>
-				withPath([pathDir], () =>
-					generateSkill({
-						command: simpleCommand(),
-						meta: {
-							name: "my-cli",
-							description: "Test",
-							version: "1.0.0",
-						},
-						agents: ["claude-code", "opencode"],
-						scope: "project",
-					}),
-				),
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Test",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+				}),
 			);
 
 			const result = await withCwd(tmpDir, () =>
-				withPath([pathDir], () =>
-					uninstallSkill({
-						name: "my-cli",
-						scope: "project",
-					}),
-				),
+				uninstallSkill({
+					name: "my-cli",
+					scope: "project",
+				}),
 			);
 
-			const targets = new Set(result.agents.map((a) => a.agent));
-			for (const universal of universalAgents) {
-				expect(targets.has(universal)).toBe(true);
+			expect(result.agents).toHaveLength(allAgentsCount);
+
+			const byAgent = new Map(result.agents.map((a) => [a.agent, a]));
+			for (const agent of ALL_AGENTS) {
+				expect(byAgent.has(agent)).toBe(true);
 			}
-			expect(targets.has("claude-code")).toBe(true);
-			expect(result.agents.length).toBe(universalAgents.length + 1);
+			// Installed additional → removed.
+			expect(byAgent.get("claude-code")?.status).toBe("removed");
+			// Unrelated additional → not-found (filesystem-only sweep, no PATH probe).
+			expect(byAgent.get("windsurf")?.status).toBe("not-found");
+			// Universals share `.agents/skills/<name>` — that path was never written,
+			// so every universal entry reports not-found.
+			for (const universal of universalAgents) {
+				expect(byAgent.get(universal)?.status).toBe("not-found");
+			}
 		});
 
 		it("treats `agents: []` as no-op (does not trigger default)", async () => {
-			const pathDir = join(tmpDir, "fake-bin");
-			await mkdir(pathDir, { recursive: true });
-			await makeFakeExecutable(pathDir, "claude");
-
 			const result = await withCwd(tmpDir, () =>
-				withPath([pathDir], () =>
-					uninstallSkill({
-						name: "my-cli",
-						agents: [],
-						scope: "project",
-					}),
-				),
+				uninstallSkill({
+					name: "my-cli",
+					agents: [],
+					scope: "project",
+				}),
 			);
 
 			expect(result.agents).toEqual([]);
@@ -1762,45 +1780,48 @@ describe("default agent resolution", () => {
 	});
 
 	describe("skillStatus", () => {
-		it("defaults to universal + detected when `agents` is omitted", async () => {
-			const pathDir = join(tmpDir, "fake-bin");
-			await mkdir(pathDir, { recursive: true });
-			await makeFakeExecutable(pathDir, "claude");
-
-			const status = await withCwd(tmpDir, () =>
-				withPath([pathDir], () =>
-					skillStatus({
+		it("defaults to all supported agents when `agents` is omitted", async () => {
+			await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
 						name: "my-cli",
-						scope: "project",
-					}),
-				),
+						description: "Test",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+				}),
 			);
 
-			const targets = new Set(status.agents.map((a) => a.agent));
-			for (const universal of universalAgents) {
-				expect(targets.has(universal)).toBe(true);
+			const status = await withCwd(tmpDir, () =>
+				skillStatus({
+					name: "my-cli",
+					scope: "project",
+				}),
+			);
+
+			expect(status.agents).toHaveLength(allAgentsCount);
+
+			const byAgent = new Map(status.agents.map((a) => [a.agent, a]));
+			for (const agent of ALL_AGENTS) {
+				expect(byAgent.has(agent)).toBe(true);
 			}
-			expect(targets.has("claude-code")).toBe(true);
-			expect(status.agents.length).toBe(universalAgents.length + 1);
-			// Nothing was installed, so all entries report `installed: false`.
-			for (const entry of status.agents) {
-				expect(entry.installed).toBe(false);
+			expect(byAgent.get("claude-code")?.installed).toBe(true);
+			expect(byAgent.get("windsurf")?.installed).toBe(false);
+			// No universal agent path was written.
+			for (const universal of universalAgents) {
+				expect(byAgent.get(universal)?.installed).toBe(false);
 			}
 		});
 
 		it("treats `agents: []` as no-op (does not trigger default)", async () => {
-			const pathDir = join(tmpDir, "fake-bin");
-			await mkdir(pathDir, { recursive: true });
-			await makeFakeExecutable(pathDir, "claude");
-
 			const status = await withCwd(tmpDir, () =>
-				withPath([pathDir], () =>
-					skillStatus({
-						name: "my-cli",
-						agents: [],
-						scope: "project",
-					}),
-				),
+				skillStatus({
+					name: "my-cli",
+					agents: [],
+					scope: "project",
+				}),
 			);
 
 			expect(status.agents).toEqual([]);

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	chmod,
 	lstat,
 	mkdir,
 	readdir,
@@ -7,10 +8,11 @@ import {
 	stat,
 	writeFile,
 } from "node:fs/promises";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import type { ArgDef, CommandNode, FlagDef } from "@crustjs/core";
 import { Crust } from "@crustjs/core";
 
+import { getUniversalAgents } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
 import {
 	generateSkill,
@@ -92,6 +94,35 @@ async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
 	} finally {
 		process.cwd = original;
 	}
+}
+
+/**
+ * Overrides `process.env.PATH` for the duration of a callback.
+ *
+ * Used to deterministically control what `detectInstalledAgents()` returns
+ * when the public entrypoints fall back to their default agent resolution.
+ * Tests pass a directory that contains zero or more fake executables.
+ */
+async function withPath<T>(dirs: string[], fn: () => Promise<T>): Promise<T> {
+	const original = process.env.PATH;
+	process.env.PATH = dirs.join(delimiter);
+	try {
+		return await fn();
+	} finally {
+		if (original === undefined) delete process.env.PATH;
+		else process.env.PATH = original;
+	}
+}
+
+/**
+ * Creates a fake POSIX executable at `dir/name`. Used to make
+ * `detectInstalledAgents()` (which probes PATH non-executingly) return a
+ * deterministic agent list during default-resolution tests.
+ */
+async function makeFakeExecutable(dir: string, name: string): Promise<void> {
+	const filePath = join(dir, name);
+	await writeFile(filePath, "#!/bin/sh\nexit 0\n", "utf-8");
+	await chmod(filePath, 0o755);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1538,5 +1569,227 @@ describe("skillStatus", () => {
 		expect(status.agents[0]?.outputDir).toBe(
 			join(tmpDir, ".claude", "skills", "my-cli"),
 		);
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Default agent resolution — omitted `agents` triggers universal + detected
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("default agent resolution", () => {
+	/**
+	 * `getUniversalAgents()` is fixed at module-load time, so we capture it
+	 * once and reuse for assertions about the default-resolution shape.
+	 */
+	const universalAgents = getUniversalAgents();
+
+	describe("generateSkill", () => {
+		it("defaults to universal + detected when `agents` is omitted", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			// `claude-code` is detected when `claude` is on PATH.
+			await makeFakeExecutable(pathDir, "claude");
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					generateSkill({
+						command: simpleCommand(),
+						meta: {
+							name: "my-cli",
+							description: "Test",
+							version: "1.0.0",
+						},
+						scope: "project",
+					}),
+				),
+			);
+
+			const targets = new Set(result.agents.map((a) => a.agent));
+			// Every universal agent is included...
+			for (const universal of universalAgents) {
+				expect(targets.has(universal)).toBe(true);
+			}
+			// ...plus the detected additional agent.
+			expect(targets.has("claude-code")).toBe(true);
+			expect(result.agents.length).toBe(universalAgents.length + 1);
+		});
+
+		it("falls back to universal-only when nothing is detected", async () => {
+			const pathDir = join(tmpDir, "empty-bin");
+			await mkdir(pathDir, { recursive: true });
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					generateSkill({
+						command: simpleCommand(),
+						meta: {
+							name: "my-cli",
+							description: "Test",
+							version: "1.0.0",
+						},
+						scope: "project",
+					}),
+				),
+			);
+
+			const targets = new Set(result.agents.map((a) => a.agent));
+			expect(result.agents.length).toBe(universalAgents.length);
+			for (const universal of universalAgents) {
+				expect(targets.has(universal)).toBe(true);
+			}
+		});
+
+		it("treats `agents: []` as no-op (does not trigger default)", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			await makeFakeExecutable(pathDir, "claude");
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					generateSkill({
+						command: simpleCommand(),
+						meta: {
+							name: "my-cli",
+							description: "Test",
+							version: "1.0.0",
+						},
+						agents: [],
+						scope: "project",
+					}),
+				),
+			);
+
+			expect(result.agents).toEqual([]);
+		});
+
+		it("honors an explicit `agents` list (default not triggered)", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			// Add many fake agents to PATH — explicit list must still win.
+			await makeFakeExecutable(pathDir, "claude");
+			await makeFakeExecutable(pathDir, "windsurf");
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					generateSkill({
+						command: simpleCommand(),
+						meta: {
+							name: "my-cli",
+							description: "Test",
+							version: "1.0.0",
+						},
+						agents: ["claude-code"],
+						scope: "project",
+					}),
+				),
+			);
+
+			expect(result.agents).toHaveLength(1);
+			expect(result.agents[0]?.agent).toBe("claude-code");
+		});
+	});
+
+	describe("uninstallSkill", () => {
+		it("defaults to universal + detected when `agents` is omitted", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			await makeFakeExecutable(pathDir, "claude");
+
+			// Install with explicit list, then uninstall using the default.
+			await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					generateSkill({
+						command: simpleCommand(),
+						meta: {
+							name: "my-cli",
+							description: "Test",
+							version: "1.0.0",
+						},
+						agents: ["claude-code", "opencode"],
+						scope: "project",
+					}),
+				),
+			);
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					uninstallSkill({
+						name: "my-cli",
+						scope: "project",
+					}),
+				),
+			);
+
+			const targets = new Set(result.agents.map((a) => a.agent));
+			for (const universal of universalAgents) {
+				expect(targets.has(universal)).toBe(true);
+			}
+			expect(targets.has("claude-code")).toBe(true);
+			expect(result.agents.length).toBe(universalAgents.length + 1);
+		});
+
+		it("treats `agents: []` as no-op (does not trigger default)", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			await makeFakeExecutable(pathDir, "claude");
+
+			const result = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					uninstallSkill({
+						name: "my-cli",
+						agents: [],
+						scope: "project",
+					}),
+				),
+			);
+
+			expect(result.agents).toEqual([]);
+		});
+	});
+
+	describe("skillStatus", () => {
+		it("defaults to universal + detected when `agents` is omitted", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			await makeFakeExecutable(pathDir, "claude");
+
+			const status = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					skillStatus({
+						name: "my-cli",
+						scope: "project",
+					}),
+				),
+			);
+
+			const targets = new Set(status.agents.map((a) => a.agent));
+			for (const universal of universalAgents) {
+				expect(targets.has(universal)).toBe(true);
+			}
+			expect(targets.has("claude-code")).toBe(true);
+			expect(status.agents.length).toBe(universalAgents.length + 1);
+			// Nothing was installed, so all entries report `installed: false`.
+			for (const entry of status.agents) {
+				expect(entry.installed).toBe(false);
+			}
+		});
+
+		it("treats `agents: []` as no-op (does not trigger default)", async () => {
+			const pathDir = join(tmpDir, "fake-bin");
+			await mkdir(pathDir, { recursive: true });
+			await makeFakeExecutable(pathDir, "claude");
+
+			const status = await withCwd(tmpDir, () =>
+				withPath([pathDir], () =>
+					skillStatus({
+						name: "my-cli",
+						agents: [],
+						scope: "project",
+					}),
+				),
+			);
+
+			expect(status.agents).toEqual([]);
+		});
 	});
 });

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -115,11 +115,25 @@ async function withPath<T>(dirs: string[], fn: () => Promise<T>): Promise<T> {
 }
 
 /**
- * Creates a fake POSIX executable at `dir/name`. Used to make
- * `detectInstalledAgents()` (which probes PATH non-executingly) return a
- * deterministic agent list during default-resolution tests.
+ * Creates a fake executable at `dir/name` that `detectInstalledAgents()`
+ * will discover via its non-executing PATH probe. The probe is
+ * platform-specific (see `isCommandOnPath` in `agents.ts`):
+ *
+ * - POSIX: checks `dir/name` with `X_OK`, so we write a shebang script
+ *   and `chmod 0o755`.
+ * - Windows: checks `dir/name + ext` for each `PATHEXT` entry (default
+ *   `.EXE;.CMD;.BAT;.COM`), so we write `dir/name.cmd`. `X_OK` collapses
+ *   to `R_OK` on Windows, so no `chmod` is needed.
  */
 async function makeFakeExecutable(dir: string, name: string): Promise<void> {
+	if (process.platform === "win32") {
+		await writeFile(
+			join(dir, `${name}.cmd`),
+			"@echo off\r\nexit /b 0\r\n",
+			"utf-8",
+		);
+		return;
+	}
 	const filePath = join(dir, name);
 	await writeFile(filePath, "#!/bin/sh\nexit 0\n", "utf-8");
 	await chmod(filePath, 0o755);

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -46,19 +46,48 @@ const DEFAULT_INSTALL_MODE: SkillInstallMode = "auto";
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Resolves the agent list for the public entrypoints when the caller omits
- * `agents`. Returning the union of universal agents and detected additional
- * agents matches the previous “manual” call-site recipe shown in docs.
+ * Resolves the agent list for `generateSkill` when the caller omits `agents`.
+ *
+ * Returns the union of universal agents and additional agents whose CLI is
+ * detected on `PATH`. This matches the previous “manual” call-site recipe
+ * shown in docs and keeps install behavior driven by what's actually
+ * available on the current machine.
  *
  * `provided !== undefined` is checked instead of truthiness so that an
  * explicit empty array (`agents: []`) continues to mean “do nothing” — only
  * a missing/undefined field triggers the default.
+ *
+ * **Note:** Triggering the default performs filesystem I/O via
+ * `detectInstalledAgents()` to probe `PATH`.
  */
-async function resolveAgents(
+async function resolveGenerateAgents(
 	provided: AgentTarget[] | undefined,
 ): Promise<AgentTarget[]> {
 	if (provided !== undefined) return provided;
 	return [...getUniversalAgents(), ...(await detectInstalledAgents())];
+}
+
+/**
+ * Resolves the agent list for `uninstallSkill` and `skillStatus` when the
+ * caller omits `agents`.
+ *
+ * Returns every supported agent so the operation can sweep all known install
+ * paths regardless of what is currently on `PATH`. This avoids cross-machine
+ * drift (an additional agent installed on machine A would otherwise be
+ * skipped on machine B if its CLI is not present), and matches how
+ * canonical-store cleanup already iterates `ALL_AGENTS`.
+ *
+ * No filesystem I/O is performed during resolution — the entrypoints already
+ * stat each per-agent path.
+ *
+ * `provided !== undefined` is checked instead of truthiness so that an
+ * explicit empty array (`agents: []`) continues to mean “do nothing”.
+ */
+function resolveAllAgentTargets(
+	provided: AgentTarget[] | undefined,
+): AgentTarget[] {
+	if (provided !== undefined) return provided;
+	return [...ALL_AGENTS];
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -153,7 +182,7 @@ export async function generateSkill(
 		force = false,
 		installMode = DEFAULT_INSTALL_MODE,
 	} = options;
-	const agents = await resolveAgents(options.agents);
+	const agents = await resolveGenerateAgents(options.agents);
 
 	// Resolve the canonical current name — do not mutate the caller's meta object
 	const resolvedName = resolveSkillName(meta.name);
@@ -339,7 +368,7 @@ export async function uninstallSkill(
 	options: UninstallOptions,
 ): Promise<UninstallResult> {
 	const { name, scope = "global" } = options;
-	const agents = await resolveAgents(options.agents);
+	const agents = resolveAllAgentTargets(options.agents);
 	const resolvedName = resolveSkillName(name);
 	const legacyResolvedName = resolveLegacySkillName(name);
 	const canonicalOutputDir = resolveCanonicalSkillPath(scope, resolvedName);
@@ -436,7 +465,7 @@ export async function skillStatus(
 	options: StatusOptions,
 ): Promise<StatusResult> {
 	const { name, scope = "global" } = options;
-	const agents = await resolveAgents(options.agents);
+	const agents = resolveAllAgentTargets(options.agents);
 	const resolvedName = resolveSkillName(name);
 	const legacyResolvedName = resolveLegacySkillName(name);
 	const results: StatusResult["agents"] = [];

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -14,6 +14,8 @@ import {
 import { dirname, join } from "node:path";
 import {
 	ALL_AGENTS,
+	detectInstalledAgents,
+	getUniversalAgents,
 	resolveAgentPath,
 	resolveCanonicalSkillPath,
 } from "./agents.ts";
@@ -22,6 +24,7 @@ import { buildManifest } from "./manifest.ts";
 import { renderSkill } from "./render.ts";
 import type {
 	AgentResult,
+	AgentTarget,
 	GenerateOptions,
 	GenerateResult,
 	InstallStatus,
@@ -37,6 +40,26 @@ import type {
 import { CRUST_MANIFEST, readInstalledVersion } from "./version.ts";
 
 const DEFAULT_INSTALL_MODE: SkillInstallMode = "auto";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Default agent resolution
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves the agent list for the public entrypoints when the caller omits
+ * `agents`. Returning the union of universal agents and detected additional
+ * agents matches the previous “manual” call-site recipe shown in docs.
+ *
+ * `provided !== undefined` is checked instead of truthiness so that an
+ * explicit empty array (`agents: []`) continues to mean “do nothing” — only
+ * a missing/undefined field triggers the default.
+ */
+async function resolveAgents(
+	provided: AgentTarget[] | undefined,
+): Promise<AgentTarget[]> {
+	if (provided !== undefined) return provided;
+	return [...getUniversalAgents(), ...(await detectInstalledAgents())];
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Naming — resolveSkillName and validation
@@ -125,12 +148,12 @@ export async function generateSkill(
 	const {
 		command,
 		meta,
-		agents,
 		scope = "global",
 		clean = true,
 		force = false,
 		installMode = DEFAULT_INSTALL_MODE,
 	} = options;
+	const agents = await resolveAgents(options.agents);
 
 	// Resolve the canonical current name — do not mutate the caller's meta object
 	const resolvedName = resolveSkillName(meta.name);
@@ -315,7 +338,8 @@ export async function generateSkill(
 export async function uninstallSkill(
 	options: UninstallOptions,
 ): Promise<UninstallResult> {
-	const { name, agents, scope = "global" } = options;
+	const { name, scope = "global" } = options;
+	const agents = await resolveAgents(options.agents);
 	const resolvedName = resolveSkillName(name);
 	const legacyResolvedName = resolveLegacySkillName(name);
 	const canonicalOutputDir = resolveCanonicalSkillPath(scope, resolvedName);
@@ -411,7 +435,8 @@ export async function uninstallSkill(
 export async function skillStatus(
 	options: StatusOptions,
 ): Promise<StatusResult> {
-	const { name, agents, scope = "global" } = options;
+	const { name, scope = "global" } = options;
+	const agents = await resolveAgents(options.agents);
 	const resolvedName = resolveSkillName(name);
 	const legacyResolvedName = resolveLegacySkillName(name);
 	const results: StatusResult["agents"] = [];

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -288,11 +288,11 @@ export interface GenerateOptions {
 	/**
 	 * Agent targets to install skills for.
 	 *
-	 * When omitted, defaults to
+	 * When omitted (or explicitly `undefined`), defaults to
 	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
-	 * of always-included universal agents and additional agents detected on
-	 * the current machine. Pass an explicit array (including the empty array)
-	 * to override.
+	 * of always-included universal agents and additional agents whose CLI is
+	 * detected on `PATH`. Pass an explicit array to override; `agents: []`
+	 * is treated as a no-op (no install performed).
 	 *
 	 * **Note:** Omitting this field performs filesystem I/O via
 	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
@@ -376,14 +376,14 @@ export interface UninstallOptions {
 	/**
 	 * Agent targets to uninstall from.
 	 *
-	 * When omitted, defaults to
-	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
-	 * of always-included universal agents and additional agents detected on
-	 * the current machine. Pass an explicit array (including the empty array)
-	 * to override.
+	 * When omitted (or explicitly `undefined`), defaults to every supported
+	 * agent so the uninstall sweep covers any path that may hold an install,
+	 * regardless of what is on the current machine's `PATH`. Pass an explicit
+	 * array to scope the uninstall; `agents: []` is treated as a no-op (no
+	 * paths are touched).
 	 *
-	 * **Note:** Omitting this field performs filesystem I/O via
-	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+	 * Default resolution does not perform `PATH` I/O — the entrypoint already
+	 * stats each per-agent path during the sweep.
 	 */
 	agents?: AgentTarget[];
 	/**
@@ -415,14 +415,14 @@ export interface StatusOptions {
 	/**
 	 * Agent targets to check.
 	 *
-	 * When omitted, defaults to
-	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
-	 * of always-included universal agents and additional agents detected on
-	 * the current machine. Pass an explicit array (including the empty array)
-	 * to override.
+	 * When omitted (or explicitly `undefined`), defaults to every supported
+	 * agent so the status sweep reports an entry for any path that may hold
+	 * an install, regardless of what is on the current machine's `PATH`. Pass
+	 * an explicit array to scope the check; `agents: []` is treated as a no-op
+	 * (returns an empty result).
 	 *
-	 * **Note:** Omitting this field performs filesystem I/O via
-	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+	 * Default resolution does not perform `PATH` I/O — the entrypoint already
+	 * stats each per-agent path during the sweep.
 	 */
 	agents?: AgentTarget[];
 	/**

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -285,8 +285,19 @@ export interface GenerateOptions {
 	command: CommandNode;
 	/** Skill metadata for the generated bundle */
 	meta: SkillMeta;
-	/** Agent targets to install skills for */
-	agents: AgentTarget[];
+	/**
+	 * Agent targets to install skills for.
+	 *
+	 * When omitted, defaults to
+	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
+	 * of always-included universal agents and additional agents detected on
+	 * the current machine. Pass an explicit array (including the empty array)
+	 * to override.
+	 *
+	 * **Note:** Omitting this field performs filesystem I/O via
+	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+	 */
+	agents?: AgentTarget[];
 	/**
 	 * Installation strategy for agent output paths.
 	 *
@@ -362,8 +373,19 @@ export interface GenerateResult {
 export interface UninstallOptions {
 	/** Skill name to uninstall */
 	name: string;
-	/** Agent targets to uninstall from */
-	agents: AgentTarget[];
+	/**
+	 * Agent targets to uninstall from.
+	 *
+	 * When omitted, defaults to
+	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
+	 * of always-included universal agents and additional agents detected on
+	 * the current machine. Pass an explicit array (including the empty array)
+	 * to override.
+	 *
+	 * **Note:** Omitting this field performs filesystem I/O via
+	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+	 */
+	agents?: AgentTarget[];
 	/**
 	 * Installation scope to uninstall from.
 	 * When `process.cwd()` is the home directory, `"project"` is treated as `"global"`.
@@ -390,8 +412,19 @@ export interface UninstallResult {
 export interface StatusOptions {
 	/** Skill name to check */
 	name: string;
-	/** Agent targets to check */
-	agents: AgentTarget[];
+	/**
+	 * Agent targets to check.
+	 *
+	 * When omitted, defaults to
+	 * `[...getUniversalAgents(), ...await detectInstalledAgents()]` — the union
+	 * of always-included universal agents and additional agents detected on
+	 * the current machine. Pass an explicit array (including the empty array)
+	 * to override.
+	 *
+	 * **Note:** Omitting this field performs filesystem I/O via
+	 * `detectInstalledAgents()` to probe `PATH` for installed agent CLIs.
+	 */
+	agents?: AgentTarget[];
 	/**
 	 * Installation scope to check.
 	 * When `process.cwd()` is the home directory, `"project"` is treated as `"global"`.


### PR DESCRIPTION
Resolves the lower-friction half of the `@crustjs/skills` DX cleanup — `TP-006`.

## What changed

The `agents` field on `GenerateOptions`, `UninstallOptions`, and `StatusOptions` is now optional. When omitted, the three entrypoints default to:

```ts
[...getUniversalAgents(), ...await detectInstalledAgents()]
```

— exactly the manual recipe the README previously showed.

## Migration

Purely additive — existing callers continue to work without modification.

```ts
// Before — manual composition
const universal = getUniversalAgents();
const additional = await detectInstalledAgents();
await generateSkill({ command, meta, agents: [...universal, ...additional], scope: "global" });

// After — same result, no manual composition
await generateSkill({ command, meta, scope: "global" });
```

`getUniversalAgents()` and `detectInstalledAgents()` remain exported for fine-grained control.

## Behavior change called out in changeset

Omitting `agents` performs filesystem I/O via `detectInstalledAgents()` (probes `PATH` for installed agent CLIs). Previously these functions did no I/O for agent resolution because the caller always supplied the list. Pass an explicit array — including `agents: []` which still means "do nothing" — to skip the probe.

## Implementation note

A new private `resolveAgents()` helper distinguishes `undefined` (use default) from `[]` (explicit no-op) — preserves back-compat for callers who pass `[]` to skip agent work. Called once per entrypoint at the top of the body.

## Verification

- `bun run check` ✅ 282 files, no fixes
- `bun run check:types` ✅ 21/21 packages
- `packages/skills` new tests: **71 pass / 0 fail** (TP-006 regression coverage)

⚠️ **Heads-up unrelated to this PR:** running `bun test` against `tests/e2e.test.ts` on this branch (and on `main`) reveals 2 pre-existing failures around SKILL.md template wording drift ("Use this skill…" vs "You should use this skill…"). These exist on `main` before this PR; `bun test` was returning exit 0 anyway, which masked them. Worth filing as a separate fix.

## Files

- `.changeset/skills-optional-agents-default.md` — minor bump
- `packages/skills/src/types.ts` — `agents?:` on 3 option types
- `packages/skills/src/generate.ts` — `resolveAgents()` helper + 3 entrypoint changes
- `packages/skills/src/generate.test.ts` — regression tests (71 pass)
- `packages/skills/README.md` — doc updates
- `apps/docs/content/docs/modules/skills.mdx` — replaces stale `universalAgents` example

🤖 Authored via Taskplane (TP-006).