### PR TITLE
feat(prompts): polymorphic `validate` slot using Standard Schema

### DIFF
--- a/.changeset/prompts-polymorphic-validate.md
+++ b/.changeset/prompts-polymorphic-validate.md
@@ -4,13 +4,14 @@
 
 # Standard Schema support on `input()` / `password()` validate slot
 
-The `validate` option on `input()` and `password()` is now polymorphic. In addition to the existing `(value: string) => true | string` function shape, you can pass any [Standard Schema v1](https://standardschema.dev/) object directly (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
+The `validate` option on `input()` and `password()` is now polymorphic. In addition to the existing function shape — `(value: string) => true | string | Promise<true | string>` — you can pass any [Standard Schema v1](https://standardschema.dev/) object directly (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
 
 When a schema is supplied, the prompt:
 
-1. Parses the raw input on submit by calling `schema['~standard'].validate(submitValue)`.
-2. Renders the **first** issue's `message` inline on rejection (single line; falls back to `"Validation failed"` when the issue message is empty).
+1. Parses the raw input on submit by `await`ing `schema['~standard'].validate(submitValue)` (so async schemas like Zod's `refine(async ...)` are supported).
+2. Renders the **first** issue's `message` inline on rejection, falling back to `"Validation failed"` when the issue message is empty.
 3. Resolves to the schema's **transformed output** type on success — no second-pass parse step.
+4. Routes `initial` and (for `input()`) non-TTY `default` through the schema as well, so the `Promise<Output>` type contract holds across every short-circuit path. A short-circuit value the schema rejects throws an `Error`.
 
 ```ts
 import { input } from "@crustjs/prompts";
@@ -20,9 +21,9 @@ const port = await input({
   message: "Port?",
   validate: z.coerce.number().int().min(1),
 });
-//    ^? Promise<number>
+//    ^? number
 ```
 
-This is a fully additive change: existing function-shape `validate` consumers see no behavior change. Only the `InputOptions` and `PasswordOptions` types pick up an extra type parameter (`InputOptions<Output = string>`), which defaults to `string` and is inferred from the shape of `validate` via function overloads.
+This is a fully additive change for function-validator consumers: existing function-shape `validate` calls see no behavior change. `InputOptions` and `PasswordOptions` pick up an extra type parameter (`InputOptions<Output = string>`) which defaults to `string` and is inferred from the shape of `validate` via function overloads.
 
-The package gains `@standard-schema/spec` (~5 KB) as a regular dependency for the spec types and runtime guard. No schema library is bundled — `zod` is a devDependency for tests only.
+The package gains `@standard-schema/spec` as a regular dependency for the spec types only; the runtime discriminator that branches on the `~standard` property is local code. No schema library is bundled — `zod` is a devDependency for tests only.

--- a/.changeset/prompts-polymorphic-validate.md
+++ b/.changeset/prompts-polymorphic-validate.md
@@ -1,0 +1,28 @@
+---
+"@crustjs/prompts": minor
+---
+
+# Standard Schema support on `input()` / `password()` validate slot
+
+The `validate` option on `input()` and `password()` is now polymorphic. In addition to the existing `(value: string) => true | string` function shape, you can pass any [Standard Schema v1](https://standardschema.dev/) object directly (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
+
+When a schema is supplied, the prompt:
+
+1. Parses the raw input on submit by calling `schema['~standard'].validate(submitValue)`.
+2. Renders the **first** issue's `message` inline on rejection (single line; falls back to `"Validation failed"` when the issue message is empty).
+3. Resolves to the schema's **transformed output** type on success — no second-pass parse step.
+
+```ts
+import { input } from "@crustjs/prompts";
+import { z } from "zod";
+
+const port = await input({
+  message: "Port?",
+  validate: z.coerce.number().int().min(1),
+});
+//    ^? Promise<number>
+```
+
+This is a fully additive change: existing function-shape `validate` consumers see no behavior change. Only the `InputOptions` and `PasswordOptions` types pick up an extra type parameter (`InputOptions<Output = string>`), which defaults to `string` and is inferred from the shape of `validate` via function overloads.
+
+The package gains `@standard-schema/spec` (~5 KB) as a regular dependency for the spec types and runtime guard. No schema library is bundled — `zod` is a devDependency for tests only.

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -12,7 +12,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 </Callout>
 
 <Callout>
-  For schema-based prompt validation, use `promptValidator()` from [`@crustjs/validate`](/docs/modules/validate#prompt-validation) to create a `validate` function from a Zod, Effect, or any Standard Schema-compatible schema.
+  Both `input()` and `password()` accept either a `(value: string) => true | string` validator **or** any [Standard Schema v1](https://standardschema.dev/) object directly (Zod, Valibot, Effect Schema, ArkType, …). When a schema is supplied, the prompt resolves to the schema's *transformed output* type — see [Schema validation](#schema-validation) below.
 </Callout>
 
 All prompt UI renders to **stderr** so it never pollutes piped stdout. Every prompt accepts an `initial` option to skip interactivity, which is useful for prefilling from CLI flags or CI environments.
@@ -81,8 +81,10 @@ const name = await input({
 | `placeholder` | `string`             | —       | Placeholder text shown when input is empty    |
 | `default`     | `string`             | —       | Value used when the user submits empty input  |
 | `initial`     | `string`             | —       | Skip prompt and return this value immediately |
-| `validate`    | `ValidateFn<string>` | —       | Return `true` or an error message string      |
+| `validate`    | `PromptValidate<Output>` | —   | Function (returns `true` or error string) **or** Standard Schema |
 | `theme`       | `PartialPromptTheme` | —       | Per-prompt theme overrides                    |
+
+See [Schema validation](#schema-validation) for the schema shape and typed return values.
 
 ### `password(options)`
 
@@ -100,8 +102,42 @@ const secret = await password({
 | `message`  | `string`             | —       | Prompt message                                |
 | `mask`     | `string`             | `"*"`   | Character used to mask the input              |
 | `initial`  | `string`             | —       | Skip prompt and return this value immediately |
-| `validate` | `ValidateFn<string>` | —       | Return `true` or an error message string      |
+| `validate` | `PromptValidate<Output>` | —   | Function (returns `true` or error string) **or** Standard Schema |
 | `theme`    | `PartialPromptTheme` | —       | Per-prompt theme overrides                    |
+
+## Schema validation
+
+The `validate` slot on `input()` and `password()` is **polymorphic**:
+
+- a `(value: string) => true | string | Promise<true | string>` validator, or
+- any [Standard Schema v1](https://standardschema.dev/) object (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
+
+When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection, and resolves to the schema's transformed `Output` type on success. There is no second-pass parse step.
+
+```ts
+import { input } from "@crustjs/prompts";
+import { z } from "zod";
+
+const port = await input({
+  message: "Port?",
+  validate: z.coerce.number().int().min(1).max(65535),
+});
+//    ^? Promise<number>
+```
+
+```ts
+import { input } from "@crustjs/prompts";
+import { Schema } from "effect";
+
+const Email = Schema.standardSchemaV1(
+  Schema.String.pipe(Schema.pattern(/.+@.+/)),
+);
+
+const email = await input({ message: "Email?", validate: Email });
+//    ^? Promise<string>
+```
+
+For command-level argument and flag validation against the same schemas, see [`@crustjs/validate`](/docs/modules/validate).
 
 ### `confirm(options)`
 
@@ -402,8 +438,9 @@ Only one prompt can be active at a time. Running a second prompt while one is al
 
 | Type                  | Description                                      |
 | --------------------- | ------------------------------------------------ |
-| `InputOptions`        | Options for `input()`                            |
-| `PasswordOptions`     | Options for `password()`                         |
+| `InputOptions<Output>`        | Options for `input()` (generic over schema output)       |
+| `PasswordOptions<Output>`     | Options for `password()` (generic over schema output)    |
+| `PromptValidate<Output>`      | Polymorphic validator union: `ValidateFn<string>` or `StandardSchemaV1<unknown, Output>` |
 | `ConfirmOptions`      | Options for `confirm()`                          |
 | `SelectOptions<T>`    | Options for `select()`                           |
 | `MultiselectOptions<T>` | Options for `multiselect()`                    |

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -81,7 +81,7 @@ const name = await input({
 | `placeholder` | `string`             | —       | Placeholder text shown when input is empty    |
 | `default`     | `string`             | —       | Value used when the user submits empty input  |
 | `initial`     | `string`             | —       | Skip prompt and return this value immediately |
-| `validate`    | `PromptValidate<Output>` | —   | Function (returns `true` or error string) **or** Standard Schema |
+| `validate`    | `ValidateFn<string>` \| Standard Schema v1 | — | Function (returns `true` or error string) **or** Standard Schema (resolves to its transformed `Output`) |
 | `theme`       | `PartialPromptTheme` | —       | Per-prompt theme overrides                    |
 
 See [Schema validation](#schema-validation) for the schema shape and typed return values.
@@ -102,7 +102,7 @@ const secret = await password({
 | `message`  | `string`             | —       | Prompt message                                |
 | `mask`     | `string`             | `"*"`   | Character used to mask the input              |
 | `initial`  | `string`             | —       | Skip prompt and return this value immediately |
-| `validate` | `PromptValidate<Output>` | —   | Function (returns `true` or error string) **or** Standard Schema |
+| `validate` | `ValidateFn<string>` \| Standard Schema v1 | — | Function (returns `true` or error string) **or** Standard Schema (resolves to its transformed `Output`) |
 | `theme`    | `PartialPromptTheme` | —       | Per-prompt theme overrides                    |
 
 ## Schema validation
@@ -112,7 +112,9 @@ The `validate` slot on `input()` and `password()` is **polymorphic**:
 - a `(value: string) => true | string | Promise<true | string>` validator, or
 - any [Standard Schema v1](https://standardschema.dev/) object (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
 
-When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection, and resolves to the schema's transformed `Output` type on success. There is no second-pass parse step.
+When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection (falling back to `"Validation failed"` for empty messages), and resolves to the schema's transformed `Output` type on success. There is no second-pass parse step.
+
+`initial` and non-TTY `default` are also parsed through the schema before being returned, so the `Promise<Output>` contract holds across every short-circuit path. A value the schema rejects throws.
 
 ```ts
 import { input } from "@crustjs/prompts";
@@ -122,7 +124,7 @@ const port = await input({
   message: "Port?",
   validate: z.coerce.number().int().min(1).max(65535),
 });
-//    ^? Promise<number>
+//    ^? number
 ```
 
 ```ts
@@ -134,7 +136,7 @@ const Email = Schema.standardSchemaV1(
 );
 
 const email = await input({ message: "Email?", validate: Email });
-//    ^? Promise<string>
+//    ^? string
 ```
 
 For command-level argument and flag validation against the same schemas, see [`@crustjs/validate`](/docs/modules/validate).
@@ -440,7 +442,6 @@ Only one prompt can be active at a time. Running a second prompt while one is al
 | --------------------- | ------------------------------------------------ |
 | `InputOptions<Output>`        | Options for `input()` (generic over schema output)       |
 | `PasswordOptions<Output>`     | Options for `password()` (generic over schema output)    |
-| `PromptValidate<Output>`      | Polymorphic validator union: `ValidateFn<string>` or `StandardSchemaV1<unknown, Output>` |
 | `ConfirmOptions`      | Options for `confirm()`                          |
 | `SelectOptions<T>`    | Options for `select()`                           |
 | `MultiselectOptions<T>` | Options for `multiselect()`                    |

--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/validate": {
       "name": "@crustjs/validate",
-      "version": "0.0.15",
+      "version": "0.1.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -209,7 +209,7 @@
     },
     "packages/validate": {
       "name": "@crustjs/validate",
-      "version": "0.1.0",
+      "version": "0.0.15",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -156,10 +156,12 @@
       "dependencies": {
         "@crustjs/progress": "workspace:*",
         "@crustjs/style": "workspace:*",
+        "@standard-schema/spec": "^1.1.0",
       },
       "devDependencies": {
         "@crustjs/config": "workspace:*",
         "bunup": "catalog:",
+        "zod": "^4.0.0",
       },
       "peerDependencies": {
         "typescript": "catalog:",
@@ -207,7 +209,7 @@
     },
     "packages/validate": {
       "name": "@crustjs/validate",
-      "version": "0.1.0",
+      "version": "0.0.15",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
       },

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -1,0 +1,69 @@
+# @crustjs/prompts
+
+Interactive terminal prompts for the [Crust](https://crustjs.com) CLI framework.
+
+`@crustjs/prompts` ships seven prompts (`input`, `password`, `confirm`, `select`, `multiselect`, `filter`, `multifilter`), a customizable theme, fuzzy matching, and a small renderer for building custom prompts. All prompt UI renders to **stderr** so it never pollutes piped stdout.
+
+## Install
+
+```sh
+bun add @crustjs/prompts
+```
+
+## Quick start
+
+```ts
+import { input, password, confirm, select } from "@crustjs/prompts";
+
+const name = await input({ message: "Project name?" });
+const useTS = await confirm({ message: "Use TypeScript?" });
+const fw = await select({
+  message: "Framework",
+  choices: ["react", "vue", "svelte"],
+});
+const secret = await password({
+  message: "Enter password:",
+  validate: (v) => v.length >= 8 || "Must be at least 8 characters",
+});
+```
+
+Pass `initial` to skip interactivity (useful for prefilling from CLI flags or in CI). When stdin is not a TTY, `default` is returned automatically when set; otherwise a `NonInteractiveError` is thrown.
+
+## Schema validation
+
+The `validate` slot on `input()` and `password()` is **polymorphic**:
+
+- a `(value: string) => true | string | Promise<true | string>` validator, or
+- any [Standard Schema v1](https://standardschema.dev/) object (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
+
+When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection, and resolves to the schema's transformed `Output` type on success — no second-pass parse step.
+
+```ts
+import { input } from "@crustjs/prompts";
+import { z } from "zod";
+
+const port = await input({
+  message: "Port?",
+  validate: z.coerce.number().int().min(1).max(65535),
+});
+//    ^? Promise<number>
+```
+
+```ts
+import { input } from "@crustjs/prompts";
+import { Schema } from "effect";
+
+const Email = Schema.standardSchemaV1(
+  Schema.String.pipe(Schema.pattern(/.+@.+/)),
+);
+
+const email = await input({ message: "Email?", validate: Email });
+//    ^? Promise<string>
+```
+
+For command-level argument and flag validation against the same schemas, see [`@crustjs/validate`](https://crustjs.com/docs/modules/validate).
+
+## More
+
+- Full docs: [crustjs.com/docs/modules/prompts](https://crustjs.com/docs/modules/prompts)
+- Source: [`packages/prompts/`](https://github.com/chenxin-yan/crust/tree/main/packages/prompts)

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -27,7 +27,7 @@ const secret = await password({
 });
 ```
 
-Pass `initial` to skip interactivity (useful for prefilling from CLI flags or in CI). When stdin is not a TTY, `default` is returned automatically when set; otherwise a `NonInteractiveError` is thrown.
+Pass `initial` to skip interactivity (useful for prefilling from CLI flags or in CI). For prompts that support a `default` (`input`, `confirm`, `multiselect`, `filter`), the default is also returned automatically when stdin is not a TTY; otherwise a `NonInteractiveError` is thrown.
 
 ## Schema validation
 
@@ -36,7 +36,7 @@ The `validate` slot on `input()` and `password()` is **polymorphic**:
 - a `(value: string) => true | string | Promise<true | string>` validator, or
 - any [Standard Schema v1](https://standardschema.dev/) object (Zod 4, Valibot, Effect Schema's `Schema.standardSchemaV1(...)`, ArkType, …).
 
-When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection, and resolves to the schema's transformed `Output` type on success — no second-pass parse step.
+When a schema is supplied, the prompt parses the raw input on submit, renders the **first** issue's `message` inline on rejection (falling back to `"Validation failed"` for empty messages), and resolves to the schema's transformed `Output` type on success — no second-pass parse step. `initial` and non-TTY `default` are parsed through the schema as well, so the `Promise<Output>` contract holds for every code path; a value the schema rejects throws.
 
 ```ts
 import { input } from "@crustjs/prompts";
@@ -46,7 +46,7 @@ const port = await input({
   message: "Port?",
   validate: z.coerce.number().int().min(1).max(65535),
 });
-//    ^? Promise<number>
+//    ^? number
 ```
 
 ```ts
@@ -58,7 +58,7 @@ const Email = Schema.standardSchemaV1(
 );
 
 const email = await input({ message: "Email?", validate: Email });
-//    ^? Promise<string>
+//    ^? string
 ```
 
 For command-level argument and flag validation against the same schemas, see [`@crustjs/validate`](https://crustjs.com/docs/modules/validate).

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -43,11 +43,13 @@
 	},
 	"dependencies": {
 		"@crustjs/progress": "workspace:*",
-		"@crustjs/style": "workspace:*"
+		"@crustjs/style": "workspace:*",
+		"@standard-schema/spec": "^1.1.0"
 	},
 	"devDependencies": {
 		"@crustjs/config": "workspace:*",
-		"bunup": "catalog:"
+		"bunup": "catalog:",
+		"zod": "^4.0.0"
 	},
 	"peerDependencies": {
 		"typescript": "catalog:"

--- a/packages/prompts/src/core/types.ts
+++ b/packages/prompts/src/core/types.ts
@@ -3,6 +3,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { StyleFn } from "@crustjs/style";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Theme
@@ -106,3 +107,38 @@ export type ValidateResult = true | string;
 export type ValidateFn<T> = (
 	value: T,
 ) => ValidateResult | Promise<ValidateResult>;
+
+/**
+ * Polymorphic validate slot for text-input prompts.
+ *
+ * Accepts either:
+ * - a {@link ValidateFn} (returns `true` for valid or a string error), or
+ * - a {@link StandardSchemaV1} schema (e.g. Zod, Valibot, Effect Schema)
+ *   that parses the raw `string` input into a transformed `Output`.
+ *
+ * When a schema is supplied, the prompt resolves to the schema's transformed
+ * output type instead of the raw `string`.
+ */
+export type PromptValidate<Output> =
+	| ValidateFn<string>
+	| StandardSchemaV1<unknown, Output>;
+
+/**
+ * Type guard: is `value` a Standard Schema v1 object?
+ *
+ * Discriminates the polymorphic `validate` slot at runtime by checking for the
+ * `~standard` property with `version === 1`. This lets `input()` / `password()`
+ * accept either a `ValidateFn<string>` or a Standard Schema without depending
+ * on any specific schema library.
+ */
+export function isStandardSchema(
+	value: unknown,
+): value is StandardSchemaV1<unknown, unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"~standard" in value &&
+		(value as { "~standard"?: { version?: unknown } })["~standard"]?.version ===
+			1
+	);
+}

--- a/packages/prompts/src/core/types.ts
+++ b/packages/prompts/src/core/types.ts
@@ -118,27 +118,42 @@ export type ValidateFn<T> = (
  *
  * When a schema is supplied, the prompt resolves to the schema's transformed
  * output type instead of the raw `string`.
+ *
+ * @internal Surfaced via the `validate` slot on `InputOptions` /
+ * `PasswordOptions`; not re-exported from the package root because callers
+ * can derive it from those option types when needed.
  */
 export type PromptValidate<Output> =
 	| ValidateFn<string>
 	| StandardSchemaV1<unknown, Output>;
 
 /**
- * Type guard: is `value` a Standard Schema v1 object?
+ * Type guard: discriminate the polymorphic `validate` slot.
  *
- * Discriminates the polymorphic `validate` slot at runtime by checking for the
- * `~standard` property with `version === 1`. This lets `input()` / `password()`
- * accept either a `ValidateFn<string>` or a Standard Schema without depending
- * on any specific schema library.
+ * Accepts both plain object schemas and callable schema instances (the
+ * Standard Schema spec only requires the `~standard` property; some vendors
+ * expose schemas as callable function-objects). Also asserts that
+ * `~standard.validate` is itself a function so a malformed value cannot slip
+ * through and crash later inside the prompt.
+ *
+ * @internal Used only by `input()` and `password()` to dispatch between the
+ * function-validator and Standard Schema branches.
  */
-export function isStandardSchema(
-	value: unknown,
-): value is StandardSchemaV1<unknown, unknown> {
+export function isStandardSchema<Output>(
+	value: PromptValidate<Output> | undefined,
+): value is StandardSchemaV1<unknown, Output> {
+	if (value === undefined || value === null) return false;
+	const t = typeof value;
+	if (t !== "object" && t !== "function") return false;
+	const std = (
+		value as {
+			"~standard"?: { version?: unknown; validate?: unknown };
+		}
+	)["~standard"];
 	return (
-		typeof value === "object" &&
-		value !== null &&
-		"~standard" in value &&
-		(value as { "~standard"?: { version?: unknown } })["~standard"]?.version ===
-			1
+		!!std &&
+		typeof std === "object" &&
+		std.version === 1 &&
+		typeof std.validate === "function"
 	);
 }

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -11,11 +11,9 @@ export type {
 	Choice,
 	PartialPromptTheme,
 	PromptTheme,
-	PromptValidate,
 	ValidateFn,
 	ValidateResult,
 } from "./core/types.ts";
-export { isStandardSchema } from "./core/types.ts";
 export type { NormalizedChoice } from "./core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -11,9 +11,11 @@ export type {
 	Choice,
 	PartialPromptTheme,
 	PromptTheme,
+	PromptValidate,
 	ValidateFn,
 	ValidateResult,
 } from "./core/types.ts";
+export { isStandardSchema } from "./core/types.ts";
 export type { NormalizedChoice } from "./core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/prompts/input.test.ts
+++ b/packages/prompts/src/prompts/input.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { z } from "zod";
 import { input } from "./input.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -637,5 +638,155 @@ describe("input — non-TTY", () => {
 		});
 
 		expect(result).toBe("from-flag");
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Standard Schema validation (TP-013)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("input — schema validation", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("resolves to string when a string schema accepts the input", async () => {
+		const promise = input({
+			message: "Name?",
+			validate: z.string().min(3),
+		});
+
+		await tick();
+		pressKey("A");
+		await tick();
+		pressKey("l");
+		await tick();
+		pressKey("i");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("Ali");
+		expect(typeof result).toBe("string");
+	});
+
+	it("resolves to the schema's transformed output (number from coerce)", async () => {
+		const promise = input({
+			message: "Port?",
+			validate: z.coerce.number().int().min(1),
+		});
+
+		await tick();
+		pressKey("4");
+		await tick();
+		pressKey("2");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe(42);
+		expect(typeof result).toBe("number");
+	});
+
+	it("renders the first issue's message and waits for retry on failure", async () => {
+		const promise = input({
+			message: "Name?",
+			validate: z.string().min(3, "Too short"),
+		});
+
+		await tick();
+		pressKey("A");
+		await tick();
+		// Submit too-short value
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain("Too short");
+
+		// Add more characters and retry
+		pressKey("l");
+		await tick();
+		pressKey("i");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("Ali");
+	});
+
+	it("falls back to 'Validation failed' when issue message is empty", async () => {
+		// Custom Standard Schema that returns an empty-message issue.
+		const emptyMessageSchema = {
+			"~standard": {
+				version: 1 as const,
+				vendor: "test",
+				validate: (value: unknown) => {
+					if (value === "ok") return { value: value as string };
+					return { issues: [{ message: "" }] };
+				},
+			},
+		};
+
+		const promise = input({
+			message: "Word?",
+			validate: emptyMessageSchema,
+		});
+
+		await tick();
+		pressKey("x");
+		await tick();
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain("Validation failed");
+
+		// Clear field, type valid value, submit
+		pressKey("", { name: "backspace" });
+		await tick();
+		pressKey("o");
+		await tick();
+		pressKey("k");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("ok");
+	});
+
+	it("awaits async schema validation", async () => {
+		const asyncSchema = z.string().refine(
+			async (v) => {
+				await new Promise((r) => setTimeout(r, 5));
+				return v === "yes";
+			},
+			{ message: "must be yes" },
+		);
+
+		const promise = input({ message: "Confirm?", validate: asyncSchema });
+
+		await tick();
+		pressKey("n");
+		await tick();
+		pressKey("o");
+		await tick();
+		pressKey("", { name: "return" });
+		await tick(20);
+
+		expect(stderrOutput).toContain("must be yes");
+
+		// Clear and type valid value
+		pressKey("", { name: "backspace" });
+		await tick();
+		pressKey("", { name: "backspace" });
+		await tick();
+		pressKey("y");
+		await tick();
+		pressKey("e");
+		await tick();
+		pressKey("s");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("yes");
 	});
 });

--- a/packages/prompts/src/prompts/input.test.ts
+++ b/packages/prompts/src/prompts/input.test.ts
@@ -752,6 +752,65 @@ describe("input — schema validation", () => {
 		expect(result).toBe("ok");
 	});
 
+	it("treats `{ issues: [] }` from a non-conformant schema as success", async () => {
+		// Spec only marks `issues === undefined` as success, but a malformed
+		// schema returning an empty array has no actual issue to surface —
+		// guarding on `?.length` prevents a phantom "Validation failed" error.
+		const emptyIssuesSchema = {
+			"~standard": {
+				version: 1 as const,
+				vendor: "test",
+				validate: (value: unknown) => ({
+					value: value as string,
+					issues: [] as const,
+				}),
+			},
+		};
+
+		const promise = input({ message: "Word?", validate: emptyIssuesSchema });
+
+		await tick();
+		pressKey("o");
+		await tick();
+		pressKey("k");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("ok");
+		expect(stderrOutput).not.toContain("Validation failed");
+	});
+
+	it("surfaces zod's built-in issue message (no custom .message override)", async () => {
+		// Sanity check that a real zod issue message reaches the renderer — we
+		// derive the expected text from the same schema instead of asserting a
+		// hard-coded string, so this can't accidentally pass when zod's default
+		// messages change.
+		const schema = z.string().min(3);
+		const expectedMessage =
+			schema.safeParse("a").error?.issues[0]?.message ?? "";
+		expect(expectedMessage).not.toBe("");
+
+		const promise = input({ message: "Code?", validate: schema });
+
+		await tick();
+		pressKey("a");
+		await tick();
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain(expectedMessage);
+
+		pressKey("b");
+		await tick();
+		pressKey("c");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("abc");
+	});
+
 	it("awaits async schema validation", async () => {
 		const asyncSchema = z.string().refine(
 			async (v) => {
@@ -790,3 +849,170 @@ describe("input — schema validation", () => {
 		expect(result).toBe("yes");
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Schema short-circuit (initial / non-TTY default) soundness
+// ────────────────────────────────────────────────────────────────────────────
+//
+// When `validate` is a Standard Schema, `initial` and non-TTY `default` must
+// flow through the schema before being returned. Otherwise the
+// `Promise<Output>` overload silently leaks a raw `string`.
+
+describe("input — schema short-circuit", () => {
+	it("parses `initial` through the schema and returns the transformed output", async () => {
+		const result = await input({
+			message: "Port?",
+			initial: "8080",
+			validate: z.coerce.number().int(),
+		});
+
+		expect(result).toBe(8080);
+		expect(typeof result).toBe("number");
+	});
+
+	it("throws when `initial` is rejected by the schema", async () => {
+		await expect(
+			input({
+				message: "Port?",
+				initial: "not-a-number",
+				validate: z.coerce.number().int(),
+			}),
+		).rejects.toThrow(/initial value rejected by schema/);
+	});
+
+	it("parses non-TTY `default` through the schema and returns transformed output", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			writable: true,
+			configurable: true,
+		});
+
+		try {
+			const result = await input({
+				message: "Port?",
+				default: "3000",
+				validate: z.coerce.number().int(),
+			});
+
+			expect(result).toBe(3000);
+			expect(typeof result).toBe("number");
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: originalIsTTY,
+				writable: true,
+				configurable: true,
+			});
+		}
+	});
+
+	it("throws when non-TTY `default` is rejected by the schema", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			writable: true,
+			configurable: true,
+		});
+
+		try {
+			await expect(
+				input({
+					message: "Port?",
+					default: "abc",
+					validate: z.coerce.number().int(),
+				}),
+			).rejects.toThrow(/default value rejected by schema/);
+		} finally {
+			Object.defineProperty(process.stdin, "isTTY", {
+				value: originalIsTTY,
+				writable: true,
+				configurable: true,
+			});
+		}
+	});
+});
+
+describe("input — schema + interactive default", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("runs schema against the default value when user submits empty", async () => {
+		const promise = input({
+			message: "Port?",
+			default: "4000",
+			validate: z.coerce.number().int(),
+		});
+
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe(4000);
+		expect(typeof result).toBe("number");
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Callable Standard Schema dispatch
+// ────────────────────────────────────────────────────────────────────────────
+//
+// The Standard Schema spec only requires the `~standard` property; some
+// vendors (e.g. Effect Schema's `Schema.standardSchemaV1`) expose schemas as
+// callable function-objects. Our guard must accept both shapes.
+
+describe("input — callable Standard Schema", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("dispatches a callable schema through the schema branch", async () => {
+		// Build a callable function that also has a `~standard` property.
+		const callable = Object.assign((_value: unknown) => undefined, {
+			"~standard": {
+				version: 1 as const,
+				vendor: "test",
+				validate: (value: unknown) => {
+					if (typeof value === "string" && value.length > 0) {
+						return { value: `[${value}]` };
+					}
+					return { issues: [{ message: "empty" }] };
+				},
+			},
+		});
+
+		const promise = input({ message: "Word?", validate: callable });
+
+		await tick();
+		pressKey("", { name: "return" });
+		await tick();
+		expect(stderrOutput).toContain("empty");
+
+		pressKey("a");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("[a]");
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+async function _inputTypeInferenceTests() {
+	// Schema overload — resolves to the schema's transformed Output.
+	const port = await input({
+		message: "?",
+		validate: z.coerce.number(),
+	});
+	const _portIsNumber: number = port;
+
+	// Function-validator overload — resolves to string.
+	const name = await input({
+		message: "?",
+		validate: (v) => v.length > 0 || "required",
+	});
+	const _nameIsString: string = name;
+
+	// No validate — resolves to string.
+	const raw = await input({ message: "?" });
+	const _rawIsString: string = raw;
+}

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -2,15 +2,18 @@
 // Input — Single-line text input prompt for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
 import { isTTY, runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { CURSOR_CHAR, handleTextEdit } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type {
-	PartialPromptTheme,
-	PromptTheme,
-	ValidateFn,
+import {
+	isStandardSchema,
+	type PartialPromptTheme,
+	type PromptTheme,
+	type PromptValidate,
+	type ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 
@@ -21,22 +24,36 @@ import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 /**
  * Options for the {@link input} prompt.
  *
+ * The `validate` slot is polymorphic: it accepts either a classic
+ * {@link ValidateFn} (returning `true` or an error string) or a
+ * {@link StandardSchemaV1} schema (Zod, Valibot, Effect Schema, …). When a
+ * schema is supplied, the prompt resolves to the schema's transformed
+ * `Output` type instead of the raw `string`.
+ *
+ * @typeParam Output - the resolved value type. Defaults to `string` (the
+ * function-validate / no-validate case). Inferred automatically from the
+ * shape of `validate` via the {@link input} overloads.
+ *
  * @example
  * ```ts
+ * // Function shape — resolves to string
  * const name = await input({
  *   message: "What is your name?",
- *   placeholder: "Enter your name",
  *   validate: (v) => v.length > 0 || "Name is required",
  * });
  * ```
  *
  * @example
  * ```ts
- * // Without a message — renders prefix + input only
- * const name = await input({ placeholder: "Enter your name" });
+ * // Schema shape — resolves to the schema's parsed output type
+ * const port = await input({
+ *   message: "Port?",
+ *   validate: z.coerce.number().int().min(1),
+ * });
+ * // typeof port === "number"
  * ```
  */
-export interface InputOptions {
+export interface InputOptions<Output = string> {
 	/** The prompt message displayed to the user */
 	readonly message?: string;
 	/** Placeholder text shown when the input is empty. Overrides the default value as visual placeholder when both are set. */
@@ -45,8 +62,11 @@ export interface InputOptions {
 	readonly default?: string;
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: string;
-	/** Validation function — return `true` for valid, or a string error message */
-	readonly validate?: ValidateFn<string>;
+	/**
+	 * Validation: either a function returning `true | string` or a
+	 * Standard Schema v1 object whose parsed output replaces the raw input.
+	 */
+	readonly validate?: PromptValidate<Output>;
 	/** Per-prompt theme overrides */
 	readonly theme?: PartialPromptTheme;
 }
@@ -65,16 +85,16 @@ interface InputState {
 // Keypress handler
 // ────────────────────────────────────────────────────────────────────────────
 
-function createHandleKey(
-	validate: ValidateFn<string> | undefined,
+function createHandleKey<Output>(
+	validate: PromptValidate<Output> | undefined,
 	defaultValue: string | undefined,
 ): (
 	key: KeypressEvent,
 	state: InputState,
 ) =>
 	| InputState
-	| SubmitResult<string>
-	| Promise<InputState | SubmitResult<string>> {
+	| SubmitResult<Output | string>
+	| Promise<InputState | SubmitResult<Output | string>> {
 	return async (key, state) => {
 		// Enter — submit
 		if (key.name === "return") {
@@ -84,10 +104,25 @@ function createHandleKey(
 					: state.value;
 
 			if (validate) {
-				const result = await validate(submitValue);
-				if (result !== true) {
-					return { ...state, error: result };
+				if (isStandardSchema(validate)) {
+					// Schema path — parse, render first issue on failure,
+					// submit the schema's transformed output on success.
+					const result = await validate["~standard"].validate(submitValue);
+					if (result.issues) {
+						return {
+							...state,
+							error: result.issues[0]?.message || "Validation failed",
+						};
+					}
+					return submit(result.value as Output);
 				}
+
+				// Function path — preserved unchanged.
+				const fnResult = await (validate as ValidateFn<string>)(submitValue);
+				if (fnResult !== true) {
+					return { ...state, error: fnResult };
+				}
+				return submit(submitValue);
 			}
 
 			return submit(submitValue);
@@ -155,15 +190,15 @@ function renderInput(
 	return output;
 }
 
-function renderSubmitted(
+function renderSubmitted<Output>(
 	_state: InputState,
-	value: string,
+	value: Output,
 	theme: PromptTheme,
 	message: string | undefined,
 ): string {
 	const prefix = theme.success(PREFIX_SUBMITTED);
 	const msg = theme.message(message ?? "Enter a value");
-	return formatSubmitted(prefix, msg, theme.success(value));
+	return formatSubmitted(prefix, msg, theme.success(String(value)));
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -182,8 +217,15 @@ function renderSubmitted(
  * In non-interactive environments (no TTY), the `default` value is returned
  * automatically if provided.
  *
+ * The `validate` slot is **polymorphic**:
+ * - When omitted or given a `ValidateFn<string>`, the prompt resolves to the
+ *   raw `string` input.
+ * - When given a Standard Schema v1 object, the schema parses the raw input
+ *   on submit; the prompt resolves to the schema's transformed `Output` type.
+ *
  * @param options - Input prompt configuration
- * @returns The user's entered text
+ * @returns The user's entered text, or the schema-parsed output when a
+ *          Standard Schema is supplied as `validate`.
  * @throws {NonInteractiveError} when stdin is not a TTY and no `initial` or `default` is provided
  *
  * @example
@@ -197,14 +239,27 @@ function renderSubmitted(
  *
  * @example
  * ```ts
- * // Skip prompt when flag is provided
- * const name = await input({
- *   message: "Name?",
- *   initial: flags.name,
+ * // Schema validation — returns the parsed/transformed value
+ * const port = await input({
+ *   message: "Port?",
+ *   validate: z.coerce.number().int().min(1),
  * });
+ * // typeof port === "number"
  * ```
  */
-export async function input(options: InputOptions): Promise<string> {
+export function input<Output>(
+	options: InputOptions<Output> & {
+		readonly validate: StandardSchemaV1<unknown, Output>;
+	},
+): Promise<Output>;
+export function input(
+	options?: Omit<InputOptions<string>, "validate"> & {
+		readonly validate?: ValidateFn<string>;
+	},
+): Promise<string>;
+export async function input<Output>(
+	options: InputOptions<Output> = {},
+): Promise<Output | string> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return options.initial;
@@ -223,7 +278,7 @@ export async function input(options: InputOptions): Promise<string> {
 		error: null,
 	};
 
-	return runPrompt<InputState, string>({
+	return runPrompt<InputState, Output | string>({
 		initialState,
 		theme,
 		render: (state, t) =>
@@ -234,7 +289,7 @@ export async function input(options: InputOptions): Promise<string> {
 				options.placeholder,
 				options.default,
 			),
-		handleKey: createHandleKey(options.validate, options.default),
+		handleKey: createHandleKey<Output>(options.validate, options.default),
 		renderSubmitted: (state, value, t) =>
 			renderSubmitted(state, value, t, options.message),
 	});

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -18,6 +18,32 @@ import {
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
+// Schema parsing helper
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run a Standard Schema against a short-circuit value (`initial` / non-TTY
+ * `default`) and return the parsed output. Throws on schema rejection so the
+ * `Promise<Output>` overload contract holds — short-circuiting can never
+ * silently return a raw `string` where the type promises a transformed value.
+ */
+async function parseShortCircuit<Output>(
+	schema: StandardSchemaV1<unknown, Output>,
+	value: string,
+	source: "initial" | "default",
+): Promise<Output> {
+	const result = await schema["~standard"].validate(value);
+	// Per spec, success is signalled by `issues === undefined`; an empty
+	// `issues: []` from a non-conformant schema would have no issue to surface,
+	// so we treat it as success rather than displaying a phantom error.
+	if (result.issues?.length) {
+		const message = result.issues[0]?.message || "Validation failed";
+		throw new Error(`${source} value rejected by schema: ${message}`);
+	}
+	return (result as { value: Output }).value;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Types
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -107,14 +133,17 @@ function createHandleKey<Output>(
 				if (isStandardSchema(validate)) {
 					// Schema path — parse, render first issue on failure,
 					// submit the schema's transformed output on success.
+					// `issues?.length` (rather than just `issues`) defends against
+					// non-conformant schemas returning `{ issues: [] }`, which has
+					// no actual issue to surface and should pass through.
 					const result = await validate["~standard"].validate(submitValue);
-					if (result.issues) {
+					if (result.issues?.length) {
 						return {
 							...state,
 							error: result.issues[0]?.message || "Validation failed",
 						};
 					}
-					return submit(result.value as Output);
+					return submit((result as { value: Output }).value);
 				}
 
 				// Function path — preserved unchanged.
@@ -257,16 +286,30 @@ export function input(
 		readonly validate?: ValidateFn<string>;
 	},
 ): Promise<string>;
+export function input<Output>(
+	options: InputOptions<Output>,
+): Promise<Output | string>;
 export async function input<Output>(
 	options: InputOptions<Output> = {},
 ): Promise<Output | string> {
-	// Short-circuit: return initial value immediately without rendering
+	// Short-circuit: return initial value immediately without rendering.
+	// When `validate` is a Standard Schema we MUST parse the short-circuit
+	// value through it so the `Promise<Output>` overload stays sound — a raw
+	// string would otherwise leak where the caller is statically promised the
+	// schema's transformed output type.
 	if (options.initial !== undefined) {
+		if (isStandardSchema(options.validate)) {
+			return parseShortCircuit(options.validate, options.initial, "initial");
+		}
 		return options.initial;
 	}
 
-	// Non-interactive fallback: return default value when stdin is not a TTY
+	// Non-interactive fallback: return default value when stdin is not a TTY.
+	// Same schema-soundness rule as above.
 	if (!isTTY() && options.default !== undefined) {
+		if (isStandardSchema(options.validate)) {
+			return parseShortCircuit(options.validate, options.default, "default");
+		}
 		return options.default;
 	}
 

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -687,6 +687,31 @@ describe("password — schema short-circuit", () => {
 			}),
 		).rejects.toThrow(/initial value rejected by schema/);
 	});
+
+	it("treats `{ issues: [] }` from a non-conformant schema as success", async () => {
+		// Spec only marks `issues === undefined` as success, but a malformed
+		// schema returning an empty array has no actual issue to surface —
+		// guarding on `?.length` prevents a phantom rejection of the
+		// short-circuit `initial` value.
+		const emptyIssuesSchema = {
+			"~standard": {
+				version: 1 as const,
+				vendor: "test",
+				validate: (value: unknown) => ({
+					value: value as string,
+					issues: [] as const,
+				}),
+			},
+		};
+
+		const result = await password({
+			message: "Word?",
+			initial: "ok",
+			validate: emptyIssuesSchema,
+		});
+
+		expect(result).toBe("ok");
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -580,4 +580,196 @@ describe("password — schema validation", () => {
 		expect(result).toBe(4242);
 		expect(typeof result).toBe("number");
 	});
+
+	it("awaits async schema validation", async () => {
+		const asyncSchema = z.string().refine(
+			async (v) => {
+				await new Promise((r) => setTimeout(r, 5));
+				return v === "open-sesame";
+			},
+			{ message: "wrong passphrase" },
+		);
+
+		const promise = password({
+			message: "Passphrase?",
+			validate: asyncSchema,
+		});
+
+		await tick();
+		for (const ch of "wrong") {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+		await tick(20);
+
+		expect(stderrOutput).toContain("wrong passphrase");
+
+		// Clear and type the correct value.
+		for (let i = 0; i < 5; i++) {
+			pressKey("", { name: "backspace" });
+			await tick();
+		}
+		for (const ch of "open-sesame") {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+		await tick(20);
+
+		const result = await promise;
+		expect(result).toBe("open-sesame");
+	});
+
+	it("falls back to 'Validation failed' when issue message is empty", async () => {
+		const emptyMessageSchema = {
+			"~standard": {
+				version: 1 as const,
+				vendor: "test",
+				validate: (value: unknown) => {
+					if (value === "good") return { value: value as string };
+					return { issues: [{ message: "" }] };
+				},
+			},
+		};
+
+		const promise = password({
+			message: "Word?",
+			validate: emptyMessageSchema,
+		});
+
+		await tick();
+		pressKey("x");
+		await tick();
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain("Validation failed");
+
+		pressKey("", { name: "backspace" });
+		await tick();
+		for (const ch of "good") {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("good");
+	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Schema short-circuit (initial) soundness
+// ────────────────────────────────────────────────────────────────────────────
+//
+// When `validate` is a Standard Schema, `initial` must flow through it.
+// Otherwise the `Promise<Output>` overload silently leaks a raw `string`.
+
+describe("password — schema short-circuit", () => {
+	it("parses `initial` through the schema and returns transformed output", async () => {
+		const result = await password({
+			message: "PIN?",
+			initial: "4242",
+			validate: z.coerce.number().int(),
+		});
+
+		expect(result).toBe(4242);
+		expect(typeof result).toBe("number");
+	});
+
+	it("throws when `initial` is rejected by the schema", async () => {
+		await expect(
+			password({
+				message: "PIN?",
+				initial: "abc",
+				validate: z.coerce.number().int(),
+			}),
+		).rejects.toThrow(/initial value rejected by schema/);
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Secrecy — raw value never appears in rendered output
+// ────────────────────────────────────────────────────────────────────────────
+//
+// The masking comment in the rendering test only said the raw value
+// shouldn't appear; it never asserted that. Tighten across the schema
+// rejection and submission paths so a regression is loud.
+
+describe("password — secrecy", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	// A unique, unlikely-to-appear-in-prompt-chrome marker so any leak fails
+	// the assertion deterministically.
+	const SECRET = "hunter2-XYZ";
+
+	it("never renders the raw value while typing or after submission", async () => {
+		const promise = password({ message: "Password?" });
+
+		await tick();
+		for (const ch of SECRET) {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+		await promise;
+
+		expect(stderrOutput).not.toContain(SECRET);
+	});
+
+	it("never renders the raw value when schema validation rejects", async () => {
+		const promise = password({
+			message: "Password?",
+			validate: z.string().min(64, "too short"),
+		});
+
+		await tick();
+		for (const ch of SECRET) {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain("too short");
+		expect(stderrOutput).not.toContain(SECRET);
+
+		// Resolve the prompt cleanly with a long-enough valid value.
+		for (let i = 0; i < SECRET.length; i++) {
+			pressKey("", { name: "backspace" });
+			await tick();
+		}
+		for (const ch of "x".repeat(64)) {
+			pressKey(ch);
+			await tick();
+		}
+		pressKey("", { name: "return" });
+		await promise;
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+async function _passwordTypeInferenceTests() {
+	// Schema overload — resolves to the schema's transformed Output.
+	const pin = await password({
+		message: "?",
+		validate: z.coerce.number(),
+	});
+	const _pinIsNumber: number = pin;
+
+	// Function-validator overload — resolves to string.
+	const secret = await password({
+		message: "?",
+		validate: (v) => v.length >= 8 || "too short",
+	});
+	const _secretIsString: string = secret;
+
+	// No validate — resolves to string.
+	const raw = await password({ message: "?" });
+	const _rawIsString: string = raw;
+}

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { z } from "zod";
 import { password } from "./password.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -503,5 +504,80 @@ describe("password — non-TTY", () => {
 		});
 
 		expect(result).toBe("secret123");
+	});
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Standard Schema validation (TP-013)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("password — schema validation", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("resolves to string when a string schema accepts the input", async () => {
+		const promise = password({
+			message: "Password?",
+			validate: z.string().min(3),
+		});
+
+		await tick();
+		pressKey("a");
+		await tick();
+		pressKey("b");
+		await tick();
+		pressKey("c");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("abc");
+		expect(typeof result).toBe("string");
+	});
+
+	it("renders the first issue's message and waits for retry on failure", async () => {
+		const promise = password({
+			message: "Password?",
+			validate: z.string().min(3, "Too short"),
+		});
+
+		await tick();
+		pressKey("a");
+		await tick();
+		pressKey("", { name: "return" });
+		await tick();
+
+		expect(stderrOutput).toContain("Too short");
+
+		pressKey("b");
+		await tick();
+		pressKey("c");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe("abc");
+	});
+
+	it("resolves to the schema's transformed output (number from coerce)", async () => {
+		const promise = password({
+			message: "PIN?",
+			validate: z.coerce.number().int().min(1000),
+		});
+
+		await tick();
+		pressKey("4");
+		await tick();
+		pressKey("2");
+		await tick();
+		pressKey("4");
+		await tick();
+		pressKey("2");
+		await tick();
+		pressKey("", { name: "return" });
+
+		const result = await promise;
+		expect(result).toBe(4242);
+		expect(typeof result).toBe("number");
 	});
 });

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -18,6 +18,28 @@ import {
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
+// Schema parsing helper
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run a Standard Schema against a short-circuit `initial` value and return
+ * the parsed output. Throws on schema rejection so the `Promise<Output>`
+ * overload contract holds. Note: only the schema's issue message surfaces in
+ * the thrown error — the original masked value never appears in the error.
+ */
+async function parseShortCircuit<Output>(
+	schema: StandardSchemaV1<unknown, Output>,
+	value: string,
+): Promise<Output> {
+	const result = await schema["~standard"].validate(value);
+	if (result.issues) {
+		const message = result.issues[0]?.message || "Validation failed";
+		throw new Error(`initial value rejected by schema: ${message}`);
+	}
+	return result.value;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Types
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -81,14 +103,17 @@ function createHandleKey<Output>(
 		if (key.name === "return") {
 			if (validate) {
 				if (isStandardSchema(validate)) {
+					// `issues?.length` (rather than just `issues`) defends against
+					// non-conformant schemas returning `{ issues: [] }`, which has
+					// no actual issue to surface and should pass through.
 					const result = await validate["~standard"].validate(state.value);
-					if (result.issues) {
+					if (result.issues?.length) {
 						return {
 							...state,
 							error: result.issues[0]?.message || "Validation failed",
 						};
 					}
-					return submit(result.value as Output);
+					return submit((result as { value: Output }).value);
 				}
 
 				const fnResult = await (validate as ValidateFn<string>)(state.value);
@@ -217,11 +242,21 @@ export function password(
 		readonly validate?: ValidateFn<string>;
 	},
 ): Promise<string>;
+export function password<Output>(
+	options: PasswordOptions<Output>,
+): Promise<Output | string>;
 export async function password<Output>(
 	options: PasswordOptions<Output> = {},
 ): Promise<Output | string> {
-	// Short-circuit: return initial value immediately without rendering
+	// Short-circuit: return initial value immediately without rendering.
+	// When `validate` is a Standard Schema we MUST parse the short-circuit
+	// value through it so the `Promise<Output>` overload stays sound — a raw
+	// string would otherwise leak where the caller is statically promised the
+	// schema's transformed output type.
 	if (options.initial !== undefined) {
+		if (isStandardSchema(options.validate)) {
+			return parseShortCircuit(options.validate, options.initial);
+		}
 		return options.initial;
 	}
 

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -32,11 +32,14 @@ async function parseShortCircuit<Output>(
 	value: string,
 ): Promise<Output> {
 	const result = await schema["~standard"].validate(value);
-	if (result.issues) {
+	// Per spec, success is signalled by `issues === undefined`; an empty
+	// `issues: []` from a non-conformant schema would have no issue to surface,
+	// so we treat it as success rather than throwing a phantom error.
+	if (result.issues?.length) {
 		const message = result.issues[0]?.message || "Validation failed";
 		throw new Error(`initial value rejected by schema: ${message}`);
 	}
-	return result.value;
+	return (result as { value: Output }).value;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -2,15 +2,18 @@
 // Password — Masked text input prompt for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
 import { runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { CURSOR_CHAR, handleTextEdit } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type {
-	PartialPromptTheme,
-	PromptTheme,
-	ValidateFn,
+import {
+	isStandardSchema,
+	type PartialPromptTheme,
+	type PromptTheme,
+	type PromptValidate,
+	type ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 
@@ -21,6 +24,11 @@ import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 /**
  * Options for the {@link password} prompt.
  *
+ * The `validate` slot is polymorphic: it accepts either a classic
+ * {@link ValidateFn} (returning `true` or an error string) or a
+ * {@link StandardSchemaV1} schema. When a schema is supplied, the prompt
+ * resolves to the schema's transformed `Output` type instead of `string`.
+ *
  * @example
  * ```ts
  * const secret = await password({
@@ -29,13 +37,16 @@ import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
  * });
  * ```
  */
-export interface PasswordOptions {
+export interface PasswordOptions<Output = string> {
 	/** The prompt message displayed to the user */
 	readonly message?: string;
 	/** Character used to mask the input (default: `"*"`) */
 	readonly mask?: string;
-	/** Validation function — return `true` for valid, or a string error message */
-	readonly validate?: ValidateFn<string>;
+	/**
+	 * Validation: either a function returning `true | string` or a
+	 * Standard Schema v1 object whose parsed output replaces the raw input.
+	 */
+	readonly validate?: PromptValidate<Output>;
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: string;
 	/** Per-prompt theme overrides */
@@ -56,23 +67,35 @@ interface PasswordState {
 // Keypress handler — reuses input's text-editing logic
 // ────────────────────────────────────────────────────────────────────────────
 
-function createHandleKey(
-	validate: ValidateFn<string> | undefined,
+function createHandleKey<Output>(
+	validate: PromptValidate<Output> | undefined,
 ): (
 	key: KeypressEvent,
 	state: PasswordState,
 ) =>
 	| PasswordState
-	| SubmitResult<string>
-	| Promise<PasswordState | SubmitResult<string>> {
+	| SubmitResult<Output | string>
+	| Promise<PasswordState | SubmitResult<Output | string>> {
 	return async (key, state) => {
 		// Enter — submit
 		if (key.name === "return") {
 			if (validate) {
-				const result = await validate(state.value);
-				if (result !== true) {
-					return { ...state, error: result };
+				if (isStandardSchema(validate)) {
+					const result = await validate["~standard"].validate(state.value);
+					if (result.issues) {
+						return {
+							...state,
+							error: result.issues[0]?.message || "Validation failed",
+						};
+					}
+					return submit(result.value as Output);
 				}
+
+				const fnResult = await (validate as ValidateFn<string>)(state.value);
+				if (fnResult !== true) {
+					return { ...state, error: fnResult };
+				}
+				return submit(state.value);
 			}
 
 			return submit(state.value);
@@ -125,9 +148,9 @@ function renderPassword(
 	return output;
 }
 
-function renderSubmitted(
+function renderSubmitted<Output>(
 	_state: PasswordState,
-	_value: string,
+	_value: Output,
 	theme: PromptTheme,
 	message: string | undefined,
 	mask: string,
@@ -156,8 +179,15 @@ function renderSubmitted(
  * If `initial` is provided, the prompt is skipped and the value is returned
  * immediately — useful for prefilling from CLI flags.
  *
+ * The `validate` slot is **polymorphic**:
+ * - When omitted or given a `ValidateFn<string>`, the prompt resolves to the
+ *   raw `string` input.
+ * - When given a Standard Schema v1 object, the schema parses the raw input
+ *   on submit; the prompt resolves to the schema's transformed `Output` type.
+ *
  * @param options - Password prompt configuration
- * @returns The user's entered password
+ * @returns The user's entered password, or the schema-parsed output when a
+ *          Standard Schema is supplied as `validate`.
  * @throws {NonInteractiveError} when stdin is not a TTY and no `initial` is provided
  *
  * @example
@@ -177,7 +207,19 @@ function renderSubmitted(
  * });
  * ```
  */
-export async function password(options: PasswordOptions): Promise<string> {
+export function password<Output>(
+	options: PasswordOptions<Output> & {
+		readonly validate: StandardSchemaV1<unknown, Output>;
+	},
+): Promise<Output>;
+export function password(
+	options?: Omit<PasswordOptions<string>, "validate"> & {
+		readonly validate?: ValidateFn<string>;
+	},
+): Promise<string>;
+export async function password<Output>(
+	options: PasswordOptions<Output> = {},
+): Promise<Output | string> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return options.initial;
@@ -192,11 +234,11 @@ export async function password(options: PasswordOptions): Promise<string> {
 		error: null,
 	};
 
-	return runPrompt<PasswordState, string>({
+	return runPrompt<PasswordState, Output | string>({
 		initialState,
 		theme,
 		render: (state, t) => renderPassword(state, t, options.message, mask),
-		handleKey: createHandleKey(options.validate),
+		handleKey: createHandleKey<Output>(options.validate),
 		renderSubmitted: (state, value, t) =>
 			renderSubmitted(state, value, t, options.message, mask),
 	});


### PR DESCRIPTION
## Summary

Makes the `validate` option on `input()` and `password()` polymorphic. Existing function-shape validators continue to work unchanged; you can now also pass any [Standard Schema v1](https://standardschema.dev/) object directly (Zod 4, Valibot, ArkType, Effect Schema's `Schema.standardSchemaV1(...)`, …).

When a schema is supplied, the prompt:

1. Parses the raw input on submit by calling `schema['~standard'].validate(submitValue)`.
2. Renders the **first** issue's `message` inline on rejection (single line; falls back to `"Validation failed"` when the issue message is empty).
3. Resolves to the schema's **transformed output** type on success — no second-pass parse step.

```ts
import { input } from "@crustjs/prompts";
import { z } from "zod";

const port = await input({
  message: "Port?",
  validate: z.coerce.number().int().min(1),
});
//    ^? Promise<number>
```

## Implementation notes

- New inline `isStandardSchema()` discriminator lives in `core/types.ts` — no `@crustjs/validate` import, keeping `@crustjs/prompts` dependency-light.
- `InputOptions` / `PasswordOptions` gain an output type parameter (`InputOptions<Output = string>`); function overloads on `input()` / `password()` infer it from the shape of `validate`. Default is still `string`, so the public surface is fully backward-compatible at the type level.
- `@standard-schema/spec ^1.1.0` added as a runtime dependency (~5 KB, types + a tiny runtime guard). `zod` is a devDependency for tests only.

## Verification

```
cd packages/prompts && bun test           # 315 pass / 0 fail
cd packages/core    && bun test           # 464 pass / 0 fail (untouched, sanity)
bun run check:types                       # 21/21 successful
```

## Task

Source task: `taskplane-tasks/TP-013-prompts-polymorphic-validate/`. Companion of #113 (the validate-side Standard Schema entry point) — that PR introduced single-entry Standard Schema parsing across `@crustjs/validate`; this PR threads the same shape through the prompts UX layer.