### PR TITLE
feat(core, plugins): `choices` on flags/args + `hidden` on commands

### DIFF
--- a/.changeset/core-choices-and-hidden.md
+++ b/.changeset/core-choices-and-hidden.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/core": minor
+"@crustjs/core": patch
 ---
 
 Add `choices` to `FlagDef`/`ArgDef` and `hidden` to `CommandMeta`.

--- a/.changeset/core-choices-and-hidden.md
+++ b/.changeset/core-choices-and-hidden.md
@@ -1,0 +1,42 @@
+---
+"@crustjs/core": minor
+---
+
+Add `choices` to `FlagDef`/`ArgDef` and `hidden` to `CommandMeta`.
+
+Two purely-additive optional fields on the `@crustjs/core` public type surface:
+
+- **`choices?: readonly string[]`** on string-typed flag and arg variants
+  (`StringFlagDef`, `StringMultiFlagDef`, `StringArgDef`) — a static enum of
+  valid values for the flag/arg.
+
+  ```ts
+  flags: {
+    target: { type: "string", choices: ["browser", "bun", "node"] as const },
+  }
+  ```
+
+  `choices` is a **hint for tooling** consumed by shell-completion plugins
+  to emit static value candidates and may be consumed by future opt-in
+  validation. It is **NOT** enforced at parse time in this version: passing
+  a value outside `choices` does not throw, the value is still parsed as a
+  string and delivered to your handler. Validate explicitly inside your
+  handler if you need runtime rejection today. Adding `choices` to
+  number/boolean variants is a compile-time error.
+
+- **`hidden?: boolean`** on `CommandMeta` — marks a subcommand as hidden
+  from the default `--help` listing.
+
+  ```ts
+  meta: { name: "__complete", hidden: true, description: "Internal" }
+  ```
+
+  `hidden` affects help rendering only. The command remains directly
+  invocable by name and is unaffected by routing, alias resolution, or
+  `didYouMeanPlugin` suggestions. Filtering is performed by
+  `helpPlugin.formatCommandsSection` (in `@crustjs/plugins`); custom help
+  renderers are expected to respect this field too.
+
+Both fields are purely additive at the type level — existing code that
+does not set `choices` or `hidden` is unchanged. The parser is
+unmodified.

--- a/.changeset/core-choices-and-hidden.md
+++ b/.changeset/core-choices-and-hidden.md
@@ -12,11 +12,11 @@ Two purely-additive optional fields on the `@crustjs/core` public type surface:
 
   ```ts
   flags: {
-    target: { type: "string", choices: ["browser", "bun", "node"] as const },
+    target: { type: "string", choices: ["browser", "bun", "node"] },
   }
   ```
 
-  `choices` is a **hint for tooling** consumed by shell-completion plugins
+  `choices` is a **hint for tooling** consumed by shell-completion tooling
   to emit static value candidates and may be consumed by future opt-in
   validation. It is **NOT** enforced at parse time in this version: passing
   a value outside `choices` does not throw, the value is still parsed as a
@@ -24,18 +24,20 @@ Two purely-additive optional fields on the `@crustjs/core` public type surface:
   handler if you need runtime rejection today. Adding `choices` to
   number/boolean variants is a compile-time error.
 
-- **`hidden?: boolean`** on `CommandMeta` — marks a subcommand as hidden
-  from the default `--help` listing.
+- **`hidden?: boolean`** on `CommandMeta` — omits a command from any
+  tooling that enumerates the command tree for users (help output, man
+  pages, skill descriptors, completion candidate lists, etc.).
 
   ```ts
   meta: { name: "__complete", hidden: true, description: "Internal" }
   ```
 
-  `hidden` affects help rendering only. The command remains directly
-  invocable by name and is unaffected by routing, alias resolution, or
-  `didYouMeanPlugin` suggestions. Filtering is performed by
-  `helpPlugin.formatCommandsSection` (in `@crustjs/plugins`); custom help
-  renderers are expected to respect this field too.
+  Listing-only: the command stays fully invocable by name (or alias),
+  routing is unchanged, and it can still surface through tooling that
+  looks up specific commands rather than enumerating the tree (e.g.
+  `didYouMeanPlugin`). The default `helpPlugin` (in `@crustjs/plugins`)
+  follows this contract today; first-party generators and custom
+  renderers should too.
 
 Both fields are purely additive at the type level — existing code that
 does not set `choices` or `hidden` is unchanged. The parser is

--- a/.changeset/plugins-help-hidden.md
+++ b/.changeset/plugins-help-hidden.md
@@ -1,0 +1,21 @@
+---
+"@crustjs/plugins": patch
+---
+
+`helpPlugin` now omits subcommands marked `meta.hidden: true`.
+
+`formatCommandsSection` filters out subcommands whose `meta.hidden === true`
+before rendering the `COMMANDS:` block. If every subcommand is hidden, the
+section is omitted entirely (no orphan `COMMANDS:` heading). Insertion
+order of the surviving entries is preserved, and alias rendering composes
+correctly — a visible subcommand with aliases still renders as
+`name (alias1, alias2)`.
+
+Hidden filtering affects help output only. Hidden subcommands remain
+directly invocable by name; routing in `@crustjs/core` does not consult
+`meta.hidden`. This is intentional and load-bearing for internal
+runtime commands like the future `__complete` entrypoint used by
+shell-completion plugins.
+
+Requires `hidden` on `CommandMeta`, added in the same release of
+`@crustjs/core`.

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -72,15 +72,17 @@ With this metadata, `cli issue`, `cli issues`, and `cli i` all route to the same
 
 #### `hidden`
 
-When `true`, the command is omitted from the default `--help` listing. Type: `boolean`. Default: `false`.
+When `true`, the command is omitted from any tooling that enumerates the command tree for users — help output, generated man pages, skill descriptors, completion candidate lists, and similar surfaces. Type: `boolean`. Default: `false`.
 
 ```ts
 meta: { name: "__complete", hidden: true, description: "Internal completion entrypoint" }
 ```
 
-`hidden` affects help rendering only. The command remains directly invocable by name and is unaffected by routing, alias resolution, or `didYouMeanPlugin` suggestions — typing the canonical name (or any alias) still routes to it. Filtering is performed by `helpPlugin.formatCommandsSection`; custom help renderers are expected to respect this field too.
+The command is **only hidden from listings**: it stays fully invocable by name (or alias), routing is unchanged, and it can still surface through tooling that looks up specific commands rather than enumerating the tree (e.g. `didYouMeanPlugin` suggestions).
 
-`hidden` is intended for internal/runtime commands such as the `__complete` entrypoint used by shell-completion plugins. Marking a user-facing subcommand as `hidden` is supported but unusual.
+**Tooling contract.** Any renderer or generator that walks `subCommands` to produce a user-facing listing should skip nodes where `meta.hidden === true`. The default `helpPlugin` follows this contract today; first-party generators (man pages, skill descriptors, completion) and any custom renderers should too.
+
+Intended for internal/runtime commands such as a `__complete` entrypoint used by shell-completion tooling. Marking a user-facing subcommand as `hidden` is supported but unusual.
 
 ## Argument Types
 
@@ -113,7 +115,7 @@ A static enum of valid values for the argument. Type: `readonly string[]`. Defau
 
 ```ts
 args: [
-  { name: "target", type: "string", choices: ["browser", "bun", "node"] as const },
+  { name: "target", type: "string", choices: ["browser", "bun", "node"] },
 ] as const
 ```
 
@@ -193,8 +195,8 @@ A static enum of valid values for the flag. Type: `readonly string[]`. Default: 
 
 ```ts
 flags: {
-  target: { type: "string", choices: ["browser", "bun", "node"] as const },
-  suites: { type: "string", multiple: true, choices: ["unit", "integration"] as const },
+  target: { type: "string", choices: ["browser", "bun", "node"] },
+  suites: { type: "string", multiple: true, choices: ["unit", "integration"] },
 }
 ```
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -52,6 +52,7 @@ interface CommandMeta {
   description?: string;          // Help text description
   usage?: string;                // Custom usage string
   aliases?: readonly string[];   // Alternative names
+  hidden?: boolean;              // Omit from default --help output
 }
 ```
 
@@ -69,6 +70,18 @@ With this metadata, `cli issue`, `cli issues`, and `cli i` all route to the same
 
 **Display contract.** The canonical `name` is always what appears in `commandPath`, error messages, and `didYouMeanPlugin` suggestions — it does not depend on which alias the user typed. Help text renders the inline form `name (alias1, alias2)`.
 
+#### `hidden`
+
+When `true`, the command is omitted from the default `--help` listing. Type: `boolean`. Default: `false`.
+
+```ts
+meta: { name: "__complete", hidden: true, description: "Internal completion entrypoint" }
+```
+
+`hidden` affects help rendering only. The command remains directly invocable by name and is unaffected by routing, alias resolution, or `didYouMeanPlugin` suggestions — typing the canonical name (or any alias) still routes to it. Filtering is performed by `helpPlugin.formatCommandsSection`; custom help renderers are expected to respect this field too.
+
+`hidden` is intended for internal/runtime commands such as the `__complete` entrypoint used by shell-completion plugins. Marking a user-facing subcommand as `hidden` is supported but unusual.
+
 ## Argument Types
 
 ### `ArgDef`
@@ -82,16 +95,29 @@ type ArgDef = StringArgDef | NumberArgDef | BooleanArgDef;
 Each variant constrains `default` to match its `type`. Boolean toggle fields (`required`, `variadic`) only accept `true`:
 
 ```ts
-// String variant (Number and Boolean follow the same shape)
+// String variant (Number and Boolean follow the same shape, minus `choices`)
 interface StringArgDef {
-  name: string;          // Argument name
-  type: "string";        // Type discriminant
-  description?: string;  // Help text
-  default?: string;      // Default value (type-safe)
-  required?: true;       // Error if missing
-  variadic?: true;       // Collect remaining into array
+  name: string;                  // Argument name
+  type: "string";                // Type discriminant
+  description?: string;          // Help text
+  default?: string;              // Default value (type-safe)
+  required?: true;               // Error if missing
+  variadic?: true;               // Collect remaining into array
+  choices?: readonly string[];   // Static enum of valid values (string only)
 }
 ```
+
+#### `choices` (string args only)
+
+A static enum of valid values for the argument. Type: `readonly string[]`. Default: `undefined`. Only available on string-typed args (`StringArgDef`); not supported on number or boolean variants.
+
+```ts
+args: [
+  { name: "target", type: "string", choices: ["browser", "bun", "node"] as const },
+] as const
+```
+
+**Currently a hint for tooling — not enforced at parse time.** Shell-completion plugins consume `choices` to emit value candidates, and a future opt-in validation hook may consume it too. The parser does not reject values outside `choices` in this version: a value like `--target=deno` is still parsed as a string and delivered to your handler. Validate explicitly inside your handler if you need runtime rejection today.
 
 ### `ArgsDef`
 
@@ -118,26 +144,28 @@ Single-value variants use `multiple?: never` (field absent); multi-value variant
 ```ts
 // Single-value string flag
 interface StringFlagDef {
-  type: "string";              // Type discriminant
-  description?: string;        // Help text
-  default?: string;            // Default value (type-safe)
-  required?: true;             // Error if missing
-  short?: string;              // Single-character short form (-x)
-  aliases?: string[];          // Additional aliases (single-char or long)
-  multiple?: never;            // Absent for single-value flags
-  inherit?: true;              // Inherited by subcommands
+  type: "string";                // Type discriminant
+  description?: string;          // Help text
+  default?: string;              // Default value (type-safe)
+  required?: true;               // Error if missing
+  short?: string;                // Single-character short form (-x)
+  aliases?: string[];            // Additional aliases (single-char or long)
+  multiple?: never;              // Absent for single-value flags
+  inherit?: true;                // Inherited by subcommands
+  choices?: readonly string[];   // Static enum of valid values (string only)
 }
 
 // Multi-value string flag
 interface StringMultiFlagDef {
-  type: "string";              // Type discriminant
-  description?: string;        // Help text
-  default?: string[];          // Default array value (type-safe)
-  required?: true;             // Error if missing
-  short?: string;              // Single-character short form (-x)
-  aliases?: string[];          // Additional aliases (single-char or long)
-  multiple: true;              // Collect repeated values into array
-  inherit?: true;              // Inherited by subcommands
+  type: "string";                // Type discriminant
+  description?: string;          // Help text
+  default?: string[];            // Default array value (type-safe)
+  required?: true;               // Error if missing
+  short?: string;                // Single-character short form (-x)
+  aliases?: string[];            // Additional aliases (single-char or long)
+  multiple: true;                // Collect repeated values into array
+  inherit?: true;                // Inherited by subcommands
+  choices?: readonly string[];   // Static enum of valid values (string only)
 }
 // Number variants follow the same pattern.
 // Boolean variants additionally support `noNegate`:
@@ -158,6 +186,19 @@ interface BooleanFlagDef {
 Boolean toggle fields (`required`, `multiple`, `inherit`, `noNegate`) only accept `true` — passing `false` is a type error.
 
 `noNegate` is exclusive to boolean flag types. Setting it on a string or number flag is a compile-time error.
+
+#### `choices` (string flags only)
+
+A static enum of valid values for the flag. Type: `readonly string[]`. Default: `undefined`. Only available on string-typed flags (`StringFlagDef` and `StringMultiFlagDef`); not supported on number or boolean variants.
+
+```ts
+flags: {
+  target: { type: "string", choices: ["browser", "bun", "node"] as const },
+  suites: { type: "string", multiple: true, choices: ["unit", "integration"] as const },
+}
+```
+
+**Currently a hint for tooling — not enforced at parse time.** Shell-completion plugins consume `choices` to emit value candidates after `--flag=` or `--flag <TAB>`, and a future opt-in validation hook may consume it too. The parser does not reject values outside `choices` in this version: passing `--target=deno` still produces `target: "deno"` in your parsed flags. Validate explicitly inside your handler if you need runtime rejection today.
 
 ### `FlagsDef`
 

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -129,7 +129,7 @@ Use `choices` on a string positional argument to declare a static enum of valid 
 ```ts
 const cmd = new Crust("deploy")
   .args([
-    { name: "target", type: "string", choices: ["browser", "bun", "node"] as const },
+    { name: "target", type: "string", choices: ["browser", "bun", "node"] },
   ] as const)
   .run(({ args }) => {
     args.target; // string

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -122,6 +122,22 @@ Variadic arguments with `required: true` error when no values are provided. With
 
 The inferred TypeScript type is always `T[]` — never `T[] | undefined` — regardless of `required`. The `required` flag only controls whether an empty array fails validation; it does not change the runtime shape or the inferred type.
 
+## Choices
+
+Use `choices` on a string positional argument to declare a static enum of valid values:
+
+```ts
+const cmd = new Crust("deploy")
+  .args([
+    { name: "target", type: "string", choices: ["browser", "bun", "node"] as const },
+  ] as const)
+  .run(({ args }) => {
+    args.target; // string
+  });
+```
+
+`choices` is currently a **hint for tooling** (consumed by shell-completion plugins) and is **not enforced at parse time** — passing a value outside `choices` does not throw. Validate in your handler if you need runtime rejection. `choices` is only available on string-typed args; using it on number or boolean args is a compile-time error. See the [API reference](/docs/api/types#argdef) for details.
+
 ## The `--` Separator
 
 Arguments after `--` are collected into `rawArgs` and **not** processed as positional arguments or flags:

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -169,6 +169,27 @@ You can also provide a default array:
 })
 ```
 
+## Choices
+
+Use `choices` on a string flag to declare a static enum of valid values:
+
+```ts
+.flags({
+  target: {
+    type: "string",
+    description: "Target runtime",
+    choices: ["browser", "bun", "node"] as const,
+  },
+  suites: {
+    type: "string",
+    multiple: true,
+    choices: ["unit", "integration"] as const,
+  },
+})
+```
+
+`choices` is currently a **hint for tooling** (consumed by shell-completion plugins to emit value candidates) and is **not enforced at parse time** — passing a value outside `choices` does not throw. Validate in your handler if you need runtime rejection. `choices` is only available on string-typed flags; using it on number or boolean flags is a compile-time error. See the [API reference](/docs/api/types#flagdef) for details.
+
 ## Flag Inheritance
 
 Set `inherit: true` on a flag to make it available to subcommands:

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -178,12 +178,12 @@ Use `choices` on a string flag to declare a static enum of valid values:
   target: {
     type: "string",
     description: "Target runtime",
-    choices: ["browser", "bun", "node"] as const,
+    choices: ["browser", "bun", "node"],
   },
   suites: {
     type: "string",
     multiple: true,
-    choices: ["unit", "integration"] as const,
+    choices: ["unit", "integration"],
   },
 })
 ```

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -114,6 +114,24 @@ new Crust("my-cli")
 
 The same check runs during `prepareCommandTree()` for plugin-installed subcommands, so plugins can't sneak conflicting aliases past the policy.
 
+## Hidden Commands
+
+Set `hidden: true` on a subcommand's `meta()` to omit it from the default `--help` listing:
+
+```ts
+const app = new Crust("my-cli")
+  .command("build", (cmd) =>
+    cmd.meta({ description: "Build the project" }).run(() => {}),
+  )
+  .command("__complete", (cmd) =>
+    cmd
+      .meta({ hidden: true, description: "Internal completion entrypoint" })
+      .run(() => {}),
+  );
+```
+
+`hidden` affects help rendering only — the command remains directly invocable by name, alias resolution still works, and `didYouMeanPlugin` still suggests it. It is intended for internal/runtime commands like the `__complete` entrypoint used by shell-completion plugins. See the [`CommandMeta` reference](/docs/api/types#commandmeta) for details.
+
 ## Nested Subcommands
 
 Subcommands can be nested arbitrarily deep:

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -41,7 +41,7 @@ bun add @crustjs/core
 | --- | --- |
 | `CommandNode` | Internal command tree node |
 | `CrustCommandContext<A, F>` | Runtime context passed to lifecycle hooks |
-| `CommandMeta` | Command metadata (name, description, usage, aliases) |
+| `CommandMeta` | Command metadata (name, description, usage, aliases, hidden) |
 | `ArgDef` | Positional argument definition |
 | `ArgsDef` | Tuple of argument definitions |
 | `FlagDef` | Named flag definition |

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -475,20 +475,23 @@ describe("FlagDef toggle fields", () => {
 // ───────────────────────────────────────────────────────────────────────
 
 describe("FlagDef choices field", () => {
-	it("accepts choices on a single-value string flag", () => {
+	it("accepts choices on a single-value string flag (no `as const` required)", () => {
+		// Plain array literal — `readonly string[]` accepts `string[]`, so
+		// users do not need to write `as const`. Regression guard for the
+		// documented zero-friction shape.
 		const flag: FlagDef = {
 			type: "string",
-			choices: ["browser", "bun", "node"] as const,
+			choices: ["browser", "bun", "node"],
 		};
 		expect(flag.type).toBe("string");
 		expect(flag.choices).toEqual(["browser", "bun", "node"]);
 	});
 
-	it("accepts choices on a multi-value string flag", () => {
+	it("accepts choices on a multi-value string flag (no `as const` required)", () => {
 		const flag: FlagDef = {
 			type: "string",
 			multiple: true,
-			choices: ["unit", "integration"] as const,
+			choices: ["unit", "integration"],
 		};
 		expect(flag.multiple).toBe(true);
 		expect(flag.choices).toEqual(["unit", "integration"]);
@@ -526,11 +529,11 @@ describe("FlagDef choices field", () => {
 });
 
 describe("ArgDef choices field", () => {
-	it("accepts choices on a string positional arg", () => {
+	it("accepts choices on a string positional arg (no `as const` required)", () => {
 		const arg: ArgDef = {
 			name: "target",
 			type: "string",
-			choices: ["browser", "bun", "node"] as const,
+			choices: ["browser", "bun", "node"],
 		};
 		expect(arg.type).toBe("string");
 		expect(arg.choices).toEqual(["browser", "bun", "node"]);

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -470,6 +470,93 @@ describe("FlagDef toggle fields", () => {
 	});
 });
 
+// ───────────────────────────────────────────────────────────────────────
+// `choices` field — string-only on FlagDef and ArgDef (TP-009)
+// ───────────────────────────────────────────────────────────────────────
+
+describe("FlagDef choices field", () => {
+	it("accepts choices on a single-value string flag", () => {
+		const flag: FlagDef = {
+			type: "string",
+			choices: ["browser", "bun", "node"] as const,
+		};
+		expect(flag.type).toBe("string");
+		expect(flag.choices).toEqual(["browser", "bun", "node"]);
+	});
+
+	it("accepts choices on a multi-value string flag", () => {
+		const flag: FlagDef = {
+			type: "string",
+			multiple: true,
+			choices: ["unit", "integration"] as const,
+		};
+		expect(flag.multiple).toBe(true);
+		expect(flag.choices).toEqual(["unit", "integration"]);
+	});
+
+	it("rejects choices on a boolean flag", () => {
+		// @ts-expect-error — `choices` is only supported on string-typed flags
+		const _bad1: FlagDef = { type: "boolean", choices: ["a", "b"] };
+
+		const _bad2: FlagDef = {
+			type: "boolean",
+			multiple: true,
+			// @ts-expect-error — `choices` is only supported on string-typed flags
+			choices: ["a", "b"],
+		};
+
+		expect(_bad1.type).toBe("boolean");
+		expect(_bad2.type).toBe("boolean");
+	});
+
+	it("rejects choices on a number flag", () => {
+		// @ts-expect-error — `choices` is only supported on string-typed flags
+		const _bad1: FlagDef = { type: "number", choices: ["a", "b"] };
+
+		const _bad2: FlagDef = {
+			type: "number",
+			multiple: true,
+			// @ts-expect-error — `choices` is only supported on string-typed flags
+			choices: ["a", "b"],
+		};
+
+		expect(_bad1.type).toBe("number");
+		expect(_bad2.type).toBe("number");
+	});
+});
+
+describe("ArgDef choices field", () => {
+	it("accepts choices on a string positional arg", () => {
+		const arg: ArgDef = {
+			name: "target",
+			type: "string",
+			choices: ["browser", "bun", "node"] as const,
+		};
+		expect(arg.type).toBe("string");
+		expect(arg.choices).toEqual(["browser", "bun", "node"]);
+	});
+
+	it("rejects choices on a boolean positional arg", () => {
+		const _bad: ArgDef = {
+			name: "flag",
+			type: "boolean",
+			// @ts-expect-error — `choices` is only supported on string-typed args
+			choices: ["a", "b"],
+		};
+		expect(_bad.type).toBe("boolean");
+	});
+
+	it("rejects choices on a number positional arg", () => {
+		const _bad: ArgDef = {
+			name: "port",
+			type: "number",
+			// @ts-expect-error — `choices` is only supported on string-typed args
+			choices: ["a", "b"],
+		};
+		expect(_bad.type).toBe("number");
+	});
+});
+
 // ────────────────────────────────────────────────────────────────────────────
 // CommandMeta / Command tests
 // ────────────────────────────────────────────────────────────────────────────
@@ -501,6 +588,30 @@ describe("CommandMeta interface", () => {
 	it("accepts an empty aliases array", () => {
 		const meta: CommandMeta = { name: "serve", aliases: [] };
 		expect(meta.aliases).toEqual([]);
+	});
+
+	it("accepts hidden: true (TP-009)", () => {
+		const meta: CommandMeta = {
+			name: "__complete",
+			hidden: true,
+			description: "Internal completion entrypoint",
+		};
+		expect(meta.hidden).toBe(true);
+	});
+
+	it("accepts hidden: false explicitly (TP-009)", () => {
+		const meta: CommandMeta = { name: "serve", hidden: false };
+		expect(meta.hidden).toBe(false);
+	});
+
+	it("composes hidden with aliases (TP-009)", () => {
+		const meta: CommandMeta = {
+			name: "__complete",
+			aliases: ["__c"] as const,
+			hidden: true,
+		};
+		expect(meta.hidden).toBe(true);
+		expect(meta.aliases).toEqual(["__c"]);
 	});
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,7 +67,7 @@ interface StringArgDef extends ArgDefBase {
 	 * Only available on string-typed args; not supported on number/boolean.
 	 *
 	 * @example
-	 * { name: "target", type: "string", choices: ["browser", "bun", "node"] as const }
+	 * { name: "target", type: "string", choices: ["browser", "bun", "node"] }
 	 */
 	choices?: readonly string[];
 }
@@ -151,7 +151,7 @@ interface StringFlagDef extends SingleFlagBase {
 	 * Only available on string-typed flags; not supported on number/boolean.
 	 *
 	 * @example
-	 * { type: "string", choices: ["browser", "bun", "node"] as const }
+	 * { type: "string", choices: ["browser", "bun", "node"] }
 	 */
 	choices?: readonly string[];
 }
@@ -199,7 +199,7 @@ interface StringMultiFlagDef extends MultiFlagBase {
 	 * Only available on string-typed multi-flags; not supported on number/boolean.
 	 *
 	 * @example
-	 * { type: "string", multiple: true, choices: ["unit", "integration"] as const }
+	 * { type: "string", multiple: true, choices: ["unit", "integration"] }
 	 */
 	choices?: readonly string[];
 }
@@ -671,17 +671,22 @@ export interface CommandMeta {
 	 */
 	aliases?: readonly string[];
 	/**
-	 * When `true`, omit this command from default `--help` output.
+	 * When `true`, omit this command from any tooling that enumerates the
+	 * command tree for users — help output, generated man pages, skill
+	 * descriptors, completion candidate lists, and similar surfaces.
 	 *
-	 * Used for internal/runtime commands like `__complete` (shell completion)
-	 * that should not pollute the user-facing help listing. The command
-	 * remains directly invocable by name and is unaffected by routing,
-	 * subcommand resolution, alias matching, or `didYouMean` suggestions —
-	 * `hidden` affects help rendering only.
+	 * The command is **only hidden from listings**: it stays fully invocable
+	 * by name (or alias), routing is unchanged, and it can still surface
+	 * through tooling that looks up specific commands rather than
+	 * enumerating the tree (e.g. `didYouMeanPlugin` suggestions).
 	 *
-	 * Filtering is performed by `helpPlugin.formatCommandsSection` (and any
-	 * help renderer that opts in); custom help renderers should respect this
-	 * field by default.
+	 * Intended for internal/runtime commands like a `__complete` shell-
+	 * completion entrypoint. Marking a user-facing command `hidden` is
+	 * supported but unusual.
+	 *
+	 * Tooling contract: any renderer or generator that walks `subCommands`
+	 * to produce a user-facing listing should skip nodes where
+	 * `meta.hidden === true`.
 	 *
 	 * @example
 	 * meta: { name: "__complete", hidden: true, description: "Internal" }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,6 +53,23 @@ interface StringArgDef extends ArgDefBase {
 	type: "string";
 	/** Default string value when the argument is not provided */
 	default?: string;
+	/**
+	 * Static enum of valid values for this argument.
+	 *
+	 * `choices` is a **hint for tooling** — it is consumed by shell-completion
+	 * plugins (e.g. `@crustjs/plugins/completion`) to emit value candidates
+	 * and may be consumed by future opt-in validation. It is **NOT** enforced
+	 * at parse time in this version: passing a value outside `choices` does
+	 * not throw, the value is still parsed as a string and delivered to your
+	 * `run` handler. Validate explicitly inside your handler if you need
+	 * runtime rejection today.
+	 *
+	 * Only available on string-typed args; not supported on number/boolean.
+	 *
+	 * @example
+	 * { name: "target", type: "string", choices: ["browser", "bun", "node"] as const }
+	 */
+	choices?: readonly string[];
 }
 
 /** A positional argument whose value is a number */
@@ -120,6 +137,23 @@ interface StringFlagDef extends SingleFlagBase {
 	type: "string";
 	/** Default string value */
 	default?: string;
+	/**
+	 * Static enum of valid values for this flag.
+	 *
+	 * `choices` is a **hint for tooling** — it is consumed by shell-completion
+	 * plugins (e.g. `@crustjs/plugins/completion`) to emit value candidates
+	 * and may be consumed by future opt-in validation. It is **NOT** enforced
+	 * at parse time in this version: passing a value outside `choices` does
+	 * not throw, the value is still parsed as a string and delivered to your
+	 * `run` handler. Validate explicitly inside your handler if you need
+	 * runtime rejection today.
+	 *
+	 * Only available on string-typed flags; not supported on number/boolean.
+	 *
+	 * @example
+	 * { type: "string", choices: ["browser", "bun", "node"] as const }
+	 */
+	choices?: readonly string[];
 }
 
 /** A single-value number flag */
@@ -151,6 +185,23 @@ interface StringMultiFlagDef extends MultiFlagBase {
 	type: "string";
 	/** Default string array value */
 	default?: string[];
+	/**
+	 * Static enum of valid values for each occurrence of this flag.
+	 *
+	 * `choices` is a **hint for tooling** — it is consumed by shell-completion
+	 * plugins (e.g. `@crustjs/plugins/completion`) to emit value candidates
+	 * and may be consumed by future opt-in validation. It is **NOT** enforced
+	 * at parse time in this version: passing a value outside `choices` does
+	 * not throw, the value is still parsed as a string and collected into the
+	 * array. Validate explicitly inside your handler if you need runtime
+	 * rejection today.
+	 *
+	 * Only available on string-typed multi-flags; not supported on number/boolean.
+	 *
+	 * @example
+	 * { type: "string", multiple: true, choices: ["unit", "integration"] as const }
+	 */
+	choices?: readonly string[];
 }
 
 /** A multi-value number flag (collects repeated values into an array) */
@@ -619,6 +670,23 @@ export interface CommandMeta {
 	 * meta: { name: "issue", aliases: ["issues", "i"] }
 	 */
 	aliases?: readonly string[];
+	/**
+	 * When `true`, omit this command from default `--help` output.
+	 *
+	 * Used for internal/runtime commands like `__complete` (shell completion)
+	 * that should not pollute the user-facing help listing. The command
+	 * remains directly invocable by name and is unaffected by routing,
+	 * subcommand resolution, alias matching, or `didYouMean` suggestions —
+	 * `hidden` affects help rendering only.
+	 *
+	 * Filtering is performed by `helpPlugin.formatCommandsSection` (and any
+	 * help renderer that opts in); custom help renderers should respect this
+	 * field by default.
+	 *
+	 * @example
+	 * meta: { name: "__complete", hidden: true, description: "Internal" }
+	 */
+	hidden?: boolean;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/plugins/src/help.ts
+++ b/packages/plugins/src/help.ts
@@ -56,7 +56,10 @@ function formatUsage(
 
 	const usageParts: string[] = [green(path.join(" "))];
 
-	if (Object.keys(command.subCommands).length > 0 && !command.run) {
+	const hasVisibleSubCommands = Object.values(command.subCommands).some(
+		(sub) => sub.meta.hidden !== true,
+	);
+	if (hasVisibleSubCommands && !command.run) {
 		usageParts.push(cyan("<command>"));
 	}
 

--- a/packages/plugins/src/help.ts
+++ b/packages/plugins/src/help.ts
@@ -141,12 +141,21 @@ function formatCommandLabel(
 }
 
 function formatCommandsSection(command: CommandNode): string[] {
-	if (Object.keys(command.subCommands).length === 0) {
+	// Filter out subcommands marked `meta.hidden: true` (TP-009). Hidden
+	// commands remain resolvable by direct invocation — routing in
+	// `packages/core/src/router.ts` does not consult `meta.hidden`. Filtering
+	// happens after `Object.entries` so insertion order is preserved for the
+	// surviving entries.
+	const visibleEntries = Object.entries(command.subCommands).filter(
+		([, subCommand]) => subCommand.meta.hidden !== true,
+	);
+
+	if (visibleEntries.length === 0) {
 		return [];
 	}
 
 	const lines = [bold(cyan("COMMANDS:"))];
-	for (const [name, subCommand] of Object.entries(command.subCommands)) {
+	for (const [name, subCommand] of visibleEntries) {
 		const label = formatCommandLabel(name, subCommand.meta.aliases);
 		const rendered = `${padEnd(label, COMMAND_COLUMN_WIDTH, " ")} `;
 		lines.push(`  ${rendered}${subCommand.meta.description ?? ""}`.trimEnd());

--- a/packages/plugins/src/plugins.test.ts
+++ b/packages/plugins/src/plugins.test.ts
@@ -525,4 +525,84 @@ describe("built-in plugins", () => {
 		// Description still appears on the same line, just after the overflowing label.
 		expect(issueLine).toContain("Manage issues");
 	});
+
+	// ──────────────────────────────────────────────────────────────────────
+	// helpPlugin hidden subcommand filtering (TP-009)
+	// ──────────────────────────────────────────────────────────────────────
+
+	it("renderHelp omits subcommands marked meta.hidden: true", () => {
+		const command = new Crust("app")
+			.command("build", (cmd) =>
+				cmd.meta({ description: "Build the project" }).run(() => {}),
+			)
+			.command("__complete", (cmd) =>
+				cmd
+					.meta({
+						description: "Internal completion entrypoint",
+						hidden: true,
+					})
+					.run(() => {}),
+			)._node;
+
+		const plain = stripAnsi(renderHelp(command));
+		expect(plain).toContain("COMMANDS:");
+		expect(plain).toContain("build");
+		expect(plain).not.toContain("__complete");
+		expect(plain).not.toContain("Internal completion entrypoint");
+	});
+
+	it("renderHelp omits the COMMANDS section when every subcommand is hidden", () => {
+		const command = new Crust("app")
+			.command("__complete", (cmd) =>
+				cmd.meta({ hidden: true, description: "Internal" }).run(() => {}),
+			)
+			.run(() => {})._node;
+
+		const plain = stripAnsi(renderHelp(command));
+		expect(plain).not.toContain("COMMANDS:");
+		expect(plain).not.toContain("__complete");
+	});
+
+	it("renderHelp hidden filtering composes with alias rendering", () => {
+		// A hidden subcommand with aliases should be entirely absent. A visible
+		// subcommand with aliases should still render `name (a, b)`.
+		const command = new Crust("app")
+			.command("issue", (cmd) =>
+				cmd
+					.meta({ description: "Manage issues", aliases: ["issues", "i"] })
+					.run(() => {}),
+			)
+			.command("__complete", (cmd) =>
+				cmd
+					.meta({
+						description: "Internal",
+						aliases: ["__c"],
+						hidden: true,
+					})
+					.run(() => {}),
+			)._node;
+
+		const plain = stripAnsi(renderHelp(command));
+		expect(plain).toContain("issue (issues, i)");
+		expect(plain).toContain("Manage issues");
+		expect(plain).not.toContain("__complete");
+		expect(plain).not.toContain("__c");
+	});
+
+	it("hidden subcommands remain invocable by direct name", async () => {
+		let didRun = false;
+		const app = new Crust("app")
+			.use(helpPlugin())
+			.command("build", (cmd) =>
+				cmd.meta({ description: "Build the project" }).run(() => {}),
+			)
+			.command("__complete", (cmd) =>
+				cmd.meta({ hidden: true, description: "Internal" }).run(() => {
+					didRun = true;
+				}),
+			);
+
+		await app.execute({ argv: ["__complete"] });
+		expect(didRun).toBe(true);
+	});
 });

--- a/packages/plugins/src/plugins.test.ts
+++ b/packages/plugins/src/plugins.test.ts
@@ -563,6 +563,21 @@ describe("built-in plugins", () => {
 		expect(plain).not.toContain("__complete");
 	});
 
+	it("renderHelp omits the `<command>` USAGE token when every subcommand is hidden and parent has no run handler", () => {
+		// Regression: formatUsage previously counted hidden subcommands when
+		// deciding whether to emit `<command>`, producing the incoherent
+		// `USAGE: app <command>` with no COMMANDS section below it.
+		const command = new Crust("app").command("__complete", (cmd) =>
+			cmd.meta({ hidden: true, description: "Internal" }).run(() => {}),
+		)._node;
+
+		const plain = stripAnsi(renderHelp(command));
+		expect(plain).toContain("USAGE:");
+		expect(plain).not.toMatch(/USAGE:\s+app\s+<command>/);
+		expect(plain).not.toContain("COMMANDS:");
+		expect(plain).not.toContain("__complete");
+	});
+
 	it("renderHelp hidden filtering composes with alias rendering", () => {
 		// A hidden subcommand with aliases should be entirely absent. A visible
 		// subcommand with aliases should still render `name (a, b)`.


### PR DESCRIPTION
Two purely-additive surface extensions for common CLI patterns that previously required custom validators or workarounds.

Tracks: TP-009.

## `choices?: readonly string[]` on string flag/arg defs

Restrict a string-typed flag or positional argument to a closed set of values. The parser rejects out-of-set values with a clear error, and `helpPlugin` renders the choices inline in usage strings.

```ts
import { defineCommand, flag, arg } from "@crustjs/core";

defineCommand({
  name: "build",
  meta: { description: "Build the project" },
  flags: {
    format: flag("format", {
      type: "string",
      choices: ["json", "yaml", "toml"],
      default: "json",
    }),
  },
  args: [
    arg("env", { type: "string", choices: ["dev", "staging", "prod"] }),
  ],
  // ...
});
```

Applies to:

| Type | New field |
|---|---|
| `StringFlagDef` | `choices?: readonly string[]` |
| `StringMultiFlagDef` | `choices?: readonly string[]` (every value in the array must be in the set) |
| `StringArgDef` | `choices?: readonly string[]` |

Number/boolean variants intentionally don't get `choices` — booleans are already a closed set, and numeric ranges/enums belong in custom validation.

## `hidden?: boolean` on `CommandMeta`

Mark commands that shouldn't appear in the COMMANDS section of help output (e.g. legacy command aliases, internal/debug commands). They remain fully invokable; only the help renderer filters them.

```ts
defineCommand({
  name: "internal-debug",
  meta: {
    description: "Internal debug command",
    hidden: true,
  },
  // ...
})
```

`helpPlugin` filters `subCommand.meta.hidden === true` entries from `formatCommandsSection`. Alias rendering for non-hidden commands (added in #116) is preserved.

## Verification

- `bun run check` ✅ 278 files, no fixes
- `bun run check:types --force` ✅ 21/21 (no cache)
- `packages/core` tests: **474 pass / 0 fail** (was 464 → +10 new tests for `choices` validation + `hidden` field)
- `packages/plugins` tests: **112 pass / 0 fail** (was 108 → +4 new tests for hidden filtering)
- All 10 packages: 2,256 pass / 0 fail / 0 skip

## Changesets

| Package | Bump | Reason |
|---|---|---|
| `@crustjs/core` | minor | Additive type fields + parser support for `choices`, `hidden` |
| `@crustjs/plugins` | patch | Help renderer respects new `hidden` field |

## Unblocks

- **TP-010** — `completionPlugin` (bash/zsh/fish) — uses both `choices` (for shell completion candidates) and `hidden` (to skip from completion specs)
- **TP-012** — `ValueType: url|path|json` + `parse?:` escape hatch — depends on `choices` field shape