### PR TITLE
feat(skills): `skillPlugin` accepts `customSkills` for hand-authored bundles

### DIFF
--- a/.changeset/skills-custom-bundles.md
+++ b/.changeset/skills-custom-bundles.md
@@ -36,7 +36,7 @@ new Crust("my-cli")
 `CustomSkillConfig.sourceDir` accepts a `URL` (`file:` protocol), an
 absolute path, or a bare relative string resolved from the nearest
 `package.json` walking up from `process.argv[1]` — the same three modes
-used by `installSkillBundle()` (TP-003). Each entry's `version` drives
+used by `installSkillBundle()`. Each entry's `version` drives
 auto-update detection (compared against the recorded `crust.json`
 version) and is typically wired to the consuming package's
 `package.json` `version`. Per-entry `scope` and `installMode` overrides
@@ -50,10 +50,11 @@ Setup-time validation enforces:
 - Each `version` is a non-empty string.
 - Each `sourceDir` is a `string` or `URL`.
 
-Per-entry failures during auto-update or interactive reconciliation are
-logged with the bundle name and never abort other entries. Plugin
-behavior is byte-identical to today when `customSkills` is omitted or
-empty.
+Bundle files are copied as raw bytes, so supporting binary assets round-trip
+unchanged. Passing `agents: []` to `installSkillBundle()` validates the
+bundle without installing it.
 
-Builds on `installSkillBundle()` (introduced in #119); resolves the
-plugin-integration half of #110.
+Per-entry failures during auto-update or interactive reconciliation are
+logged with the bundle name and never abort other entries. When
+`customSkills` is omitted or empty, only the generated main skill is
+managed.

--- a/.changeset/skills-custom-bundles.md
+++ b/.changeset/skills-custom-bundles.md
@@ -1,0 +1,59 @@
+---
+"@crustjs/skills": minor
+---
+
+`skillPlugin` now accepts a `customSkills` array for managing hand-authored
+skill bundles alongside the auto-generated command-reference skill.
+
+Each entry is reconciled through the same plugin lifecycle as the main
+skill — auto-update on version change, surfaced in the interactive `skill`
+subcommand multiselect (one prompt per bundle, in array order, after the
+main-skill prompt), supports uninstall via the same toggle UX, and respects
+`autoUpdate: false` and `--all` non-interactive mode.
+
+```ts
+import { Crust } from "@crustjs/core";
+import { skillPlugin } from "@crustjs/skills";
+import pkg from "./package.json" with { type: "json" };
+
+new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .use(
+    skillPlugin({
+      version: pkg.version,
+      customSkills: [
+        {
+          name: "funnel-builder",
+          sourceDir: "skills/funnel-builder",
+          version: pkg.version,
+        },
+      ],
+    }),
+  )
+  .run(() => {});
+```
+
+`CustomSkillConfig.sourceDir` accepts a `URL` (`file:` protocol), an
+absolute path, or a bare relative string resolved from the nearest
+`package.json` walking up from `process.argv[1]` — the same three modes
+used by `installSkillBundle()` (TP-003). Each entry's `version` drives
+auto-update detection (compared against the recorded `crust.json`
+version) and is typically wired to the consuming package's
+`package.json` `version`. Per-entry `scope` and `installMode` overrides
+are optional; unset values inherit from the plugin's `defaultScope` /
+`installMode`.
+
+Setup-time validation enforces:
+- Each `name` satisfies `isValidSkillName`.
+- No `name` collides with the main skill's name.
+- All `name` values are unique within the array.
+- Each `version` is a non-empty string.
+- Each `sourceDir` is a `string` or `URL`.
+
+Per-entry failures during auto-update or interactive reconciliation are
+logged with the bundle name and never abort other entries. Plugin
+behavior is byte-identical to today when `customSkills` is omitted or
+empty.
+
+Builds on `installSkillBundle()` (introduced in #119); resolves the
+plugin-integration half of #110.

--- a/.changeset/skills-custom-bundles.md
+++ b/.changeset/skills-custom-bundles.md
@@ -3,13 +3,10 @@
 ---
 
 `skillPlugin` now accepts a `customSkills` array for managing hand-authored
-skill bundles alongside the auto-generated command-reference skill.
-
-Each entry is reconciled through the same plugin lifecycle as the main
-skill — auto-update on version change, surfaced in the interactive `skill`
-subcommand multiselect (one prompt per bundle, in array order, after the
-main-skill prompt), supports uninstall via the same toggle UX, and respects
-`autoUpdate: false` and `--all` non-interactive mode.
+skill bundles alongside the auto-generated command-reference skill. Each
+entry runs through the same lifecycle as the main skill (auto-update,
+interactive multiselect, `skill update`) and adds its own multiselect
+prompt after the main one, in array order.
 
 ```ts
 import { Crust } from "@crustjs/core";
@@ -54,7 +51,12 @@ Bundle files are copied as raw bytes, so supporting binary assets round-trip
 unchanged. Passing `agents: []` to `installSkillBundle()` validates the
 bundle without installing it.
 
-Per-entry failures during auto-update or interactive reconciliation are
-logged with the bundle name and never abort other entries. When
-`customSkills` is omitted or empty, only the generated main skill is
-managed.
+Per-entry failures are logged with the bundle name and never abort other
+entries. Failures from explicit `skill --all` and `skill update` set a
+non-zero exit code so automation notices partial failures; startup
+auto-update remains warning-only. When `customSkills` is omitted or empty,
+only the generated main skill is managed.
+
+The bundle's `SKILL.md` frontmatter `name:` must equal the configured
+`name` — mismatches are rejected at install time so plugin status /
+uninstall paths can never drift from the canonical install location.

--- a/.changeset/skills-custom-version-optional.md
+++ b/.changeset/skills-custom-version-optional.md
@@ -1,0 +1,34 @@
+---
+"@crustjs/skills": minor
+---
+
+`CustomSkillConfig.version` is now optional in `skillPlugin`'s
+`customSkills`. When omitted, the entry inherits the plugin's top-level
+`version` — the typical case when the bundle ships in the same package as
+the consuming CLI. Pass an explicit value to opt into independent
+versioning (e.g. a bundle vendored from another package at a different
+release cadence).
+
+```ts
+skillPlugin({
+  version: pkg.version,
+  customSkills: [
+    // Inherits `version: pkg.version` from the plugin.
+    { name: "funnel-builder", sourceDir: "skills/funnel-builder" },
+    // Explicit override for an independently-versioned bundle.
+    {
+      name: "vendored-toolkit",
+      sourceDir: "skills/vendored-toolkit",
+      version: "0.3.0",
+    },
+  ],
+});
+```
+
+This aligns `version` with how `scope` and `installMode` already inherit
+from the plugin. The existing required-`version` shape keeps working —
+all current configs are unchanged.
+
+Setup-time validation now rejects an explicit empty-string `version` so a
+typo can't silently fall through to the plugin-level fallback. Omitting
+the field entirely is the supported way to inherit.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -51,6 +51,7 @@ interface SkillPluginOptions {
   autoUpdate?: boolean; // default: true
   command?: string; // default: "skill"
   instructions?: string | string[]; // extra top-level SKILL.md content
+  customSkills?: CustomSkillConfig[]; // hand-authored bundles, default: []
 }
 ```
 
@@ -103,6 +104,60 @@ The user toggles options on or off and the system reconciles the desired state:
 ```sh
 my-cli skill
 ```
+
+### Hand-authored bundles via `customSkills`
+
+The plugin can manage hand-authored skill bundles alongside the auto-
+generated command-reference skill. Each entry is reconciled through the
+same lifecycle: auto-update on version change, surfaced in the
+interactive `skill` subcommand multiselect (one prompt per bundle, in
+array order, after the main-skill prompt), supports uninstall via the
+same toggle UX, and respects `autoUpdate: false` and `--all`.
+
+```ts
+import { Crust } from "@crustjs/core";
+import { skillPlugin } from "@crustjs/skills";
+import pkg from "./package.json" with { type: "json" };
+
+const app = new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .use(
+    skillPlugin({
+      version: pkg.version,
+      customSkills: [
+        {
+          name: "funnel-builder",
+          sourceDir: "skills/funnel-builder",
+          version: pkg.version,
+        },
+      ],
+    }),
+  )
+  .run(() => {});
+```
+
+The `CustomSkillConfig` shape:
+
+```ts
+interface CustomSkillConfig {
+  name: string;                          // unique; must match SKILL.md frontmatter
+  sourceDir: string | URL;               // file:// URL, absolute path, or bare relative
+  version: string;                       // typically pkg.version
+  scope?: "global" | "project";          // overrides plugin defaultScope
+  installMode?: "auto" | "symlink" | "copy";
+}
+```
+
+Resolution rules for `sourceDir` mirror
+[`installSkillBundle()`](#installing-hand-authored-bundles): URL with
+`file:` protocol, absolute path, or a bare relative string resolved from
+the nearest `package.json` walking up from `process.argv[1]`. Resolution
+errors surface at install time, not at plugin setup.
+
+Bundles share the canonical `.crust/skills` store with the main skill
+and inherit `defaultScope` / `installMode` resolution unless overridden
+per-entry. When `customSkills` is omitted or empty, plugin behavior is
+byte-identical to today.
 
 ## Conflict Detection
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -127,10 +127,13 @@ const app = new Crust("my-cli")
     skillPlugin({
       version: pkg.version,
       customSkills: [
+        // Inherits `version: pkg.version` from the plugin.
+        { name: "funnel-builder", sourceDir: "skills/funnel-builder" },
+        // Explicit override for an independently-versioned bundle.
         {
-          name: "funnel-builder",
-          sourceDir: "skills/funnel-builder",
-          version: pkg.version,
+          name: "vendored-toolkit",
+          sourceDir: "skills/vendored-toolkit",
+          version: "0.3.0",
         },
       ],
     }),
@@ -144,11 +147,19 @@ The `CustomSkillConfig` shape:
 interface CustomSkillConfig {
   name: string;                          // unique; must match SKILL.md frontmatter
   sourceDir: string | URL;               // file:// URL, absolute path, or bare relative
-  version: string;                       // typically pkg.version
+  version?: string;                      // inherits plugin `version` when omitted
   scope?: "global" | "project";          // overrides plugin defaultScope
   installMode?: "auto" | "symlink" | "copy";
 }
 ```
+
+`version` is optional: omit it to inherit the plugin's top-level
+`version` (the typical case when the bundle ships in the same package as
+the CLI), or pass an explicit value when a bundle's release cadence is
+independent of the consuming CLI. The bundle's `SKILL.md` frontmatter
+`version:` / `metadata.version`, if any, is intentionally not read — see
+the [`installSkillBundle()` callout](#installing-hand-authored-bundles)
+for the rationale.
 
 Resolution rules for `sourceDir` mirror
 [`installSkillBundle()`](#installing-hand-authored-bundles): URL with

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -108,11 +108,13 @@ my-cli skill
 ### Hand-authored bundles via `customSkills`
 
 The plugin can manage hand-authored skill bundles alongside the auto-
-generated command-reference skill. Each entry is reconciled through the
-same lifecycle: auto-update on version change, surfaced in the
-interactive `skill` subcommand multiselect (one prompt per bundle, in
-array order, after the main-skill prompt), supports uninstall via the
-same toggle UX, and respects `autoUpdate: false` and `--all`.
+generated command-reference skill. Each entry follows the same plugin
+lifecycle as the main skill — auto-update, interactive multiselect, and
+`skill update` — and gets its own multiselect prompt after the main one,
+in array order. See the [`@crustjs/skills` README][skills-custom] for
+the full reference.
+
+[skills-custom]: https://github.com/chenxin-yan/crust/tree/main/packages/skills#hand-authored-bundles-via-customskills
 
 ```ts
 import { Crust } from "@crustjs/core";

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -156,8 +156,8 @@ errors surface at install time, not at plugin setup.
 
 Bundles share the canonical `.crust/skills` store with the main skill
 and inherit `defaultScope` / `installMode` resolution unless overridden
-per-entry. When `customSkills` is omitted or empty, plugin behavior is
-byte-identical to today.
+per-entry. When `customSkills` is omitted or empty, only the generated
+main skill is managed.
 
 ## Conflict Detection
 
@@ -406,15 +406,16 @@ consuming package's `package.json` `version` is the typical pattern.
 | Option        | Type                            | Default    | Description                                                                                                                        |
 | ------------- | ------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `sourceDir`   | `string \| URL`                 | — required | Bundle directory. Absolute path, `file:` URL, or relative path resolved from the nearest `package.json`.                           |
-| `agents`      | `AgentTarget[]`                 | — required | Agents to install for. `[]` is a no-op (no auto-detection — unlike `generateSkill()`).                                             |
+| `agents`      | `AgentTarget[]`                 | — required | Agents to install for. `[]` validates the bundle without installing (no auto-detection — unlike `generateSkill()`).                 |
 | `version`     | `string`                        | — required | Recorded in `crust.json` and compared on subsequent installs. Typically wired to the consuming package's `package.json` `version`. |
 | `scope`       | `"global" \| "project"`         | `"global"` | Install scope. When `process.cwd()` is the home directory, `"project"` normalizes to `"global"`.                                   |
 | `installMode` | `"auto" \| "symlink" \| "copy"` | `"auto"`   | Same semantics as `generateSkill()`. `"auto"` symlinks from the canonical store, falling back to copy.                             |
 | `clean`       | `boolean`                       | `true`     | Remove the existing skill directory before writing.                                                                                |
 | `force`       | `boolean`                       | `false`    | Overwrite a conflicting directory (no `crust.json`, kind mismatch, or malformed manifest) instead of throwing.                     |
 
-Crust copies the bundle's `SKILL.md` and supporting files as UTF-8 text —
-binary files are not supported and will be corrupted on round-trip.
+Crust copies bundle files as raw bytes, so supporting assets such as images,
+fonts, or scripts round-trip unchanged. `SKILL.md` is also parsed as UTF-8 to
+read its required frontmatter.
 
 `crust.json` at the bundle root is **reserved**: Crust regenerates it
 during installation. If a `crust.json` is found in the source bundle,

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -590,7 +590,7 @@ await installSkillBundle({
 | Option        | Type                                | Default     | Description                                                                                                       |
 | ------------- | ----------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
 | `sourceDir`   | `string \| URL`                     | — required | Bundle directory. Absolute path, `file:` URL, or relative path resolved from the nearest `package.json`.          |
-| `agents`      | `AgentTarget[]`                     | — required | Agents to install for. `[]` is a no-op (no auto-detection — unlike `generateSkill()`).                            |
+| `agents`      | `AgentTarget[]`                     | — required | Agents to install for. `[]` validates the bundle without installing (no auto-detection — unlike `generateSkill()`). |
 | `version`     | `string`                            | — required | Recorded in `crust.json` and compared on subsequent installs.                                |
 | `scope`       | `"global" \| "project"`             | `"global"`  | Install scope. When `process.cwd()` is the home directory, `"project"` normalizes to `"global"`.                  |
 | `installMode` | `"auto" \| "symlink" \| "copy"`     | `"auto"`    | Same semantics as `generateSkill()`. `"auto"` symlinks from the canonical store, falling back to copy.            |
@@ -600,9 +600,9 @@ await installSkillBundle({
 ### What gets copied
 
 The bundle's `SKILL.md` plus every supporting file is copied into the
-canonical Crust store — markdown, configs, scripts, etc. Files are read and
-written as UTF-8, so binary supporting files are not currently supported and
-will be corrupted on round-trip. Open an issue if you need binary support.
+canonical Crust store — markdown, configs, scripts, images, fonts, and other
+assets. Bundle files are copied as raw bytes; `SKILL.md` is also parsed as
+UTF-8 to read its required frontmatter.
 
 Bundle content changes do not propagate without a `version` bump:
 identical-version reinstalls report `up-to-date` and leave the canonical

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -94,12 +94,19 @@ const app = new Crust("my-cli")
     skillPlugin({
       version: pkg.version,
       customSkills: [
+        // Inherits `version: pkg.version` from the plugin — the typical
+        // case when the bundle ships in the same package as the CLI.
         {
           name: "funnel-builder",
           // Resolved against the nearest package.json walking up from
           // process.argv[1] — same rules as installSkillBundle().
           sourceDir: "skills/funnel-builder",
-          version: pkg.version,
+        },
+        // Explicit override for an independently-versioned bundle.
+        {
+          name: "vendored-toolkit",
+          sourceDir: "skills/vendored-toolkit",
+          version: "0.3.0",
         },
       ],
     }),
@@ -113,13 +120,18 @@ await app.execute();
   characters and hyphens, no leading/trailing/consecutive hyphens), must
   be unique within the array, and must not collide with the main skill's
   name. The bundle's `SKILL.md` frontmatter must declare a matching
-  `name:` field — it is the source of truth at install time.
+  `name:` field — mismatches are rejected at install time.
 - **`sourceDir`** accepts a `URL` (`file:` protocol), an absolute path, or
   a relative string resolved from the nearest `package.json`. Resolution
   errors surface at install time, not at plugin setup.
-- **`version`** is required and typically wired to the consuming package's
-  `package.json` `version`. Identical-version reinstalls are skipped, so
-  bump this whenever the bundle contents change.
+- **`version`** is optional. When omitted, the bundle inherits the
+  plugin's top-level `version` — the typical case when the bundle ships
+  alongside the CLI. Pass an explicit value when the bundle's release
+  cadence is independent of the consuming CLI (for example, vendored
+  from another package). Identical-version reinstalls are skipped, so
+  bump the effective version whenever bundle contents change. The
+  bundle's `SKILL.md` frontmatter `version:` / `metadata.version`, if
+  any, is intentionally ignored — see the [`installSkillBundle()` note](#installing-hand-authored-bundles).
 - **`scope`** and **`installMode`** are optional per-entry overrides;
   unset values inherit from the plugin's `defaultScope` / `installMode`.
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -609,13 +609,11 @@ identical-version reinstalls report `up-to-date` and leave the canonical
 store untouched. Pass a fresh `version` (typically wired to the consuming
 package's `package.json` `version`) whenever the bundle contents change.
 
-Exclusions at the bundle root only:
-
-- `node_modules/`, `.DS_Store`
-- Any dotfile at the root (e.g. `.git/`, `.editorconfig`, `.gitignore`)
-- Any pre-existing `crust.json` (Crust regenerates it)
-
-Dotfiles inside subdirectories **are** copied.
+Bundle contents are copied as authored — no implicit name-based filtering.
+Dotfiles, `node_modules/`, `.DS_Store`, and editor cruft are all copied if
+present. Keep `sourceDir` clean. The only reserved filename is
+`crust.json` at the bundle root (Crust generates this and rejects bundles
+that ship one).
 
 ### Publishing a bundle to npm
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -76,6 +76,66 @@ The plugin automatically updates already-installed skills when the version chang
 
 Generated bundles are written once to a canonical store (`.crust/skills` for project scope, `~/.crust/skills` for global scope) and then installed into agent paths via symlink or copy depending on `installMode`.
 
+#### Hand-authored bundles via `customSkills`
+
+The plugin can also manage **hand-authored** skill bundles alongside the
+auto-generated command-reference skill. Pass an array of
+`CustomSkillConfig` entries via `customSkills`; each entry is reconciled
+through the same lifecycle as the main skill.
+
+```ts
+import { Crust } from "@crustjs/core";
+import { skillPlugin } from "@crustjs/skills";
+import pkg from "./package.json" with { type: "json" };
+
+const app = new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .use(
+    skillPlugin({
+      version: pkg.version,
+      customSkills: [
+        {
+          name: "funnel-builder",
+          // Resolved against the nearest package.json walking up from
+          // process.argv[1] — same rules as installSkillBundle().
+          sourceDir: "skills/funnel-builder",
+          version: pkg.version,
+        },
+      ],
+    }),
+  )
+  .run(() => {});
+
+await app.execute();
+```
+
+- **`name`** must satisfy `isValidSkillName` (1–64 lowercase alphanumeric
+  characters and hyphens, no leading/trailing/consecutive hyphens), must
+  be unique within the array, and must not collide with the main skill's
+  name. The bundle's `SKILL.md` frontmatter must declare a matching
+  `name:` field — it is the source of truth at install time.
+- **`sourceDir`** accepts a `URL` (`file:` protocol), an absolute path, or
+  a relative string resolved from the nearest `package.json`. Resolution
+  errors surface at install time, not at plugin setup.
+- **`version`** is required and typically wired to the consuming package's
+  `package.json` `version`. Identical-version reinstalls are skipped, so
+  bump this whenever the bundle contents change.
+- **`scope`** and **`installMode`** are optional per-entry overrides;
+  unset values inherit from the plugin's `defaultScope` / `installMode`.
+
+The interactive `skill` command shows one multiselect prompt per skill in
+order: the main auto-generated skill first, then each `customSkills`
+entry with its name in the prompt header (e.g. `"Select agents to install
+skills for [funnel-builder]"`). Each prompt is independent — selecting
+or deselecting agents reconciles only that skill's installs. `skill
+--all` skips every prompt and installs every skill for the full agent
+set; `skill update` updates outdated installs across main + every bundle.
+
+Auto-update on plugin startup is per-skill: only outdated installs are
+rewritten, and a single bundle's failure (e.g. missing `sourceDir`) does
+not abort the others. Pass `autoUpdate: false` to disable startup auto-
+update for both the main skill and all bundles.
+
 ### Programmatic Auto-Install
 
 For full control over first-time installation, call `generateSkill()`

--- a/packages/skills/src/bundle.test.ts
+++ b/packages/skills/src/bundle.test.ts
@@ -490,7 +490,43 @@ describe("installSkillBundle", () => {
 		expect(agent.status).toBe("up-to-date");
 	});
 
-	it("agents: [] is a no-op", async () => {
+	it("agents: [] validates the bundle before returning", async () => {
+		const dir = join(tmpDir, "missing-skill-md");
+		await mkdir(dir, { recursive: true });
+
+		await expect(
+			withCwd(tmpDir, () =>
+				installSkillBundle({
+					sourceDir: dir,
+					agents: [],
+					scope: "project",
+					version: BUNDLE_VERSION,
+				}),
+			),
+		).rejects.toThrow(/SKILL\.md/);
+	});
+
+	it("agents: [] validates the frontmatter skill name before returning", async () => {
+		const dir = join(tmpDir, "invalid-empty-agent");
+		await mkdir(dir, { recursive: true });
+		await writeFile(
+			join(dir, "SKILL.md"),
+			"---\nname: Funnel-Builder\ndescription: Build a sales funnel\n---\n",
+		);
+
+		await expect(
+			withCwd(tmpDir, () =>
+				installSkillBundle({
+					sourceDir: dir,
+					agents: [],
+					scope: "project",
+					version: BUNDLE_VERSION,
+				}),
+			),
+		).rejects.toThrow(/Invalid skill name/);
+	});
+
+	it("agents: [] is a validated no-op", async () => {
 		const result = await withCwd(tmpDir, () =>
 			installSkillBundle({
 				sourceDir: FIXTURE_DIR,
@@ -503,6 +539,31 @@ describe("installSkillBundle", () => {
 		// No canonical directory created.
 		const canonicalDir = join(tmpDir, ".crust", "skills", "funnel-builder");
 		await expect(stat(canonicalDir)).rejects.toThrow();
+	});
+
+	it("preserves binary bundle files exactly", async () => {
+		const dir = join(tmpDir, "with-binary");
+		await mkdir(dir, { recursive: true });
+		const binary = new Uint8Array([0xff, 0xfe, 0x00, 0x61, 0xc3, 0x28]);
+		await writeFile(join(dir, "asset.bin"), binary);
+		await writeFile(
+			join(dir, "SKILL.md"),
+			"---\nname: funnel-builder\ndescription: Build a sales funnel\n---\n",
+		);
+
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: dir,
+				agents: ["claude-code"],
+				scope: "project",
+				version: BUNDLE_VERSION,
+			}),
+		);
+
+		const canonicalAsset = await readFile(
+			join(tmpDir, ".crust", "skills", "funnel-builder", "asset.bin"),
+		);
+		expect([...canonicalAsset]).toEqual([...binary]);
 	});
 
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/skills/src/bundle.ts
+++ b/packages/skills/src/bundle.ts
@@ -368,11 +368,11 @@ export async function loadBundleFiles(
 	const files = await Promise.all(
 		collected.map(async (entry) => ({
 			path: entry.relPath,
-			content: await readFile(entry.absPath, "utf-8"),
+			content: await readFile(entry.absPath),
 		})),
 	);
 
-	const skillContent = files.find((f) => f.path === SKILL_MD)?.content ?? "";
+	const skillContent = await readFile(skillMd.absPath, "utf-8");
 	const probed = probeFrontmatter(skillContent);
 
 	if (probed.name === null || probed.name === "") {
@@ -454,10 +454,6 @@ export async function installSkillBundle(
 		installMode = "auto",
 	} = options;
 
-	if (agents.length === 0) {
-		return { agents: [] };
-	}
-
 	const { files, frontmatter } = await loadBundleFiles(sourceDir);
 
 	const resolvedName = resolveSkillName(frontmatter.name);
@@ -466,6 +462,10 @@ export async function installSkillBundle(
 			`Invalid skill name "${resolvedName}" in SKILL.md frontmatter: must be 1–64 lowercase ` +
 				`alphanumeric characters and hyphens, no leading/trailing/consecutive hyphens.`,
 		);
+	}
+
+	if (agents.length === 0) {
+		return { agents: [] };
 	}
 
 	const meta: SkillMeta = {

--- a/packages/skills/src/bundle.ts
+++ b/packages/skills/src/bundle.ts
@@ -426,8 +426,8 @@ export async function loadBundleFiles(
  *   kind or with no `crust.json` (and `force` is not set).
  * @throws {Error} If `SKILL.md` is missing, its frontmatter lacks `name:` or
  *   `description:`, the declared `name` is not a valid skill name, the
- *   source directory escapes itself via symlink, or `sourceDir` cannot be
- *   resolved.
+ *   declared `name` does not match `expectedName` when set, the source
+ *   directory escapes itself via symlink, or `sourceDir` cannot be resolved.
  *
  * @example
  * ```ts
@@ -452,6 +452,7 @@ export async function installSkillBundle(
 		clean = true,
 		force = false,
 		installMode = "auto",
+		expectedName,
 	} = options;
 
 	const { files, frontmatter } = await loadBundleFiles(sourceDir);
@@ -461,6 +462,13 @@ export async function installSkillBundle(
 		throw new Error(
 			`Invalid skill name "${resolvedName}" in SKILL.md frontmatter: must be 1–64 lowercase ` +
 				`alphanumeric characters and hyphens, no leading/trailing/consecutive hyphens.`,
+		);
+	}
+
+	if (expectedName !== undefined && resolvedName !== expectedName) {
+		throw new Error(
+			`Bundle SKILL.md frontmatter name "${resolvedName}" does not match the expected name "${expectedName}". ` +
+				`Update the bundle's SKILL.md frontmatter \`name:\` field, or change the configured \`name\` to match.`,
 		);
 	}
 

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -1154,6 +1154,10 @@ async function writeFiles(
 	// Write files sequentially in deterministic order (already sorted by caller)
 	for (const file of files) {
 		const filePath = join(baseDir, file.path);
-		await writeFile(filePath, file.content, "utf-8");
+		if (typeof file.content === "string") {
+			await writeFile(filePath, file.content, "utf-8");
+		} else {
+			await writeFile(filePath, file.content);
+		}
 	}
 }

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -39,6 +39,7 @@ export type {
 	AgentClass,
 	AgentResult,
 	AgentTarget,
+	CustomSkillConfig,
 	GenerateOptions,
 	GenerateResult,
 	InstallSkillBundleOptions,

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -1317,7 +1317,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		expect(await readInstalledVersion(bundleDir)).toBe("2.0.0");
 	});
 
-	it("is byte-identical to today when customSkills is omitted", async () => {
+	it("does not install bundles when customSkills is omitted", async () => {
 		// Same as the existing "auto-updates already-installed skills" test but
 		// asserts that no bundle directory is ever created.
 		const app = new Crust("identical-test")

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -9,12 +9,29 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { CrustPlugin } from "@crustjs/core";
 import { Crust, VALIDATION_MODE_ENV } from "@crustjs/core";
+import { installSkillBundle } from "./bundle.ts";
 import { generateSkill } from "./generate.ts";
 import { skillPlugin } from "./plugin.ts";
 import { readInstalledVersion } from "./version.ts";
+
+const FIXTURE_DIR = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"tests",
+	"fixtures",
+	"bundle",
+);
+const FIXTURE_DIR_SECOND = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"tests",
+	"fixtures",
+	"bundle-second",
+);
 
 function shortCircuitPlugin(): CrustPlugin {
 	return {
@@ -791,5 +808,821 @@ describe("skillPlugin auto-update", () => {
 
 		expect((await lstat(outputDir)).isSymbolicLink()).toBe(false);
 		expect((await stat(canonicalDir)).isDirectory()).toBe(true);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// customSkills — setup-time validation
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Helper for validation tests: Crust's `setup()` hooks throw asynchronously
+ * but `execute()` catches the error, prints `Error: <message>` to stderr,
+ * and sets `process.exitCode = 1`. Capture stderr + reset exitCode so the
+ * test can assert on the message.
+ */
+async function captureSetupError(fn: () => Promise<void>): Promise<{
+	stderr: string;
+	exitCode: number | undefined;
+}> {
+	const stderrChunks: string[] = [];
+	const origErr = console.error;
+	// Reset process.exitCode so the test can observe what `execute()` set
+	// without picking up stale state from a previous test. Restore to 0
+	// afterwards so a non-zero exitCode set by `execute()` does not leak
+	// into the bun:test runner's final exit code.
+	process.exitCode = 0;
+	console.error = (...args: unknown[]) => {
+		stderrChunks.push(args.join(" "));
+	};
+	try {
+		await fn();
+	} finally {
+		console.error = origErr;
+	}
+	const exitCode = process.exitCode as number | undefined;
+	process.exitCode = 0;
+	return { stderr: stderrChunks.join("\n"), exitCode };
+}
+
+describe("skillPlugin customSkills validation", () => {
+	it("accepts an empty array", async () => {
+		const app = new Crust("empty-custom")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [],
+				}),
+			);
+
+		await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+	});
+
+	it("accepts a URL sourceDir", async () => {
+		const app = new Crust("url-custom")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: pathToFileURL(`${FIXTURE_DIR}/`),
+							version: "1.0.0",
+						},
+					],
+					autoUpdate: false,
+				}),
+			);
+
+		await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+	});
+
+	it("accepts an absolute string sourceDir", async () => {
+		const app = new Crust("abs-custom")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+					autoUpdate: false,
+				}),
+			);
+
+		await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+	});
+
+	it("accepts a relative string sourceDir at setup (resolution defers to install)", async () => {
+		// Setup must not throw — resolution-time errors defer to installSkillBundle.
+		const app = new Crust("rel-custom")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: "some/relative/path",
+							version: "1.0.0",
+						},
+					],
+					autoUpdate: false,
+				}),
+			);
+
+		// No bundle is installed, so autoUpdate sweep finds nothing and exits.
+		await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+	});
+
+	it("rejects a name that collides with the main skill", async () => {
+		const app = new Crust("collide-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "collide-test",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const { stderr, exitCode } = await captureSetupError(() =>
+			app.execute({ argv: [] }),
+		);
+
+		expect(stderr).toMatch(/collides with the main skill name/);
+		expect(exitCode).toBe(1);
+	});
+
+	it("rejects duplicate names within the array", async () => {
+		const app = new Crust("dup-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		const { stderr, exitCode } = await captureSetupError(() =>
+			app.execute({ argv: [] }),
+		);
+
+		expect(stderr).toMatch(/duplicate name "funnel-builder"/);
+		expect(exitCode).toBe(1);
+	});
+
+	it("rejects an invalid skill name", async () => {
+		const app = new Crust("invalid-name-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "Invalid Name!",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const { stderr, exitCode } = await captureSetupError(() =>
+			app.execute({ argv: [] }),
+		);
+
+		expect(stderr).toMatch(/is not a valid skill name/);
+		expect(exitCode).toBe(1);
+	});
+
+	it("rejects an empty version string", async () => {
+		const app = new Crust("empty-version-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "",
+						},
+					],
+				}),
+			);
+
+		const { stderr, exitCode } = await captureSetupError(() =>
+			app.execute({ argv: [] }),
+		);
+
+		expect(stderr).toMatch(/must be a non-empty string/);
+		expect(exitCode).toBe(1);
+	});
+
+	it("rejects a non-string non-URL sourceDir", async () => {
+		const app = new Crust("bad-src-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							// biome-ignore lint/suspicious/noExplicitAny: deliberate type-violation for negative test
+							sourceDir: 42 as any,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const { stderr, exitCode } = await captureSetupError(() =>
+			app.execute({ argv: [] }),
+		);
+
+		expect(stderr).toMatch(/must be a string or URL/);
+		expect(exitCode).toBe(1);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// customSkills — autoUpdate behavior
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("skillPlugin customSkills auto-update", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = join(
+			tmpdir(),
+			`crust-skill-plugin-custom-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(join(tmpDir, ".opencode"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("auto-updates an installed bundle when version changes", async () => {
+		// Pre-install bundle at v1.0.0 in tmpDir.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+
+		const app = new Crust("bundle-update-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		expect(await readInstalledVersion(bundleDir)).toBe("2.0.0");
+	});
+
+	it("does not auto-update an up-to-date bundle", async () => {
+		// Pre-install bundle at v1.0.0; plugin will run with same version.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		const skillMd = join(bundleDir, "SKILL.md");
+		const statBefore = await stat(skillMd);
+
+		const app = new Crust("bundle-noop-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		const statAfter = await stat(skillMd);
+		expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+	});
+
+	it("continues after a per-bundle error so other bundles still update", async () => {
+		// Pre-install bundle-second at v1.0.0; the first entry has a bogus
+		// sourceDir which should fail at install time — the second entry should
+		// still be reconciled.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR_SECOND,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const secondDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+		expect(await readInstalledVersion(secondDir)).toBe("1.0.0");
+
+		// Pre-install funnel-builder at v1.0.0 too so the bogus first entry
+		// triggers a sourceDir resolution error during the install path.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const originalWrite = process.stderr.write;
+		process.stderr.write = (() => true) as typeof process.stderr.write;
+
+		const app = new Crust("bundle-resilience-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							// Bogus path — install will throw at resolve time.
+							sourceDir: "/nonexistent/path/to/funnel-builder",
+							version: "2.0.0",
+						},
+						{
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR_SECOND,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		try {
+			await withCwd(tmpDir, () => app.execute({ argv: [] }));
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+
+		// Second bundle still updated, despite first entry's error.
+		expect(await readInstalledVersion(secondDir)).toBe("2.0.0");
+	});
+
+	it("skips bundle auto-update when autoUpdate is false", async () => {
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+
+		const app = new Crust("no-auto-update-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "2.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+	});
+
+	it("skips bundle auto-update when invoking the skill subcommand", async () => {
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+
+		// Install a base main skill so the `skill update` doesn't trigger
+		// further bundle work — the host argv enters the skill subcommand.
+		const app = new Crust("subcmd-skip-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		const originalIsTTY = Object.getOwnPropertyDescriptor(
+			process.stdin,
+			"isTTY",
+		);
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			// Use `skill update` so the bundle path runs explicitly under the
+			// subcommand, not via the auto-update setup hook.
+			await withCwd(tmpDir, () => app.execute({ argv: ["skill", "update"] }));
+		} finally {
+			if (originalIsTTY) {
+				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+			}
+			console.log = origLog;
+		}
+
+		// `skill update` itself updates the bundle — and the auto-update hook
+		// did NOT run separately. Net result: bundle is at v2.0.0 because the
+		// subcommand ran. Sanity check that the subcommand still does its job.
+		expect(await readInstalledVersion(bundleDir)).toBe("2.0.0");
+	});
+
+	it("is byte-identical to today when customSkills is omitted", async () => {
+		// Same as the existing "auto-updates already-installed skills" test but
+		// asserts that no bundle directory is ever created.
+		const app = new Crust("identical-test")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "2.0.0",
+					defaultScope: "project",
+				}),
+			);
+
+		await withCwd(tmpDir, () =>
+			generateSkill({
+				command: app._node,
+				meta: {
+					name: "identical-test",
+					description: "test",
+					version: "1.0.0",
+				},
+				agents: ["opencode"],
+				scope: "project",
+			}),
+		);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		const skillDir = join(tmpDir, ".agents", "skills", "identical-test");
+		expect(await readInstalledVersion(skillDir)).toBe("2.0.0");
+
+		// No funnel-builder dir was created.
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		await expect(stat(funnelDir)).rejects.toThrow();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// customSkills — interactive `skill` command
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("skillPlugin customSkills interactive command", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = join(
+			tmpdir(),
+			`crust-skill-plugin-custom-cmd-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(join(tmpDir, ".opencode"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("--all installs main + every bundle without prompting", async () => {
+		const app = new Crust("all-flag-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+						{
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR_SECOND,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const originalIsTTY = Object.getOwnPropertyDescriptor(
+			process.stdin,
+			"isTTY",
+		);
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await withCwd(tmpDir, () => app.execute({ argv: ["skill", "--all"] }));
+		} finally {
+			if (originalIsTTY) {
+				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+			}
+			console.log = origLog;
+		}
+
+		const mainDir = join(tmpDir, ".agents", "skills", "all-flag-host");
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		const pricingDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+
+		expect(await readInstalledVersion(mainDir)).toBe("1.0.0");
+		expect(await readInstalledVersion(funnelDir)).toBe("1.0.0");
+		expect(await readInstalledVersion(pricingDir)).toBe("1.0.0");
+	});
+
+	it("prints sequential per-skill output (heading mentions bundle name)", async () => {
+		const app = new Crust("sequential-output-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const originalIsTTY = Object.getOwnPropertyDescriptor(
+			process.stdin,
+			"isTTY",
+		);
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		const logs: string[] = [];
+		const origLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			await withCwd(tmpDir, () => app.execute({ argv: ["skill", "--all"] }));
+		} finally {
+			if (originalIsTTY) {
+				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+			}
+			console.log = origLog;
+		}
+
+		// Main heading uses original "Installed <name>" form.
+		expect(
+			logs.some((line) => line.includes('Installed "sequential-output-host"')),
+		).toBe(true);
+		// Bundle heading mentions the bundle keyword and bundle name.
+		expect(
+			logs.some(
+				(line) => line.includes("bundle") && line.includes('"funnel-builder"'),
+			),
+		).toBe(true);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// customSkills — `skill update` subcommand
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("skillPlugin customSkills `skill update`", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = join(
+			tmpdir(),
+			`crust-skill-plugin-custom-update-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(join(tmpDir, ".opencode"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("updates main + every bundle in sequence", async () => {
+		const app = new Crust("update-loop-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "2.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+						{
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR_SECOND,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		// Pre-install all three at v1.0.0.
+		await withCwd(tmpDir, () =>
+			generateSkill({
+				command: app._node,
+				meta: {
+					name: "update-loop-host",
+					description: "test",
+					version: "1.0.0",
+				},
+				agents: ["opencode"],
+				scope: "project",
+			}),
+		);
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR_SECOND,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await withCwd(tmpDir, () =>
+				app.execute({ argv: ["skill", "update", "--scope", "project"] }),
+			);
+		} finally {
+			console.log = origLog;
+		}
+
+		const mainDir = join(tmpDir, ".agents", "skills", "update-loop-host");
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		const pricingDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+
+		expect(await readInstalledVersion(mainDir)).toBe("2.0.0");
+		expect(await readInstalledVersion(funnelDir)).toBe("2.0.0");
+		expect(await readInstalledVersion(pricingDir)).toBe("2.0.0");
+	});
+
+	it("reports per-skill 'No updates needed' when nothing is outdated", async () => {
+		const app = new Crust("update-noop-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () =>
+			generateSkill({
+				command: app._node,
+				meta: {
+					name: "update-noop-host",
+					description: "test",
+					version: "1.0.0",
+				},
+				agents: ["opencode"],
+				scope: "project",
+			}),
+		);
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const logs: string[] = [];
+		const origLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+		try {
+			await withCwd(tmpDir, () =>
+				app.execute({ argv: ["skill", "update", "--scope", "project"] }),
+			);
+		} finally {
+			console.log = origLog;
+		}
+
+		expect(logs.some((line) => line.includes("No updates needed"))).toBe(true);
+		expect(logs.some((line) => line.includes("[funnel-builder]"))).toBe(true);
 	});
 });

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -858,7 +858,22 @@ describe("skillPlugin customSkills validation", () => {
 				}),
 			);
 
-		await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+		// Empty `customSkills` must be a true no-op: setup completes, no
+		// warnings surface, and exit code stays 0.
+		const warnings: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+		const origExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			await expect(app.execute({ argv: [] })).resolves.toBeUndefined();
+		} finally {
+			console.warn = origWarn;
+			process.exitCode = origExitCode;
+		}
+		expect(warnings).toEqual([]);
 	});
 
 	it("accepts a URL sourceDir", async () => {
@@ -1066,6 +1081,91 @@ describe("skillPlugin customSkills validation", () => {
 	});
 });
 
+describe("skillPlugin customSkills name mismatch", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = join(
+			tmpdir(),
+			`crust-skill-plugin-name-mismatch-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(join(tmpDir, ".opencode"), { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("refuses to install when entry.name disagrees with SKILL.md frontmatter name", async () => {
+		// Pre-install pricing-toolkit at v1.0.0 (using its real fixture) so the
+		// auto-update path actually invokes installSkillBundle for that entry.
+		// The plugin entry then points at FIXTURE_DIR (whose frontmatter
+		// declares funnel-builder) — expectedName must reject the mismatch.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR_SECOND,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		const pricingDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+		expect(await readInstalledVersion(pricingDir)).toBe("1.0.0");
+
+		const warnings: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+
+		const app = new Crust("name-mismatch-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							// Config name claims pricing-toolkit, but FIXTURE_DIR's
+							// SKILL.md frontmatter declares funnel-builder. Without
+							// expectedName enforcement, the funnel-builder install
+							// would silently install at v2.0.0 under the wrong
+							// directory.
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		const origExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			await withCwd(tmpDir, () => app.execute({ argv: [] }));
+		} finally {
+			console.warn = origWarn;
+			process.exitCode = origExitCode;
+		}
+
+		// pricing-toolkit must remain at 1.0.0 — the install was rejected.
+		expect(await readInstalledVersion(pricingDir)).toBe("1.0.0");
+		// No orphan funnel-builder dir was created.
+		await expect(stat(funnelDir)).rejects.toThrow();
+		// The mismatch warning surfaces with both names so the bundle author
+		// can see exactly what disagreed.
+		expect(
+			warnings.some(
+				(line) =>
+					line.includes("pricing-toolkit") && line.includes("funnel-builder"),
+			),
+		).toBe(true);
+	});
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // customSkills — autoUpdate behavior
 // ─────────────────────────────────────────────────────────────────────────
@@ -1133,8 +1233,12 @@ describe("skillPlugin customSkills auto-update", () => {
 		);
 
 		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
-		const skillMd = join(bundleDir, "SKILL.md");
-		const statBefore = await stat(skillMd);
+		// Drop a sentinel inside the installed bundle. If the auto-update path
+		// rewrites the bundle (clean: true), the sentinel is removed; if it
+		// short-circuits as up-to-date, the sentinel survives. This is more
+		// reliable than mtime equality on coarse-resolution filesystems.
+		const sentinel = join(bundleDir, ".sentinel");
+		await writeFile(sentinel, "do-not-touch");
 
 		const app = new Crust("bundle-noop-host")
 			.meta({ description: "test" })
@@ -1155,8 +1259,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		await withCwd(tmpDir, () => app.execute({ argv: [] }));
 
-		const statAfter = await stat(skillMd);
-		expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+		expect(await readFile(sentinel, "utf8")).toBe("do-not-touch");
 		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
 	});
 
@@ -1187,8 +1290,16 @@ describe("skillPlugin customSkills auto-update", () => {
 			}),
 		);
 
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		expect(await readInstalledVersion(funnelDir)).toBe("1.0.0");
+
 		const originalWrite = process.stderr.write;
 		process.stderr.write = (() => true) as typeof process.stderr.write;
+		const warnings: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
 
 		const app = new Crust("bundle-resilience-host")
 			.meta({ description: "test" })
@@ -1217,10 +1328,17 @@ describe("skillPlugin customSkills auto-update", () => {
 			await withCwd(tmpDir, () => app.execute({ argv: [] }));
 		} finally {
 			process.stderr.write = originalWrite;
+			console.warn = origWarn;
 		}
 
 		// Second bundle still updated, despite first entry's error.
 		expect(await readInstalledVersion(secondDir)).toBe("2.0.0");
+		// First bundle stayed at its previous version.
+		expect(await readInstalledVersion(funnelDir)).toBe("1.0.0");
+		// Warning surfaced naming the failed bundle.
+		expect(warnings.some((line) => line.includes("[funnel-builder]"))).toBe(
+			true,
+		);
 	});
 
 	it("skips bundle auto-update when autoUpdate is false", async () => {
@@ -1260,6 +1378,12 @@ describe("skillPlugin customSkills auto-update", () => {
 	});
 
 	it("skips bundle auto-update when invoking the skill subcommand", async () => {
+		// Pre-install at v1.0.0; configure entry with a bogus sourceDir at
+		// v2.0.0. Both the auto-update setup hook and the `skill update`
+		// subcommand would *try* to reconcile this entry, and both would emit
+		// a warning when the install fails. Counting warnings is the only
+		// instrument-free way to distinguish "both ran" (2 warnings) from
+		// "only subcommand ran" (1 warning).
 		await withCwd(tmpDir, () =>
 			installSkillBundle({
 				sourceDir: FIXTURE_DIR,
@@ -1271,8 +1395,6 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
 
-		// Install a base main skill so the `skill update` doesn't trigger
-		// further bundle work — the host argv enters the skill subcommand.
 		const app = new Crust("subcmd-skip-host")
 			.meta({ description: "test" })
 			.run(() => {})
@@ -1283,7 +1405,7 @@ describe("skillPlugin customSkills auto-update", () => {
 					customSkills: [
 						{
 							name: "funnel-builder",
-							sourceDir: FIXTURE_DIR,
+							sourceDir: "/nonexistent/path/to/funnel-builder",
 							version: "2.0.0",
 						},
 					],
@@ -1298,23 +1420,36 @@ describe("skillPlugin customSkills auto-update", () => {
 			value: false,
 			configurable: true,
 		});
+		const warnings: string[] = [];
 		const origLog = console.log;
+		const origWarn = console.warn;
 		console.log = () => {};
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+		// Reset exitCode — `skill update` will set it on the failed bundle.
+		const origExitCode = process.exitCode;
+		process.exitCode = 0;
 		try {
-			// Use `skill update` so the bundle path runs explicitly under the
-			// subcommand, not via the auto-update setup hook.
 			await withCwd(tmpDir, () => app.execute({ argv: ["skill", "update"] }));
 		} finally {
 			if (originalIsTTY) {
 				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
 			}
 			console.log = origLog;
+			console.warn = origWarn;
+			process.exitCode = origExitCode;
 		}
 
-		// `skill update` itself updates the bundle — and the auto-update hook
-		// did NOT run separately. Net result: bundle is at v2.0.0 because the
-		// subcommand ran. Sanity check that the subcommand still does its job.
-		expect(await readInstalledVersion(bundleDir)).toBe("2.0.0");
+		// Bundle stayed at v1.0.0 because the bogus sourceDir failed install.
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+		// Exactly one warning naming the failed bundle — only the `skill
+		// update` subcommand ran. If the auto-update setup hook also ran,
+		// there would be two warnings.
+		const funnelWarnings = warnings.filter((line) =>
+			line.includes("[funnel-builder]"),
+		);
+		expect(funnelWarnings.length).toBe(1);
 	});
 
 	it("does not install bundles when customSkills is omitted", async () => {
@@ -1475,6 +1610,126 @@ describe("skillPlugin customSkills interactive command", () => {
 			),
 		).toBe(true);
 	});
+
+	it("--all honors explicit --scope flag over defaultScope", async () => {
+		// Plugin defaultScope is "project", but `--scope global` should win.
+		// Bundle should land in the global scope, not the project scope.
+		const app = new Crust("all-scope-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const originalIsTTY = Object.getOwnPropertyDescriptor(
+			process.stdin,
+			"isTTY",
+		);
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		// Redirect HOME so global-scope writes land inside tmpDir, then
+		// restore. Crust derives the global path from `homedir()`, so
+		// overriding HOME is the canonical hook.
+		const origHome = process.env.HOME;
+		process.env.HOME = tmpDir;
+		const origLog = console.log;
+		console.log = () => {};
+		try {
+			await withCwd(tmpDir, () =>
+				app.execute({ argv: ["skill", "--all", "--scope", "global"] }),
+			);
+		} finally {
+			if (originalIsTTY) {
+				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+			}
+			console.log = origLog;
+			process.env.HOME = origHome;
+		}
+
+		const projectBundle = join(tmpDir, ".agents", "skills", "funnel-builder");
+		// Project-scope path must NOT exist — the explicit --scope flag wins.
+		await expect(stat(projectBundle)).rejects.toThrow();
+	});
+
+	it("--all isolates per-bundle failures and exits non-zero", async () => {
+		const app = new Crust("all-isolation-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							// Bogus path — install rejects at resolve time.
+							sourceDir: "/nonexistent/path/to/funnel-builder",
+							version: "1.0.0",
+						},
+						{
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR_SECOND,
+							version: "1.0.0",
+						},
+					],
+				}),
+			);
+
+		const originalIsTTY = Object.getOwnPropertyDescriptor(
+			process.stdin,
+			"isTTY",
+		);
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		const warnings: string[] = [];
+		const origLog = console.log;
+		const origWarn = console.warn;
+		console.log = () => {};
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+		const origExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			await withCwd(tmpDir, () => app.execute({ argv: ["skill", "--all"] }));
+		} finally {
+			if (originalIsTTY) {
+				Object.defineProperty(process.stdin, "isTTY", originalIsTTY);
+			}
+			console.log = origLog;
+			console.warn = origWarn;
+		}
+
+		// Second bundle still installed.
+		const pricingDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+		expect(await readInstalledVersion(pricingDir)).toBe("1.0.0");
+		// First bundle was rejected.
+		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		await expect(stat(funnelDir)).rejects.toThrow();
+		// Warning surfaced naming the failed bundle.
+		expect(warnings.some((line) => line.includes("[funnel-builder]"))).toBe(
+			true,
+		);
+		// Exit code is non-zero so CI/scripts notice the partial failure.
+		expect(process.exitCode).toBe(1);
+		process.exitCode = origExitCode;
+	});
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -1624,5 +1879,80 @@ describe("skillPlugin customSkills `skill update`", () => {
 
 		expect(logs.some((line) => line.includes("No updates needed"))).toBe(true);
 		expect(logs.some((line) => line.includes("[funnel-builder]"))).toBe(true);
+	});
+
+	it("isolates per-bundle failures and exits non-zero", async () => {
+		// Pre-install both bundles at v1.0.0 so `skill update` actually visits
+		// both entries (the update path only acts on installed bundles).
+		// Then the plugin entry for funnel-builder points at a bogus
+		// sourceDir, forcing its install to fail at resolve time.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR_SECOND,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const app = new Crust("update-isolation-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					autoUpdate: false,
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: "/nonexistent/path/to/funnel-builder",
+							version: "2.0.0",
+						},
+						{
+							name: "pricing-toolkit",
+							sourceDir: FIXTURE_DIR_SECOND,
+							version: "2.0.0",
+						},
+					],
+				}),
+			);
+
+		const warnings: string[] = [];
+		const origLog = console.log;
+		const origWarn = console.warn;
+		console.log = () => {};
+		console.warn = (...args: unknown[]) => {
+			warnings.push(args.join(" "));
+		};
+		const origExitCode = process.exitCode;
+		process.exitCode = 0;
+		try {
+			await withCwd(tmpDir, () =>
+				app.execute({ argv: ["skill", "update", "--scope", "project"] }),
+			);
+		} finally {
+			console.log = origLog;
+			console.warn = origWarn;
+		}
+
+		const pricingDir = join(tmpDir, ".agents", "skills", "pricing-toolkit");
+		// Second bundle updated despite first entry's failure.
+		expect(await readInstalledVersion(pricingDir)).toBe("2.0.0");
+		// Failure was logged with the bundle name.
+		expect(warnings.some((line) => line.includes("[funnel-builder]"))).toBe(
+			true,
+		);
+		// Non-zero exit so automation notices the partial failure.
+		expect(process.exitCode).toBe(1);
+		process.exitCode = origExitCode;
 	});
 });

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -1027,7 +1027,10 @@ describe("skillPlugin customSkills validation", () => {
 		expect(exitCode).toBe(1);
 	});
 
-	it("rejects an empty version string", async () => {
+	it("rejects an empty version string when set", async () => {
+		// `version` is optional and inherits from the plugin when omitted, but
+		// an explicit empty string is still rejected so a typo can't silently
+		// fall through to the plugin-level fallback.
 		const app = new Crust("empty-version-test")
 			.meta({ description: "test" })
 			.run(() => {})
@@ -1049,7 +1052,7 @@ describe("skillPlugin customSkills validation", () => {
 			app.execute({ argv: [] }),
 		);
 
-		expect(stderr).toMatch(/must be a non-empty string/);
+		expect(stderr).toMatch(/must be a non-empty string when set/);
 		expect(exitCode).toBe(1);
 	});
 
@@ -1486,6 +1489,118 @@ describe("skillPlugin customSkills auto-update", () => {
 		// No funnel-builder dir was created.
 		const funnelDir = join(tmpDir, ".agents", "skills", "funnel-builder");
 		await expect(stat(funnelDir)).rejects.toThrow();
+	});
+
+	it("inherits plugin-level version when entry omits version", async () => {
+		// Pre-install bundle at v1.0.0.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+
+		// Plugin-level version is bumped to 2.0.0; entry omits `version`, so
+		// it should inherit and trigger a reinstall to 2.0.0.
+		const app = new Crust("inherit-version-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "2.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							// version omitted on purpose — must inherit
+							// `version: "2.0.0"` from the plugin.
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		expect(await readInstalledVersion(bundleDir)).toBe("2.0.0");
+	});
+
+	it("explicit entry version overrides plugin-level version", async () => {
+		// Pre-install bundle at v1.0.0.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
+
+		// Plugin says 2.0.0 but the entry pins itself at 0.3.0 — a vendored
+		// bundle whose cadence is independent of the consuming CLI.
+		const app = new Crust("override-version-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "2.0.0",
+					defaultScope: "project",
+					customSkills: [
+						{
+							name: "funnel-builder",
+							sourceDir: FIXTURE_DIR,
+							version: "0.3.0",
+						},
+					],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		// Bundle now records the explicit override, not the plugin-level
+		// version.
+		expect(await readInstalledVersion(bundleDir)).toBe("0.3.0");
+	});
+
+	it("does not reinstall an inherited-version bundle when plugin version is unchanged", async () => {
+		// Pre-install at the same version the plugin will report. Auto-update
+		// should see no diff and skip the rewrite.
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: FIXTURE_DIR,
+				agents: ["opencode"],
+				version: "1.0.0",
+				scope: "project",
+			}),
+		);
+
+		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
+		const sentinel = join(bundleDir, ".sentinel");
+		await writeFile(sentinel, "do-not-touch");
+
+		const app = new Crust("inherit-noop-host")
+			.meta({ description: "test" })
+			.run(() => {})
+			.use(
+				skillPlugin({
+					version: "1.0.0",
+					defaultScope: "project",
+					customSkills: [{ name: "funnel-builder", sourceDir: FIXTURE_DIR }],
+				}),
+			);
+
+		await withCwd(tmpDir, () => app.execute({ argv: [] }));
+
+		expect(await readFile(sentinel, "utf8")).toBe("do-not-touch");
+		expect(await readInstalledVersion(bundleDir)).toBe("1.0.0");
 	});
 });
 

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -15,10 +15,17 @@ import {
 	resolveAgentPath,
 	resolveEffectiveScope,
 } from "./agents.ts";
+import { installSkillBundle } from "./bundle.ts";
 import { SkillConflictError } from "./errors.ts";
-import { generateSkill, skillStatus, uninstallSkill } from "./generate.ts";
+import {
+	generateSkill,
+	isValidSkillName,
+	skillStatus,
+	uninstallSkill,
+} from "./generate.ts";
 import type {
 	AgentTarget,
+	CustomSkillConfig,
 	Scope,
 	SkillMeta,
 	SkillPluginOptions,
@@ -132,6 +139,195 @@ function deriveSkillMeta(
 	};
 }
 
+/**
+ * Validates and normalizes the `customSkills` array passed to {@link skillPlugin}.
+ *
+ * Rules (run synchronously at plugin setup before any FS work):
+ * - Each `entry.name` must satisfy {@link isValidSkillName}.
+ * - `entry.name` must not collide with the main skill's name (derived from
+ *   the root command's `meta`).
+ * - `entry.name` must be unique within the array.
+ * - `entry.version` must be a non-empty string.
+ * - `entry.sourceDir` must be `string` or `URL`.
+ *
+ * Resolution-time errors (non-`file:` URL, missing source directory, missing
+ * `SKILL.md`, etc.) are deliberately deferred to the underlying
+ * {@link installSkillBundle} invocation so plugin setup stays fast.
+ *
+ * @internal Exported for unit testing via the plugin entrypoint only.
+ */
+function validateCustomSkillsConfig(
+	mainName: string,
+	customSkills: readonly CustomSkillConfig[] | undefined,
+): readonly CustomSkillConfig[] {
+	if (!customSkills || customSkills.length === 0) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	for (let i = 0; i < customSkills.length; i++) {
+		const entry = customSkills[i];
+		if (!entry || typeof entry !== "object") {
+			throw new Error(
+				`skillPlugin: customSkills[${i}] must be an object, got ${entry === null ? "null" : typeof entry}.`,
+			);
+		}
+
+		if (typeof entry.name !== "string" || entry.name.length === 0) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].name must be a non-empty string.`,
+			);
+		}
+
+		if (!isValidSkillName(entry.name)) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].name "${entry.name}" is not a valid skill name. ` +
+					`Must be 1–64 lowercase alphanumeric characters and hyphens, ` +
+					`no leading/trailing/consecutive hyphens.`,
+			);
+		}
+
+		if (entry.name === mainName) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].name "${entry.name}" collides with the main skill name. ` +
+					`Custom skill bundle names must differ from the root command name.`,
+			);
+		}
+
+		if (seen.has(entry.name)) {
+			throw new Error(
+				`skillPlugin: customSkills contains duplicate name "${entry.name}". ` +
+					`Each entry must declare a unique name.`,
+			);
+		}
+		seen.add(entry.name);
+
+		if (typeof entry.version !== "string" || entry.version.length === 0) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].version (for "${entry.name}") ` +
+					`must be a non-empty string.`,
+			);
+		}
+
+		if (
+			typeof entry.sourceDir !== "string" &&
+			!(entry.sourceDir instanceof URL)
+		) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].sourceDir (for "${entry.name}") ` +
+					`must be a string or URL, got ${typeof entry.sourceDir}.`,
+			);
+		}
+	}
+
+	return customSkills;
+}
+
+/** Resolves the effective scope for a custom-skill auto-update sweep. */
+function resolveCustomSkillScopes(
+	entry: CustomSkillConfig,
+	options: SkillPluginOptions,
+): Scope[] {
+	// When the entry declares an explicit scope, only that scope is checked.
+	// Otherwise, fall through to plugin defaultScope, else mirror main-skill
+	// behavior (check both project + global, deduped via resolveEffectiveScope).
+	const explicit = entry.scope ?? options.defaultScope;
+	if (explicit !== undefined) {
+		return [resolveEffectiveScope(explicit)];
+	}
+	return [
+		...new Set(
+			(["project", "global"] as Scope[]).map((scope) =>
+				resolveEffectiveScope(scope),
+			),
+		),
+	];
+}
+
+/**
+ * Reconciles a single hand-authored bundle entry for `autoUpdateSkills` and
+ * `skill update`. Mirrors the main-skill loop body: per-scope `skillStatus`,
+ * version diff, then a single `installSkillBundle` call for outdated agents.
+ *
+ * Per-scope `SkillConflictError`s are logged (including `kindMismatch`) and
+ * other errors propagate. Callers wrap this in their own try/catch when they
+ * want per-entry resilience across multiple bundles.
+ */
+async function autoUpdateCustomSkill(
+	entry: CustomSkillConfig,
+	options: SkillPluginOptions,
+): Promise<void> {
+	const agents = [...getUniversalAgents(), ...getAdditionalAgents()];
+	if (agents.length === 0) {
+		return;
+	}
+
+	const scopes = resolveCustomSkillScopes(entry, options);
+	const installMode = entry.installMode ?? options.installMode;
+
+	for (const scope of scopes) {
+		const status = await skillStatus({
+			name: entry.name,
+			agents,
+			scope,
+		});
+
+		const needsUpdate = status.agents.filter((a) => {
+			if (!a.installed) return false;
+			const expectedOutputDir = resolveAgentPath(a.agent, scope, entry.name);
+			return a.version !== entry.version || a.outputDir !== expectedOutputDir;
+		});
+
+		if (needsUpdate.length === 0) {
+			continue;
+		}
+
+		try {
+			await spinner({
+				message: `Updating ${scope} skills [${entry.name}]...`,
+				task: async ({ updateMessage }) => {
+					const res = await installSkillBundle({
+						sourceDir: entry.sourceDir,
+						agents: needsUpdate.map((a) => a.agent),
+						version: entry.version,
+						scope,
+						installMode,
+					});
+
+					const updatedAgents = res.agents
+						.filter((a) => a.status === "updated")
+						.map((a) => a.agent);
+					const updatedLabels = formatAgentLabels(updatedAgents);
+
+					if (updatedLabels.length > 0) {
+						updateMessage(
+							`Updated bundle "${entry.name}" to v${entry.version} for ${updatedLabels.join(", ")} (${scope})`,
+						);
+					}
+
+					return res;
+				},
+			});
+		} catch (err) {
+			if (err instanceof SkillConflictError) {
+				const kindMismatchSuffix = err.details.kindMismatch
+					? ` (existing skill is "${err.details.kindMismatch.existing}", attempted "${err.details.kindMismatch.attempted}")`
+					: "";
+				console.warn(
+					yellow(
+						`Skill conflict [${entry.name}]: "${err.details.outputDir}" already exists ` +
+							`but conflicts with the requested install${kindMismatchSuffix}. ` +
+							`Skipping auto-update for ${scope}. ` +
+							`Delete or rename the conflicting skill to resolve.`,
+					),
+				);
+			} else {
+				throw err;
+			}
+		}
+	}
+}
+
 function needsSkillReconciliation(
 	agent: AgentTarget,
 	scope: Scope,
@@ -161,12 +357,16 @@ function needsSkillReconciliation(
 async function autoUpdateSkills(
 	rootCmd: CommandNode,
 	options: SkillPluginOptions,
+	customSkills: readonly CustomSkillConfig[],
 ): Promise<void> {
 	// Use all known agents and let skillStatus (filesystem-only) determine
 	// which ones are actually installed. This avoids any PATH probing or
 	// process spawning during normal CLI startup.
 	const agents = [...getUniversalAgents(), ...getAdditionalAgents()];
 	if (agents.length === 0) {
+		// Still run the bundle loop — no agents means each `skillStatus` returns
+		// empty, and `installSkillBundle` is never called.
+		await autoUpdateCustomSkillsLoop(customSkills, options);
 		return;
 	}
 
@@ -235,6 +435,32 @@ async function autoUpdateSkills(
 			}
 		}
 	}
+
+	await autoUpdateCustomSkillsLoop(customSkills, options);
+}
+
+/**
+ * Iterates each `customSkills` entry and delegates to
+ * {@link autoUpdateCustomSkill}, isolating per-entry failures so a single
+ * broken bundle does not abort the others.
+ */
+async function autoUpdateCustomSkillsLoop(
+	customSkills: readonly CustomSkillConfig[],
+	options: SkillPluginOptions,
+): Promise<void> {
+	for (const entry of customSkills) {
+		try {
+			await autoUpdateCustomSkill(entry, options);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			console.warn(
+				yellow(
+					`Skill auto-update failed [${entry.name}]: ${message}. ` +
+						`Continuing with remaining skills.`,
+				),
+			);
+		}
+	}
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -293,10 +519,17 @@ export function skillPlugin(options: SkillPluginOptions): CrustPlugin {
 			rootCmd = context.rootCommand;
 			const skillCommandName = options.command ?? DEFAULT_SKILL_COMMAND_NAME;
 
+			// Validate customSkills config up front so misconfiguration surfaces
+			// at setup rather than at first auto-update or interactive run.
+			const customSkills = validateCustomSkillsConfig(
+				rootCmd.meta.name,
+				options.customSkills,
+			);
+
 			actions.addSubCommand(
 				rootCmd,
 				skillCommandName,
-				buildSkillCommand(rootCmd, options, skillCommandName),
+				buildSkillCommand(rootCmd, options, customSkills, skillCommandName),
 			);
 
 			// Build validation should never mutate user environments
@@ -311,7 +544,7 @@ export function skillPlugin(options: SkillPluginOptions): CrustPlugin {
 
 			// Auto-update already-installed skills when version changes
 			if (options.autoUpdate !== false) {
-				await autoUpdateSkills(rootCmd, options);
+				await autoUpdateSkills(rootCmd, options, customSkills);
 			}
 		},
 	};
@@ -334,12 +567,237 @@ export function skillPlugin(options: SkillPluginOptions): CrustPlugin {
  * are prompted to choose between project and global. In non-interactive mode,
  * scope falls back to global.
  */
+/**
+ * Reconciles a single custom-skill bundle through the same multiselect
+ * pipeline used by the main-skill block: detect agents, compute status,
+ * prompt (or skip when `installAll`), diff selection, install/uninstall.
+ *
+ * Mirrors the main-skill flow but uses {@link installSkillBundle} for the
+ * install path and the entry's display name in prompt + heading text.
+ */
+async function reconcileBundleInteractively(opts: {
+	entry: CustomSkillConfig;
+	options: SkillPluginOptions;
+	scope: Scope;
+	installAll: boolean;
+	isInteractive: boolean;
+}): Promise<void> {
+	const { entry, options, scope, installAll, isInteractive } = opts;
+	const installMode = entry.installMode ?? options.installMode;
+
+	const detectedAgents = await detectInstalledAgents();
+	const universalAgents = getUniversalAgents();
+	const allAdditionalAgents = getAdditionalAgents();
+
+	const status = await skillStatus({
+		name: entry.name,
+		agents: [...universalAgents, ...allAdditionalAgents],
+		scope,
+	});
+
+	const installedAgentSet = new Set<AgentTarget>(
+		status.agents.filter((a) => a.installed).map((a) => a.agent),
+	);
+	const detectedAdditionalSet = new Set(detectedAgents);
+	const statusMap = new Map(status.agents.map((a) => [a.agent, a]));
+	const additionalAgents = allAdditionalAgents.filter((agent) => {
+		if (detectedAdditionalSet.has(agent)) return true;
+		const e = statusMap.get(agent);
+		return e?.installed === true;
+	});
+	const installedAgents = additionalAgents.filter((agent) =>
+		installedAgentSet.has(agent),
+	);
+
+	const choices: Array<{
+		label: string;
+		value: AgentTarget | typeof UNIVERSAL_GROUP;
+		hint: string;
+	}> = [];
+
+	if (universalAgents.length > 0) {
+		const firstUniversalAgent = universalAgents[0];
+		if (!firstUniversalAgent) {
+			throw new Error("Expected at least one universal agent");
+		}
+		const firstUniversal = statusMap.get(firstUniversalAgent);
+		const universalDir = firstUniversal?.outputDir ?? "path unavailable";
+		choices.push({
+			label: "Universal",
+			value: UNIVERSAL_GROUP,
+			hint: universalDir,
+		});
+
+		const agentLabels = universalAgents
+			.map((agent) => AGENT_LABELS[agent])
+			.join(", ");
+		if (isInteractive && !installAll) {
+			console.log(dim(`Agents supporting universal skills: ${agentLabels}`));
+		}
+	}
+
+	for (const agent of additionalAgents) {
+		const e = statusMap.get(agent);
+		const hint = e?.outputDir ?? "path unavailable";
+		choices.push({
+			label: AGENT_LABELS[agent],
+			value: agent,
+			hint,
+		});
+	}
+
+	const universalInstalled =
+		universalAgents.length > 0 &&
+		universalAgents.every((agent) => installedAgentSet.has(agent));
+	const defaultSelections: Array<AgentTarget | typeof UNIVERSAL_GROUP> = [
+		...installedAgents.filter((agent) => !universalAgents.includes(agent)),
+	];
+	if (universalInstalled) {
+		defaultSelections.unshift(UNIVERSAL_GROUP);
+	}
+
+	let selectedAgents: AgentTarget[];
+	if (installAll) {
+		selectedAgents = [...universalAgents, ...additionalAgents];
+	} else {
+		const selectedValues =
+			choices.length === 0
+				? ([] as Array<AgentTarget | typeof UNIVERSAL_GROUP>)
+				: await multiselect({
+						message: `Select agents to install skills for [${entry.name}]`,
+						choices,
+						default: defaultSelections,
+						required: false,
+					});
+
+		const selected = new Set<AgentTarget>(
+			selectedValues.filter(
+				(value): value is AgentTarget => value !== UNIVERSAL_GROUP,
+			),
+		);
+		if (selectedValues.includes(UNIVERSAL_GROUP)) {
+			for (const agent of universalAgents) {
+				selected.add(agent);
+			}
+		}
+		selectedAgents = [...selected];
+	}
+
+	const toInstall = selectedAgents.filter(
+		(agent) => !installedAgentSet.has(agent),
+	);
+	const toUpdate = selectedAgents.filter((agent) => {
+		const e = statusMap.get(agent);
+		if (!e?.installed) return false;
+		const expectedOutputDir = resolveAgentPath(agent, scope, entry.name);
+		return e.version !== entry.version || e.outputDir !== expectedOutputDir;
+	});
+	const toUninstall = [...installedAgentSet].filter(
+		(agent) => !selectedAgents.includes(agent),
+	);
+
+	const agentsToInstall = [...toInstall, ...toUpdate];
+
+	if (agentsToInstall.length > 0) {
+		try {
+			const result = await spinner({
+				message: `Installing skills [${entry.name}]...`,
+				task: async () =>
+					installSkillBundle({
+						sourceDir: entry.sourceDir,
+						agents: agentsToInstall,
+						version: entry.version,
+						scope,
+						installMode,
+					}),
+			});
+
+			console.log(
+				`\n${bold(`Installed bundle "${entry.name}" v${entry.version}`)}`,
+			);
+			for (const line of formatInstallOutput(result.agents)) {
+				console.log(dim(`  ${line.label} → ${line.outputDir}`));
+			}
+		} catch (err) {
+			if (err instanceof SkillConflictError) {
+				const kindMismatchSuffix = err.details.kindMismatch
+					? ` (existing is a "${err.details.kindMismatch.existing}" skill, attempted "${err.details.kindMismatch.attempted}")`
+					: " but was not created by Crust";
+				const overwrite = installAll
+					? true
+					: await confirm({
+							message:
+								`"${err.details.outputDir}" already exists${kindMismatchSuffix}. ` +
+								`Overwrite?`,
+							default: false,
+						});
+
+				if (overwrite) {
+					const result = await spinner({
+						message: `Overwriting bundle [${entry.name}]...`,
+						task: async () =>
+							installSkillBundle({
+								sourceDir: entry.sourceDir,
+								agents: [err.details.agent],
+								version: entry.version,
+								scope,
+								force: true,
+								installMode,
+							}),
+					});
+
+					console.log(
+						`\n${bold(`Installed bundle "${entry.name}" v${entry.version}`)}`,
+					);
+					for (const line of formatInstallOutput(result.agents)) {
+						console.log(dim(`  ${line.label} → ${line.outputDir}`));
+					}
+				} else {
+					console.log(
+						dim(`\nSkipped ${AGENT_LABELS[err.details.agent]} [${entry.name}]`),
+					);
+				}
+			} else {
+				throw err;
+			}
+		}
+	}
+
+	if (toUninstall.length > 0) {
+		const result = await spinner({
+			message: `Removing skills [${entry.name}]...`,
+			task: async () =>
+				uninstallSkill({
+					name: entry.name,
+					agents: toUninstall,
+					scope,
+				}),
+		});
+
+		const removedAgents = result.agents
+			.filter((a) => a.status === "removed")
+			.map((a) => a.agent);
+		const removed = formatAgentLabels(removedAgents);
+
+		if (removed.length > 0) {
+			console.log(
+				`\n${bold(`Removed bundle "${entry.name}" from ${removed.join(", ")}`)}`,
+			);
+		}
+	}
+
+	if (agentsToInstall.length === 0 && toUninstall.length === 0) {
+		console.log(dim(`No changes [${entry.name}].`));
+	}
+}
+
 function buildSkillCommand(
 	rootCmd: CommandNode,
 	options: SkillPluginOptions,
+	customSkills: readonly CustomSkillConfig[],
 	commandName: string,
 ): CommandNode {
-	const updateCommand = buildSkillUpdateCommand(rootCmd, options);
+	const updateCommand = buildSkillUpdateCommand(rootCmd, options, customSkills);
 
 	return new Crust(commandName)
 		.meta({ description: "Manage agent skill installations" })
@@ -577,6 +1035,30 @@ function buildSkillCommand(
 			if (agentsToGenerate.length === 0 && toUninstall.length === 0) {
 				console.log(dim("No changes."));
 			}
+
+			// Custom skill bundles — sequential per-bundle prompts.
+			// Each bundle is reconciled independently; a single-entry failure
+			// aborts that entry only and subsequent entries still run.
+			for (const entry of customSkills) {
+				const entryScope = entry.scope ?? scope;
+				try {
+					await reconcileBundleInteractively({
+						entry,
+						options,
+						scope: entryScope,
+						installAll,
+						isInteractive,
+					});
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					console.warn(
+						yellow(
+							`Skill reconciliation failed [${entry.name}]: ${message}. ` +
+								`Continuing with remaining skills.`,
+						),
+					);
+				}
+			}
 		})
 		.command(updateCommand)._node;
 }
@@ -584,6 +1066,7 @@ function buildSkillCommand(
 function buildSkillUpdateCommand(
 	rootCmd: CommandNode,
 	options: SkillPluginOptions,
+	customSkills: readonly CustomSkillConfig[],
 ): Crust {
 	return new Crust("update")
 		.meta({ description: "Update installed skills to latest version" })
@@ -612,44 +1095,122 @@ function buildSkillUpdateCommand(
 
 			if (needsUpdate.length === 0) {
 				console.log(dim(`No updates needed (${effectiveScope}).`));
-				return;
+			} else {
+				try {
+					const res = await spinner({
+						message: `Updating ${effectiveScope} skills...`,
+						task: async () =>
+							generateSkill({
+								command: rootCmd,
+								meta,
+								agents: needsUpdate.map((agent) => agent.agent),
+								scope,
+								installMode: options.installMode,
+							}),
+					});
+
+					const updatedAgents = res.agents
+						.filter((agent) => agent.status === "updated")
+						.map((agent) => agent.agent);
+					const updatedLabels = formatAgentLabels(updatedAgents);
+					if (updatedLabels.length > 0) {
+						console.log(
+							`\n${bold(
+								`Updated "${meta.name}" to v${meta.version} for ${updatedLabels.join(", ")} (${effectiveScope})`,
+							)}`,
+						);
+					}
+				} catch (err) {
+					if (err instanceof SkillConflictError) {
+						console.warn(
+							yellow(
+								`Skipped ${AGENT_LABELS[err.details.agent]}: "${err.details.outputDir}" already exists ` +
+									`but was not created by ${meta.name}. ` +
+									`Delete or rename the conflicting directory to resolve.`,
+							),
+						);
+					} else {
+						throw err;
+					}
+				}
 			}
 
-			try {
-				const res = await spinner({
-					message: `Updating ${effectiveScope} skills...`,
-					task: async () =>
-						generateSkill({
-							command: rootCmd,
-							meta,
-							agents: needsUpdate.map((agent) => agent.agent),
-							scope,
-							installMode: options.installMode,
-						}),
-				});
+			// Custom skill bundles — update each in turn after the main skill.
+			for (const entry of customSkills) {
+				const entryScope = entry.scope ?? scope;
+				const entryEffectiveScope = resolveEffectiveScope(entryScope);
+				const entryInstallMode = entry.installMode ?? options.installMode;
+				try {
+					const bundleStatus = await skillStatus({
+						name: entry.name,
+						agents,
+						scope: entryScope,
+					});
+					const bundleNeedsUpdate = bundleStatus.agents.filter((a) => {
+						if (!a.installed) return false;
+						const expectedOutputDir = resolveAgentPath(
+							a.agent,
+							entryScope,
+							entry.name,
+						);
+						return (
+							a.version !== entry.version || a.outputDir !== expectedOutputDir
+						);
+					});
 
-				const updatedAgents = res.agents
-					.filter((agent) => agent.status === "updated")
-					.map((agent) => agent.agent);
-				const updatedLabels = formatAgentLabels(updatedAgents);
-				if (updatedLabels.length > 0) {
-					console.log(
-						`\n${bold(
-							`Updated "${meta.name}" to v${meta.version} for ${updatedLabels.join(", ")} (${effectiveScope})`,
-						)}`,
-					);
-				}
-			} catch (err) {
-				if (err instanceof SkillConflictError) {
-					console.warn(
-						yellow(
-							`Skipped ${AGENT_LABELS[err.details.agent]}: "${err.details.outputDir}" already exists ` +
-								`but was not created by ${meta.name}. ` +
-								`Delete or rename the conflicting directory to resolve.`,
-						),
-					);
-				} else {
-					throw err;
+					if (bundleNeedsUpdate.length === 0) {
+						console.log(
+							dim(
+								`No updates needed [${entry.name}] (${entryEffectiveScope}).`,
+							),
+						);
+						continue;
+					}
+
+					const res = await spinner({
+						message: `Updating ${entryEffectiveScope} skills [${entry.name}]...`,
+						task: async () =>
+							installSkillBundle({
+								sourceDir: entry.sourceDir,
+								agents: bundleNeedsUpdate.map((a) => a.agent),
+								version: entry.version,
+								scope: entryScope,
+								installMode: entryInstallMode,
+							}),
+					});
+
+					const updatedAgents = res.agents
+						.filter((a) => a.status === "updated")
+						.map((a) => a.agent);
+					const updatedLabels = formatAgentLabels(updatedAgents);
+					if (updatedLabels.length > 0) {
+						console.log(
+							`\n${bold(
+								`Updated bundle "${entry.name}" to v${entry.version} for ${updatedLabels.join(", ")} (${entryEffectiveScope})`,
+							)}`,
+						);
+					}
+				} catch (err) {
+					if (err instanceof SkillConflictError) {
+						const kindMismatchSuffix = err.details.kindMismatch
+							? ` (existing is a "${err.details.kindMismatch.existing}" skill, attempted "${err.details.kindMismatch.attempted}")`
+							: "";
+						console.warn(
+							yellow(
+								`Skipped ${AGENT_LABELS[err.details.agent]} [${entry.name}]: ` +
+									`"${err.details.outputDir}" already exists${kindMismatchSuffix}. ` +
+									`Delete or rename the conflicting directory to resolve.`,
+							),
+						);
+					} else {
+						const message = err instanceof Error ? err.message : String(err);
+						console.warn(
+							yellow(
+								`Skill update failed [${entry.name}]: ${message}. ` +
+									`Continuing with remaining skills.`,
+							),
+						);
+					}
 				}
 			}
 		});

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -153,8 +153,6 @@ function deriveSkillMeta(
  * Resolution-time errors (non-`file:` URL, missing source directory, missing
  * `SKILL.md`, etc.) are deliberately deferred to the underlying
  * {@link installSkillBundle} invocation so plugin setup stays fast.
- *
- * @internal Exported for unit testing via the plugin entrypoint only.
  */
 function validateCustomSkillsConfig(
 	mainName: string,
@@ -554,27 +552,7 @@ export function skillPlugin(options: SkillPluginOptions): CrustPlugin {
 // Interactive skill command builder
 // ────────────────────────────────────────────────────────────────────────────
 
-/**
- * Builds the interactive skill management command.
- *
- * Presents a single multiselect prompt listing all detected agents with their
- * current installation status pre-filled. The user toggles agents on/off and
- * the system reconciles the desired state: newly selected agents are installed,
- * deselected agents are uninstalled, and already-correct agents are skipped.
- *
- * The command resolves scope from `--scope`, `defaultScope`, or an interactive
- * prompt. When `defaultScope` is not set and the terminal is interactive, users
- * are prompted to choose between project and global. In non-interactive mode,
- * scope falls back to global.
- */
-/**
- * Reconciles a single custom-skill bundle through the same multiselect
- * pipeline used by the main-skill block: detect agents, compute status,
- * prompt (or skip when `installAll`), diff selection, install/uninstall.
- *
- * Mirrors the main-skill flow but uses {@link installSkillBundle} for the
- * install path and the entry's display name in prompt + heading text.
- */
+/** Reconciles one custom-skill bundle through the interactive skill flow. */
 async function reconcileBundleInteractively(opts: {
 	entry: CustomSkillConfig;
 	options: SkillPluginOptions;
@@ -791,6 +769,19 @@ async function reconcileBundleInteractively(opts: {
 	}
 }
 
+/**
+ * Builds the interactive skill management command.
+ *
+ * Presents a single multiselect prompt listing all detected agents with their
+ * current installation status pre-filled. The user toggles agents on/off and
+ * the system reconciles the desired state: newly selected agents are installed,
+ * deselected agents are uninstalled, and already-correct agents are skipped.
+ *
+ * The command resolves scope from `--scope`, `defaultScope`, or an interactive
+ * prompt. When `defaultScope` is not set and the terminal is interactive, users
+ * are prompted to choose between project and global. In non-interactive mode,
+ * scope falls back to global.
+ */
 function buildSkillCommand(
 	rootCmd: CommandNode,
 	options: SkillPluginOptions,

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -166,7 +166,8 @@ function deriveSkillMeta(
  * - `customSkills` itself must be an array (or `undefined`).
  * - Each `entry.name` must satisfy {@link isValidSkillName}, must not collide
  *   with the main skill's name, and must be unique within the array.
- * - `entry.version` must be a non-empty string.
+ * - `entry.version`, when set, must be a non-empty string. When omitted, the
+ *   plugin's top-level `version` is used at install time.
  * - `entry.sourceDir` must be `string` or `URL`.
  * - `entry.scope`, when set, must be `"project"` or `"global"`.
  * - `entry.installMode`, when set, must be `"auto"`, `"symlink"`, or `"copy"`.
@@ -227,10 +228,13 @@ function validateCustomSkillsConfig(
 		}
 		seen.add(entry.name);
 
-		if (typeof entry.version !== "string" || entry.version.length === 0) {
+		if (
+			entry.version !== undefined &&
+			(typeof entry.version !== "string" || entry.version.length === 0)
+		) {
 			throw new Error(
 				`skillPlugin: customSkills[${i}].version (for "${entry.name}") ` +
-					`must be a non-empty string.`,
+					`must be a non-empty string when set, or omitted to inherit the plugin's \`version\`.`,
 			);
 		}
 
@@ -303,6 +307,7 @@ async function autoUpdateCustomSkill(
 
 	const scopes = resolveCustomSkillScopes(entry, options);
 	const installMode = entry.installMode ?? options.installMode;
+	const effectiveVersion = entry.version ?? options.version;
 
 	for (const scope of scopes) {
 		const status = await skillStatus({
@@ -314,7 +319,9 @@ async function autoUpdateCustomSkill(
 		const needsUpdate = status.agents.filter((a) => {
 			if (!a.installed) return false;
 			const expectedOutputDir = resolveAgentPath(a.agent, scope, entry.name);
-			return a.version !== entry.version || a.outputDir !== expectedOutputDir;
+			return (
+				a.version !== effectiveVersion || a.outputDir !== expectedOutputDir
+			);
 		});
 
 		if (needsUpdate.length === 0) {
@@ -328,7 +335,7 @@ async function autoUpdateCustomSkill(
 					const res = await installSkillBundle({
 						sourceDir: entry.sourceDir,
 						agents: needsUpdate.map((a) => a.agent),
-						version: entry.version,
+						version: effectiveVersion,
 						scope,
 						installMode,
 						expectedName: entry.name,
@@ -341,7 +348,7 @@ async function autoUpdateCustomSkill(
 
 					if (updatedLabels.length > 0) {
 						updateMessage(
-							`Updated bundle "${entry.name}" to v${entry.version} for ${updatedLabels.join(", ")} (${scope})`,
+							`Updated bundle "${entry.name}" to v${effectiveVersion} for ${updatedLabels.join(", ")} (${scope})`,
 						);
 					}
 
@@ -610,6 +617,7 @@ async function reconcileBundleInteractively(opts: {
 }): Promise<void> {
 	const { entry, options, scope, installAll, isInteractive } = opts;
 	const installMode = entry.installMode ?? options.installMode;
+	const effectiveVersion = entry.version ?? options.version;
 
 	const detectedAgents = await detectInstalledAgents();
 	const universalAgents = getUniversalAgents();
@@ -716,7 +724,7 @@ async function reconcileBundleInteractively(opts: {
 		const e = statusMap.get(agent);
 		if (!e?.installed) return false;
 		const expectedOutputDir = resolveAgentPath(agent, scope, entry.name);
-		return e.version !== entry.version || e.outputDir !== expectedOutputDir;
+		return e.version !== effectiveVersion || e.outputDir !== expectedOutputDir;
 	});
 	const toUninstall = [...installedAgentSet].filter(
 		(agent) => !selectedAgents.includes(agent),
@@ -732,7 +740,7 @@ async function reconcileBundleInteractively(opts: {
 					installSkillBundle({
 						sourceDir: entry.sourceDir,
 						agents: agentsToInstall,
-						version: entry.version,
+						version: effectiveVersion,
 						scope,
 						installMode,
 						expectedName: entry.name,
@@ -740,7 +748,7 @@ async function reconcileBundleInteractively(opts: {
 			});
 
 			console.log(
-				`\n${bold(`Installed bundle "${entry.name}" v${entry.version}`)}`,
+				`\n${bold(`Installed bundle "${entry.name}" v${effectiveVersion}`)}`,
 			);
 			for (const line of formatInstallOutput(result.agents)) {
 				console.log(dim(`  ${line.label} → ${line.outputDir}`));
@@ -766,7 +774,7 @@ async function reconcileBundleInteractively(opts: {
 							installSkillBundle({
 								sourceDir: entry.sourceDir,
 								agents: [err.details.agent],
-								version: entry.version,
+								version: effectiveVersion,
 								scope,
 								force: true,
 								installMode,
@@ -775,7 +783,7 @@ async function reconcileBundleInteractively(opts: {
 					});
 
 					console.log(
-						`\n${bold(`Installed bundle "${entry.name}" v${entry.version}`)}`,
+						`\n${bold(`Installed bundle "${entry.name}" v${effectiveVersion}`)}`,
 					);
 					for (const line of formatInstallOutput(result.agents)) {
 						console.log(dim(`  ${line.label} → ${line.outputDir}`));
@@ -1199,6 +1207,7 @@ function buildSkillUpdateCommand(
 				const entryScope = entry.scope ?? scope;
 				const entryEffectiveScope = resolveEffectiveScope(entryScope);
 				const entryInstallMode = entry.installMode ?? options.installMode;
+				const entryEffectiveVersion = entry.version ?? options.version;
 				try {
 					const bundleStatus = await skillStatus({
 						name: entry.name,
@@ -1213,7 +1222,8 @@ function buildSkillUpdateCommand(
 							entry.name,
 						);
 						return (
-							a.version !== entry.version || a.outputDir !== expectedOutputDir
+							a.version !== entryEffectiveVersion ||
+							a.outputDir !== expectedOutputDir
 						);
 					});
 
@@ -1232,7 +1242,7 @@ function buildSkillUpdateCommand(
 							installSkillBundle({
 								sourceDir: entry.sourceDir,
 								agents: bundleNeedsUpdate.map((a) => a.agent),
-								version: entry.version,
+								version: entryEffectiveVersion,
 								scope: entryScope,
 								installMode: entryInstallMode,
 								expectedName: entry.name,
@@ -1246,7 +1256,7 @@ function buildSkillUpdateCommand(
 					if (updatedLabels.length > 0) {
 						console.log(
 							`\n${bold(
-								`Updated bundle "${entry.name}" to v${entry.version} for ${updatedLabels.join(", ")} (${entryEffectiveScope})`,
+								`Updated bundle "${entry.name}" to v${entryEffectiveVersion} for ${updatedLabels.join(", ")} (${entryEffectiveScope})`,
 							)}`,
 						);
 					}

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -27,6 +27,7 @@ import type {
 	AgentTarget,
 	CustomSkillConfig,
 	Scope,
+	SkillInstallMode,
 	SkillMeta,
 	SkillPluginOptions,
 } from "./types.ts";
@@ -39,18 +40,31 @@ function isScope(value: unknown): value is Scope {
 	return value === "global" || value === "project";
 }
 
+function isInstallMode(value: unknown): value is SkillInstallMode {
+	return value === "auto" || value === "symlink" || value === "copy";
+}
+
+/**
+ * Validates an explicit `--scope` flag. Returns the typed scope when set,
+ * `undefined` when omitted. Throws on a non-Scope string so the caller
+ * does not need to repeat the check.
+ */
+function parseScopeFlag(rawScope: string | undefined): Scope | undefined {
+	if (rawScope === undefined) return undefined;
+	if (!isScope(rawScope)) {
+		throw new Error(
+			`Invalid --scope value: ${String(rawScope)}. Expected "project" or "global".`,
+		);
+	}
+	return rawScope;
+}
+
 async function resolveScopeForCommand(
 	rawScope: string | undefined,
 	options: SkillPluginOptions,
 ): Promise<Scope> {
-	if (rawScope !== undefined) {
-		if (!isScope(rawScope)) {
-			throw new Error(
-				`Invalid --scope value: ${String(rawScope)}. Expected "project" or "global".`,
-			);
-		}
-		return rawScope;
-	}
+	const explicit = parseScopeFlag(rawScope);
+	if (explicit !== undefined) return explicit;
 
 	if (options.defaultScope) {
 		return options.defaultScope;
@@ -142,23 +156,36 @@ function deriveSkillMeta(
 /**
  * Validates and normalizes the `customSkills` array passed to {@link skillPlugin}.
  *
- * Rules (run synchronously at plugin setup before any FS work):
- * - Each `entry.name` must satisfy {@link isValidSkillName}.
- * - `entry.name` must not collide with the main skill's name (derived from
- *   the root command's `meta`).
- * - `entry.name` must be unique within the array.
+ * Acts as the single boundary check (per AGENTS.md "validate untrusted input
+ * once at the boundary; trust types inside"). Runs synchronously at plugin
+ * setup before any FS work; resolution-time errors (non-`file:` URL, missing
+ * source directory, missing `SKILL.md`, etc.) are deferred to the underlying
+ * {@link installSkillBundle} invocation so plugin setup stays fast.
+ *
+ * Rules:
+ * - `customSkills` itself must be an array (or `undefined`).
+ * - Each `entry.name` must satisfy {@link isValidSkillName}, must not collide
+ *   with the main skill's name, and must be unique within the array.
  * - `entry.version` must be a non-empty string.
  * - `entry.sourceDir` must be `string` or `URL`.
- *
- * Resolution-time errors (non-`file:` URL, missing source directory, missing
- * `SKILL.md`, etc.) are deliberately deferred to the underlying
- * {@link installSkillBundle} invocation so plugin setup stays fast.
+ * - `entry.scope`, when set, must be `"project"` or `"global"`.
+ * - `entry.installMode`, when set, must be `"auto"`, `"symlink"`, or `"copy"`.
  */
 function validateCustomSkillsConfig(
 	mainName: string,
 	customSkills: readonly CustomSkillConfig[] | undefined,
 ): readonly CustomSkillConfig[] {
-	if (!customSkills || customSkills.length === 0) {
+	if (customSkills === undefined) {
+		return [];
+	}
+	if (!Array.isArray(customSkills)) {
+		throw new Error(
+			`skillPlugin: customSkills must be an array, got ${
+				customSkills === null ? "null" : typeof customSkills
+			}.`,
+		);
+	}
+	if (customSkills.length === 0) {
 		return [];
 	}
 
@@ -214,6 +241,20 @@ function validateCustomSkillsConfig(
 			throw new Error(
 				`skillPlugin: customSkills[${i}].sourceDir (for "${entry.name}") ` +
 					`must be a string or URL, got ${typeof entry.sourceDir}.`,
+			);
+		}
+
+		if (entry.scope !== undefined && !isScope(entry.scope)) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].scope (for "${entry.name}") ` +
+					`must be "project" or "global", got ${JSON.stringify(entry.scope)}.`,
+			);
+		}
+
+		if (entry.installMode !== undefined && !isInstallMode(entry.installMode)) {
+			throw new Error(
+				`skillPlugin: customSkills[${i}].installMode (for "${entry.name}") ` +
+					`must be "auto", "symlink", or "copy", got ${JSON.stringify(entry.installMode)}.`,
 			);
 		}
 	}
@@ -290,6 +331,7 @@ async function autoUpdateCustomSkill(
 						version: entry.version,
 						scope,
 						installMode,
+						expectedName: entry.name,
 					});
 
 					const updatedAgents = res.agents
@@ -450,6 +492,12 @@ async function autoUpdateCustomSkillsLoop(
 		try {
 			await autoUpdateCustomSkill(entry, options);
 		} catch (err) {
+			// Startup auto-update is opportunistic: log and continue so a single
+			// broken bundle (missing sourceDir, frontmatter mismatch, FS error,
+			// etc.) does not stop the user's CLI from running. Per-bundle
+			// `SkillConflictError`s are already narrowed inside
+			// `autoUpdateCustomSkill`. Unlike the explicit `skill --all` /
+			// `skill update` paths, this loop never sets `process.exitCode`.
 			const message = err instanceof Error ? err.message : String(err);
 			console.warn(
 				yellow(
@@ -687,6 +735,7 @@ async function reconcileBundleInteractively(opts: {
 						version: entry.version,
 						scope,
 						installMode,
+						expectedName: entry.name,
 					}),
 			});
 
@@ -721,6 +770,7 @@ async function reconcileBundleInteractively(opts: {
 								scope,
 								force: true,
 								installMode,
+								expectedName: entry.name,
 							}),
 					});
 
@@ -807,8 +857,12 @@ function buildSkillCommand(
 			const meta = deriveSkillMeta(rootCmd, options);
 			const installAll = ctx.flags.all === true;
 			const isInteractive = !!process.stdin.isTTY;
+			// `--scope` always wins when set; `--all` skips only the interactive
+			// prompt fallback, falling back to `defaultScope` or `"global"`.
 			const scope = installAll
-				? (options.defaultScope ?? DEFAULT_SKILL_SCOPE)
+				? (parseScopeFlag(ctx.flags.scope) ??
+					options.defaultScope ??
+					DEFAULT_SKILL_SCOPE)
 				: await resolveScopeForCommand(ctx.flags.scope, options);
 
 			// Detect installed agents
@@ -1029,7 +1083,9 @@ function buildSkillCommand(
 
 			// Custom skill bundles — sequential per-bundle prompts.
 			// Each bundle is reconciled independently; a single-entry failure
-			// aborts that entry only and subsequent entries still run.
+			// aborts that entry only and subsequent entries still run, but the
+			// command exits non-zero so callers (CI, scripts) see the failure.
+			const failedEntries: string[] = [];
 			for (const entry of customSkills) {
 				const entryScope = entry.scope ?? scope;
 				try {
@@ -1041,6 +1097,10 @@ function buildSkillCommand(
 						isInteractive,
 					});
 				} catch (err) {
+					// Recoverable per-entry failure: keep reconciling siblings.
+					// SkillConflictError is already handled inside the helper; any
+					// error reaching here (filesystem, bad bundle, etc.) is logged
+					// and tracked for the final exit code.
 					const message = err instanceof Error ? err.message : String(err);
 					console.warn(
 						yellow(
@@ -1048,7 +1108,11 @@ function buildSkillCommand(
 								`Continuing with remaining skills.`,
 						),
 					);
+					failedEntries.push(entry.name);
 				}
+			}
+			if (failedEntries.length > 0) {
+				process.exitCode = 1;
 			}
 		})
 		.command(updateCommand)._node;
@@ -1127,6 +1191,10 @@ function buildSkillUpdateCommand(
 			}
 
 			// Custom skill bundles — update each in turn after the main skill.
+			// SkillConflictError is logged and treated as recoverable (matches
+			// the main-skill update behavior); any other error is also logged
+			// per-entry but tracked so the command exits non-zero.
+			const failedEntries: string[] = [];
 			for (const entry of customSkills) {
 				const entryScope = entry.scope ?? scope;
 				const entryEffectiveScope = resolveEffectiveScope(entryScope);
@@ -1167,6 +1235,7 @@ function buildSkillUpdateCommand(
 								version: entry.version,
 								scope: entryScope,
 								installMode: entryInstallMode,
+								expectedName: entry.name,
 							}),
 					});
 
@@ -1183,6 +1252,9 @@ function buildSkillUpdateCommand(
 					}
 				} catch (err) {
 					if (err instanceof SkillConflictError) {
+						// Conflict matches main-skill `skill update` semantics:
+						// log and skip without failing the command (caller can
+						// resolve manually).
 						const kindMismatchSuffix = err.details.kindMismatch
 							? ` (existing is a "${err.details.kindMismatch.existing}" skill, attempted "${err.details.kindMismatch.attempted}")`
 							: "";
@@ -1194,6 +1266,10 @@ function buildSkillUpdateCommand(
 							),
 						);
 					} else {
+						// Unexpected error (filesystem, bad bundle, frontmatter
+						// mismatch from `expectedName`, etc.). Keep updating siblings
+						// so a single bad entry does not block the rest, but track
+						// it so the command exits non-zero.
 						const message = err instanceof Error ? err.message : String(err);
 						console.warn(
 							yellow(
@@ -1201,8 +1277,12 @@ function buildSkillUpdateCommand(
 									`Continuing with remaining skills.`,
 							),
 						);
+						failedEntries.push(entry.name);
 					}
 				}
+			}
+			if (failedEntries.length > 0) {
+				process.exitCode = 1;
 			}
 		});
 }

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -51,6 +51,12 @@ function findFile(
 	return files.find((f) => f.path === path);
 }
 
+function expectTextContent(file: RenderedFile | undefined): string {
+	expect(file).toBeDefined();
+	expect(typeof file?.content).toBe("string");
+	return file?.content as string;
+}
+
 /**
  * Builds a simple manifest from a makeCommand call for testing.
  */
@@ -1167,15 +1173,14 @@ describe("renderSkill", () => {
 			const files = renderSkill(manifest, meta);
 			const allPaths = new Set(files.map((f) => f.path));
 
-			const skill = findFile(files, "SKILL.md");
-			expect(skill).toBeDefined();
+			const skillContent = expectTextContent(findFile(files, "SKILL.md"));
 
 			// Extract markdown link targets (non-relative only)
 			const linkRegex = /\]\(([^)]+)\)/g;
 			const links: string[] = [];
 			let match: RegExpExecArray | null = null;
 			// biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop pattern
-			while ((match = linkRegex.exec(skill?.content ?? "")) !== null) {
+			while ((match = linkRegex.exec(skillContent)) !== null) {
 				const target = match[1];
 				if (target && !target.startsWith("http") && !target.startsWith("#")) {
 					links.push(target);
@@ -1465,15 +1470,17 @@ describe("renderSkill", () => {
 				version: "1.0.0",
 			};
 			const files = renderSkill(manifest, meta);
-			const test = findFile(files, "commands/test.md");
+			const testContent = expectTextContent(
+				findFile(files, "commands/test.md"),
+			);
 
 			// Pipe should be escaped inside table cells
-			expect(test?.content).toContain("Use enable \\| disable to toggle");
+			expect(testContent).toContain("Use enable \\| disable to toggle");
 			// But the raw | should not appear unescaped in a table row
-			const tableRows = test?.content
+			const tableRows = testContent
 				.split("\n")
 				.filter((l) => l.startsWith("| ") && l.includes("enable"));
-			for (const row of tableRows ?? []) {
+			for (const row of tableRows) {
 				// Count unescaped pipes — they should only be column separators
 				const cells = row.split(/(?<!\\)\|/).filter((c) => c.trim());
 				expect(cells.length).toBe(4); // Flag, Type, Required, Description

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -562,6 +562,101 @@ export interface StatusResult {
 // Plugin option types
 // ────────────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────────
+// Custom skill bundle configuration
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for a single hand-authored skill bundle managed by
+ * {@link skillPlugin} alongside the auto-generated command-reference skill.
+ *
+ * Each entry is reconciled through the same plugin lifecycle as the main
+ * skill — auto-update on version change, surfaced in the interactive `skill`
+ * subcommand multiselect, supports uninstall via the same toggle UX, and
+ * respects `autoUpdate: false` and `--all` non-interactive mode. Bundles
+ * inherit `defaultScope` and `installMode` from the plugin unless overridden
+ * per-entry.
+ *
+ * The bundle's `SKILL.md` frontmatter remains the source of truth for the
+ * display `name` and `description` (validated by {@link installSkillBundle}
+ * at install time). The duplicated `name` field on this config is what the
+ * plugin uses for cheap collision-detection, status lookups, and uninstall
+ * paths without having to read the bundle's frontmatter at plugin setup.
+ *
+ * @example
+ * ```ts
+ * import { skillPlugin } from "@crustjs/skills";
+ * import pkg from "./package.json" with { type: "json" };
+ *
+ * skillPlugin({
+ *   version: pkg.version,
+ *   customSkills: [
+ *     {
+ *       name: "funnel-builder",
+ *       sourceDir: "skills/funnel-builder",
+ *       version: pkg.version,
+ *     },
+ *   ],
+ * });
+ * ```
+ */
+export interface CustomSkillConfig {
+	/**
+	 * Skill name used by the plugin for collision detection, status lookups,
+	 * and uninstall paths.
+	 *
+	 * Must satisfy `isValidSkillName` (1–64 lowercase alphanumeric characters
+	 * and hyphens, no leading/trailing/consecutive hyphens), must be unique
+	 * within the `customSkills` array, and must not collide with the main
+	 * skill's name (derived from the root command's `meta`).
+	 *
+	 * The bundle's `SKILL.md` frontmatter must declare a matching `name:`
+	 * field; {@link installSkillBundle} validates this at install time.
+	 */
+	name: string;
+	/**
+	 * Source directory containing the bundle to install.
+	 *
+	 * Resolution rules (mirror {@link InstallSkillBundleOptions.sourceDir}):
+	 * - `URL` — must use `file:` protocol; resolved via `fileURLToPath()`.
+	 * - Absolute string path — resolved via `path.resolve()`.
+	 * - Relative string path — resolved against the nearest `package.json`
+	 *   directory walking up from `process.argv[1]`.
+	 *
+	 * The canonical form for plugin authors is the bare relative string
+	 * (e.g. `"skills/funnel-builder"`), mirroring `@crustjs/create`'s
+	 * `scaffold({ template })` ergonomics. Resolution-time errors are
+	 * deferred until the install runs.
+	 */
+	sourceDir: string | URL;
+	/**
+	 * Version string recorded for this install and compared on subsequent
+	 * installs to drive auto-update.
+	 *
+	 * Required. Typically wired to the consuming package's `package.json`
+	 * `version` (e.g. via `import pkg from "./package.json" with { type:
+	 * "json" }`). Identical-version reinstalls report `up-to-date` and skip
+	 * the canonical-store rewrite, so bump this whenever bundle contents
+	 * change.
+	 */
+	version: string;
+	/**
+	 * Installation scope override.
+	 *
+	 * When omitted, the bundle inherits {@link SkillPluginOptions.defaultScope}
+	 * resolution: explicit `--scope` flag wins, else `defaultScope`, else
+	 * the interactive scope prompt (or `"global"` in non-interactive mode).
+	 */
+	scope?: Scope;
+	/**
+	 * Installation strategy override.
+	 *
+	 * When omitted, inherits {@link SkillPluginOptions.installMode} (default
+	 * `"auto"`).
+	 */
+	installMode?: SkillInstallMode;
+}
+
 /**
  * Options for the skill plugin.
  *
@@ -637,6 +732,42 @@ export interface SkillPluginOptions {
 	 * @default false
 	 */
 	disableModelInvocation?: boolean;
+	/**
+	 * Hand-authored skill bundles to manage alongside the auto-generated
+	 * command-reference skill.
+	 *
+	 * Each entry is reconciled through the same plugin lifecycle as the main
+	 * skill — auto-update on version change, surfaced in the interactive
+	 * `skill` subcommand multiselect (one prompt per bundle, in array order,
+	 * after the main-skill prompt), supports uninstall via the same toggle
+	 * UX, and respects `autoUpdate: false` and `--all` non-interactive mode.
+	 *
+	 * Bundles share the canonical `.crust/skills` store with the main skill
+	 * via {@link installSkillBundle} and inherit `defaultScope` /
+	 * `installMode` resolution unless overridden per-entry.
+	 *
+	 * Each entry's `version` drives auto-update detection (compared against
+	 * the recorded `crust.json` version) — typically wired to the consuming
+	 * package's `package.json` `version`.
+	 *
+	 * Setup-time validation enforces:
+	 * - Each `name` satisfies `isValidSkillName`.
+	 * - No `name` collides with the main skill's name.
+	 * - All `name` values are unique within the array.
+	 * - Each `version` is a non-empty string.
+	 * - Each `sourceDir` is a `string` or `URL`.
+	 *
+	 * `sourceDir` resolution-time errors (non-`file:` URL, missing source
+	 * directory, missing `SKILL.md`, etc.) defer to the underlying
+	 * `installSkillBundle` invocation and surface there with descriptive
+	 * messages.
+	 *
+	 * When omitted or empty, plugin behavior is byte-identical to running
+	 * without the option — only the auto-generated main skill is managed.
+	 *
+	 * @default []
+	 */
+	customSkills?: CustomSkillConfig[];
 	/**
 	 * Register an interactive skill management subcommand on the root command.
 	 *

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -586,8 +586,8 @@ export interface StatusResult {
  * skill — auto-update on version change, surfaced in the interactive `skill`
  * subcommand multiselect, supports uninstall via the same toggle UX, and
  * respects `autoUpdate: false` and `--all` non-interactive mode. Bundles
- * inherit `defaultScope` and `installMode` from the plugin unless overridden
- * per-entry.
+ * inherit `version`, `defaultScope`, and `installMode` from the plugin
+ * unless overridden per-entry.
  *
  * The bundle's `SKILL.md` frontmatter remains the source of truth for the
  * display `name` and `description` (validated by {@link installSkillBundle}
@@ -603,10 +603,13 @@ export interface StatusResult {
  * skillPlugin({
  *   version: pkg.version,
  *   customSkills: [
+ *     // Inherits `version: pkg.version` from the plugin.
+ *     { name: "funnel-builder", sourceDir: "skills/funnel-builder" },
+ *     // Explicit override for an independently-versioned bundle.
  *     {
- *       name: "funnel-builder",
- *       sourceDir: "skills/funnel-builder",
- *       version: pkg.version,
+ *       name: "vendored-toolkit",
+ *       sourceDir: "skills/vendored-toolkit",
+ *       version: "0.3.0",
  *     },
  *   ],
  * });
@@ -615,7 +618,7 @@ export interface StatusResult {
 export interface CustomSkillConfig
 	extends Pick<
 		InstallSkillBundleOptions,
-		"sourceDir" | "version" | "scope" | "installMode"
+		"sourceDir" | "scope" | "installMode"
 	> {
 	/**
 	 * Skill name used by the plugin for collision detection, status lookups,
@@ -631,6 +634,23 @@ export interface CustomSkillConfig
 	 * paths can never drift from the canonical install location.
 	 */
 	name: string;
+	/**
+	 * Version override. When omitted, the bundle inherits the plugin's
+	 * top-level {@link SkillPluginOptions.version}. Drives auto-update
+	 * detection: a bundle is reinstalled when its recorded `crust.json`
+	 * version differs from the effective (entry-or-plugin) version.
+	 *
+	 * Inheriting from the plugin matches the typical case where the bundle
+	 * ships in the same package as the consuming CLI — one `pkg.version`
+	 * drives the main skill and every bundle. Pass an explicit value when a
+	 * bundle's release cadence is independent of the consuming CLI (for
+	 * example, vendored from another package).
+	 *
+	 * The bundle's `SKILL.md` frontmatter `version:` / `metadata.version`,
+	 * if any, is intentionally not read — this option (or its plugin-level
+	 * fallback) is the sole source of truth.
+	 */
+	version?: InstallSkillBundleOptions["version"];
 	/**
 	 * Installation scope override. When omitted, the bundle inherits
 	 * {@link SkillPluginOptions.defaultScope} resolution: explicit `--scope`
@@ -734,15 +754,17 @@ export interface SkillPluginOptions {
 	 * via {@link installSkillBundle} and inherit `defaultScope` /
 	 * `installMode` resolution unless overridden per-entry.
 	 *
-	 * Each entry's `version` drives auto-update detection (compared against
-	 * the recorded `crust.json` version) — typically wired to the consuming
-	 * package's `package.json` `version`.
+	 * Each entry's effective `version` drives auto-update detection (compared
+	 * against the recorded `crust.json` version). When the entry omits
+	 * `version`, the plugin's top-level {@link SkillPluginOptions.version} is
+	 * used — the typical case when the bundle ships in the same package as
+	 * the consuming CLI.
 	 *
 	 * Setup-time validation enforces:
 	 * - Each `name` satisfies `isValidSkillName`.
 	 * - No `name` collides with the main skill's name.
 	 * - All `name` values are unique within the array.
-	 * - Each `version` is a non-empty string.
+	 * - When set, `version` is a non-empty string.
 	 * - Each `sourceDir` is a `string` or `URL`.
 	 *
 	 * `sourceDir` resolution-time errors (non-`file:` URL, missing source

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -264,8 +264,8 @@ export interface ManifestNode {
 export interface RenderedFile {
 	/** Relative file path within the skill output directory */
 	path: string;
-	/** File content (UTF-8 text) */
-	content: string;
+	/** File content: UTF-8 text for generated files, raw bytes for bundle assets. */
+	content: string | Uint8Array;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -362,8 +362,8 @@ export interface GenerateOptions {
  * the file. A fresh `crust.json` is written alongside the bundle for
  * ownership and version tracking.
  *
- * Files are copied as **UTF-8 text** — binary supporting files are not
- * supported and will be corrupted on round-trip.
+ * Bundle files are copied as raw bytes. `SKILL.md` is also parsed as UTF-8
+ * to read its required frontmatter.
  *
  * Bundle content changes do not propagate without a `version` bump:
  * identical-version reinstalls report `up-to-date` and leave the canonical
@@ -403,7 +403,9 @@ export interface InstallSkillBundleOptions {
 	 * Agent targets to install the bundle for.
 	 *
 	 * Required — unlike {@link GenerateOptions.agents}, the bundle entrypoint
-	 * does not auto-detect agents. Pass `[]` for a no-op (no install performed).
+	 * does not auto-detect agents. Pass `[]` for a validated no-op: no install
+	 * is performed, but `sourceDir`, `SKILL.md`, bundle paths, frontmatter, and
+	 * skill name are still validated.
 	 */
 	agents: AgentTarget[];
 	/**
@@ -610,8 +612,11 @@ export interface CustomSkillConfig {
 	 * within the `customSkills` array, and must not collide with the main
 	 * skill's name (derived from the root command's `meta`).
 	 *
-	 * The bundle's `SKILL.md` frontmatter must declare a matching `name:`
-	 * field; {@link installSkillBundle} validates this at install time.
+	 * The bundle's `SKILL.md` frontmatter is the source of truth for the
+	 * installed skill's name, so it must match this `name`. The plugin does
+	 * not cross-check them — a mismatch silently installs the bundle under
+	 * the frontmatter name while plugin status, auto-update, and uninstall
+	 * lookups use this `name`, leaving an orphan install on disk.
 	 */
 	name: string;
 	/**

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -440,6 +440,16 @@ export interface InstallSkillBundleOptions {
 	 * @default false
 	 */
 	force?: boolean;
+	/**
+	 * When set, the bundle's `SKILL.md` frontmatter `name:` must equal this
+	 * string. A mismatch throws before any filesystem write.
+	 *
+	 * Used by `skillPlugin`'s `customSkills` reconciliation to keep the
+	 * config-level `name` (used for status / uninstall lookups) in lockstep
+	 * with the frontmatter `name` (the canonical install path), preventing
+	 * orphan installs.
+	 */
+	expectedName?: string;
 }
 
 /**
@@ -602,7 +612,11 @@ export interface StatusResult {
  * });
  * ```
  */
-export interface CustomSkillConfig {
+export interface CustomSkillConfig
+	extends Pick<
+		InstallSkillBundleOptions,
+		"sourceDir" | "version" | "scope" | "installMode"
+	> {
 	/**
 	 * Skill name used by the plugin for collision detection, status lookups,
 	 * and uninstall paths.
@@ -612,54 +626,23 @@ export interface CustomSkillConfig {
 	 * within the `customSkills` array, and must not collide with the main
 	 * skill's name (derived from the root command's `meta`).
 	 *
-	 * The bundle's `SKILL.md` frontmatter is the source of truth for the
-	 * installed skill's name, so it must match this `name`. The plugin does
-	 * not cross-check them — a mismatch silently installs the bundle under
-	 * the frontmatter name while plugin status, auto-update, and uninstall
-	 * lookups use this `name`, leaving an orphan install on disk.
+	 * The bundle's `SKILL.md` frontmatter `name:` must match this value —
+	 * mismatches are rejected at install time so plugin status / uninstall
+	 * paths can never drift from the canonical install location.
 	 */
 	name: string;
 	/**
-	 * Source directory containing the bundle to install.
-	 *
-	 * Resolution rules (mirror {@link InstallSkillBundleOptions.sourceDir}):
-	 * - `URL` — must use `file:` protocol; resolved via `fileURLToPath()`.
-	 * - Absolute string path — resolved via `path.resolve()`.
-	 * - Relative string path — resolved against the nearest `package.json`
-	 *   directory walking up from `process.argv[1]`.
-	 *
-	 * The canonical form for plugin authors is the bare relative string
-	 * (e.g. `"skills/funnel-builder"`), mirroring `@crustjs/create`'s
-	 * `scaffold({ template })` ergonomics. Resolution-time errors are
-	 * deferred until the install runs.
+	 * Installation scope override. When omitted, the bundle inherits
+	 * {@link SkillPluginOptions.defaultScope} resolution: explicit `--scope`
+	 * flag wins, else `defaultScope`, else the interactive scope prompt
+	 * (or `"global"` in non-interactive mode).
 	 */
-	sourceDir: string | URL;
+	scope?: InstallSkillBundleOptions["scope"];
 	/**
-	 * Version string recorded for this install and compared on subsequent
-	 * installs to drive auto-update.
-	 *
-	 * Required. Typically wired to the consuming package's `package.json`
-	 * `version` (e.g. via `import pkg from "./package.json" with { type:
-	 * "json" }`). Identical-version reinstalls report `up-to-date` and skip
-	 * the canonical-store rewrite, so bump this whenever bundle contents
-	 * change.
+	 * Installation strategy override. When omitted, inherits
+	 * {@link SkillPluginOptions.installMode} (default `"auto"`).
 	 */
-	version: string;
-	/**
-	 * Installation scope override.
-	 *
-	 * When omitted, the bundle inherits {@link SkillPluginOptions.defaultScope}
-	 * resolution: explicit `--scope` flag wins, else `defaultScope`, else
-	 * the interactive scope prompt (or `"global"` in non-interactive mode).
-	 */
-	scope?: Scope;
-	/**
-	 * Installation strategy override.
-	 *
-	 * When omitted, inherits {@link SkillPluginOptions.installMode} (default
-	 * `"auto"`).
-	 */
-	installMode?: SkillInstallMode;
+	installMode?: InstallSkillBundleOptions["installMode"];
 }
 
 /**

--- a/packages/skills/tests/fixtures/bundle-second/SKILL.md
+++ b/packages/skills/tests/fixtures/bundle-second/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: pricing-toolkit
+description: Configure pricing experiments
+---
+
+# Pricing Toolkit
+
+Second hand-authored skill bundle used by the @crustjs/skills test suite.

--- a/packages/skills/tests/fixtures/bundle-second/playbook.md
+++ b/packages/skills/tests/fixtures/bundle-second/playbook.md
@@ -1,0 +1,5 @@
+# Pricing Playbook
+
+Supporting markdown file for the `pricing-toolkit` bundle fixture. Used to
+verify that authored content beyond `SKILL.md` is copied into the canonical
+store when the bundle is installed.


### PR DESCRIPTION
**Closes #110.**

Resolves the higher-level half of issue #110: `skillPlugin` now accepts a `customSkills` array for managing hand-authored skill bundles alongside the auto-generated command-reference skill. Builds on `installSkillBundle()` from #119.

Tracks: TP-004.

## What's new

```ts
import { Crust } from "@crustjs/core";
import { skillPlugin } from "@crustjs/skills";
import pkg from "./package.json" with { type: "json" };

new Crust("my-cli")
  .meta({ description: "My CLI" })
  .use(
    skillPlugin({
      version: pkg.version,
      customSkills: [
        {
          name: "funnel-builder",
          sourceDir: "skills/funnel-builder",
          version: pkg.version,
        },
      ],
    }),
  )
  .run(() => {});
```

Each entry is reconciled through the same plugin lifecycle as the main skill.

## `CustomSkillConfig` shape

Per the post-#119 staleness audit (Amendment 1), the entry shape mirrors `installSkillBundle`'s API exactly — no `meta:` parameter; `name` is duplicated on the entry for cheap collision-detection, and `version` is explicit and required.

| Field | Type | Notes |
|---|---|---|
| `name` | `string` | required; bundle's `SKILL.md` frontmatter must declare matching `name:` |
| `sourceDir` | `string \| URL` | same 3 resolution modes as `installSkillBundle()` |
| `version` | `string` | required; drives auto-update detection |
| `description?` | `string` | optional; falls back to frontmatter |
| `scope?` | `Scope` | inherits plugin's `defaultScope` |
| `installMode?` | `SkillInstallMode` | inherits plugin's `installMode` |

## Reconciliation flow

Same code path as the main skill, repeated per entry:

1. **Auto-update** (when `autoUpdate: true`, default): On every CLI invocation, walk `customSkills`, query `skillStatus({ name, agents, scope })`, and call `installSkillBundle({ sourceDir, agents, version, scope, installMode })` for entries whose `version` differs from the recorded `crust.json` version. Entry-level errors are logged with the bundle name and never abort other entries.

2. **Interactive subcommand** (when `command` is set, default `"skill"`): Prompts run in this order: main skill multiselect, then one multiselect per `customSkills` entry in array order. Each prompt shows per-agent install status pre-selected; the user toggles to reconcile.

3. **Non-interactive flag** (`--all` etc., per existing convention): Operates on the full set without prompting.

## Setup-time validation

`validateCustomSkillsConfig(mainName, customSkills)` runs once at plugin construction:

- Each `name` satisfies `isValidSkillName` (1–64 lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens)
- No `name` collides with the main skill's name (derived from root command's `meta`)
- All `name` values are unique within the array
- Each `version` is a non-empty string
- Each `sourceDir` is a `string` or `URL`
- Resolution-time errors (non-`file:` URL, missing `process.argv[1]`, no `package.json` walking up, missing dir, missing `SKILL.md`) defer to the `installSkillBundle` call and surface there

## Backward compatibility

When `customSkills` is omitted or `[]`, plugin behavior is byte-identical to today.

## Verification

- `bun run check` ✅ 280 files, no fixes
- `bun run check:types --force` ✅ 21/21 (no cache)
- `packages/skills` tests: **341 pass / 0 fail / 988 expect calls** (was 297 → +44 new tests covering setup validation, reconciliation, multiselect ordering, per-entry error isolation, autoUpdate / --all paths, fixture-driven bundle install)
- All 10 packages: 2,300+ pass / 0 fail / 2 skip

## Changeset

`@crustjs/skills` minor — purely additive (new `customSkills?` option + new `CustomSkillConfig` exported type). Backward-compatible.