### PR TITLE
feat(plugins): `completionPlugin` — static bash/zsh/fish completion

### DIFF
--- a/.changeset/plugins-completion-static.md
+++ b/.changeset/plugins-completion-static.md
@@ -1,0 +1,63 @@
+---
+"@crustjs/plugins": minor
+---
+
+Add `completionPlugin` for shell tab-completion.
+
+The new plugin registers a `completion <shell>` subcommand on the root command
+that emits a self-contained tab-completion script for **bash**, **zsh**, or
+**fish**. The strategy is **pure-static**: the plugin walks the live command
+tree at run time and prints a fully-baked script. There are no runtime
+callbacks, no hidden `__complete` subcommand, and no shell-out on TAB — the
+generated script is the artifact users install into their shell.
+
+```ts
+import { Crust } from "@crustjs/core";
+import { completionPlugin } from "@crustjs/plugins";
+
+new Crust("my-cli")
+  .use(completionPlugin({ version: "1.0.0" }))
+  .command("build", (cmd) =>
+    cmd.flags({
+      target: { type: "string", choices: ["browser", "bun", "node"] },
+    }).run(() => {}),
+  )
+  .run(() => {});
+```
+
+```sh
+# Print to stdout — pipe into the shell's auto-discovery directory.
+my-cli completion bash > ~/.local/share/bash-completion/completions/my-cli
+
+# Or generate every supported shell at packaging time.
+my-cli completion bash --output-dir completions/
+# → completions/my-cli, completions/_my-cli, completions/my-cli.fish
+```
+
+Highlights:
+
+- **All three shells from one walk.** The bash template ships a Cobra-style
+  init shim so it works on systems without the `bash-completion` package
+  (macOS default bash, Alpine, NixOS without the package). The zsh template
+  uses `_arguments -C` with `->state` subcommand routing and emits
+  description-rich menus. The fish template emits declarative `complete -c`
+  rules with chained `__fish_seen_subcommand_from` predicates.
+- **Choices and aliases surface end-to-end.** Static enums declared via
+  the `choices` field on `FlagDef`/`ArgDef` become value lists in the
+  generated scripts. Command aliases (`meta.aliases`) are tab-completable
+  and resolve to the canonical command's flags.
+- **`--output-dir` for distributors.** Writes all configured shells with
+  the canonical filenames Homebrew, Nix, AUR, and Debian expect
+  (`<bin>` for bash, `_<bin>` for zsh, `<bin>.fish` for fish) — no rename
+  needed. Use the `shells` option to scope down.
+- **Drift is mitigated by versioned headers.** Each generated script's
+  first line embeds the binary name and version, so users (and `diff`)
+  spot stale completion files at a glance, with the regenerate command
+  inline.
+
+Limitations (v1):
+
+- No dynamic value completion (per-flag/per-arg `complete?:` callbacks);
+  intentionally deferred to a future minor bump. Adding them is
+  non-breaking, so v1 ships pure-static today and grows into a hybrid later.
+- No PowerShell template (planned for v2).

--- a/.changeset/plugins-completion-static.md
+++ b/.changeset/plugins-completion-static.md
@@ -38,14 +38,33 @@ Highlights:
 
 - **All three shells from one walk.** The bash template ships a Cobra-style
   init shim so it works on systems without the `bash-completion` package
-  (macOS default bash, Alpine, NixOS without the package). The zsh template
-  uses `_arguments -C` with `->state` subcommand routing and emits
-  description-rich menus. The fish template emits declarative `complete -c`
-  rules with chained `__fish_seen_subcommand_from` predicates.
+  (macOS default bash, Alpine, NixOS without the package), handles the
+  `--` end-of-options terminator, the `--name=value` form, and value-flag
+  context. The zsh template uses `_arguments -C` with `->state` subcommand
+  routing and emits description-rich menus, including positional choices
+  and `_files` fallback for free-form string flags. The fish template
+  emits declarative `complete -c` rules gated on a per-script ordered
+  path predicate that walks `commandline -opc` left-to-right — unlike
+  fish's stock `__fish_seen_subcommand_from`, the predicate is order-
+  sensitive, so nested commands that reuse names at different depths
+  route correctly.
 - **Choices and aliases surface end-to-end.** Static enums declared via
   the `choices` field on `FlagDef`/`ArgDef` become value lists in the
-  generated scripts. Command aliases (`meta.aliases`) are tab-completable
-  and resolve to the canonical command's flags.
+  generated scripts (flags **and** the first positional arg, in all
+  three shells). Command aliases (`meta.aliases`) are tab-completable
+  and resolve to the canonical command's flags. Boolean toggles also
+  surface their `--no-<name>` negation candidate (unless `noNegate: true`).
+- **Strict input validation.** Command names, flag names, flag aliases,
+  short flags, arg names, and `binName` must match
+  `/^[A-Za-z0-9][A-Za-z0-9._-]*$/`. Choice values must match
+  `/^[A-Za-z0-9][A-Za-z0-9_.+:@/-]*$/`. The plugin throws at `setup()`
+  time with a clear error if any input falls outside this set, rather
+  than silently mis-quote the generated script. Description text and the
+  `version` string flow through per-shell escapes; control characters
+  are scrubbed at the boundary so they cannot break out of comment lines.
+  `binName` is additionally rejected if it contains path separators or
+  `..`, and the `--output-dir` writer verifies that resolved paths stay
+  inside the requested directory.
 - **`--output-dir` for distributors.** Writes all configured shells with
   the canonical filenames Homebrew, Nix, AUR, and Debian expect
   (`<bin>` for bash, `_<bin>` for zsh, `<bin>.fish` for fish) — no rename

--- a/.changeset/plugins-man-hidden-and-choices.md
+++ b/.changeset/plugins-man-hidden-and-choices.md
@@ -1,0 +1,56 @@
+---
+"@crustjs/plugins": minor
+"@crustjs/man": minor
+"@crustjs/core": patch
+---
+
+Make the `choices`, `meta.aliases`, and `meta.hidden` contracts consistent
+across every consumer (help, did-you-mean, man, completion).
+
+A cross-consumer audit found three gaps:
+
+- `helpPlugin` rendered output omitted the `choices` list for both flags
+  and positional args, so users could not discover valid values from
+  `--help` without resorting to shell completion or source-reading.
+- `didYouMeanPlugin` and the `@crustjs/man` manpage generator both
+  walked the command tree without filtering `meta.hidden: true`, so
+  internal commands (e.g. `__complete`) leaked into typo suggestions,
+  the "Available commands" fallback, and published man pages.
+- `@crustjs/man` omitted long flag aliases (`def.aliases`) and `choices`
+  from the OPTIONS / ARGUMENTS sections, leaving the man page strictly
+  less informative than `--help`.
+- The completion plugin's bash and fish templates only surfaced
+  `choices` for the **first** positional argument; zsh respected every
+  slot. Variadic-with-choices arguments and multi-positional commands
+  silently fell through to file completion in bash/fish.
+
+Changes:
+
+- `helpPlugin` renders `[choices: a, b, c]` after the description for
+  every flag and arg that declares a `choices` list, composed with
+  `[default: ...]` when both are present.
+- `didYouMeanPlugin` skips `meta.hidden: true` siblings in both the
+  Levenshtein suggestion corpus (canonical names **and** aliases) and
+  the "Available commands" fallback list.
+- `@crustjs/man` filters `meta.hidden: true` subcommands from the
+  SUBCOMMANDS section (and skips the section entirely when every
+  subcommand is hidden), surfaces flag and arg `choices` as a
+  `[choices: ...]` suffix, and includes long flag aliases in OPTIONS
+  labels (`-o, --output, --out`, plus `--no-` negation for every long
+  spelling on boolean flags).
+- `completionPlugin` bash and fish templates now track positional slot
+  index past the resolved command path and emit per-slot choice
+  candidates. Variadic-with-choices arguments are handled correctly
+  (the choice list applies at every slot from the variadic's declared
+  index onwards). The fish template gains a second per-script helper
+  `__<ident>_path_at_arg` that the existing `__<ident>_path_is` is
+  layered alongside; subcommand and flag rules continue to use the
+  original predicate.
+
+Core / docs:
+
+- `CommandMeta.hidden` JSDoc now enumerates every tooling surface the
+  flag affects (help, completion, did-you-mean, man, skills) and is
+  explicit that there is intentionally no analogous `FlagDef.hidden` —
+  the workaround for flag-level hiding is to register without a
+  description.

--- a/apps/docs/content/docs/guide/plugins.mdx
+++ b/apps/docs/content/docs/guide/plugins.mdx
@@ -39,6 +39,7 @@ Crust ships with these official plugins:
 | [`versionPlugin()`](/docs/modules/plugins/version)                | Adds `--version` / `-v` to the root command                 |
 | [`didYouMeanPlugin()`](/docs/modules/plugins/did-you-mean)        | Suggests corrections for mistyped subcommands               |
 | [`updateNotifierPlugin()`](/docs/modules/plugins/update-notifier) | Checks npm for newer versions and displays an update notice |
+| [`completionPlugin()`](/docs/modules/plugins/completion)          | Generates bash/zsh/fish tab-completion scripts              |
 
 ## Plugin Order
 

--- a/apps/docs/content/docs/modules/plugins/completion.mdx
+++ b/apps/docs/content/docs/modules/plugins/completion.mdx
@@ -253,6 +253,17 @@ the CLI's startup time on every shell launch.
   `foo/_my-cli`, and `foo/my-cli.fish`. This matches the packaging-time
   use case where distributors want every artifact in one go. Use the
   print path (no `--output-dir`) when you want a single shell only.
+- **Strict identifier and choice-value validation.** Command names, flag
+  names, flag aliases, short flags, arg names, and `binName` must match
+  `/^[A-Za-z0-9][A-Za-z0-9._-]*$/`. Choice values (on flags **and** args)
+  must match `/^[A-Za-z0-9][A-Za-z0-9_.+:@/-]*$/` — enough for things like
+  `us-east-1`, `node@20`, or `text/plain`, but not whitespace, quotes, or
+  shell metacharacters. The plugin throws at `setup()` time with a clear
+  error if any input falls outside this set, rather than silently mis-quote
+  the generated script. Description text is free-form and goes through
+  per-shell escaping; control characters (newlines, NUL, ESC, …) are
+  scrubbed at the boundary so they cannot break out of comment lines or
+  shell-quoted strings.
 
 ## Design notes
 
@@ -279,10 +290,5 @@ The two choices are equally valid; we picked pure-static for v1 because:
    `__complete` subcommand, no middleware bypass).
 3. Adding dynamic per-arg/per-flag callbacks later is non-breaking — we can
    evolve into a hybrid without changing the v1 contract.
-
-Research artifacts: see `/tmp/crust-completion-research/` (bash, zsh, fish
-protocol references) and `/tmp/crust-completion-verification/` (oracle
-red-team review, distribution patterns) in the repo's research drop for the
-full evaluation.
 
 </details>

--- a/apps/docs/content/docs/modules/plugins/completion.mdx
+++ b/apps/docs/content/docs/modules/plugins/completion.mdx
@@ -1,0 +1,288 @@
+---
+title: Completion
+description: Generate shell tab-completion scripts for bash, zsh, and fish.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The completion plugin adds a `completion <shell>` subcommand that emits a
+tab-completion script for **bash**, **zsh**, or **fish**. The strategy is
+**pure-static**: the plugin walks your live command tree at run time and
+prints a self-contained script — no hidden subcommand, no runtime callbacks,
+no shell-out on TAB.
+
+## Usage
+
+```ts
+import { Crust } from "@crustjs/core";
+import { completionPlugin } from "@crustjs/plugins";
+import pkg from "../package.json";
+
+const main = new Crust("my-cli")
+  .meta({ description: "My CLI" })
+  .use(completionPlugin({ version: pkg.version }))
+  .command("build", (cmd) =>
+    cmd
+      .meta({ description: "Build artifact" })
+      .flags({
+        target: { type: "string", choices: ["browser", "bun", "node"] },
+      })
+      .run(() => {}),
+  )
+  .run(() => {});
+
+await main.execute();
+```
+
+```sh
+$ my-cli completion bash | head -1
+# completion script for my-cli v1.0.0 — regenerate with: my-cli completion bash
+```
+
+## Options
+
+| Option     | Type                                     | Default                    | Description                                                                       |
+| ---------- | ---------------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
+| `command`  | `string`                                 | `"completion"`             | Subcommand name. Override only if `completion` collides with an existing command. |
+| `binName`  | `string`                                 | root command's `meta.name` | Binary name embedded in generated scripts (the `complete -F` target, etc.).       |
+| `shells`   | `Array<"bash" \| "zsh" \| "fish">`       | `["bash", "zsh", "fish"]`  | Shells written by `--output-dir`. The CLI accepts any of these as `<shell>`.      |
+| `version`  | `string`                                 | `"0.0.0"`                  | Free-form version string embedded in script headers. Pass `pkg.version`.          |
+
+## Per-shell install
+
+The runtime contract is the same in every shell: print to stdout, redirect into
+the shell's auto-discovery directory.
+
+### Bash
+
+```sh
+# Per-user (lazy-loaded by bash-completion ≥ 2.0)
+mkdir -p ~/.local/share/bash-completion/completions
+my-cli completion bash > ~/.local/share/bash-completion/completions/my-cli
+```
+
+Or eval inline (shell-startup cost):
+
+```sh
+# in ~/.bashrc
+eval "$(my-cli completion bash)"
+```
+
+The generated script ships a Cobra-style fallback init shim, so it works on
+systems that do **not** have the `bash-completion` package installed (macOS
+default bash, Alpine, NixOS without the package).
+
+### Zsh
+
+```sh
+# Per-user — drop into a directory on $fpath
+mkdir -p ~/.zsh/completions
+my-cli completion zsh > ~/.zsh/completions/_my-cli
+```
+
+Then in `~/.zshrc`, *before* `compinit`:
+
+```zsh
+fpath=(~/.zsh/completions $fpath)
+autoload -Uz compinit && compinit
+```
+
+Or eval inline:
+
+```zsh
+# in ~/.zshrc, after `autoload -Uz compinit && compinit`
+eval "$(my-cli completion zsh)"
+```
+
+### Fish
+
+```sh
+my-cli completion fish > ~/.config/fish/completions/my-cli.fish
+```
+
+Fish auto-loads files in `~/.config/fish/completions/` the first time you
+invoke the matching command. No `source` line needed.
+
+Or eval inline:
+
+```fish
+# in ~/.config/fish/config.fish
+my-cli completion fish | source
+```
+
+## Packaging recipes
+
+The generated filenames match every major packaging system's expectations
+(`<bin>` for bash, `_<bin>` for zsh, `<bin>.fish` for fish), so no rename is
+needed. The two installation patterns are **runtime-invocation** (run the
+binary at install time) and **pre-generated files** (ship the artifacts in
+the source tarball).
+
+### Homebrew
+
+Modern formulae use the `generate_completions_from_executable` helper, which
+runs the freshly-built binary at brew install time:
+
+```ruby
+class MyCli < Formula
+  # ...
+  def install
+    bin.install "my-cli"
+    generate_completions_from_executable(bin/"my-cli", "completion")
+  end
+end
+```
+
+The helper passes the shell name (`bash`/`zsh`/`fish`) as the trailing argv,
+which matches the plugin's positional `<shell>` argument exactly.
+
+### Nix
+
+`installShellCompletion` from `installShellFiles` accepts the artifacts
+directly with no `--cmd` rename:
+
+```nix
+{ stdenv, installShellFiles }:
+stdenv.mkDerivation {
+  # ...
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd my-cli \
+      --bash <($out/bin/my-cli completion bash) \
+      --zsh  <($out/bin/my-cli completion zsh)  \
+      --fish <($out/bin/my-cli completion fish)
+  '';
+}
+```
+
+The `canExecute` guard is required: under cross-compilation the host can't
+run the target binary. Cross builds will skip completion install — see the
+**Cross-compile note** below for the workaround.
+
+### AUR (Arch Linux)
+
+Standard PKGBUILD pattern:
+
+```bash
+package() {
+  install -Dm755 my-cli "$pkgdir/usr/bin/my-cli"
+  install -Dm644 <("$pkgdir/usr/bin/my-cli" completion bash) \
+    "$pkgdir/usr/share/bash-completion/completions/my-cli"
+  "$pkgdir/usr/bin/my-cli" completion zsh \
+    > "$pkgdir/usr/share/zsh/site-functions/_my-cli"
+  "$pkgdir/usr/bin/my-cli" completion fish \
+    > "$pkgdir/usr/share/fish/vendor_completions.d/my-cli.fish"
+}
+```
+
+### Debian
+
+For bash-only completion (the common case in Debian), add a
+`debian/my-cli.bash-completion` file via `dh_bash-completion`. The newer
+`dh-shell-completions` helper supports zsh/fish too.
+
+## Cross-compile note (nixpkgs)
+
+`bun build --compile` produces per-platform binaries. When nixpkgs builds
+aarch64-darwin from x86_64-linux (and vice versa), the binary cannot run at
+build time and the `canExecute` guard above skips completion install — your
+aarch64-darwin users get no completion.
+
+The fix is to **ship pre-generated completion files in the npm tarball** so
+the derivation never needs to invoke the binary. Add a `prepublishOnly`
+script:
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "prepublishOnly": "bun run dist/my-cli.js completion bash --output-dir completions/"
+  },
+  "files": ["dist", "completions"]
+}
+```
+
+Then a Nix derivation can copy the files verbatim with no `canExecute` guard:
+
+```nix
+postInstall = ''
+  installShellCompletion \
+    --bash completions/my-cli \
+    --zsh  completions/_my-cli \
+    --fish completions/my-cli.fish
+'';
+```
+
+Passing `--output-dir <path>` writes **all configured shells** in one
+invocation (bash/zsh/fish by default; restrict via the `shells` option), with
+canonical filenames the helpers consume directly.
+
+## Drift handling
+
+A pure-static script is a snapshot of the command tree at the moment you
+generated it. After upgrading the CLI, regenerate:
+
+```sh
+my-cli completion bash > ~/.local/share/bash-completion/completions/my-cli
+```
+
+Every generated script's first line includes the binary name and version it
+was built from, so users (and `diff`) can spot stale completion files at a
+glance:
+
+```text
+# completion script for my-cli v1.0.0 — regenerate with: my-cli completion bash
+```
+
+For installation paths that re-run the CLI on each login (`eval "$(my-cli
+completion bash)"` in `~/.bashrc`), drift is impossible — the cost is paying
+the CLI's startup time on every shell launch.
+
+## Limitations (v1)
+
+- **No dynamic value completion.** Per-flag/per-arg `complete?:` callbacks
+  are intentionally deferred to a future minor bump. Adding them is
+  non-breaking, so v1 ships pure-static today and grows into a hybrid
+  later. Use the static `choices` field on flags and args (see
+  [`@crustjs/core`](/docs/modules/core)) for fixed enums today; that's enough
+  for the majority of CLI flags.
+- **No PowerShell.** PowerShell completion is on the v2 roadmap.
+- **`--output-dir` writes every configured shell.** Even if you invoke
+  `my-cli completion bash --output-dir foo/`, the plugin writes `foo/my-cli`,
+  `foo/_my-cli`, and `foo/my-cli.fish`. This matches the packaging-time
+  use case where distributors want every artifact in one go. Use the
+  print path (no `--output-dir`) when you want a single shell only.
+
+## Design notes
+
+<details>
+<summary>Why pure-static? (vs Cobra/clap_complete-style delegate)</summary>
+
+Cobra and clap_complete generate small bootstrap scripts that shell out to
+the binary on every TAB. That trades stale-after-upgrade drift for a
+~5–10 ms subprocess cost per completion (worse on JVM/Node startups). The
+delegate pattern also breaks if the binary moves on `$PATH` or fails to
+launch.
+
+Pure-static — the pattern used by oclif's `plugin-autocomplete`, jujutsu,
+mise, and Zellij — emits a self-contained script with the command tree
+baked in. Cost on TAB is zero; cost is one regeneration per CLI upgrade,
+mitigated by the `--output-dir` packaging path which lets distributors do
+the regeneration at packaging time.
+
+The two choices are equally valid; we picked pure-static for v1 because:
+
+1. Crust commands are defined declaratively at build time, so the tree is
+   already enumerable without any extra plumbing.
+2. It ships cleanly without any changes to `@crustjs/core` (no hidden
+   `__complete` subcommand, no middleware bypass).
+3. Adding dynamic per-arg/per-flag callbacks later is non-breaking — we can
+   evolve into a hybrid without changing the v1 contract.
+
+Research artifacts: see `/tmp/crust-completion-research/` (bash, zsh, fish
+protocol references) and `/tmp/crust-completion-verification/` (oracle
+red-team review, distribution patterns) in the repo's research drop for the
+full evaluation.
+
+</details>

--- a/apps/docs/content/docs/modules/plugins/completion.mdx
+++ b/apps/docs/content/docs/modules/plugins/completion.mdx
@@ -41,12 +41,12 @@ $ my-cli completion bash | head -1
 
 ## Options
 
-| Option     | Type                                     | Default                    | Description                                                                       |
-| ---------- | ---------------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
-| `command`  | `string`                                 | `"completion"`             | Subcommand name. Override only if `completion` collides with an existing command. |
-| `binName`  | `string`                                 | root command's `meta.name` | Binary name embedded in generated scripts (the `complete -F` target, etc.).       |
-| `shells`   | `Array<"bash" \| "zsh" \| "fish">`       | `["bash", "zsh", "fish"]`  | Shells written by `--output-dir`. The CLI accepts any of these as `<shell>`.      |
-| `version`  | `string`                                 | `"0.0.0"`                  | Free-form version string embedded in script headers. Pass `pkg.version`.          |
+| Option    | Type                               | Default                    | Description                                                                       |
+| --------- | ---------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
+| `command` | `string`                           | `"completion"`             | Subcommand name. Override only if `completion` collides with an existing command. |
+| `binName` | `string`                           | root command's `meta.name` | Binary name embedded in generated scripts (the `complete -F` target, etc.).       |
+| `shells`  | `Array<"bash" \| "zsh" \| "fish">` | `["bash", "zsh", "fish"]`  | Shells written by `--output-dir`. The CLI accepts any of these as `<shell>`.      |
+| `version` | `string`                           | `"0.0.0"`                  | Free-form version string embedded in script headers. Pass `pkg.version`.          |
 
 ## Per-shell install
 
@@ -80,7 +80,7 @@ mkdir -p ~/.zsh/completions
 my-cli completion zsh > ~/.zsh/completions/_my-cli
 ```
 
-Then in `~/.zshrc`, *before* `compinit`:
+Then in `~/.zshrc`, _before_ `compinit`:
 
 ```zsh
 fpath=(~/.zsh/completions $fpath)
@@ -197,9 +197,9 @@ script:
 // package.json
 {
   "scripts": {
-    "prepublishOnly": "bun run dist/my-cli.js completion bash --output-dir completions/"
+    "prepublishOnly": "bun run dist/my-cli.js completion bash --output-dir completions/",
   },
-  "files": ["dist", "completions"]
+  "files": ["dist", "completions"],
 }
 ```
 
@@ -264,31 +264,3 @@ the CLI's startup time on every shell launch.
   per-shell escaping; control characters (newlines, NUL, ESC, …) are
   scrubbed at the boundary so they cannot break out of comment lines or
   shell-quoted strings.
-
-## Design notes
-
-<details>
-<summary>Why pure-static? (vs Cobra/clap_complete-style delegate)</summary>
-
-Cobra and clap_complete generate small bootstrap scripts that shell out to
-the binary on every TAB. That trades stale-after-upgrade drift for a
-~5–10 ms subprocess cost per completion (worse on JVM/Node startups). The
-delegate pattern also breaks if the binary moves on `$PATH` or fails to
-launch.
-
-Pure-static — the pattern used by oclif's `plugin-autocomplete`, jujutsu,
-mise, and Zellij — emits a self-contained script with the command tree
-baked in. Cost on TAB is zero; cost is one regeneration per CLI upgrade,
-mitigated by the `--output-dir` packaging path which lets distributors do
-the regeneration at packaging time.
-
-The two choices are equally valid; we picked pure-static for v1 because:
-
-1. Crust commands are defined declaratively at build time, so the tree is
-   already enumerable without any extra plumbing.
-2. It ships cleanly without any changes to `@crustjs/core` (no hidden
-   `__complete` subcommand, no middleware bypass).
-3. Adding dynamic per-arg/per-flag callbacks later is non-breaking — we can
-   evolve into a hybrid without changing the v1 contract.
-
-</details>

--- a/apps/docs/content/docs/modules/plugins/index.mdx
+++ b/apps/docs/content/docs/modules/plugins/index.mdx
@@ -22,6 +22,7 @@ bun add @crustjs/plugins
 | [`versionPlugin()`](/docs/modules/plugins/version)                | Adds `--version` / `-v` to display version               |
 | [`didYouMeanPlugin()`](/docs/modules/plugins/did-you-mean)        | Suggests corrections for mistyped subcommands            |
 | [`updateNotifierPlugin()`](/docs/modules/plugins/update-notifier) | Checks npm for newer versions and displays update notice |
+| [`completionPlugin()`](/docs/modules/plugins/completion)          | Generates bash/zsh/fish tab-completion scripts           |
 
 ### Utilities
 
@@ -40,6 +41,8 @@ bun add @crustjs/plugins
 | `UpdateNotifierCacheAdapter`  | Cache adapter interface for update notifier       |
 | `UpdateNotifierPackageManager` | Package manager union for update notifier        |
 | `UpdateNotifierInstallScope`  | Install scope union for update notifier           |
+| `CompletionPluginOptions`     | Options for the completion plugin                 |
+| `CompletionShell`             | `"bash" \| "zsh" \| "fish"` shell union           |
 
 Manual pages are provided by [`@crustjs/man`](/docs/modules/man) (build-time mdoc), not by this package.
 

--- a/apps/docs/content/docs/modules/plugins/index.mdx
+++ b/apps/docs/content/docs/modules/plugins/index.mdx
@@ -55,6 +55,7 @@ import {
   versionPlugin,
   didYouMeanPlugin,
   updateNotifierPlugin,
+  completionPlugin,
 } from "@crustjs/plugins";
 import { Crust } from "@crustjs/core";
 
@@ -65,6 +66,7 @@ const main = new Crust("my-cli")
   .use(didYouMeanPlugin({ mode: "help" }))
   .use(helpPlugin())
   .use(updateNotifierPlugin({ packageName: "my-cli", currentVersion: "1.0.0" }))
+  .use(completionPlugin({ version: "1.0.0" }))
   .run(() => {
     console.log("Hello!");
   });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -671,22 +671,36 @@ export interface CommandMeta {
 	 */
 	aliases?: readonly string[];
 	/**
-	 * When `true`, omit this command from any tooling that enumerates the
-	 * command tree for users — help output, generated man pages, skill
-	 * descriptors, completion candidate lists, and similar surfaces.
+	 * When `true`, omit this command from every tooling surface that
+	 * enumerates the command tree for users:
 	 *
-	 * The command is **only hidden from listings**: it stays fully invocable
-	 * by name (or alias), routing is unchanged, and it can still surface
-	 * through tooling that looks up specific commands rather than
-	 * enumerating the tree (e.g. `didYouMeanPlugin` suggestions).
+	 * - `helpPlugin` rendered output (subcommand list + USAGE token)
+	 * - `@crustjs/man` generated man pages (`SUBCOMMANDS` section)
+	 * - `completionPlugin` candidate lists (recursively — hidden
+	 *   subcommands and their descendants never appear in generated
+	 *   bash/zsh/fish scripts)
+	 * - `didYouMeanPlugin` typo suggestions and "Available commands"
+	 *   list (so internal names never surface in error UX)
+	 * - `skillPlugin` manifests
 	 *
-	 * Intended for internal/runtime commands like a `__complete` shell-
-	 * completion entrypoint. Marking a user-facing command `hidden` is
-	 * supported but unusual.
+	 * The command is **only hidden from listings**: routing in
+	 * `@crustjs/core` does not consult `meta.hidden`, so it stays fully
+	 * invocable by direct name (or alias). The intended use case is
+	 * internal/runtime commands like a `__complete` shell-completion
+	 * entrypoint. Marking a user-facing command `hidden` is supported but
+	 * unusual.
 	 *
-	 * Tooling contract: any renderer or generator that walks `subCommands`
-	 * to produce a user-facing listing should skip nodes where
-	 * `meta.hidden === true`.
+	 * **Scope: commands only.** There is no analogous `hidden` field on
+	 * `FlagDef` or `ArgDef`; flags and positional arguments always surface
+	 * in help, completion, and man output. If you need a flag that does
+	 * not advertise itself, the workaround is to register it through a
+	 * plugin's `setup()` hook without describing it (omit `description`),
+	 * which suppresses its description body but still lists the spelling
+	 * — there is intentionally no full hide mechanism at the flag layer.
+	 *
+	 * Tooling contract: any renderer or generator that walks
+	 * `subCommands` to produce a user-facing listing should skip nodes
+	 * where `meta.hidden === true`.
 	 *
 	 * @example
 	 * meta: { name: "__complete", hidden: true, description: "Internal" }

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -97,4 +97,123 @@ describe("renderManPageMdoc", () => {
 		const width = Number(widthMatch?.[1]);
 		expect(width).toBeGreaterThanOrEqual("issue (issues, i)".length);
 	});
+
+	it("omits `meta.hidden: true` subcommands from the SUBCOMMANDS section", async () => {
+		// Mirrors the helpPlugin contract: hidden commands stay invocable
+		// but never appear in published man pages.
+		const app = new Crust("demo")
+			.meta({ description: "Demo." })
+			.command(
+				new Crust("build")
+					.meta({ description: "Build the project" })
+					.run(() => {}),
+			)
+			.command(
+				new Crust("__complete")
+					.meta({ description: "Internal completion entrypoint", hidden: true })
+					.run(() => {}),
+			);
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		expect(mdoc).toContain(".It Nm build");
+		expect(mdoc).not.toContain("__complete");
+	});
+
+	it("omits the SUBCOMMANDS section entirely when every subcommand is hidden", async () => {
+		const app = new Crust("demo")
+			.command(
+				new Crust("__complete")
+					.meta({ hidden: true, description: "Internal" })
+					.run(() => {}),
+			)
+			.run(() => {});
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		expect(mdoc).not.toContain(".Sh SUBCOMMANDS");
+		expect(mdoc).not.toContain("__complete");
+	});
+
+	it("renders flag `choices` as `[choices: ...]` after the description", async () => {
+		const app = new Crust("demo")
+			.meta({ description: "Demo." })
+			.flags({
+				target: {
+					type: "string",
+					choices: ["browser", "bun", "node"],
+					description: "Build target",
+				},
+			})
+			.run(() => {});
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		expect(mdoc).toContain(".It Sy --target");
+		expect(mdoc).toContain("Build target [choices: browser, bun, node]");
+	});
+
+	it("renders positional-arg `choices` in the ARGUMENTS section", async () => {
+		const app = new Crust("demo")
+			.meta({ description: "Demo." })
+			.args([
+				{
+					name: "env",
+					type: "string",
+					required: true,
+					choices: ["dev", "staging", "prod"],
+					description: "Target environment",
+				},
+			])
+			.run(() => {});
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		expect(mdoc).toContain(".Sh ARGUMENTS");
+		expect(mdoc).toContain(".It Ql <env>");
+		expect(mdoc).toContain("Target environment [choices: dev, staging, prod]");
+	});
+
+	it("includes long flag aliases (`def.aliases`) alongside the canonical spelling", async () => {
+		const app = new Crust("demo")
+			.meta({ description: "Demo." })
+			.flags({
+				output: {
+					type: "string",
+					short: "o",
+					aliases: ["out"],
+					description: "Where to write",
+				},
+			})
+			.run(() => {});
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		// Both the canonical `--output` and the alias `--out` appear in the
+		// label, comma-separated, after the short flag.
+		expect(mdoc).toContain(".It Sy -o, --output, --out");
+	});
+
+	it("includes `--no-` negation for every long-form spelling of a boolean flag", async () => {
+		const app = new Crust("demo")
+			.flags({
+				color: {
+					type: "boolean",
+					aliases: ["colour"],
+					description: "Use colour",
+				},
+			})
+			.run(() => {});
+
+		const { root } = await app.prepareCommandTree();
+		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
+
+		// Canonical + alias + both negations, in declaration order.
+		expect(mdoc).toContain(".It Sy --color, --colour, --no-color, --no-colour");
+	});
 });

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -84,14 +84,66 @@ function formatUsagePlain(
 	return parts.join(" ");
 }
 
+/**
+ * Render the labels for a single flag definition for the `OPTIONS`
+ * tagged-list. The output is a comma-joined sequence of spellings:
+ *
+ *   `-o, --output, --out, --no-output, --no-out`
+ *
+ * Order: short flag first (when present), canonical long form, every
+ * declared long alias (`def.aliases`), then — for boolean flags that
+ * have not opted out of negation — the `--no-<spelling>` forms in the
+ * same order. Long aliases are surfaced so the man page documents the
+ * complete callable surface of the flag; without them users only see
+ * the canonical name and have no way to discover that `--out` is
+ * equivalent.
+ */
 function formatFlagLabels(name: string, def: FlagDef): string {
+	const longNames: string[] = [name];
+	if (def.aliases) {
+		for (const alias of def.aliases) longNames.push(alias);
+	}
 	const labels: string[] = [];
 	if (def.short) labels.push(`-${def.short}`);
-	labels.push(`--${name}`);
+	for (const long of longNames) labels.push(`--${long}`);
 	if (def.type === "boolean" && !def.noNegate) {
-		labels.push(`--no-${name}`);
+		for (const long of longNames) labels.push(`--no-${long}`);
 	}
 	return labels.join(", ");
+}
+
+/**
+ * Render a trailing `[choices: a, b, c]` hint when the supplied list is
+ * non-empty. Returns an empty string otherwise so the caller can
+ * unconditionally concatenate.
+ *
+ * Takes the raw `choices` array directly rather than a `def` object —
+ * `FlagDef` and `ArgDef` are discriminated unions whose number/boolean
+ * variants do not carry `choices` at all, so a structural `{ choices? }`
+ * parameter fails TS excess-property checks. Each caller already has
+ * access to `def.choices` (typed as `readonly string[] | undefined`),
+ * so passing it directly avoids the union narrowing.
+ */
+function formatChoicesSuffix(choices: readonly string[] | undefined): string {
+	if (!choices || choices.length === 0) return "";
+	return `[choices: ${choices.join(", ")}]`;
+}
+
+/**
+ * Join a flag/arg description, its default-value suffix, and its
+ * choices-suffix into a single mdoc body. Each piece is optional;
+ * separators collapse so we never emit a stray double-space.
+ */
+function formatDescriptionWithChoices(
+	description: string | undefined,
+	defaultValue: unknown,
+	choices: readonly string[] | undefined,
+): string {
+	const base = formatDescription(description, defaultValue);
+	const suffix = formatChoicesSuffix(choices);
+	if (!suffix) return base;
+	if (!base) return suffix;
+	return `${base} ${suffix}`;
 }
 
 function dtTitle(name: string): string {
@@ -140,6 +192,11 @@ function formatSubcommandLabel(
 function longestSubcommandWidth(command: CommandNode): string {
 	let max = 8;
 	for (const [name, sub] of Object.entries(command.subCommands)) {
+		// Hidden subcommands are not rendered (see SUBCOMMANDS loop) and
+		// therefore must not influence the column width — a long hidden
+		// internal command name would otherwise stretch the layout for
+		// every visible peer.
+		if (sub.meta.hidden === true) continue;
 		const label = formatSubcommandLabel(name, sub.meta.aliases);
 		max = Math.max(max, label.length);
 	}
@@ -208,13 +265,21 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		lines.push(escapeMdocBodyLine(rawLine));
 	}
 
-	const subNames = Object.keys(root.subCommands);
-	if (subNames.length > 0) {
+	// Filter subcommands marked `meta.hidden: true`. Hidden subcommands
+	// remain invocable by direct name (the router does not consult
+	// `meta.hidden`); they are excluded from generated documentation so
+	// internal commands (e.g. `__complete`) do not surface in published
+	// man pages. Matches the contract upheld by `helpPlugin` and
+	// `completionPlugin`.
+	const visibleSubEntries = Object.entries(root.subCommands).filter(
+		([, sub]) => sub.meta.hidden !== true,
+	);
+	if (visibleSubEntries.length > 0) {
 		lines.push(".Sh SUBCOMMANDS");
 		lines.push(`.Bl -tag -width ${longestSubcommandWidth(root)}`);
-		for (const subName of subNames.sort()) {
-			const sub = root.subCommands[subName];
-			if (!sub) continue;
+		for (const [subName, sub] of visibleSubEntries.sort(([a], [b]) =>
+			a.localeCompare(b),
+		)) {
 			// `.It Nm <name> (alias1, alias2)` keeps the canonical name marked up
 			// as a name macro while letting aliases ride along as plain text.
 			// Parens and commas are not mdoc macros, so no escaping is needed.
@@ -238,7 +303,15 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		for (const [flagName, def] of flagEntries) {
 			const labels = formatFlagLabels(flagName, def);
 			lines.push(`.It Sy ${labels}`);
-			const body = formatDescription(def.description, def.default).trim();
+			// `choices` only exists on string-typed flag variants; number/
+			// boolean flags narrow to `undefined` and `formatChoicesSuffix`
+			// renders that as the empty string.
+			const choices = def.type === "string" ? def.choices : undefined;
+			const body = formatDescriptionWithChoices(
+				def.description,
+				def.default,
+				choices,
+			).trim();
 			if (body) {
 				lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
 			}
@@ -251,7 +324,12 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		lines.push(".Bl -tag -width 12n");
 		for (const arg of root.args) {
 			lines.push(`.It Ql ${formatArgToken(arg)}`);
-			const body = formatDescription(arg.description, arg.default).trim();
+			const choices = arg.type === "string" ? arg.choices : undefined;
+			const body = formatDescriptionWithChoices(
+				arg.description,
+				arg.default,
+				choices,
+			).trim();
 			if (body) {
 				lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
 			}

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -168,6 +168,37 @@ updateNotifierPlugin({
 
 > **Note:** Version comparison uses standard semver (`major.minor.patch`). Prerelease suffixes are stripped before comparison — `1.2.3-beta.1` is treated as `1.2.3`.
 
+### Completion
+
+The `completionPlugin()` adds a `completion <shell>` subcommand that emits a self-contained tab-completion script for **bash**, **zsh**, or **fish**.
+
+```ts
+import { Crust } from "@crustjs/core";
+import { completionPlugin } from "@crustjs/plugins";
+import pkg from "../package.json";
+
+const app = new Crust("my-cli")
+  .use(completionPlugin({ version: pkg.version }))
+  .command("build", (cmd) =>
+    cmd
+      .meta({ description: "Build artifact" })
+      .flags({ target: { type: "string", choices: ["browser", "bun", "node"] } })
+      .run(() => {}),
+  )
+  .run(() => {});
+
+await app.execute();
+```
+
+```sh
+# Print to stdout (one shell at a time)
+my-cli completion bash > ~/.local/share/bash-completion/completions/my-cli
+# Or write all configured shells in one go (packaging-time)
+my-cli completion bash --output-dir completions/
+```
+
+See [the completion guide](https://crustjs.com/docs/modules/plugins/completion) for per-shell install paths, packaging recipes, and the v1 limitations (notably the strict identifier/choice-value validation).
+
 ## Documentation
 
 See the full docs at [crustjs.com](https://crustjs.com).

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -17,6 +17,7 @@ bun add @crustjs/plugins
 | `versionPlugin(version)` | Adds `--version` / `-v` flag |
 | `didYouMeanPlugin(options?)` | Suggests corrections for mistyped subcommands via Levenshtein matching |
 | `updateNotifierPlugin(options)` | Checks npm for newer versions and displays an update notice |
+| `completionPlugin(options?)` | Adds a `completion <shell>` subcommand that emits bash/zsh/fish tab-completion scripts |
 
 ## Usage
 

--- a/packages/plugins/src/completion/adversarial.test.ts
+++ b/packages/plugins/src/completion/adversarial.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Crust } from "@crustjs/core";
+import { completionPlugin } from "./index.ts";
+import type { CompletionSpec } from "./spec.ts";
+import { renderBash } from "./templates/bash.ts";
+import { renderFish } from "./templates/fish.ts";
+import { renderZsh } from "./templates/zsh.ts";
+import { walkCommandNode } from "./walker.ts";
+
+/**
+ * Adversarial test suite. These tests exercise the validation/escape
+ * boundary that protects the generated shell scripts from injection,
+ * the documented behaviour for `--`/`--name=value`/`--no-` in bash, the
+ * order-sensitive fish path predicate, and `--output-dir` traversal.
+ *
+ * They are intentionally separate from the per-shell `*.test.ts` files
+ * so the per-shell suites stay focused on the renderer's happy path.
+ */
+
+// ── Walker validation ────────────────────────────────────────────────────
+
+describe("walker · validation", () => {
+	it("rejects command names containing whitespace", () => {
+		const cli = new Crust("bad")
+			.command("two words" as string, (c) => c.run(() => {}))
+			.run(() => {});
+		expect(() => walkCommandNode(cli._node)).toThrow(/invalid command name/);
+	});
+
+	it("rejects flag names with shell metacharacters", () => {
+		const cli = new Crust("bad")
+			.flags({ "a;rm": { type: "boolean" } } as never)
+			.run(() => {});
+		expect(() => walkCommandNode(cli._node)).toThrow(/invalid flag name/);
+	});
+
+	it("rejects choice values containing spaces", () => {
+		const cli = new Crust("bad")
+			.flags({
+				target: {
+					type: "string",
+					choices: ["a", "two words", "c"],
+				},
+			})
+			.run(() => {});
+		expect(() => walkCommandNode(cli._node)).toThrow(
+			/unsupported choice value/,
+		);
+	});
+
+	it("rejects choice values containing single quotes", () => {
+		const cli = new Crust("bad")
+			.flags({
+				target: { type: "string", choices: ["a", "it's", "c"] },
+			})
+			.run(() => {});
+		expect(() => walkCommandNode(cli._node)).toThrow(
+			/unsupported choice value/,
+		);
+	});
+
+	it("strips control characters from descriptions instead of throwing", () => {
+		const cli = new Crust("safe")
+			.meta({ description: "first line\nsecond line\rstill same line" })
+			.run(() => {});
+		const spec = walkCommandNode(cli._node);
+		// Newlines and CR collapse to spaces during normalisation.
+		expect(spec.root.description).toBe(
+			"first line second line still same line",
+		);
+		// And the value never contains a raw newline that could break
+		// out of an emitted comment line.
+		expect(spec.root.description).not.toMatch(/[\r\n]/);
+	});
+});
+
+// ── Comment/header injection ─────────────────────────────────────────────
+
+describe("renderBash / renderZsh / renderFish · header injection", () => {
+	const minimal: CompletionSpec = {
+		root: { name: "x", flags: [], args: [], subCommands: [] },
+	};
+
+	it.each([
+		["bash", renderBash],
+		["zsh", renderZsh],
+		["fish", renderFish],
+	] as const)("%s strips newlines from `version` so the header stays a single comment line", (_shell, render) => {
+		// Without sanitisation, an embedded `\n` would terminate the
+		// `# ...` comment line and turn the rest into executable shell
+		// when the script is `eval`'d (the documented install path). The
+		// invariant we care about is: the embedded text remains *inside*
+		// the comment line, not that the textual payload disappears
+		// (the textual payload is inert because it's commented out).
+		const evil = "1.0\necho ATTACK #";
+		const out = render(minimal, "x", evil);
+		const headerLine = out.split("\n").find((l) => l.includes("v1.0"));
+		expect(headerLine).toBeDefined();
+		// The full payload is on the *same* line as `v1.0` (i.e. inside
+		// the comment), not on a follow-up line.
+		expect(headerLine).toContain("ATTACK");
+		// And no second comment-less line containing `echo ATTACK` exists
+		// (which would happen if the newline survived).
+		const nonCommentLines = out
+			.split("\n")
+			.filter((l) => l.length > 0 && !l.startsWith("#"))
+			.filter((l) => l.includes("ATTACK"));
+		expect(nonCommentLines).toEqual([]);
+	});
+});
+
+// ── --no- negation ───────────────────────────────────────────────────────
+
+describe("--no- negation", () => {
+	const spec: CompletionSpec = {
+		root: {
+			name: "mycli",
+			flags: [
+				{ name: "force", type: "boolean", takesValue: false },
+				{
+					name: "color",
+					type: "boolean",
+					takesValue: false,
+					noNegate: true,
+				},
+			],
+			args: [],
+			subCommands: [],
+		},
+	};
+
+	it("bash: emits --no-<name> for negatable boolean flags", () => {
+		const out = renderBash(spec, "mycli", "1");
+		expect(out).toContain("--no-force");
+		// `noNegate` flag has its negation suppressed.
+		expect(out).not.toContain("--no-color");
+	});
+
+	it("zsh: emits --no-<name> as a separate spec", () => {
+		const out = renderZsh(spec, "mycli", "1");
+		expect(out).toContain("--no-force");
+		expect(out).not.toContain("--no-color");
+	});
+
+	it("fish: emits --no-<name> as its own complete rule", () => {
+		const out = renderFish(spec, "mycli", "1");
+		expect(out).toMatch(/-l 'no-force'/);
+		expect(out).not.toMatch(/-l 'no-color'/);
+	});
+});
+
+// ── bash behaviour: -- terminator + --name=value + value-flag context ────
+
+describe("renderBash · behavioural · -- and --name=value", () => {
+	const spec: CompletionSpec = {
+		root: {
+			name: "mycli",
+			flags: [],
+			args: [],
+			subCommands: [
+				{
+					name: "build",
+					flags: [
+						{
+							name: "target",
+							type: "string",
+							takesValue: true,
+							choices: ["browser", "node"],
+						},
+						{ name: "out", type: "string", takesValue: true },
+					],
+					args: [],
+					subCommands: [],
+				},
+			],
+		},
+	};
+
+	let scriptPath: string;
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "tp010-bash-adv-"));
+		scriptPath = join(tmpDir, "mycli-completion.bash");
+		await Bun.write(scriptPath, renderBash(spec, "mycli", "1"));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function complete(words: string[]): Promise<string[]> {
+		const compWords = words
+			.map((w, i) => `COMP_WORDS[${i}]=${shq(w)}`)
+			.join("\n");
+		const cword = words.length - 1;
+		const driver = `
+set -e
+source ${shq(scriptPath)}
+${compWords}
+COMP_CWORD=${cword}
+COMP_LINE=${shq(words.join(" "))}
+COMP_POINT=${words.join(" ").length}
+_mycli
+for r in "\${COMPREPLY[@]}"; do printf '%s\\n' "$r"; done
+`;
+		const proc = Bun.spawn(["bash", "-c", driver], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [out, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(`bash exit ${code}\n${err}\n${out}`);
+		}
+		return out
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l.length > 0)
+			.sort();
+	}
+	function shq(value: string): string {
+		return `'${value.replace(/'/g, `'\\''`)}'`;
+	}
+
+	it("`--name=value` form completes the value's choice list", async () => {
+		const candidates = await complete(["mycli", "build", "--target=br"]);
+		// Bash sees one current token `--target=br`; the script splits on
+		// `=` and offers the choices that match prefix `br`.
+		expect(candidates).toContain("--target=browser");
+		expect(candidates).not.toContain("--target=node");
+	});
+
+	it("after `--`, no subcommand or flag candidates are offered", async () => {
+		const candidates = await complete(["mycli", "build", "--", ""]);
+		// Past the `--` terminator we return without setting COMPREPLY,
+		// so the candidate set is empty (filename completion happens via
+		// `complete -o default` at the bash level).
+		expect(candidates).toEqual([]);
+	});
+
+	it("after a free-form value flag, no subcommand candidates are offered", async () => {
+		// `--out` is a value-taking flag with no choices; the next word
+		// is a free-form value, not a subcommand.
+		const candidates = await complete(["mycli", "build", "--out", ""]);
+		expect(candidates).toEqual([]);
+	});
+});
+
+// ── --output-dir traversal ───────────────────────────────────────────────
+
+describe("completionPlugin · --output-dir traversal", () => {
+	let stdoutBuf: Buffer[];
+	let originalWrite: typeof process.stdout.write;
+	let originalError: typeof console.error;
+	let originalExitCode: typeof process.exitCode;
+
+	beforeEach(() => {
+		stdoutBuf = [];
+		originalWrite = process.stdout.write.bind(process.stdout);
+		originalError = console.error;
+		originalExitCode = process.exitCode;
+		process.stdout.write = ((chunk: unknown) => {
+			if (typeof chunk === "string") {
+				stdoutBuf.push(Buffer.from(chunk, "utf8"));
+			} else if (chunk instanceof Uint8Array) {
+				stdoutBuf.push(Buffer.from(chunk));
+			}
+			return true;
+		}) as typeof process.stdout.write;
+		console.error = () => {};
+	});
+
+	afterEach(() => {
+		process.stdout.write = originalWrite;
+		console.error = originalError;
+		process.exitCode = originalExitCode;
+	});
+
+	it("rejects a binName containing path separators at setup time", async () => {
+		// `binName` validation runs during the plugin's `setup()`. Crust
+		// catches setup errors and reports them via stderr + exitCode=1,
+		// rather than rethrowing, so we observe both side-effects to
+		// confirm the error fired before any file could be written.
+		const stderrChunks: string[] = [];
+		const origError = console.error;
+		console.error = (...args: unknown[]) => {
+			stderrChunks.push(args.map((a) => String(a)).join(" "));
+		};
+		try {
+			const cli = new Crust("real")
+				.use(completionPlugin({ binName: "../pwn" }))
+				.run(() => {});
+			await cli.execute({ argv: ["completion", "bash"] });
+		} finally {
+			console.error = origError;
+		}
+		expect(stderrChunks.join("\n")).toMatch(/invalid binName/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("does not write outside --output-dir", async () => {
+		// Even if validation were bypassed, the plugin's resolved-path
+		// check would refuse to write outside `targetDir`. We test the
+		// happy path here: a normal binName lands inside the target dir
+		// and nothing escapes.
+		const tmp = await mkdtemp(join(tmpdir(), "tp010-traversal-"));
+		try {
+			const cli = new Crust("good")
+				.use(completionPlugin({ version: "1" }))
+				.run(() => {});
+			await cli.execute({
+				argv: ["completion", "bash", "--output-dir", tmp],
+			});
+			const entries = await readdir(tmp);
+			// Exactly the per-shell files for `good`, nothing else.
+			expect(entries.sort()).toEqual(["_good", "good", "good.fish"]);
+			// Files are non-empty and contain the expected header.
+			const head = await readFile(join(tmp, "good"), "utf8");
+			expect(head).toContain("# completion script for good v1");
+		} finally {
+			await rm(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+// ── fish · ordered path predicate behaviour ───────────────────────────────
+
+describe("renderFish · ordered subcommand predicate", () => {
+	const spec: CompletionSpec = {
+		root: {
+			name: "mycli",
+			flags: [],
+			args: [],
+			subCommands: [
+				{
+					name: "build",
+					flags: [],
+					args: [],
+					subCommands: [
+						{
+							name: "deploy", // same word at depth 2 and depth 1 below
+							flags: [{ name: "fast", type: "boolean", takesValue: false }],
+							args: [],
+							subCommands: [],
+						},
+					],
+				},
+				{
+					name: "deploy", // depth-1 deploy
+					flags: [{ name: "slow", type: "boolean", takesValue: false }],
+					args: [],
+					subCommands: [],
+				},
+			],
+		},
+	};
+
+	it("emits a path-walking helper that only matches the in-order canonical path", () => {
+		const out = renderFish(spec, "mycli", "1");
+		// One helper, used by both the build subcmd and its child.
+		expect(out).toContain("function __mycli_path_is");
+		// build's `deploy` child is gated on the depth-2 path
+		// `[build, deploy]`, NOT on `seen_subcommand_from deploy`. The
+		// relevant rule includes `'build'` then `'deploy'` then a leaf
+		// block (empty for the leaf).
+		expect(out).toMatch(
+			/-n '__mycli_path_is \\'build\\' \\'deploy\\' \\'\\''.*-l 'fast'/,
+		);
+		// Top-level deploy's `slow` flag is gated on the depth-1 path
+		// `[deploy]`. Its block is empty (no children).
+		expect(out).toMatch(/-n '__mycli_path_is \\'deploy\\' \\'\\''.*-l 'slow'/);
+	});
+});

--- a/packages/plugins/src/completion/escape.test.ts
+++ b/packages/plugins/src/completion/escape.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import {
+	assertSafeBinName,
+	assertSafeChoiceValue,
+	assertSafeIdentifier,
+	bashSingleQuote,
+	fishSingleQuote,
+	sanitizeForComment,
+	sanitizeFreeText,
+	zshArgsDescription,
+	zshDescribeField,
+	zshSingleQuote,
+} from "./escape.ts";
+
+describe("assertSafeIdentifier", () => {
+	it("accepts simple identifiers", () => {
+		expect(assertSafeIdentifier("build", "command")).toBe("build");
+		expect(assertSafeIdentifier("my-cli", "command")).toBe("my-cli");
+		expect(assertSafeIdentifier("a.b.c", "command")).toBe("a.b.c");
+		expect(assertSafeIdentifier("h", "short flag")).toBe("h");
+	});
+
+	it.each([
+		["empty", ""],
+		["leading hyphen", "-flag"],
+		["leading dot", ".hidden"],
+		["whitespace", "two words"],
+		["single quote", "it's"],
+		["double quote", 'a"b'],
+		["semicolon", "a;b"],
+		["dollar", "a$b"],
+		["backtick", "a`b"],
+		["parenthesis", "a(b"],
+		["newline", "a\nb"],
+		["NUL", "a\0b"],
+		["bracket", "a[b"],
+		["star", "a*b"],
+	])("rejects %s", (_label, value) => {
+		expect(() => assertSafeIdentifier(value, "name")).toThrow(/invalid name/);
+	});
+});
+
+describe("assertSafeBinName", () => {
+	it("accepts simple binary names", () => {
+		expect(assertSafeBinName("mycli")).toBe("mycli");
+		expect(assertSafeBinName("my-cli")).toBe("my-cli");
+		expect(assertSafeBinName("crust.bin")).toBe("crust.bin");
+	});
+
+	it.each([
+		["empty", ""],
+		["dot", "."],
+		["dotdot", ".."],
+		["forward slash", "../pwn"],
+		["forward slash mid", "foo/bar"],
+		["backslash", "foo\\bar"],
+		["space", "foo bar"],
+		["semicolon", "foo;rm"],
+		["newline", "foo\necho"],
+		["NUL", "foo\0bar"],
+		["leading hyphen", "-mycli"],
+	])("rejects %s", (_label, value) => {
+		expect(() => assertSafeBinName(value)).toThrow();
+	});
+});
+
+describe("assertSafeChoiceValue", () => {
+	it("accepts realistic choice values", () => {
+		for (const v of [
+			"browser",
+			"us-east-1",
+			"node@20",
+			"text/plain",
+			"1.0.0",
+			"a:b",
+			"a+b",
+		]) {
+			expect(assertSafeChoiceValue(v)).toBe(v);
+		}
+	});
+
+	it.each([
+		["whitespace", "two words"],
+		["single quote", "it's"],
+		["dollar", "$pwd"],
+		["backtick", "`whoami`"],
+		["semicolon", "a;b"],
+		["pipe", "a|b"],
+		["parenthesis", "a(b)"],
+		["newline", "a\nb"],
+		["empty", ""],
+		["leading hyphen is treated as flag-ish", "-bad"],
+	])("rejects %s", (_label, value) => {
+		expect(() => assertSafeChoiceValue(value)).toThrow(
+			/unsupported choice value/,
+		);
+	});
+});
+
+describe("sanitizeFreeText / sanitizeForComment", () => {
+	it("strips controls but keeps ordinary printable text", () => {
+		expect(sanitizeFreeText("hello world")).toBe("hello world");
+		// Tabs are preserved (descriptions occasionally use them).
+		expect(sanitizeFreeText("a\tb")).toBe("a\tb");
+	});
+
+	it("replaces NUL, CR, LF, and other C0/C1 controls with a space", () => {
+		expect(sanitizeFreeText("a\nb")).toBe("a b");
+		expect(sanitizeFreeText("a\rb\nc")).toBe("a b c");
+		expect(sanitizeFreeText("a\0b")).toBe("a b");
+		expect(sanitizeFreeText("a\x1bb")).toBe("a b"); // ESC
+		expect(sanitizeFreeText("a\x7fb")).toBe("a b"); // DEL
+	});
+
+	it("sanitizeForComment is sanitizeFreeText for v1", () => {
+		// Documents the named alias for clarity at call sites; if the
+		// shapes ever diverge this assertion forces a deliberate update.
+		expect(sanitizeForComment("a\nb")).toBe(sanitizeFreeText("a\nb"));
+	});
+});
+
+describe("bashSingleQuote", () => {
+	it("wraps in single quotes", () => {
+		expect(bashSingleQuote("hello")).toBe("'hello'");
+	});
+
+	it("close-and-reopens around embedded single quotes", () => {
+		expect(bashSingleQuote("it's")).toBe("'it'\\''s'");
+	});
+
+	it('leaves $ ` \\ " alone (inside single quotes they are literal)', () => {
+		expect(bashSingleQuote('a$b`c\\d"e')).toBe(`'a$b\`c\\d"e'`);
+	});
+});
+
+describe("zshSingleQuote / zshArgsDescription / zshDescribeField", () => {
+	it("zshSingleQuote uses the same close-and-reopen idiom as bash", () => {
+		expect(zshSingleQuote("it's")).toBe("'it'\\''s'");
+	});
+
+	it("zshArgsDescription escapes [ ] : \\ ' and drops newlines", () => {
+		expect(zshArgsDescription("a:b")).toBe("a\\:b");
+		expect(zshArgsDescription("a[b]c")).toBe("a\\[b\\]c");
+		expect(zshArgsDescription("a\\b")).toBe("a\\\\b");
+		expect(zshArgsDescription("it's")).toBe("it'\\''s");
+		expect(zshArgsDescription("a\nb")).toBe("a b");
+	});
+
+	it("zshDescribeField escapes the colon separator and backslash", () => {
+		expect(zshDescribeField("a:b")).toBe("a\\:b");
+		expect(zshDescribeField("a\\b")).toBe("a\\\\b");
+		expect(zshDescribeField("a\nb")).toBe("a b");
+	});
+});
+
+describe("fishSingleQuote", () => {
+	it("wraps in single quotes", () => {
+		expect(fishSingleQuote("hello")).toBe("'hello'");
+	});
+
+	it("escapes \\ before '", () => {
+		// Order matters: backslash must be doubled BEFORE single-quote
+		// escaping, otherwise `\` introduced by the apostrophe escape
+		// would itself get doubled.
+		expect(fishSingleQuote("it's")).toBe("'it\\'s'");
+		expect(fishSingleQuote("a\\b")).toBe("'a\\\\b'");
+		expect(fishSingleQuote("a\\'b")).toBe("'a\\\\\\'b'");
+	});
+});

--- a/packages/plugins/src/completion/escape.ts
+++ b/packages/plugins/src/completion/escape.ts
@@ -1,0 +1,246 @@
+/**
+ * Per-shell quoting and validation helpers used by the completion
+ * templates and by the plugin's output-path handling.
+ *
+ * Why this exists: the completion templates inline a lot of CLI-author
+ * provided text — command names, flag names, descriptions, choice values,
+ * `binName`, `version` — into emitted shell scripts. Those scripts are
+ * routinely installed via `eval "$(mycli completion bash)"` (it is the
+ * documented install path), so any unsanitised interpolation is at
+ * minimum a foot-gun and at worst arbitrary code execution at install
+ * time. Centralising the escaping rules in one module keeps the templates
+ * pure rendering code and gives us a single place to test the adversarial
+ * inputs.
+ *
+ * Two complementary strategies are used:
+ *
+ * 1. **Validate identifiers** — command/flag/alias/bin names are
+ *    programmer-controlled identifiers in the source CLI definition.
+ *    They have no business containing whitespace, quotes, semicolons, or
+ *    control characters. We reject those at spec/render time with a
+ *    clear error rather than try to escape them through three different
+ *    shell grammars.
+ * 2. **Escape free-form text** — descriptions, choice values, version
+ *    strings, and the embedded comment headers are user-facing prose.
+ *    Those go through per-shell escape helpers so the templates can
+ *    interpolate them safely.
+ */
+
+/**
+ * Choice-value shape accepted for `flags[].choices` and `args[].choices`.
+ *
+ * Looser than {@link IDENT_PATTERN} so legitimate enumerated values like
+ * `us-east-1`, `1.0`, `text/plain`, or `node@20` flow through unchanged,
+ * but still excludes whitespace, quotes, and shell metacharacters that
+ * would force per-shell escaping inside the emitted action lists
+ * (`compgen -W`, zsh `(...)` action, fish `-a`).
+ *
+ * If a CLI legitimately needs choice values containing whitespace or
+ * shell-special characters, we'd need a richer per-shell escaping scheme;
+ * that's out of scope for v1. We fail fast with a clear message rather
+ * than silently mis-quote.
+ */
+// Require an alphanumeric first character so values can never be confused
+// with flags by completion shells (e.g. bash's `compgen` treating `-x` as
+// an option). Subsequent chars allow the broader safe set.
+const CHOICE_VALUE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.+:@/-]*$/;
+
+export function assertSafeChoiceValue(value: string): string {
+	if (!CHOICE_VALUE_PATTERN.test(value)) {
+		throw new Error(
+			`completion plugin: unsupported choice value ${JSON.stringify(value)} — ` +
+				`must match /^[A-Za-z0-9_.+:@/-]+$/. ` +
+				`Whitespace and shell metacharacters are not supported in v1.`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Identifier shape accepted for command names, flag names, flag aliases,
+ * short flags, and arg names.
+ *
+ * - First char must be alphanumeric (avoids leading `-` which `complete`
+ *   would interpret as an option in bash/fish).
+ * - Subsequent chars: alphanumeric, `_`, `.`, or `-`.
+ * - Single-character names are allowed (covers single-char short flags).
+ *
+ * This is deliberately conservative. CLI authors who want a command
+ * named `foo:bar` or `it's` are out of scope for v1 — every shell would
+ * need bespoke escaping for `case` patterns, `compdef`, and fish
+ * predicate code.
+ */
+const IDENT_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*)?$/;
+
+/** Throw if `name` is not a safe identifier; otherwise return it. */
+export function assertSafeIdentifier(name: string, kind: string): string {
+	if (!IDENT_PATTERN.test(name)) {
+		throw new Error(
+			`completion plugin: invalid ${kind} ${JSON.stringify(name)} — ` +
+				`must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/. ` +
+				`Whitespace, quotes, and shell metacharacters are not supported.`,
+		);
+	}
+	return name;
+}
+
+/**
+ * Validate `binName` for use as the program name in generated scripts and
+ * as a filesystem basename when `--output-dir` is set.
+ *
+ * Stricter than {@link assertSafeIdentifier} because `binName` also
+ * becomes a filename and a `complete -F`/`compdef` argument that's
+ * easier to break than option names.
+ */
+export function assertSafeBinName(binName: string): string {
+	if (binName.length === 0) {
+		throw new Error("completion plugin: binName must not be empty");
+	}
+	if (
+		binName.includes("/") ||
+		binName.includes("\\") ||
+		binName === ".." ||
+		binName === "."
+	) {
+		throw new Error(
+			`completion plugin: invalid binName ${JSON.stringify(binName)} — ` +
+				`path separators and "."/".." are not allowed (used as a filename in --output-dir mode).`,
+		);
+	}
+	return assertSafeIdentifier(binName, "binName");
+}
+
+// ── Free-form text sanitisation ────────────────────────────────────────────
+
+/**
+ * Strip control characters from `value` so it can be safely embedded in
+ * a shell comment line or shell-quoted string without smuggling a
+ * newline that would terminate the comment / break the quote nesting.
+ *
+ * Replaces NUL, CR, LF, vertical-tab, form-feed, and other C0/C1 controls
+ * with a single space. We keep horizontal tab as-is (descriptions
+ * occasionally use it for alignment).
+ */
+export function sanitizeFreeText(value: string): string {
+	// Range covers C0 controls (NUL–BS, LF–US) plus DEL. We deliberately
+	// keep horizontal tab (0x09) since descriptions occasionally use it
+	// for alignment; everything else — including LF and CR — collapses
+	// to a single space so callers can safely embed values in shell
+	// comment lines and shell-quoted strings.
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately match controls
+	return value.replace(/[\x00-\x08\x0A-\x1F\x7F]/g, " ");
+}
+
+/**
+ * Sanitise a value for inclusion as the **header comment** in a generated
+ * shell script. Strips controls including newlines so a single line stays
+ * a single line.
+ */
+export function sanitizeForComment(value: string): string {
+	return sanitizeFreeText(value);
+}
+
+// ── Bash ──────────────────────────────────────────────────────────────────
+
+/**
+ * Wrap `value` as a bash single-quoted shell word.
+ *
+ * Single quotes have no escape sequence in bash, so embedded single quotes
+ * close-and-reopen the quote: `'foo'\''bar'`. This is the canonical
+ * `printf %q`-style safe form: the result is always exactly one shell
+ * token regardless of the input bytes (after sanitisation).
+ *
+ * Callers should pass values that have already had control characters
+ * scrubbed via {@link sanitizeFreeText} when the value is free-form
+ * (description, version, choice value).
+ */
+export function bashSingleQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Escape a single value for inclusion as a literal-matched key in a bash
+ * `case` pattern, when the entire pattern is wrapped in double quotes.
+ *
+ * Inside `"..."` quotes, bash treats `*?[]{}|()` as literals, so the only
+ * remaining concern is the double-quote characters in the active set:
+ * `\`, `$`, `` ` ``, `"`. We escape those.
+ *
+ * The result is meant to be placed inside `"..."`; callers add the outer
+ * quotes themselves so they can build patterns like
+ * `"<path>|<word>"` from multiple escaped pieces.
+ */
+export function bashDoubleQuoteInner(value: string): string {
+	return value.replace(/[\\$`"]/g, "\\$&");
+}
+
+// ── Zsh ───────────────────────────────────────────────────────────────────
+
+/**
+ * Wrap `value` as a zsh single-quoted shell word.
+ *
+ * Identical idiom to bash: `'foo'\''bar'`.
+ */
+export function zshSingleQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Escape free-form text for use inside the `[...]` description bracket of
+ * a zsh `_arguments` spec.
+ *
+ * `_arguments` parses spec strings with `:` as the field separator and
+ * `[...]` as the description bracket; backslash escapes both. We also
+ * scrub newlines (descriptions are one-liners in completion menus) and
+ * single quotes (the spec is wrapped in single quotes by the caller).
+ */
+export function zshArgsDescription(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/\[/g, "\\[")
+		.replace(/]/g, "\\]")
+		.replace(/:/g, "\\:")
+		.replace(/'/g, "'\\''")
+		.replace(/[\r\n]+/g, " ");
+}
+
+/**
+ * Escape a value for inclusion as the **name** field of a `_describe`
+ * item (the part before the `:` description separator). `_describe`
+ * splits each item on the first un-escaped `:`, so embedded colons
+ * must be escaped. Backslashes also need escaping because they're the
+ * escape character.
+ *
+ * The result is meant to be placed inside zsh single quotes by the
+ * caller (we do NOT include outer quotes); call {@link zshSingleQuote}
+ * on the assembled `name:desc` string when emitting.
+ */
+export function zshDescribeField(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/:/g, "\\:")
+		.replace(/[\r\n]+/g, " ");
+}
+
+// ── Fish ──────────────────────────────────────────────────────────────────
+
+/**
+ * Wrap `value` as a fish single-quoted shell word. Fish single quotes
+ * only escape `\\` and `\'`; everything else is literal.
+ */
+export function fishSingleQuote(value: string): string {
+	return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * Build a fish-tokenised candidate list for use as the body of `-a` (the
+ * argument completion list). Per fish's `complete --arguments` behaviour,
+ * the value is split on **un-quoted** spaces, so each candidate gets
+ * single-quoted independently and joined with a literal space.
+ *
+ * Empty list → empty string; callers should skip the `-a` flag entirely
+ * in that case.
+ */
+export function fishArgList(values: readonly string[]): string {
+	return values.map(fishSingleQuote).join(" ");
+}

--- a/packages/plugins/src/completion/index.test.ts
+++ b/packages/plugins/src/completion/index.test.ts
@@ -103,9 +103,11 @@ describe("completionPlugin", () => {
 		await app.execute({ argv: ["completion", "bash"] });
 		const out = getStdout();
 		expect(out.startsWith("# completion script for mycli v1.2.3")).toBe(true);
-		expect(out).toContain("complete -o default -F _mycli mycli");
-		expect(out).toContain("browser bun node"); // build --target choices
-		expect(out).toContain("dev staging prod"); // deploy prod --env choices
+		expect(out).toContain("complete -o default -F _mycli 'mycli'");
+		// Choice values are validated to a safe character set and emitted
+		// bare in the `compgen -W` wordlist.
+		expect(out).toContain("browser bun node"); // build --target
+		expect(out).toContain("dev staging prod"); // deploy prod --env
 	});
 
 	it("`mycli completion zsh` prints a zsh script with #compdef header", async () => {
@@ -122,8 +124,12 @@ describe("completionPlugin", () => {
 		await app.execute({ argv: ["completion", "fish"] });
 		const out = getStdout();
 		expect(out.startsWith("# completion script for mycli v1.2.3")).toBe(true);
-		expect(out).toContain("complete -c mycli -f");
-		expect(out).toContain("__fish_use_subcommand");
+		expect(out).toContain("complete -c 'mycli' -f");
+		// We replaced the order-insensitive `__fish_seen_subcommand_from`
+		// chain with a per-script helper that walks `commandline -opc`
+		// left-to-right.
+		expect(out).toContain("function __mycli_path_is");
+		expect(out).toContain("__mycli_path_is");
 	});
 
 	it("rejects unsupported shell names with a clear stderr message", async () => {
@@ -160,13 +166,13 @@ describe("completionPlugin", () => {
 
 			const bash = await readFile(join(tmpDir, "mycli"), "utf8");
 			expect(bash).toContain("# completion script for mycli v1.2.3");
-			expect(bash).toContain("complete -o default -F _mycli mycli");
+			expect(bash).toContain("complete -o default -F _mycli 'mycli'");
 
 			const zsh = await readFile(join(tmpDir, "_mycli"), "utf8");
 			expect(zsh.startsWith("#compdef mycli\n")).toBe(true);
 
 			const fish = await readFile(join(tmpDir, "mycli.fish"), "utf8");
-			expect(fish).toContain("complete -c mycli -f");
+			expect(fish).toContain("complete -c 'mycli' -f");
 		});
 
 		it("writes nothing to stdout in --output-dir mode", async () => {

--- a/packages/plugins/src/completion/index.test.ts
+++ b/packages/plugins/src/completion/index.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Crust } from "@crustjs/core";
+import { completionPlugin } from "./index.ts";
+
+let stdoutBuf: Buffer[];
+let stderrChunks: string[];
+let originalWrite: typeof process.stdout.write;
+let originalError: typeof console.error;
+let originalExitCode: typeof process.exitCode;
+
+beforeEach(() => {
+	stdoutBuf = [];
+	stderrChunks = [];
+	originalWrite = process.stdout.write.bind(process.stdout);
+	originalError = console.error;
+	originalExitCode = process.exitCode;
+
+	// Capture process.stdout.write directly because the plugin uses
+	// `process.stdout.write(script)` rather than `console.log` (it writes a
+	// trailing-newline-bearing script and we want it byte-exact).
+	process.stdout.write = ((chunk: unknown) => {
+		if (typeof chunk === "string") {
+			stdoutBuf.push(Buffer.from(chunk, "utf8"));
+		} else if (chunk instanceof Uint8Array) {
+			stdoutBuf.push(Buffer.from(chunk));
+		}
+		return true;
+	}) as typeof process.stdout.write;
+
+	console.error = (...args: unknown[]) => {
+		stderrChunks.push(args.map((a) => String(a)).join(" "));
+	};
+});
+
+afterEach(() => {
+	process.stdout.write = originalWrite;
+	console.error = originalError;
+	process.exitCode = originalExitCode;
+});
+
+function getStdout(): string {
+	return Buffer.concat(stdoutBuf).toString("utf8");
+}
+
+function buildCli() {
+	return new Crust("mycli")
+		.meta({ description: "Test CLI" })
+		.use(completionPlugin({ version: "1.2.3" }))
+		.command("build", (cmd) =>
+			cmd
+				.meta({ description: "Build artifact" })
+				.flags({
+					target: { type: "string", choices: ["browser", "bun", "node"] },
+				})
+				.run(() => {}),
+		)
+		.command("deploy", (cmd) =>
+			cmd
+				.meta({ description: "Deploy", aliases: ["dep"] })
+				.command("prod", (sub) =>
+					sub
+						.meta({ description: "Production deploy" })
+						.flags({
+							env: {
+								type: "string",
+								choices: ["dev", "staging", "prod"],
+							},
+						})
+						.run(() => {}),
+				)
+				.run(() => {}),
+		)
+		.run(() => {});
+}
+
+describe("completionPlugin", () => {
+	it("registers a `completion` subcommand on the root command (after setup)", async () => {
+		const app = buildCli();
+		// Plugin `setup()` runs as part of `execute()`. Run a print-mode
+		// invocation so setup fires and the subcommand becomes visible on
+		// the live command tree, then verify the registration.
+		await app.execute({ argv: ["completion", "bash"] });
+		expect(Object.keys(app._node.subCommands)).toContain("completion");
+		const completionNode = app._node.subCommands.completion;
+		expect(completionNode?.meta.description).toBe(
+			"Generate shell tab-completion scripts",
+		);
+	});
+
+	it("exposes options: command name override", async () => {
+		const app = new Crust("mycli")
+			.use(completionPlugin({ command: "shell-completion" }))
+			.run(() => {});
+		await app.execute({ argv: ["shell-completion", "bash"] });
+		expect(Object.keys(app._node.subCommands)).toContain("shell-completion");
+	});
+
+	it("`mycli completion bash` prints a bash script to stdout", async () => {
+		const app = buildCli();
+		await app.execute({ argv: ["completion", "bash"] });
+		const out = getStdout();
+		expect(out.startsWith("# completion script for mycli v1.2.3")).toBe(true);
+		expect(out).toContain("complete -o default -F _mycli mycli");
+		expect(out).toContain("browser bun node"); // build --target choices
+		expect(out).toContain("dev staging prod"); // deploy prod --env choices
+	});
+
+	it("`mycli completion zsh` prints a zsh script with #compdef header", async () => {
+		const app = buildCli();
+		await app.execute({ argv: ["completion", "zsh"] });
+		const out = getStdout();
+		expect(out.startsWith("#compdef mycli\n")).toBe(true);
+		expect(out).toContain("_arguments -C");
+		expect(out).toContain(":target:(browser bun node)");
+	});
+
+	it("`mycli completion fish` prints a fish script", async () => {
+		const app = buildCli();
+		await app.execute({ argv: ["completion", "fish"] });
+		const out = getStdout();
+		expect(out.startsWith("# completion script for mycli v1.2.3")).toBe(true);
+		expect(out).toContain("complete -c mycli -f");
+		expect(out).toContain("__fish_use_subcommand");
+	});
+
+	it("rejects unsupported shell names with a clear stderr message", async () => {
+		// `choices` on `<shell>` is advisory at parse time (TP-009 contract),
+		// so the parser hands the value through to the run handler. The
+		// plugin's run handler is responsible for validation — verify it
+		// emits a clear error to stderr and sets exit code 1.
+		const app = buildCli();
+		await app.execute({ argv: ["completion", "powershell"] });
+		expect(stderrChunks.join("\n")).toContain('Unsupported shell "powershell"');
+		expect(process.exitCode).toBe(1);
+	});
+
+	describe("--output-dir", () => {
+		let tmpDir: string;
+
+		beforeEach(async () => {
+			tmpDir = await mkdtemp(join(tmpdir(), "tp010-completion-"));
+		});
+
+		afterEach(async () => {
+			await rm(tmpDir, { recursive: true, force: true });
+		});
+
+		it("writes all three shell files with canonical filenames", async () => {
+			const app = buildCli();
+			await app.execute({
+				argv: ["completion", "bash", "--output-dir", tmpDir],
+			});
+
+			// Per spec: bash → `<bin>`, zsh → `_<bin>`, fish → `<bin>.fish`.
+			const entries = (await readdir(tmpDir)).sort();
+			expect(entries).toEqual(["_mycli", "mycli", "mycli.fish"]);
+
+			const bash = await readFile(join(tmpDir, "mycli"), "utf8");
+			expect(bash).toContain("# completion script for mycli v1.2.3");
+			expect(bash).toContain("complete -o default -F _mycli mycli");
+
+			const zsh = await readFile(join(tmpDir, "_mycli"), "utf8");
+			expect(zsh.startsWith("#compdef mycli\n")).toBe(true);
+
+			const fish = await readFile(join(tmpDir, "mycli.fish"), "utf8");
+			expect(fish).toContain("complete -c mycli -f");
+		});
+
+		it("writes nothing to stdout in --output-dir mode", async () => {
+			const app = buildCli();
+			await app.execute({
+				argv: ["completion", "fish", "--output-dir", tmpDir],
+			});
+			expect(getStdout()).toBe("");
+		});
+
+		it("creates the output directory if it does not exist", async () => {
+			const nested = join(tmpDir, "nested", "completions");
+			const app = buildCli();
+			await app.execute({
+				argv: ["completion", "bash", "--output-dir", nested],
+			});
+			const entries = (await readdir(nested)).sort();
+			expect(entries).toEqual(["_mycli", "mycli", "mycli.fish"]);
+		});
+
+		it("respects the `shells` option to limit which files are written", async () => {
+			const app = new Crust("tinycli")
+				.use(
+					completionPlugin({
+						version: "0.1.0",
+						shells: ["bash", "zsh"],
+					}),
+				)
+				.run(() => {});
+			await app.execute({
+				argv: ["completion", "bash", "--output-dir", tmpDir],
+			});
+			const entries = (await readdir(tmpDir)).sort();
+			expect(entries).toEqual(["_tinycli", "tinycli"]);
+		});
+	});
+});

--- a/packages/plugins/src/completion/index.ts
+++ b/packages/plugins/src/completion/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 import { Crust, type CrustPlugin } from "@crustjs/core";
+import { assertSafeBinName, sanitizeFreeText } from "./escape.ts";
 import { renderBash } from "./templates/bash.ts";
 import { renderFish } from "./templates/fish.ts";
 import { renderZsh } from "./templates/zsh.ts";
@@ -109,7 +110,17 @@ export function completionPlugin(
 		name: "completion",
 		setup(context, actions) {
 			const rootCommand = context.rootCommand;
-			const binName = options.binName ?? rootCommand.meta.name;
+			// Validate `binName` once, at setup, so misconfigured CLIs fail
+			// loudly during plugin registration rather than at script-emit
+			// time. The walker also re-validates command/flag identifiers
+			// when it builds the spec.
+			const binName = assertSafeBinName(
+				options.binName ?? rootCommand.meta.name,
+			);
+			// `version` flows into header comments only; sanitise to drop
+			// control characters (newlines especially) so they cannot break
+			// out of the comment line in the emitted script.
+			const safeVersion = sanitizeFreeText(version);
 
 			// Build the completion subcommand using a fresh `Crust` builder.
 			// The handler closes over `rootCommand` so it can walk the live
@@ -156,7 +167,7 @@ export function completionPlugin(
 							requestedShell,
 							spec,
 							binName,
-							version,
+							safeVersion,
 						);
 						process.stdout.write(script);
 						return;
@@ -170,8 +181,22 @@ export function completionPlugin(
 					await mkdir(targetDir, { recursive: true });
 					for (const shell of shells) {
 						const filename = filenameForShell(shell, binName);
-						const script = renderForShell(shell, spec, binName, version);
+						const script = renderForShell(shell, spec, binName, safeVersion);
 						const targetPath = resolvePath(targetDir, filename);
+						// Defence-in-depth: even though `binName` is validated
+						// upstream (rejects path separators / `..`), verify the
+						// resolved path stays inside `targetDir`. This catches
+						// future regressions in the validator and platform-
+						// specific edge cases (e.g. Windows drive letters).
+						if (
+							targetPath !== targetDir &&
+							!targetPath.startsWith(`${targetDir}/`) &&
+							!targetPath.startsWith(`${targetDir}\\`)
+						) {
+							throw new Error(
+								`completion plugin: refusing to write outside output dir (${targetPath})`,
+							);
+						}
 						await writeFile(targetPath, script, "utf8");
 					}
 				})._node;

--- a/packages/plugins/src/completion/index.ts
+++ b/packages/plugins/src/completion/index.ts
@@ -1,0 +1,182 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
+import { Crust, type CrustPlugin } from "@crustjs/core";
+import { renderBash } from "./templates/bash.ts";
+import { renderFish } from "./templates/fish.ts";
+import { renderZsh } from "./templates/zsh.ts";
+import { walkCommandNode } from "./walker.ts";
+
+/** The set of shells supported by the v1 completion plugin. */
+export type CompletionShell = "bash" | "zsh" | "fish";
+
+const SUPPORTED_SHELLS: readonly CompletionShell[] = [
+	"bash",
+	"zsh",
+	"fish",
+] as const;
+
+/** Options for {@link completionPlugin}. */
+export interface CompletionPluginOptions {
+	/**
+	 * Subcommand name. Defaults to `"completion"`. Override only if the
+	 * default conflicts with an existing user-defined command.
+	 */
+	command?: string;
+	/**
+	 * Binary name embedded in generated scripts (the `complete -F` target,
+	 * the `#compdef` line, the `complete -c <bin>` rules). Defaults to the
+	 * root command's `meta.name`.
+	 */
+	binName?: string;
+	/**
+	 * Shells to emit when running `<bin> completion <shell> --output-dir`.
+	 * Defaults to all three. The positional `<shell>` argument is always
+	 * the union of these values regardless of any narrower setting (we
+	 * intentionally keep the user-facing CLI predictable).
+	 */
+	shells?: readonly CompletionShell[];
+	/**
+	 * Free-form version string embedded in generated script headers. The
+	 * walker does not parse it — it flows through as text. Defaults to
+	 * `"0.0.0"`. Pass your `package.json` version when wiring the plugin.
+	 */
+	version?: string;
+}
+
+/** Filename convention for each shell's drop-in completion file. */
+function filenameForShell(shell: CompletionShell, binName: string): string {
+	switch (shell) {
+		case "bash":
+			// bash-completion expects the file named exactly after the command
+			// (no extension) under
+			// `~/.local/share/bash-completion/completions/`.
+			return binName;
+		case "zsh":
+			// zsh's `compinit` autoloads files named `_<command>` from $fpath.
+			return `_${binName}`;
+		case "fish":
+			// fish auto-loads `~/.config/fish/completions/<command>.fish`.
+			return `${binName}.fish`;
+	}
+}
+
+function renderForShell(
+	shell: CompletionShell,
+	spec: ReturnType<typeof walkCommandNode>,
+	binName: string,
+	version: string,
+): string {
+	switch (shell) {
+		case "bash":
+			return renderBash(spec, binName, version);
+		case "zsh":
+			return renderZsh(spec, binName, version);
+		case "fish":
+			return renderFish(spec, binName, version);
+	}
+}
+
+/**
+ * Build a `CrustPlugin` that registers a `completion <shell>` subcommand
+ * which emits a tab-completion script for bash, zsh, or fish.
+ *
+ * **Strategy: pure-static.** The walk happens lazily inside `run()` (not
+ * at `setup()` time) so plugin order is irrelevant — any subcommands or
+ * inherited flags added by other plugins are visible by the time we
+ * generate the script. The walker projects `rootCommand` to a small
+ * `CompletionSpec`; per-shell renderers turn that into a self-contained
+ * shell script with no runtime callbacks.
+ *
+ * **Print vs `--output-dir`.**
+ * - With no `--output-dir`: print the script for the requested `<shell>`
+ *   to stdout (the install pattern is
+ *   `mycli completion bash > ~/.local/share/...`).
+ * - With `--output-dir <path>`: write **all** configured shells' files
+ *   into the directory using the canonical per-shell filename
+ *   (`<bin>` for bash, `_<bin>` for zsh, `<bin>.fish` for fish). This
+ *   is the artifact-generation path used by Homebrew, Nix, and similar
+ *   distribution channels — distributors run it once at packaging time
+ *   and the resulting files become drop-ins.
+ */
+export function completionPlugin(
+	options: CompletionPluginOptions = {},
+): CrustPlugin {
+	const subcommandName = options.command ?? "completion";
+	const shells = options.shells ?? SUPPORTED_SHELLS;
+	const version = options.version ?? "0.0.0";
+
+	return {
+		name: "completion",
+		setup(context, actions) {
+			const rootCommand = context.rootCommand;
+			const binName = options.binName ?? rootCommand.meta.name;
+
+			// Build the completion subcommand using a fresh `Crust` builder.
+			// The handler closes over `rootCommand` so it can walk the live
+			// tree at run time (lazy walk — see contract above).
+			const node = new Crust(subcommandName)
+				.meta({
+					description: "Generate shell tab-completion scripts",
+				})
+				.args([
+					{
+						name: "shell",
+						type: "string",
+						required: true,
+						description: "Shell to generate completion for",
+						choices: SUPPORTED_SHELLS,
+					},
+				] as const)
+				.flags({
+					"output-dir": {
+						type: "string",
+						description:
+							"Write all configured shells' scripts into this directory instead of printing to stdout",
+					},
+				})
+				.run(async (ctx) => {
+					const requestedShell = ctx.args.shell as CompletionShell;
+					if (!SUPPORTED_SHELLS.includes(requestedShell)) {
+						// `choices` is advisory at parse time (TP-009 pinned this
+						// behaviour). Validate explicitly so users get a clear
+						// error instead of an unrelated stack trace.
+						console.error(
+							`Unsupported shell "${requestedShell}". Supported: ${SUPPORTED_SHELLS.join(", ")}`,
+						);
+						process.exitCode = 1;
+						return;
+					}
+
+					const spec = walkCommandNode(rootCommand);
+					const outputDir = ctx.flags["output-dir"];
+
+					if (outputDir === undefined) {
+						// Print path: emit the requested shell's script to stdout.
+						const script = renderForShell(
+							requestedShell,
+							spec,
+							binName,
+							version,
+						);
+						process.stdout.write(script);
+						return;
+					}
+
+					// File path: write **all** configured shells. This matches
+					// the packaging-time use case — distributors generate every
+					// supported file in one invocation regardless of which
+					// shell they nominally requested.
+					const targetDir = resolvePath(outputDir);
+					await mkdir(targetDir, { recursive: true });
+					for (const shell of shells) {
+						const filename = filenameForShell(shell, binName);
+						const script = renderForShell(shell, spec, binName, version);
+						const targetPath = resolvePath(targetDir, filename);
+						await writeFile(targetPath, script, "utf8");
+					}
+				})._node;
+
+			actions.addSubCommand(rootCommand, subcommandName, node);
+		},
+	};
+}

--- a/packages/plugins/src/completion/spec.ts
+++ b/packages/plugins/src/completion/spec.ts
@@ -58,6 +58,14 @@ export interface CompletionFlag {
 	 */
 	multiple?: true;
 	/**
+	 * `true` when the boolean flag has explicitly opted out of `--no-`
+	 * negation (mirrors `BooleanFlagDef.noNegate` in core). Only
+	 * meaningful for `type: "boolean"` flags; absent on string/number.
+	 * Templates use this to decide whether to emit the `--no-<name>`
+	 * candidate alongside `--<name>`.
+	 */
+	noNegate?: true;
+	/**
 	 * Static enumeration of valid values, surfaced from TP-009's `choices`
 	 * field on `StringFlagDef` / `StringMultiFlagDef`. When present,
 	 * templates emit a fixed value list (`--flag=(a b c)` in zsh,

--- a/packages/plugins/src/completion/spec.ts
+++ b/packages/plugins/src/completion/spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Internal data shape produced by the completion-plugin walker.
+ *
+ * The walker traverses the live `CommandNode` tree (built by the user's
+ * `Crust` builder) and projects it down to a small, serialisable description
+ * of every visible command, flag, and positional argument. Per-shell template
+ * renderers (`bash.ts`, `zsh.ts`, `fish.ts`) consume this spec — they never
+ * touch `CommandNode` directly. This decoupling keeps the templates pure
+ * functions that are easy to snapshot-test.
+ *
+ * The spec intentionally **excludes** anything a generated shell script
+ * cannot use:
+ *
+ * - Subcommands marked `meta.hidden === true` are dropped during the walk
+ *   (the same listing contract the help renderer follows).
+ * - Boolean flags surface with `takesValue: false` so templates know not to
+ *   offer value candidates after them.
+ * - Description strings have ANSI escape sequences stripped — completion
+ *   scripts run in a wide variety of terminals (and inside `bash -n` /
+ *   `zsh -n` / `fish -n` parsers) where embedded SGR codes are noise at
+ *   best and a syntax hazard at worst.
+ *
+ * The shape is **internal to `@crustjs/plugins`**: it is not exported from
+ * the package entrypoint and may change across patch releases.
+ */
+
+/** Description of a single named flag attached to a command. */
+export interface CompletionFlag {
+	/**
+	 * The canonical long name with **no** leading dashes — the same key used
+	 * in `CommandNode.effectiveFlags`. Templates prepend `--` when emitting.
+	 */
+	name: string;
+	/**
+	 * Single-character short alias with **no** leading dash, when present.
+	 * Templates prepend `-` when emitting.
+	 */
+	short?: string;
+	/**
+	 * Additional long aliases with **no** leading dashes, when the flag
+	 * definition declares any. Templates prepend `--` when emitting.
+	 */
+	aliases?: readonly string[];
+	/** Underlying value type — discriminator from `FlagDef.type`. */
+	type: "string" | "number" | "boolean";
+	/** Human-readable description, ANSI-stripped, ready to embed verbatim. */
+	description?: string;
+	/**
+	 * `true` when the flag consumes the next token as a value
+	 * (`string`/`number` flags). `false` for boolean toggles, which never
+	 * take a value (the parser supports `--no-flag` for negation).
+	 */
+	takesValue: boolean;
+	/**
+	 * `true` when the flag is repeatable (`multiple: true` in `FlagDef`).
+	 * Templates use this to relax mutual-exclusion or de-dup logic where
+	 * each shell supports it.
+	 */
+	multiple?: true;
+	/**
+	 * Static enumeration of valid values, surfaced from TP-009's `choices`
+	 * field on `StringFlagDef` / `StringMultiFlagDef`. When present,
+	 * templates emit a fixed value list (`--flag=(a b c)` in zsh,
+	 * `-x -a 'a b c'` in fish, etc.). Only string-typed flags can carry
+	 * choices today; absent on number/boolean.
+	 */
+	choices?: readonly string[];
+}
+
+/** Description of a single positional argument attached to a command. */
+export interface CompletionArg {
+	/** Argument name (used as the key in the parsed result and in help). */
+	name: string;
+	/** Underlying value type — discriminator from `ArgDef.type`. */
+	type: "string" | "number" | "boolean";
+	/** Human-readable description, ANSI-stripped. */
+	description?: string;
+	/** `true` when the argument is required (per `ArgDef.required`). */
+	required: boolean;
+	/**
+	 * `true` when the argument collects all remaining positional values
+	 * (per `ArgDef.variadic`). Templates use this to keep offering value
+	 * candidates beyond the declared positional slot.
+	 */
+	variadic: boolean;
+	/**
+	 * Static enumeration of valid values, surfaced from TP-009's `choices`
+	 * field on `StringArgDef`. Only string-typed args can carry choices.
+	 */
+	choices?: readonly string[];
+}
+
+/** Description of a single command node — recursive via `subCommands`. */
+export interface CompletionCommand {
+	/**
+	 * The canonical command name. The router records canonical names in
+	 * `commandPath` regardless of which alias the user typed (TP-016), so
+	 * the spec keeps the canonical name as the source of truth and exposes
+	 * any alternative spellings via `aliases`.
+	 */
+	name: string;
+	/**
+	 * Additional sibling-level alternatives for `name`, surfaced from
+	 * `CommandMeta.aliases` (TP-016). When present, templates emit alias
+	 * spellings as completion candidates that resolve to the same node, so
+	 * users can tab-complete any alias.
+	 */
+	aliases?: readonly string[];
+	/** Human-readable description, ANSI-stripped. */
+	description?: string;
+	/**
+	 * Flags visible on this command. Walker captures `effectiveFlags` (not
+	 * `localFlags`), so inherited flags appear at every depth — matching
+	 * what the parser actually accepts at this level.
+	 */
+	flags: readonly CompletionFlag[];
+	/** Positional arguments declared on this command. */
+	args: readonly CompletionArg[];
+	/**
+	 * Visible subcommands. Nodes whose `meta.hidden === true` are omitted
+	 * here (recursively); routing still resolves them by direct name, but
+	 * shell completion never offers them as candidates.
+	 */
+	subCommands: readonly CompletionCommand[];
+}
+
+/**
+ * The full spec produced for a single CLI tree.
+ *
+ * Per-shell template renderers receive this plus `(binName, version)` and
+ * emit a self-contained completion script.
+ */
+export interface CompletionSpec {
+	/** The root command (`rootCommand` from the plugin context). */
+	root: CompletionCommand;
+}

--- a/packages/plugins/src/completion/templates/bash.test.ts
+++ b/packages/plugins/src/completion/templates/bash.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CompletionSpec } from "../spec.ts";
+import { renderBash } from "./bash.ts";
+
+/**
+ * Fixture spec used across snapshot + behavioural tests. Mirrors a small
+ * but representative tree: a flat subcommand (`build`), a nested
+ * subcommand (`deploy prod`), and a flag with choices on `build --target`.
+ */
+const fixture: CompletionSpec = {
+	root: {
+		name: "mycli",
+		description: "Test CLI",
+		flags: [
+			{ name: "help", short: "h", type: "boolean", takesValue: false },
+			{ name: "version", short: "v", type: "boolean", takesValue: false },
+		],
+		args: [],
+		subCommands: [
+			{
+				name: "build",
+				description: "Build artifact",
+				flags: [
+					{ name: "release", type: "boolean", takesValue: false },
+					{
+						name: "target",
+						type: "string",
+						takesValue: true,
+						choices: ["browser", "bun", "node"],
+					},
+				],
+				args: [],
+				subCommands: [],
+			},
+			{
+				name: "deploy",
+				aliases: ["dep"],
+				description: "Deploy",
+				flags: [],
+				args: [],
+				subCommands: [
+					{
+						name: "prod",
+						description: "Production deploy",
+						flags: [
+							{
+								name: "env",
+								type: "string",
+								takesValue: true,
+								choices: ["dev", "staging", "prod"],
+							},
+						],
+						args: [],
+						subCommands: [],
+					},
+				],
+			},
+		],
+	},
+};
+
+describe("renderBash", () => {
+	it("first line is the header comment with bin + version + regenerate hint", () => {
+		const script = renderBash(fixture, "mycli", "1.2.3");
+		const firstLine = script.split("\n")[0];
+		expect(firstLine).toBe(
+			"# completion script for mycli v1.2.3 — regenerate with: mycli completion bash",
+		);
+	});
+
+	it("registers via `complete -F _<bin>` and includes a fallback init shim", () => {
+		const script = renderBash(fixture, "mycli", "1.0.0");
+		expect(script).toContain("__mycli_init_completion()");
+		expect(script).toContain("complete -o default -F _mycli mycli");
+		// Fallback for systems without bash-completion.
+		expect(script).toContain("declare -F _init_completion");
+	});
+
+	it("sanitises bin names with hyphens to valid bash identifiers", () => {
+		const script = renderBash(fixture, "my-cli", "0.1.0");
+		// Function name must use underscores, but `complete -F` target
+		// should remain the on-disk binary name.
+		expect(script).toContain("_my_cli()");
+		expect(script).toContain("__my_cli_init_completion()");
+		expect(script).toContain("complete -o default -F _my_cli my-cli");
+	});
+
+	it("produces a stable golden snapshot for the fixture", () => {
+		const script = renderBash(fixture, "mycli", "1.0.0");
+		// We do not pin the entire script byte-for-byte; instead we assert
+		// the structural landmarks are present and in the expected order.
+		// This is the "golden" the task requires while remaining tolerant
+		// of cosmetic touch-ups.
+		const idxHeader = script.indexOf("# completion script for mycli");
+		const idxInit = script.indexOf("__mycli_init_completion()");
+		const idxMain = script.indexOf("_mycli() {");
+		const idxRegister = script.indexOf("complete -o default -F _mycli mycli");
+		expect(idxHeader).toBeGreaterThanOrEqual(0);
+		expect(idxInit).toBeGreaterThan(idxHeader);
+		expect(idxMain).toBeGreaterThan(idxInit);
+		expect(idxRegister).toBeGreaterThan(idxMain);
+
+		// Verify the path-walk dispatch covers both canonical names and aliases.
+		expect(script).toContain('"|build")');
+		expect(script).toContain('"|deploy")');
+		expect(script).toContain('"|dep")'); // alias of `deploy`
+		expect(script).toContain('"deploy|prod")');
+
+		// Verify choice handling for build --target.
+		expect(script).toContain('"build|--target")');
+		expect(script).toContain('compgen -W "browser bun node"');
+		expect(script).toContain('"deploy:prod|--env")');
+		expect(script).toContain('compgen -W "dev staging prod"');
+	});
+});
+
+/**
+ * Behavioural subprocess tests: source the generated script under a fresh
+ * `bash -c` and drive `_mycli` with synthetic `COMP_WORDS`/`COMP_CWORD`,
+ * asserting `COMPREPLY` reflects the expected candidate set. This proves
+ * the rendered script is not just shaped right but actually runs.
+ */
+describe("renderBash · behavioural subprocess tests", () => {
+	let scriptPath: string;
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "tp010-bash-"));
+		scriptPath = join(tmpDir, "mycli-completion.bash");
+		const script = renderBash(fixture, "mycli", "1.0.0");
+		await writeFile(scriptPath, script, "utf8");
+	});
+
+	afterAll(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	/**
+	 * Drive the completion function as bash itself would. We:
+	 *  - source the generated script (registers `_mycli`),
+	 *  - set COMP_WORDS/COMP_CWORD for the cursor position,
+	 *  - call `_mycli`,
+	 *  - print `COMPREPLY` separated by newlines.
+	 *
+	 * Returning the candidates as a sorted array gives stable equality
+	 * checks regardless of how bash orders them.
+	 */
+	async function runCompletion(words: string[]): Promise<string[]> {
+		const compWordsLines = words
+			.map((w, i) => `COMP_WORDS[${i}]=${shQuote(w)}`)
+			.join("\n");
+		const compCword = words.length - 1;
+		const driver = `
+set -e
+source ${shQuote(scriptPath)}
+${compWordsLines}
+COMP_CWORD=${compCword}
+COMP_LINE=${shQuote(words.join(" "))}
+COMP_POINT=${words.join(" ").length}
+_mycli
+for r in "\${COMPREPLY[@]}"; do printf '%s\\n' "$r"; done
+`;
+		const proc = Bun.spawn(["bash", "-c", driver], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [out, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(`bash exited ${code}\nstderr:\n${err}\nstdout:\n${out}`);
+		}
+		return out
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l.length > 0)
+			.sort();
+	}
+
+	function shQuote(value: string): string {
+		// Single-quote, escape any embedded single quotes.
+		return `'${value.replace(/'/g, `'\\''`)}'`;
+	}
+
+	it("scenario 1 — top-level subcommand: `mycli <TAB>` lists build and deploy", async () => {
+		const completions = await runCompletion(["mycli", ""]);
+		expect(completions).toContain("build");
+		expect(completions).toContain("deploy");
+		// Alias for deploy is also offered.
+		expect(completions).toContain("dep");
+	});
+
+	it("scenario 1b — prefix match narrows the list", async () => {
+		const completions = await runCompletion(["mycli", "b"]);
+		expect(completions).toContain("build");
+		expect(completions).not.toContain("deploy");
+	});
+
+	it("scenario 2 — nested subcommand: `mycli deploy <TAB>` lists prod", async () => {
+		const completions = await runCompletion(["mycli", "deploy", ""]);
+		expect(completions).toContain("prod");
+		// Should not bleed top-level subcommands here.
+		expect(completions).not.toContain("build");
+	});
+
+	it("scenario 2b — alias-resolved nested subcommand: `mycli dep <TAB>` lists prod", async () => {
+		const completions = await runCompletion(["mycli", "dep", ""]);
+		expect(completions).toContain("prod");
+	});
+
+	it("scenario 3 — flag with choices: `mycli build --target <TAB>` lists target values", async () => {
+		const completions = await runCompletion(["mycli", "build", "--target", ""]);
+		expect(completions.sort()).toEqual(["browser", "bun", "node"]);
+	});
+
+	it("scenario 3b — nested flag with choices: `mycli deploy prod --env <TAB>`", async () => {
+		const completions = await runCompletion([
+			"mycli",
+			"deploy",
+			"prod",
+			"--env",
+			"",
+		]);
+		expect(completions.sort()).toEqual(["dev", "prod", "staging"]);
+	});
+
+	it("offers flag candidates when current token starts with `-`", async () => {
+		const completions = await runCompletion(["mycli", "build", "--"]);
+		expect(completions).toContain("--release");
+		expect(completions).toContain("--target");
+	});
+});

--- a/packages/plugins/src/completion/templates/bash.test.ts
+++ b/packages/plugins/src/completion/templates/bash.test.ts
@@ -74,7 +74,9 @@ describe("renderBash", () => {
 	it("registers via `complete -F _<bin>` and includes a fallback init shim", () => {
 		const script = renderBash(fixture, "mycli", "1.0.0");
 		expect(script).toContain("__mycli_init_completion()");
-		expect(script).toContain("complete -o default -F _mycli mycli");
+		// Bin name is single-quoted as defence-in-depth even though it has
+		// already passed `assertSafeBinName`.
+		expect(script).toContain("complete -o default -F _mycli 'mycli'");
 		// Fallback for systems without bash-completion.
 		expect(script).toContain("declare -F _init_completion");
 	});
@@ -85,7 +87,7 @@ describe("renderBash", () => {
 		// should remain the on-disk binary name.
 		expect(script).toContain("_my_cli()");
 		expect(script).toContain("__my_cli_init_completion()");
-		expect(script).toContain("complete -o default -F _my_cli my-cli");
+		expect(script).toContain("complete -o default -F _my_cli 'my-cli'");
 	});
 
 	it("produces a stable golden snapshot for the fixture", () => {
@@ -97,7 +99,7 @@ describe("renderBash", () => {
 		const idxHeader = script.indexOf("# completion script for mycli");
 		const idxInit = script.indexOf("__mycli_init_completion()");
 		const idxMain = script.indexOf("_mycli() {");
-		const idxRegister = script.indexOf("complete -o default -F _mycli mycli");
+		const idxRegister = script.indexOf("complete -o default -F _mycli 'mycli'");
 		expect(idxHeader).toBeGreaterThanOrEqual(0);
 		expect(idxInit).toBeGreaterThan(idxHeader);
 		expect(idxMain).toBeGreaterThan(idxInit);
@@ -109,7 +111,9 @@ describe("renderBash", () => {
 		expect(script).toContain('"|dep")'); // alias of `deploy`
 		expect(script).toContain('"deploy|prod")');
 
-		// Verify choice handling for build --target.
+		// Verify choice handling for build --target. Choice values are
+		// validated to a safe character set and emitted bare in the
+		// `compgen -W` wordlist.
 		expect(script).toContain('"build|--target")');
 		expect(script).toContain('compgen -W "browser bun node"');
 		expect(script).toContain('"deploy:prod|--env")');

--- a/packages/plugins/src/completion/templates/bash.test.ts
+++ b/packages/plugins/src/completion/templates/bash.test.ts
@@ -239,3 +239,159 @@ for r in "\${COMPREPLY[@]}"; do printf '%s\\n' "$r"; done
 		expect(completions).toContain("--target");
 	});
 });
+
+/**
+ * Behavioural tests for per-slot positional-argument choices. Verifies
+ * that bash offers slot N's `choices` for the N-th positional, not just
+ * the first — the historical limitation called out in the consistency
+ * audit.
+ */
+describe("renderBash · multi-positional choices", () => {
+	const multiPosFixture: CompletionSpec = {
+		root: {
+			name: "mp",
+			flags: [],
+			args: [],
+			subCommands: [
+				{
+					name: "two",
+					description: "two fixed positional slots",
+					flags: [],
+					args: [
+						{
+							name: "first",
+							type: "string",
+							required: true,
+							variadic: false,
+							choices: ["alpha", "beta"],
+						},
+						{
+							name: "second",
+							type: "string",
+							required: true,
+							variadic: false,
+							choices: ["gamma", "delta"],
+						},
+					],
+					subCommands: [],
+				},
+				{
+					name: "vary",
+					description: "variadic with choices from slot 1",
+					flags: [],
+					args: [
+						{
+							name: "mode",
+							type: "string",
+							required: true,
+							variadic: false,
+							choices: ["start", "stop"],
+						},
+						{
+							name: "items",
+							type: "string",
+							required: false,
+							variadic: true,
+							choices: ["a", "b", "c"],
+						},
+					],
+					subCommands: [],
+				},
+			],
+		},
+	};
+
+	let scriptPath: string;
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "tp010-bash-multipos-"));
+		scriptPath = join(tmpDir, "mp-completion.bash");
+		const script = renderBash(multiPosFixture, "mp", "1.0.0");
+		await writeFile(scriptPath, script, "utf8");
+	});
+
+	afterAll(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function runCompletion(words: string[]): Promise<string[]> {
+		const shQuote = (v: string) => `'${v.replace(/'/g, `'\\''`)}'`;
+		const compWordsLines = words
+			.map((w, i) => `COMP_WORDS[${i}]=${shQuote(w)}`)
+			.join("\n");
+		const compCword = words.length - 1;
+		const driver = `
+set -e
+source ${shQuote(scriptPath)}
+${compWordsLines}
+COMP_CWORD=${compCword}
+COMP_LINE=${shQuote(words.join(" "))}
+COMP_POINT=${words.join(" ").length}
+_mp
+for r in "\${COMPREPLY[@]}"; do printf '%s\\n' "$r"; done
+`;
+		const proc = Bun.spawn(["bash", "-c", driver], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [out, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(`bash exited ${code}\nstderr:\n${err}\nstdout:\n${out}`);
+		}
+		return out
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l.length > 0)
+			.sort();
+	}
+
+	it("slot 0 of `mp two` offers the first arg's choices", async () => {
+		const completions = await runCompletion(["mp", "two", ""]);
+		expect(completions).toContain("alpha");
+		expect(completions).toContain("beta");
+		expect(completions).not.toContain("gamma");
+	});
+
+	it("slot 1 of `mp two` offers the second arg's choices (not the first's)", async () => {
+		const completions = await runCompletion(["mp", "two", "alpha", ""]);
+		expect(completions).toContain("gamma");
+		expect(completions).toContain("delta");
+		expect(completions).not.toContain("alpha");
+		expect(completions).not.toContain("beta");
+	});
+
+	it("variadic-with-choices offers the variadic list at every slot >= variadicFrom", async () => {
+		// Slot 0 still gets the `mode` arg's choices.
+		const slot0 = await runCompletion(["mp", "vary", ""]);
+		expect(slot0).toContain("start");
+		expect(slot0).toContain("stop");
+		expect(slot0).not.toContain("a");
+
+		// Slot 1: enters the variadic.
+		const slot1 = await runCompletion(["mp", "vary", "start", ""]);
+		expect(slot1.sort()).toEqual(["a", "b", "c"]);
+
+		// Slot 2 and beyond: still the variadic list.
+		const slot2 = await runCompletion(["mp", "vary", "start", "a", ""]);
+		expect(slot2.sort()).toEqual(["a", "b", "c"]);
+	});
+
+	it("intervening flags do not count toward the positional slot index", async () => {
+		// `--unknown=x` and `--foo bar` between positionals should be
+		// skipped; slot 1 should still offer the second arg's choices.
+		const completions = await runCompletion([
+			"mp",
+			"two",
+			"alpha",
+			"--unknown=x",
+			"",
+		]);
+		expect(completions).toContain("gamma");
+		expect(completions).toContain("delta");
+	});
+});

--- a/packages/plugins/src/completion/templates/bash.ts
+++ b/packages/plugins/src/completion/templates/bash.ts
@@ -1,0 +1,301 @@
+import type {
+	CompletionCommand,
+	CompletionFlag,
+	CompletionSpec,
+} from "../spec.ts";
+
+/**
+ * Pure-static bash completion script renderer.
+ *
+ * Strategy: at generation time we walk the command tree and emit a
+ * self-contained bash function that performs the full completion logic
+ * locally — no `__complete` subprocess shell-out, no runtime callbacks.
+ *
+ * The generated script:
+ *
+ * 1. Defines a Cobra-style fallback init shim
+ *    (`__<bin>_init_completion`) so the script works even when the
+ *    `bash-completion` package is not installed (macOS default bash,
+ *    Alpine, NixOS without the package).
+ * 2. Walks `COMP_WORDS` left-to-right, skipping option words, and
+ *    advances a `cmd_path` through the static command tree using a
+ *    `case` dispatch keyed by `"<parent-path>|<word>"`.
+ * 3. Once the path is resolved, picks completion candidates:
+ *    - if the previous token is a known flag-with-choices, offers the
+ *      static value list,
+ *    - else if the current token starts with `-`, offers the flag set
+ *      for the resolved command,
+ *    - else offers the subcommand list (canonical names + aliases).
+ * 4. Registers via `complete -F _<bin> <bin>`.
+ */
+
+/**
+ * Convert an arbitrary command name into a bash identifier. Bash function
+ * names cannot contain `-`; we map every non-`[A-Za-z0-9_]` to `_` so
+ * generated function names are always valid.
+ */
+function toShellIdent(name: string): string {
+	return name.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+/**
+ * Quote a value for safe inclusion inside a double-quoted bash string.
+ * We only inline command names, flag spellings, and choice values — none of
+ * which can legitimately carry control characters — so this is a defensive
+ * check rather than a sanitiser. We escape `"`, `\`, `$`, and backtick.
+ */
+function bashQuote(value: string): string {
+	return value.replace(/[\\$`"]/g, "\\$&");
+}
+
+/**
+ * Render the space-separated wordlist of subcommand candidates for a
+ * single command. Includes canonical names and any declared aliases so
+ * users can tab-complete either spelling.
+ */
+function subcmdWordlist(node: CompletionCommand): string {
+	const words: string[] = [];
+	for (const sub of node.subCommands) {
+		words.push(sub.name);
+		if (sub.aliases !== undefined) {
+			for (const alias of sub.aliases) words.push(alias);
+		}
+	}
+	return words.map(bashQuote).join(" ");
+}
+
+/**
+ * Render the space-separated wordlist of flag candidates for a single
+ * command. Includes long names, short alias (with single-dash prefix), and
+ * any extra long aliases. Boolean flags with `noNegate !== true` are not
+ * specially marked here — we leave `--no-foo` out of completion candidates
+ * by default to keep menus tight (users who know the negation form will
+ * type it manually). The visible set is what `effectiveFlags` exposes.
+ */
+function flagWordlist(node: CompletionCommand): string {
+	const words: string[] = [];
+	for (const flag of node.flags) {
+		words.push(`--${flag.name}`);
+		if (flag.short !== undefined) words.push(`-${flag.short}`);
+		if (flag.aliases !== undefined) {
+			for (const alias of flag.aliases) words.push(`--${alias}`);
+		}
+	}
+	return words.map(bashQuote).join(" ");
+}
+
+interface BashCase {
+	/**
+	 * `<parent-path>|<word>` — empty parent path is `""`, child paths use
+	 * `:` as a separator (e.g. `"deploy:prod"`).
+	 */
+	key: string;
+	/** New `cmd_path` to set when this branch matches. */
+	cmdPath: string;
+	/** Subcommand wordlist for the new path. */
+	subcmds: string;
+	/** Flag wordlist for the new path. */
+	flags: string;
+}
+
+/**
+ * Recursively collect every (parent-path, child-word) edge in the command
+ * tree as a `case` branch the dispatch loop can consume. Aliases are
+ * surfaced as additional `case` keys that resolve to the same `cmd_path`,
+ * matching the router's alias-aware behaviour (TP-016).
+ */
+function collectPathCases(
+	parentPath: string,
+	parent: CompletionCommand,
+	out: BashCase[],
+): void {
+	for (const sub of parent.subCommands) {
+		const newPath = parentPath === "" ? sub.name : `${parentPath}:${sub.name}`;
+		const subcmds = subcmdWordlist(sub);
+		const flags = flagWordlist(sub);
+
+		// Canonical name edge.
+		out.push({
+			key: `${parentPath}|${sub.name}`,
+			cmdPath: newPath,
+			subcmds,
+			flags,
+		});
+
+		// Alias edges resolve to the same cmd_path so children of the
+		// canonical node are reachable via either spelling.
+		if (sub.aliases !== undefined) {
+			for (const alias of sub.aliases) {
+				out.push({
+					key: `${parentPath}|${alias}`,
+					cmdPath: newPath,
+					subcmds,
+					flags,
+				});
+			}
+		}
+
+		collectPathCases(newPath, sub, out);
+	}
+}
+
+interface ChoiceCase {
+	/** `<cmd_path>|<flag-spelling>` (long, short, or alias). */
+	key: string;
+	/** Space-separated value list. */
+	values: string;
+}
+
+/**
+ * For every flag at every command depth that declares `choices`, emit a
+ * `case` branch mapping `<path>|<flag-spelling>` → values. Each spelling
+ * (long, short, alias) gets its own branch so the lookup is constant-time
+ * regardless of how the user wrote the flag.
+ */
+function collectChoiceCases(
+	cmdPath: string,
+	node: CompletionCommand,
+	out: ChoiceCase[],
+): void {
+	for (const flag of node.flags) {
+		if (flag.choices === undefined) continue;
+		const values = flag.choices.map(bashQuote).join(" ");
+		const spellings = flagSpellings(flag);
+		for (const spelling of spellings) {
+			out.push({ key: `${cmdPath}|${spelling}`, values });
+		}
+	}
+	for (const sub of node.subCommands) {
+		const subPath = cmdPath === "" ? sub.name : `${cmdPath}:${sub.name}`;
+		collectChoiceCases(subPath, sub, out);
+	}
+}
+
+function flagSpellings(flag: CompletionFlag): string[] {
+	const out: string[] = [`--${flag.name}`];
+	if (flag.short !== undefined) out.push(`-${flag.short}`);
+	if (flag.aliases !== undefined) {
+		for (const alias of flag.aliases) out.push(`--${alias}`);
+	}
+	return out;
+}
+
+/**
+ * Render a self-contained bash completion script for the given spec.
+ *
+ * @param spec     The walker output describing the command tree.
+ * @param binName  The user-facing binary name (the `complete -F` target).
+ *                 Should be the name the user actually invokes — usually
+ *                 the root `meta.name`. Special characters are tolerated
+ *                 in the registration line; the helper function name is
+ *                 derived via `toShellIdent` so it remains a valid bash
+ *                 identifier.
+ * @param version  Free-form version string for the header comment. We do
+ *                 not parse it; the value flows through verbatim.
+ */
+export function renderBash(
+	spec: CompletionSpec,
+	binName: string,
+	version: string,
+): string {
+	const ident = toShellIdent(binName);
+	const fnName = `_${ident}`;
+	const initFn = `__${ident}_init_completion`;
+
+	const rootSubcmds = subcmdWordlist(spec.root);
+	const rootFlags = flagWordlist(spec.root);
+
+	const pathCases: BashCase[] = [];
+	collectPathCases("", spec.root, pathCases);
+
+	const choiceCases: ChoiceCase[] = [];
+	collectChoiceCases("", spec.root, choiceCases);
+
+	const lines: string[] = [];
+
+	// Header — first line per task spec.
+	lines.push(
+		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion bash`,
+	);
+	lines.push("");
+
+	// Cobra-style init shim. Provides cur/prev/words/cword without depending
+	// on the bash-completion package. Reference: spf13/cobra
+	// bash_completionsV2.go lines 48–54.
+	lines.push(`${initFn}() {`);
+	lines.push("\tCOMPREPLY=()");
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+	lines.push('\tcur="${COMP_WORDS[COMP_CWORD]}"');
+	lines.push(
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+		'\tif (( COMP_CWORD > 0 )); then prev="${COMP_WORDS[COMP_CWORD-1]}"; else prev=""; fi',
+	);
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+	lines.push('\twords=("${COMP_WORDS[@]}")');
+	lines.push("\tcword=$COMP_CWORD");
+	lines.push("}");
+	lines.push("");
+
+	// Main completion function.
+	lines.push(`${fnName}() {`);
+	lines.push("\tlocal cur prev words cword");
+	lines.push("\tif declare -F _init_completion >/dev/null 2>&1; then");
+	lines.push('\t\t_init_completion -n "=" || return');
+	lines.push("\telse");
+	lines.push(`\t\t${initFn} || return`);
+	lines.push("\tfi");
+	lines.push("");
+	lines.push('\tlocal cmd_path=""');
+	lines.push("\tlocal i=1");
+	lines.push(`\tlocal subcmds="${rootSubcmds}"`);
+	lines.push(`\tlocal flags="${rootFlags}"`);
+	lines.push("");
+	lines.push("\twhile (( i < cword )); do");
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+	lines.push('\t\tlocal w="${words[$i]}"');
+	lines.push('\t\tif [[ "$w" == -* ]]; then');
+	lines.push("\t\t\t((i++)); continue");
+	lines.push("\t\tfi");
+	lines.push('\t\tcase "$cmd_path|$w" in');
+	for (const c of pathCases) {
+		lines.push(`\t\t\t"${bashQuote(c.key)}")`);
+		lines.push(`\t\t\t\tcmd_path="${bashQuote(c.cmdPath)}"`);
+		lines.push(`\t\t\t\tsubcmds="${c.subcmds}"`);
+		lines.push(`\t\t\t\tflags="${c.flags}"`);
+		lines.push("\t\t\t\t;;");
+	}
+	lines.push("\t\t\t*) break ;;");
+	lines.push("\t\tesac");
+	lines.push("\t\t((i++))");
+	lines.push("\tdone");
+	lines.push("");
+
+	// Flag-with-choices: if previous word matches, offer the value list.
+	if (choiceCases.length > 0) {
+		lines.push('\tcase "$cmd_path|$prev" in');
+		for (const c of choiceCases) {
+			lines.push(`\t\t"${bashQuote(c.key)}")`);
+			lines.push(`\t\t\tCOMPREPLY=( $(compgen -W "${c.values}" -- "$cur") )`);
+			lines.push("\t\t\treturn");
+			lines.push("\t\t\t;;");
+		}
+		lines.push("\tesac");
+		lines.push("");
+	}
+
+	// Default branch: flags vs subcmds.
+	lines.push('\tif [[ "$cur" == -* ]]; then');
+	lines.push('\t\tCOMPREPLY=( $(compgen -W "$flags" -- "$cur") )');
+	lines.push("\telse");
+	lines.push('\t\tCOMPREPLY=( $(compgen -W "$subcmds" -- "$cur") )');
+	lines.push("\tfi");
+	lines.push("}");
+	lines.push("");
+
+	// Registration. `-o default` lets bash fall through to filename
+	// completion when our wordlists return nothing — handy for free
+	// positional args that take filesystem paths.
+	lines.push(`complete -o default -F ${fnName} ${bashQuote(binName)}`);
+
+	return `${lines.join("\n")}\n`;
+}

--- a/packages/plugins/src/completion/templates/bash.ts
+++ b/packages/plugins/src/completion/templates/bash.ts
@@ -1,4 +1,10 @@
+import {
+	bashDoubleQuoteInner,
+	bashSingleQuote,
+	sanitizeForComment,
+} from "../escape.ts";
 import type {
+	CompletionArg,
 	CompletionCommand,
 	CompletionFlag,
 	CompletionSpec,
@@ -17,43 +23,47 @@ import type {
  *    (`__<bin>_init_completion`) so the script works even when the
  *    `bash-completion` package is not installed (macOS default bash,
  *    Alpine, NixOS without the package).
- * 2. Walks `COMP_WORDS` left-to-right, skipping option words, and
- *    advances a `cmd_path` through the static command tree using a
- *    `case` dispatch keyed by `"<parent-path>|<word>"`.
+ * 2. Walks `COMP_WORDS` left-to-right, advancing a `cmd_path` through
+ *    the static command tree. Stops walking at the `--` end-of-options
+ *    terminator and skips value-taking flag pairs so we don't mistake a
+ *    flag value for a subcommand.
  * 3. Once the path is resolved, picks completion candidates:
- *    - if the previous token is a known flag-with-choices, offers the
- *      static value list,
- *    - else if the current token starts with `-`, offers the flag set
- *      for the resolved command,
- *    - else offers the subcommand list (canonical names + aliases).
- * 4. Registers via `complete -F _<bin> <bin>`.
+ *    - if the user is mid-`--name=value`, splits on `=` and offers the
+ *      static value list (or files) for that flag,
+ *    - else if the previous token is a known flag-with-choices, offers
+ *      the static value list,
+ *    - else if the previous token is a known free-form value flag,
+ *      falls back to file completion,
+ *    - else if the current token starts with `-`, offers the flag set,
+ *    - else offers the subcommand list and the resolved command's
+ *      positional choices (or files for free-form positionals).
+ * 4. Registers via `complete -F _<bin> <bin>` with the bin name passed
+ *    through {@link bashSingleQuote}.
  */
 
 /**
- * Convert an arbitrary command name into a bash identifier. Bash function
- * names cannot contain `-`; we map every non-`[A-Za-z0-9_]` to `_` so
- * generated function names are always valid.
+ * Convert a (validated) command name into a bash identifier. Bash
+ * function names cannot contain `-` or `.`; we map the validated
+ * identifier set down to `[A-Za-z0-9_]` so generated function names are
+ * always valid even when names contain `-` or `.`.
  */
 function toShellIdent(name: string): string {
 	return name.replace(/[^A-Za-z0-9_]/g, "_");
 }
 
 /**
- * Quote a value for safe inclusion inside a double-quoted bash string.
- * We only inline command names, flag spellings, and choice values — none of
- * which can legitimately carry control characters — so this is a defensive
- * check rather than a sanitiser. We escape `"`, `\`, `$`, and backtick.
- */
-function bashQuote(value: string): string {
-	return value.replace(/[\\$`"]/g, "\\$&");
-}
-
-/**
- * Render the space-separated wordlist of subcommand candidates for a
- * single command. Includes canonical names and any declared aliases so
- * users can tab-complete either spelling.
+ * Render the wordlist of subcommand candidates for a single command —
+ * each candidate as a bash-quoted shell word so values containing
+ * spaces (theoretical: identifier validation rejects them) or shell
+ * metacharacters (theoretical: same) survive `compgen -W` splitting.
+ *
+ * Includes canonical names and any declared aliases.
  */
 function subcmdWordlist(node: CompletionCommand): string {
+	// Names are validated identifiers (`assertSafeIdentifier`), so a
+	// space-joined bare list is safe to embed in `compgen -W` and in
+	// `for x in $list` loops — both do bash word-splitting that
+	// doesn't strip quotes from already-quoted tokens.
 	const words: string[] = [];
 	for (const sub of node.subCommands) {
 		words.push(sub.name);
@@ -61,16 +71,13 @@ function subcmdWordlist(node: CompletionCommand): string {
 			for (const alias of sub.aliases) words.push(alias);
 		}
 	}
-	return words.map(bashQuote).join(" ");
+	return words.join(" ");
 }
 
 /**
- * Render the space-separated wordlist of flag candidates for a single
- * command. Includes long names, short alias (with single-dash prefix), and
- * any extra long aliases. Boolean flags with `noNegate !== true` are not
- * specially marked here — we leave `--no-foo` out of completion candidates
- * by default to keep menus tight (users who know the negation form will
- * type it manually). The visible set is what `effectiveFlags` exposes.
+ * Render the wordlist of flag candidates for a single command. Includes
+ * long names, short alias, extra long aliases, and `--no-<name>` for
+ * boolean flags that haven't opted out via `noNegate`.
  */
 function flagWordlist(node: CompletionCommand): string {
 	const words: string[] = [];
@@ -80,8 +87,17 @@ function flagWordlist(node: CompletionCommand): string {
 		if (flag.aliases !== undefined) {
 			for (const alias of flag.aliases) words.push(`--${alias}`);
 		}
+		// `--no-<name>` for boolean toggles. Mirrors the parser's
+		// negation-acceptance contract (core/parser.ts) so users can tab
+		// to either spelling. Boolean multi-flags also support negation.
+		if (flag.type === "boolean" && flag.noNegate !== true) {
+			words.push(`--no-${flag.name}`);
+			if (flag.aliases !== undefined) {
+				for (const alias of flag.aliases) words.push(`--no-${alias}`);
+			}
+		}
 	}
-	return words.map(bashQuote).join(" ");
+	return words.join(" ");
 }
 
 interface BashCase {
@@ -96,6 +112,8 @@ interface BashCase {
 	subcmds: string;
 	/** Flag wordlist for the new path. */
 	flags: string;
+	/** Space-separated list of flag spellings that take a value at this depth. */
+	valueFlags: string;
 }
 
 /**
@@ -113,6 +131,7 @@ function collectPathCases(
 		const newPath = parentPath === "" ? sub.name : `${parentPath}:${sub.name}`;
 		const subcmds = subcmdWordlist(sub);
 		const flags = flagWordlist(sub);
+		const valueFlags = valueFlagWordlist(sub);
 
 		// Canonical name edge.
 		out.push({
@@ -120,6 +139,7 @@ function collectPathCases(
 			cmdPath: newPath,
 			subcmds,
 			flags,
+			valueFlags,
 		});
 
 		// Alias edges resolve to the same cmd_path so children of the
@@ -131,6 +151,7 @@ function collectPathCases(
 					cmdPath: newPath,
 					subcmds,
 					flags,
+					valueFlags,
 				});
 			}
 		}
@@ -142,7 +163,7 @@ function collectPathCases(
 interface ChoiceCase {
 	/** `<cmd_path>|<flag-spelling>` (long, short, or alias). */
 	key: string;
-	/** Space-separated value list. */
+	/** Bash-quoted, space-joined value list. */
 	values: string;
 }
 
@@ -159,7 +180,10 @@ function collectChoiceCases(
 ): void {
 	for (const flag of node.flags) {
 		if (flag.choices === undefined) continue;
-		const values = flag.choices.map(bashQuote).join(" ");
+		// Choice values are validated to a safe character set, so we can
+		// emit them bare inside the `compgen -W` wordlist without per-
+		// candidate quoting. This keeps the generated script readable.
+		const values = flag.choices.join(" ");
 		const spellings = flagSpellings(flag);
 		for (const spelling of spellings) {
 			out.push({ key: `${cmdPath}|${spelling}`, values });
@@ -168,6 +192,37 @@ function collectChoiceCases(
 	for (const sub of node.subCommands) {
 		const subPath = cmdPath === "" ? sub.name : `${cmdPath}:${sub.name}`;
 		collectChoiceCases(subPath, sub, out);
+	}
+}
+
+interface ArgChoiceCase {
+	/** `<cmd_path>` of the command whose first positional has choices. */
+	key: string;
+	/** Bash-quoted, space-joined value list. */
+	values: string;
+}
+
+/**
+ * Collect, per command, the *first* positional argument's choice list (if
+ * any). Bash's `compgen -W` model is best at offering one set of
+ * candidates at a time; we surface positional choices for the first slot
+ * and fall through to file completion for further slots.
+ */
+function collectArgChoiceCases(
+	cmdPath: string,
+	node: CompletionCommand,
+	out: ArgChoiceCase[],
+): void {
+	const firstArg: CompletionArg | undefined = node.args[0];
+	if (firstArg !== undefined && firstArg.choices !== undefined) {
+		out.push({
+			key: cmdPath,
+			values: firstArg.choices.join(" "),
+		});
+	}
+	for (const sub of node.subCommands) {
+		const subPath = cmdPath === "" ? sub.name : `${cmdPath}:${sub.name}`;
+		collectArgChoiceCases(subPath, sub, out);
 	}
 }
 
@@ -181,17 +236,27 @@ function flagSpellings(flag: CompletionFlag): string[] {
 }
 
 /**
+ * Render the wordlist of *value-taking* flag spellings for a single
+ * command. Used to drive both flag-value context (after `--target`) and
+ * the path walker's "skip the next token" heuristic.
+ */
+function valueFlagWordlist(node: CompletionCommand): string {
+	const words: string[] = [];
+	for (const flag of node.flags) {
+		if (!flag.takesValue) continue;
+		for (const spelling of flagSpellings(flag)) words.push(spelling);
+	}
+	return words.join(" ");
+}
+
+/**
  * Render a self-contained bash completion script for the given spec.
  *
  * @param spec     The walker output describing the command tree.
- * @param binName  The user-facing binary name (the `complete -F` target).
- *                 Should be the name the user actually invokes — usually
- *                 the root `meta.name`. Special characters are tolerated
- *                 in the registration line; the helper function name is
- *                 derived via `toShellIdent` so it remains a valid bash
- *                 identifier.
- * @param version  Free-form version string for the header comment. We do
- *                 not parse it; the value flows through verbatim.
+ * @param binName  The user-facing binary name. Validated via
+ *                 {@link assertSafeBinName} upstream.
+ * @param version  Free-form version string for the header comment;
+ *                 control characters are stripped before emission.
  */
 export function renderBash(
 	spec: CompletionSpec,
@@ -204,6 +269,7 @@ export function renderBash(
 
 	const rootSubcmds = subcmdWordlist(spec.root);
 	const rootFlags = flagWordlist(spec.root);
+	const rootValueFlags = valueFlagWordlist(spec.root);
 
 	const pathCases: BashCase[] = [];
 	collectPathCases("", spec.root, pathCases);
@@ -211,11 +277,15 @@ export function renderBash(
 	const choiceCases: ChoiceCase[] = [];
 	collectChoiceCases("", spec.root, choiceCases);
 
+	const argChoiceCases: ArgChoiceCase[] = [];
+	collectArgChoiceCases("", spec.root, argChoiceCases);
+
 	const lines: string[] = [];
 
-	// Header — first line per task spec.
+	const safeBin = sanitizeForComment(binName);
+	const safeVersion = sanitizeForComment(version);
 	lines.push(
-		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion bash`,
+		`# completion script for ${safeBin} v${safeVersion} — regenerate with: ${safeBin} completion bash`,
 	);
 	lines.push("");
 
@@ -236,6 +306,18 @@ export function renderBash(
 	lines.push("}");
 	lines.push("");
 
+	// Helper: test whether the previous token is a value-taking flag at
+	// the current depth. Returns 0 (true) when prev is in $valueFlags,
+	// 1 otherwise.
+	lines.push(`__${ident}_prev_is_value_flag() {`);
+	lines.push("\tlocal candidate");
+	lines.push("\tfor candidate in $valueFlags; do");
+	lines.push('\t\tif [[ "$candidate" == "$prev" ]]; then return 0; fi');
+	lines.push("\tdone");
+	lines.push("\treturn 1");
+	lines.push("}");
+	lines.push("");
+
 	// Main completion function.
 	lines.push(`${fnName}() {`);
 	lines.push("\tlocal cur prev words cword");
@@ -246,22 +328,44 @@ export function renderBash(
 	lines.push("\tfi");
 	lines.push("");
 	lines.push('\tlocal cmd_path=""');
+	lines.push(`\tlocal subcmds="${bashDoubleQuoteInner(rootSubcmds)}"`);
+	lines.push(`\tlocal flags="${bashDoubleQuoteInner(rootFlags)}"`);
+	lines.push(`\tlocal valueFlags="${bashDoubleQuoteInner(rootValueFlags)}"`);
 	lines.push("\tlocal i=1");
-	lines.push(`\tlocal subcmds="${rootSubcmds}"`);
-	lines.push(`\tlocal flags="${rootFlags}"`);
+	lines.push("\tlocal end_of_options=0");
 	lines.push("");
 	lines.push("\twhile (( i < cword )); do");
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
 	lines.push('\t\tlocal w="${words[$i]}"');
-	lines.push('\t\tif [[ "$w" == -* ]]; then');
+	// `--` terminator: stop subcommand routing for the rest of the line.
+	lines.push('\t\tif [[ "$w" == "--" ]]; then');
+	lines.push("\t\t\tend_of_options=1");
+	lines.push("\t\t\t((i++)); break");
+	lines.push("\t\tfi");
+	// `--name=value` form: the equals sign is part of one token, so we
+	// don't need to skip a following value token.
+	lines.push('\t\tif [[ "$w" == --*=* ]]; then');
 	lines.push("\t\t\t((i++)); continue");
+	lines.push("\t\tfi");
+	// Bare flag: if it's a value-taking flag, skip the value too.
+	lines.push('\t\tif [[ "$w" == -* ]]; then');
+	lines.push("\t\t\tlocal candidate");
+	lines.push("\t\t\tlocal _was_value_flag=0");
+	lines.push("\t\t\tfor candidate in $valueFlags; do");
+	lines.push(
+		'\t\t\t\tif [[ "$candidate" == "$w" ]]; then _was_value_flag=1; break; fi',
+	);
+	lines.push("\t\t\tdone");
+	lines.push("\t\t\tif (( _was_value_flag )); then ((i+=2)); else ((i++)); fi");
+	lines.push("\t\t\tcontinue");
 	lines.push("\t\tfi");
 	lines.push('\t\tcase "$cmd_path|$w" in');
 	for (const c of pathCases) {
-		lines.push(`\t\t\t"${bashQuote(c.key)}")`);
-		lines.push(`\t\t\t\tcmd_path="${bashQuote(c.cmdPath)}"`);
-		lines.push(`\t\t\t\tsubcmds="${c.subcmds}"`);
-		lines.push(`\t\t\t\tflags="${c.flags}"`);
+		lines.push(`\t\t\t"${bashDoubleQuoteInner(c.key)}")`);
+		lines.push(`\t\t\t\tcmd_path="${bashDoubleQuoteInner(c.cmdPath)}"`);
+		lines.push(`\t\t\t\tsubcmds="${bashDoubleQuoteInner(c.subcmds)}"`);
+		lines.push(`\t\t\t\tflags="${bashDoubleQuoteInner(c.flags)}"`);
+		lines.push(`\t\t\t\tvalueFlags="${bashDoubleQuoteInner(c.valueFlags)}"`);
 		lines.push("\t\t\t\t;;");
 	}
 	lines.push("\t\t\t*) break ;;");
@@ -270,12 +374,48 @@ export function renderBash(
 	lines.push("\tdone");
 	lines.push("");
 
+	// After `--`: stop offering subcommands/flags entirely; bash falls
+	// through to file completion via `complete -o default`.
+	lines.push("\tif (( end_of_options )); then");
+	lines.push("\t\treturn");
+	lines.push("\tfi");
+	lines.push("");
+
+	// `--name=value` partial: split, look up, offer either choice values
+	// or fall through to default (file) completion.
+	lines.push('\tif [[ "$cur" == --*=* ]]; then');
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+	lines.push('\t\tlocal _flag="${cur%%=*}"');
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+	lines.push('\t\tlocal _value="${cur#*=}"');
+	if (choiceCases.length > 0) {
+		// `compgen -P` prefixes every candidate with `${_flag}=` so bash's
+		// command-line replacement substitutes the full token (otherwise
+		// readline would replace `--target=br` with bare `browser`).
+		lines.push('\t\tcase "$cmd_path|$_flag" in');
+		for (const c of choiceCases) {
+			lines.push(`\t\t\t"${bashDoubleQuoteInner(c.key)}")`);
+			lines.push(
+				`\t\t\t\tCOMPREPLY=( $(compgen -P "\${_flag}=" -W "${bashDoubleQuoteInner(c.values)}" -- "$_value") )`,
+			);
+			lines.push("\t\t\t\treturn");
+			lines.push("\t\t\t\t;;");
+		}
+		lines.push("\t\tesac");
+	}
+	// Free-form `--name=value`: let bash file-complete the value portion.
+	lines.push("\t\treturn");
+	lines.push("\tfi");
+	lines.push("");
+
 	// Flag-with-choices: if previous word matches, offer the value list.
 	if (choiceCases.length > 0) {
 		lines.push('\tcase "$cmd_path|$prev" in');
 		for (const c of choiceCases) {
-			lines.push(`\t\t"${bashQuote(c.key)}")`);
-			lines.push(`\t\t\tCOMPREPLY=( $(compgen -W "${c.values}" -- "$cur") )`);
+			lines.push(`\t\t"${bashDoubleQuoteInner(c.key)}")`);
+			lines.push(
+				`\t\t\tCOMPREPLY=( $(compgen -W "${bashDoubleQuoteInner(c.values)}" -- "$cur") )`,
+			);
 			lines.push("\t\t\treturn");
 			lines.push("\t\t\t;;");
 		}
@@ -283,10 +423,32 @@ export function renderBash(
 		lines.push("");
 	}
 
-	// Default branch: flags vs subcmds.
+	// Free-form value flag context: previous token is a known
+	// value-taking flag with no choices → fall through to file completion
+	// via `complete -o default` (we just return with no COMPREPLY set).
+	lines.push(`\tif __${ident}_prev_is_value_flag; then`);
+	lines.push("\t\treturn");
+	lines.push("\tfi");
+	lines.push("");
+
+	// Default branch: flags vs subcmds vs positional choices.
 	lines.push('\tif [[ "$cur" == -* ]]; then');
 	lines.push('\t\tCOMPREPLY=( $(compgen -W "$flags" -- "$cur") )');
 	lines.push("\telse");
+	if (argChoiceCases.length > 0) {
+		// Try the resolved command's positional-choice list first; if it
+		// returns nothing, fall through to the subcommand list.
+		lines.push('\t\tcase "$cmd_path" in');
+		for (const c of argChoiceCases) {
+			lines.push(`\t\t\t"${bashDoubleQuoteInner(c.key)}")`);
+			lines.push(
+				`\t\t\t\tCOMPREPLY=( $(compgen -W "${bashDoubleQuoteInner(c.values)} $subcmds" -- "$cur") )`,
+			);
+			lines.push("\t\t\t\treturn");
+			lines.push("\t\t\t\t;;");
+		}
+		lines.push("\t\tesac");
+	}
 	lines.push('\t\tCOMPREPLY=( $(compgen -W "$subcmds" -- "$cur") )');
 	lines.push("\tfi");
 	lines.push("}");
@@ -294,8 +456,9 @@ export function renderBash(
 
 	// Registration. `-o default` lets bash fall through to filename
 	// completion when our wordlists return nothing — handy for free
-	// positional args that take filesystem paths.
-	lines.push(`complete -o default -F ${fnName} ${bashQuote(binName)}`);
+	// positional args that take filesystem paths and for free-form
+	// flag values after we `return` without setting COMPREPLY.
+	lines.push(`complete -o default -F ${fnName} ${bashSingleQuote(binName)}`);
 
 	return `${lines.join("\n")}\n`;
 }

--- a/packages/plugins/src/completion/templates/bash.ts
+++ b/packages/plugins/src/completion/templates/bash.ts
@@ -195,30 +195,66 @@ function collectChoiceCases(
 	}
 }
 
-interface ArgChoiceCase {
-	/** `<cmd_path>` of the command whose first positional has choices. */
-	key: string;
-	/** Bash-quoted, space-joined value list. */
-	values: string;
+/**
+ * Per-command summary of positional-argument choices. Built once per
+ * command and consumed by the runtime walker to map a `(cmd_path,
+ * pos_idx)` pair to a candidate list.
+ *
+ * `bySlot` lists *fixed-slot* arguments with choices, in declaration
+ * order. `variadicFrom` is set when the command ends in a variadic
+ * positional that has choices — the choice list then applies to every
+ * slot from `variadicFrom` onwards.
+ */
+interface ArgChoiceEntry {
+	/** Command path key (e.g. `""`, `"build"`, `"remote:add"`). */
+	cmdPath: string;
+	/**
+	 * Fixed-slot positional choices. Index N's choice list is at `bySlot[N]`
+	 * when defined; gaps (no choices) are `undefined`. The array length is
+	 * the number of declared *non-variadic* positionals.
+	 */
+	bySlot: ReadonlyArray<string | undefined>;
+	/** Slot index from which `variadicValues` applies, or `undefined`. */
+	variadicFrom?: number;
+	/** Bash-quoted, space-joined value list for the variadic tail. */
+	variadicValues?: string;
 }
 
 /**
- * Collect, per command, the *first* positional argument's choice list (if
- * any). Bash's `compgen -W` model is best at offering one set of
- * candidates at a time; we surface positional choices for the first slot
- * and fall through to file completion for further slots.
+ * Collect per-command positional choice entries, recursively. Returns
+ * one {@link ArgChoiceEntry} per command that has at least one positional
+ * arg with a `choices` list (variadic or otherwise). Commands with no
+ * positional choices are omitted so the rendered case-block stays
+ * tight.
  */
 function collectArgChoiceCases(
 	cmdPath: string,
 	node: CompletionCommand,
-	out: ArgChoiceCase[],
+	out: ArgChoiceEntry[],
 ): void {
-	const firstArg: CompletionArg | undefined = node.args[0];
-	if (firstArg !== undefined && firstArg.choices !== undefined) {
-		out.push({
-			key: cmdPath,
-			values: firstArg.choices.join(" "),
-		});
+	const bySlot: Array<string | undefined> = [];
+	let variadicFrom: number | undefined;
+	let variadicValues: string | undefined;
+	let hasAny = false;
+	node.args.forEach((arg: CompletionArg, idx: number) => {
+		if (arg.variadic) {
+			if (arg.choices !== undefined) {
+				variadicFrom = idx;
+				// Validated bare values — see comment in `collectChoiceCases`.
+				variadicValues = arg.choices.join(" ");
+				hasAny = true;
+			}
+			return;
+		}
+		if (arg.choices !== undefined) {
+			bySlot[idx] = arg.choices.join(" ");
+			hasAny = true;
+		} else {
+			bySlot[idx] = undefined;
+		}
+	});
+	if (hasAny) {
+		out.push({ cmdPath, bySlot, variadicFrom, variadicValues });
 	}
 	for (const sub of node.subCommands) {
 		const subPath = cmdPath === "" ? sub.name : `${cmdPath}:${sub.name}`;
@@ -277,8 +313,8 @@ export function renderBash(
 	const choiceCases: ChoiceCase[] = [];
 	collectChoiceCases("", spec.root, choiceCases);
 
-	const argChoiceCases: ArgChoiceCase[] = [];
-	collectArgChoiceCases("", spec.root, argChoiceCases);
+	const argChoiceEntries: ArgChoiceEntry[] = [];
+	collectArgChoiceCases("", spec.root, argChoiceEntries);
 
 	const lines: string[] = [];
 
@@ -435,21 +471,89 @@ export function renderBash(
 	lines.push('\tif [[ "$cur" == -* ]]; then');
 	lines.push('\t\tCOMPREPLY=( $(compgen -W "$flags" -- "$cur") )');
 	lines.push("\telse");
-	if (argChoiceCases.length > 0) {
-		// Try the resolved command's positional-choice list first; if it
-		// returns nothing, fall through to the subcommand list.
+	if (argChoiceEntries.length > 0) {
+		// Count completed positional tokens between the resolved command
+		// path and the cursor. Token classes we *skip*:
+		//  - `--`                  (end-of-options terminator)
+		//  - `--name=value`        (single token, value is inlined)
+		//  - bare flags `-*`       (and the next token if the flag takes a value)
+		// What remains is positional values. `pos_idx` is the slot the
+		// cursor is currently filling (0 for the first positional slot).
+		lines.push("\t\tlocal pos_idx=0");
+		lines.push("\t\tlocal _pidx_j=$i");
+		lines.push("\t\tlocal _pidx_skip_next=0");
+		lines.push("\t\twhile (( _pidx_j < cword )); do");
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: bash variable expansion
+		lines.push('\t\t\tlocal _pidx_w="${words[$_pidx_j]}"');
+		lines.push("\t\t\tif (( _pidx_skip_next )); then");
+		lines.push("\t\t\t\t_pidx_skip_next=0");
+		lines.push("\t\t\t\t((_pidx_j++)); continue");
+		lines.push("\t\t\tfi");
+		lines.push('\t\t\tif [[ "$_pidx_w" == "--" ]]; then');
+		lines.push("\t\t\t\t((_pidx_j++)); continue");
+		lines.push("\t\t\tfi");
+		lines.push('\t\t\tif [[ "$_pidx_w" == --*=* ]]; then');
+		lines.push("\t\t\t\t((_pidx_j++)); continue");
+		lines.push("\t\t\tfi");
+		lines.push('\t\t\tif [[ "$_pidx_w" == -* ]]; then');
+		lines.push("\t\t\t\tlocal _pidx_cand");
+		lines.push("\t\t\t\tfor _pidx_cand in $valueFlags; do");
+		lines.push(
+			'\t\t\t\t\tif [[ "$_pidx_cand" == "$_pidx_w" ]]; then _pidx_skip_next=1; break; fi',
+		);
+		lines.push("\t\t\t\tdone");
+		lines.push("\t\t\t\t((_pidx_j++)); continue");
+		lines.push("\t\t\tfi");
+		// Use `pos_idx=$((pos_idx + 1))` rather than `((pos_idx++))` so the
+		// statement's exit code is always 0. Bash treats `((expr))` as
+		// false when `expr` evaluates to 0, and `((pos_idx++))` evaluates
+		// to the *old* value of `pos_idx` — incrementing from 0 to 1
+		// would return exit code 1, which kills consumers that source
+		// the script under `set -e`.
+		lines.push("\t\t\tpos_idx=$((pos_idx + 1))");
+		lines.push("\t\t\t((_pidx_j++))");
+		lines.push("\t\tdone");
+		lines.push('\t\tlocal pos_choices=""');
+		// Per-command, nested per-slot case. The slot ladder includes a
+		// `*)` fallback for variadic-with-choices commands so every slot
+		// from `variadicFrom` onwards offers the variadic candidate set.
 		lines.push('\t\tcase "$cmd_path" in');
-		for (const c of argChoiceCases) {
-			lines.push(`\t\t\t"${bashDoubleQuoteInner(c.key)}")`);
-			lines.push(
-				`\t\t\t\tCOMPREPLY=( $(compgen -W "${bashDoubleQuoteInner(c.values)} $subcmds" -- "$cur") )`,
-			);
-			lines.push("\t\t\t\treturn");
+		for (const entry of argChoiceEntries) {
+			lines.push(`\t\t\t"${bashDoubleQuoteInner(entry.cmdPath)}")`);
+			lines.push('\t\t\t\tcase "$pos_idx" in');
+			entry.bySlot.forEach((values, idx) => {
+				if (values === undefined) return;
+				lines.push(`\t\t\t\t\t${idx})`);
+				lines.push(`\t\t\t\t\t\tpos_choices="${bashDoubleQuoteInner(values)}"`);
+				lines.push("\t\t\t\t\t\t;;");
+			});
+			if (
+				entry.variadicFrom !== undefined &&
+				entry.variadicValues !== undefined
+			) {
+				lines.push("\t\t\t\t\t*)");
+				lines.push(
+					`\t\t\t\t\t\tif (( pos_idx >= ${entry.variadicFrom} )); then pos_choices="${bashDoubleQuoteInner(entry.variadicValues)}"; fi`,
+				);
+				lines.push("\t\t\t\t\t\t;;");
+			}
+			lines.push("\t\t\t\tesac");
 			lines.push("\t\t\t\t;;");
 		}
 		lines.push("\t\tesac");
+		// At slot 0, blend positional choices with subcommand candidates so
+		// commands that offer BOTH a positional choice list AND subcommands
+		// surface both. At slot >0 we never offer subcommands.
+		lines.push("\t\tif (( pos_idx == 0 )); then");
+		lines.push(
+			'\t\t\tCOMPREPLY=( $(compgen -W "$pos_choices $subcmds" -- "$cur") )',
+		);
+		lines.push("\t\telse");
+		lines.push('\t\t\tCOMPREPLY=( $(compgen -W "$pos_choices" -- "$cur") )');
+		lines.push("\t\tfi");
+	} else {
+		lines.push('\t\tCOMPREPLY=( $(compgen -W "$subcmds" -- "$cur") )');
 	}
-	lines.push('\t\tCOMPREPLY=( $(compgen -W "$subcmds" -- "$cur") )');
 	lines.push("\tfi");
 	lines.push("}");
 	lines.push("");

--- a/packages/plugins/src/completion/templates/fish.test.ts
+++ b/packages/plugins/src/completion/templates/fish.test.ts
@@ -144,6 +144,84 @@ describe("renderFish", () => {
 		expect(helpLine).toContain("-s 'h'");
 	});
 
+	it("emits per-slot positional choice rules gated on `__<ident>_path_at_arg`", () => {
+		// Each fixed-slot positional choice should produce one rule per
+		// candidate value, conditioned on the new per-arg-index helper.
+		// Variadic-with-choices positionals use the `*<N>` spec.
+		const spec: CompletionSpec = {
+			root: {
+				name: "mp",
+				flags: [],
+				args: [],
+				subCommands: [
+					{
+						name: "two",
+						flags: [],
+						args: [
+							{
+								name: "first",
+								type: "string",
+								required: true,
+								variadic: false,
+								choices: ["alpha", "beta"],
+							},
+							{
+								name: "second",
+								type: "string",
+								required: true,
+								variadic: false,
+								choices: ["gamma", "delta"],
+							},
+						],
+						subCommands: [],
+					},
+					{
+						name: "vary",
+						flags: [],
+						args: [
+							{
+								name: "items",
+								type: "string",
+								required: false,
+								variadic: true,
+								choices: ["a", "b"],
+							},
+						],
+						subCommands: [],
+					},
+				],
+			},
+		};
+		const script = renderFish(spec, "mp", "1.0.0");
+
+		// The per-arg-index helper is emitted exactly once.
+		expect(script).toContain("function __mp_path_at_arg");
+
+		// Slot 0 of `two` -> exact spec `0`; one rule per choice value.
+		expect(script).toContain("-n '__mp_path_at_arg \\'two\\' \\'0\\' \\'\\''");
+		expect(
+			script
+				.split("\n")
+				.filter((l) => l.includes("__mp_path_at_arg \\'two\\' \\'0\\'")).length,
+		).toBe(2); // one rule per choice value
+
+		// Slot 1 of `two` -> exact spec `1`.
+		expect(
+			script
+				.split("\n")
+				.filter((l) => l.includes("__mp_path_at_arg \\'two\\' \\'1\\'")).length,
+		).toBe(2);
+
+		// `vary`'s variadic arg lives at index 0 and is declared variadic
+		// -> spec is `*0` (matches every slot >= 0).
+		expect(
+			script
+				.split("\n")
+				.filter((l) => l.includes("__mp_path_at_arg \\'vary\\' \\'*0\\'"))
+				.length,
+		).toBe(2);
+	});
+
 	it("escapes single quotes in descriptions", () => {
 		const spec: CompletionSpec = {
 			root: {

--- a/packages/plugins/src/completion/templates/fish.test.ts
+++ b/packages/plugins/src/completion/templates/fish.test.ts
@@ -1,0 +1,226 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CompletionSpec } from "../spec.ts";
+import { renderFish } from "./fish.ts";
+
+const fixture: CompletionSpec = {
+	root: {
+		name: "mycli",
+		description: "Test CLI",
+		flags: [
+			{ name: "help", short: "h", type: "boolean", takesValue: false },
+			{ name: "version", short: "v", type: "boolean", takesValue: false },
+		],
+		args: [],
+		subCommands: [
+			{
+				name: "build",
+				description: "Build artifact",
+				flags: [
+					{ name: "release", type: "boolean", takesValue: false },
+					{
+						name: "target",
+						type: "string",
+						takesValue: true,
+						choices: ["browser", "bun", "node"],
+					},
+				],
+				args: [],
+				subCommands: [],
+			},
+			{
+				name: "deploy",
+				aliases: ["dep"],
+				description: "Deploy",
+				flags: [],
+				args: [],
+				subCommands: [
+					{
+						name: "prod",
+						description: "Production deploy",
+						flags: [
+							{
+								name: "env",
+								type: "string",
+								takesValue: true,
+								choices: ["dev", "staging", "prod"],
+							},
+						],
+						args: [],
+						subCommands: [],
+					},
+				],
+			},
+		],
+	},
+};
+
+describe("renderFish", () => {
+	it("first line is the header comment with bin + version + regenerate hint", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		const firstLine = script.split("\n")[0];
+		expect(firstLine).toBe(
+			"# completion script for mycli v1.0.0 — regenerate with: mycli completion fish",
+		);
+	});
+
+	it("disables global file completion before emitting rules", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		expect(script).toContain("complete -c mycli -f");
+	});
+
+	it("emits subcommand rules gated on __fish_use_subcommand at the top level", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		expect(script).toContain(
+			"complete -c mycli -n '__fish_use_subcommand' -f -a 'build' -d 'Build artifact'",
+		);
+		// Aliases of `deploy` get their own rule.
+		expect(script).toContain(
+			"complete -c mycli -n '__fish_use_subcommand' -f -a 'deploy' -d 'Deploy'",
+		);
+		expect(script).toContain(
+			"complete -c mycli -n '__fish_use_subcommand' -f -a 'dep' -d 'Deploy'",
+		);
+	});
+
+	it("emits choice flags as `-x -a 'opt1 opt2 opt3'`", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// build --target choices, gated on the build subcommand chain.
+		expect(script).toMatch(
+			/complete -c mycli -n '__fish_seen_subcommand_from build[^']*' -x -l target -a 'browser bun node'/,
+		);
+	});
+
+	it("nested subcommand rules use chained `seen_subcommand_from` predicates", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// deploy prod --env should be gated on the chain: seen deploy and seen prod.
+		expect(script).toMatch(
+			/seen_subcommand_from deploy dep.*seen_subcommand_from prod.*-x -l env -a 'dev staging prod'/,
+		);
+	});
+
+	it("negates deeper subcommand candidates so flags do not bleed past depth", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// At `mycli deploy <here>` we should NOT show deploy's flags after
+		// the user has typed `prod`, so the predicate carries
+		// `not __fish_seen_subcommand_from prod`.
+		expect(script).toContain("not __fish_seen_subcommand_from prod");
+	});
+
+	it("emits boolean flags without -r/-x", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// `--release` is a boolean toggle on `build`. Should not have -r or -x.
+		const releaseLine = script
+			.split("\n")
+			.find((l) => l.includes("-l release"));
+		expect(releaseLine).toBeDefined();
+		expect(releaseLine).not.toMatch(/-r\b/);
+		expect(releaseLine).not.toMatch(/-x\b/);
+	});
+
+	it("emits short alias on flags via -s", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		const helpLine = script.split("\n").find((l) => l.includes("-l help"));
+		expect(helpLine).toBeDefined();
+		expect(helpLine).toContain("-s h");
+	});
+
+	it("escapes single quotes in descriptions", () => {
+		const spec: CompletionSpec = {
+			root: {
+				name: "x",
+				flags: [
+					{
+						name: "fancy",
+						type: "string",
+						takesValue: true,
+						description: "it's complicated",
+					},
+				],
+				args: [],
+				subCommands: [],
+			},
+		};
+		const script = renderFish(spec, "x", "1.0.0");
+		expect(script).toContain("it\\'s complicated");
+	});
+});
+
+const fishAvailable = await isFishAvailable();
+const describeIfFish = fishAvailable ? describe : describe.skip;
+
+describeIfFish("renderFish · fish -n parse check", () => {
+	let scriptPath: string;
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "tp010-fish-"));
+		scriptPath = join(tmpDir, "mycli.fish");
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		await writeFile(scriptPath, script, "utf8");
+	});
+
+	afterAll(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("parses cleanly under `fish -n`", async () => {
+		const proc = Bun.spawn(["fish", "-n", scriptPath], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		expect(err).toBe("");
+		expect(code).toBe(0);
+	});
+
+	it("sources cleanly under fish and registers complete rules", async () => {
+		const driver = `
+source ${shQuoteForFish(scriptPath)}
+complete -c mycli | head -3
+echo SOURCE_OK
+`;
+		const proc = Bun.spawn(["fish", "-c", driver], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [out, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(`fish failed: ${err}\nstdout:\n${out}`);
+		}
+		expect(out).toContain("SOURCE_OK");
+	});
+});
+
+if (!fishAvailable) {
+	describe("renderFish · fish behavioural tests", () => {
+		it.skip("fish not available on PATH — skipping behavioural tests", () => {});
+	});
+}
+
+async function isFishAvailable(): Promise<boolean> {
+	try {
+		const proc = Bun.spawn(["fish", "--version"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		return proc.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+function shQuoteForFish(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/plugins/src/completion/templates/fish.test.ts
+++ b/packages/plugins/src/completion/templates/fish.test.ts
@@ -68,63 +68,80 @@ describe("renderFish", () => {
 
 	it("disables global file completion before emitting rules", () => {
 		const script = renderFish(fixture, "mycli", "1.0.0");
-		expect(script).toContain("complete -c mycli -f");
+		// Bin name is single-quoted as defence-in-depth.
+		expect(script).toContain("complete -c 'mycli' -f");
 	});
 
-	it("emits subcommand rules gated on __fish_use_subcommand at the top level", () => {
+	it("emits a per-script ordered path-resolution helper", () => {
 		const script = renderFish(fixture, "mycli", "1.0.0");
+		// Replaces the order-insensitive `__fish_seen_subcommand_from`
+		// chain with a helper that walks `commandline -opc` left-to-right.
+		expect(script).toContain("function __mycli_path_is");
+		expect(script).toContain("commandline -opc");
+	});
+
+	it("emits subcommand rules gated on __<ident>_path_is at the top level", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// Top-level rules call the helper with the leaf-block list (the
+		// canonical+alias spellings of the root's children) as the only
+		// argument — no consumed-path prefix. The condition is itself
+		// fish-single-quoted, so embedded `'` from the helper args are
+		// emitted as `\'` (fish's single-quote escape sequence).
+		expect(script).toContain("-n '__mycli_path_is \\'build deploy dep\\''");
+		// Build / deploy / deploy-alias rules each carry their own `-a`.
+		expect(script).toMatch(/-f -a 'build' -d 'Build artifact'/);
+		expect(script).toMatch(/-f -a 'deploy' -d 'Deploy'/);
+		expect(script).toMatch(/-f -a 'dep' -d 'Deploy'/);
+	});
+
+	it("emits choice flags as one rule per candidate", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// We deliberately emit one `complete` rule per candidate — fish
+		// accumulates them — so we never need to embed a multi-value
+		// list inside a single shell-token (which would force
+		// triple-nested fish quoting).
+		expect(script).toMatch(/-x -l 'target' -a 'browser'/);
+		expect(script).toMatch(/-x -l 'target' -a 'bun'/);
+		expect(script).toMatch(/-x -l 'target' -a 'node'/);
+	});
+
+	it("nested subcommand rules call __<ident>_path_is with the consumed path", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// `deploy prod --env` lives at depth 2; the helper receives the
+		// depth-1 spelling list (`deploy dep`), then the leaf block
+		// (empty here because `prod` has no children). Embedded `'`s in
+		// the helper-call string are escaped as `\'` by fish.
 		expect(script).toContain(
-			"complete -c mycli -n '__fish_use_subcommand' -f -a 'build' -d 'Build artifact'",
+			"-n '__mycli_path_is \\'deploy dep\\' \\'prod\\' \\'\\''",
 		);
-		// Aliases of `deploy` get their own rule.
+	});
+
+	it("negates deeper subcommand candidates via the helper's leaf-block list", () => {
+		const script = renderFish(fixture, "mycli", "1.0.0");
+		// At depth `[deploy]` the leaf-block list is `prod` (its only
+		// child); the helper rejects when `prod` has already appeared.
 		expect(script).toContain(
-			"complete -c mycli -n '__fish_use_subcommand' -f -a 'deploy' -d 'Deploy'",
+			"-n '__mycli_path_is \\'deploy dep\\' \\'prod\\''",
 		);
-		expect(script).toContain(
-			"complete -c mycli -n '__fish_use_subcommand' -f -a 'dep' -d 'Deploy'",
-		);
-	});
-
-	it("emits choice flags as `-x -a 'opt1 opt2 opt3'`", () => {
-		const script = renderFish(fixture, "mycli", "1.0.0");
-		// build --target choices, gated on the build subcommand chain.
-		expect(script).toMatch(
-			/complete -c mycli -n '__fish_seen_subcommand_from build[^']*' -x -l target -a 'browser bun node'/,
-		);
-	});
-
-	it("nested subcommand rules use chained `seen_subcommand_from` predicates", () => {
-		const script = renderFish(fixture, "mycli", "1.0.0");
-		// deploy prod --env should be gated on the chain: seen deploy and seen prod.
-		expect(script).toMatch(
-			/seen_subcommand_from deploy dep.*seen_subcommand_from prod.*-x -l env -a 'dev staging prod'/,
-		);
-	});
-
-	it("negates deeper subcommand candidates so flags do not bleed past depth", () => {
-		const script = renderFish(fixture, "mycli", "1.0.0");
-		// At `mycli deploy <here>` we should NOT show deploy's flags after
-		// the user has typed `prod`, so the predicate carries
-		// `not __fish_seen_subcommand_from prod`.
-		expect(script).toContain("not __fish_seen_subcommand_from prod");
 	});
 
 	it("emits boolean flags without -r/-x", () => {
 		const script = renderFish(fixture, "mycli", "1.0.0");
-		// `--release` is a boolean toggle on `build`. Should not have -r or -x.
+		// `--release` is a boolean toggle on `build`. The canonical rule
+		// (matching `-l 'release'` exactly) must not carry -r or -x.
 		const releaseLine = script
 			.split("\n")
-			.find((l) => l.includes("-l release"));
+			.find((l) => l.includes("-l 'release'"));
 		expect(releaseLine).toBeDefined();
-		expect(releaseLine).not.toMatch(/-r\b/);
-		expect(releaseLine).not.toMatch(/-x\b/);
+		expect(releaseLine).not.toMatch(/ -r\b/);
+		expect(releaseLine).not.toMatch(/ -x\b/);
 	});
 
 	it("emits short alias on flags via -s", () => {
 		const script = renderFish(fixture, "mycli", "1.0.0");
-		const helpLine = script.split("\n").find((l) => l.includes("-l help"));
+		const helpLine = script.split("\n").find((l) => l.includes("-l 'help'"));
 		expect(helpLine).toBeDefined();
-		expect(helpLine).toContain("-s h");
+		expect(helpLine).toContain("-s 'h'");
 	});
 
 	it("escapes single quotes in descriptions", () => {
@@ -144,7 +161,10 @@ describe("renderFish", () => {
 			},
 		};
 		const script = renderFish(spec, "x", "1.0.0");
-		expect(script).toContain("it\\'s complicated");
+		// Description goes through `fishSingleQuote`, which produces
+		// `'it\'s complicated'` — fish single-quote with `\'` for the
+		// embedded apostrophe.
+		expect(script).toContain("-d 'it\\'s complicated'");
 	});
 });
 

--- a/packages/plugins/src/completion/templates/fish.ts
+++ b/packages/plugins/src/completion/templates/fish.ts
@@ -1,0 +1,250 @@
+import type { CompletionCommand, CompletionSpec } from "../spec.ts";
+
+/**
+ * Pure-static fish completion script renderer.
+ *
+ * Strategy: emit declarative `complete -c <bin>` rules — one per
+ * subcommand candidate, one per flag of every reachable command. Fish
+ * accumulates rules into an in-memory table at `source` time and consults
+ * them on every TAB; there's no entry-point function, no subprocess, and
+ * no shell state to manage.
+ *
+ * Subcommand routing uses chained
+ * `-n '__fish_seen_subcommand_from <parent-chain>; and not __fish_seen_subcommand_from <siblings>'`
+ * predicates. That's slightly more verbose than the bash/zsh dispatch but
+ * is fish's idiomatic shape and matches what `share/completions/git.fish`
+ * and the Cobra/clap_complete fish output emit.
+ */
+
+/**
+ * Escape a string for inclusion inside a fish single-quoted string. Fish
+ * single quotes only escape `\\` and `\'`; everything else is literal.
+ */
+function escSingleQuoted(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/**
+ * Escape arbitrary text for inclusion in a fish description (`-d '...'`).
+ * Same rules as a fish single-quoted string. We also collapse newlines.
+ */
+function escDescription(value: string): string {
+	return escSingleQuoted(value.replace(/[\r\n]+/g, " "));
+}
+
+/**
+ * Render a single `complete -c <bin> ...` rule line. Trailing flags omitted
+ * when not applicable so the output stays readable.
+ */
+interface RuleParts {
+	condition?: string;
+	short?: string;
+	long?: string;
+	arguments?: string;
+	description?: string;
+	exclusive?: boolean;
+	requireParameter?: boolean;
+	noFiles?: boolean;
+}
+
+function renderRule(binName: string, parts: RuleParts): string {
+	const segments: string[] = [`complete -c ${binName}`];
+	if (parts.condition !== undefined) {
+		segments.push(`-n '${parts.condition}'`);
+	}
+	if (parts.exclusive) segments.push("-x");
+	else if (parts.requireParameter) segments.push("-r");
+	else if (parts.noFiles) segments.push("-f");
+	if (parts.short !== undefined) segments.push(`-s ${parts.short}`);
+	if (parts.long !== undefined) segments.push(`-l ${parts.long}`);
+	if (parts.arguments !== undefined) {
+		segments.push(`-a '${parts.arguments}'`);
+	}
+	if (parts.description !== undefined) {
+		segments.push(`-d '${escDescription(parts.description)}'`);
+	}
+	return segments.join(" ");
+}
+
+/**
+ * Build the fish predicate that matches "we are currently inside the
+ * command path `path`, and no further subcommand has been entered yet".
+ *
+ * - Empty path  → `__fish_use_subcommand`
+ *   (top level: no subcommand entered yet)
+ * - `["build"]` → `__fish_seen_subcommand_from build; and not __fish_seen_subcommand_from <build's children>`
+ *   …but if `build` has no subcommands, just the first half.
+ *
+ * The full chain matters for nested commands: at `mycli deploy prod` we
+ * need `seen_subcommand_from deploy; and seen_subcommand_from prod`.
+ */
+function inPathPredicate(
+	path: readonly CompletionCommand[],
+): string | undefined {
+	if (path.length === 0) {
+		return "__fish_use_subcommand";
+	}
+
+	// Build the chain of `seen_subcommand_from` clauses, one per depth
+	// step. Each clause must accept any spelling (canonical + aliases).
+	const seenClauses: string[] = [];
+	for (const node of path) {
+		const spellings = [node.name, ...(node.aliases ?? [])].join(" ");
+		seenClauses.push(`__fish_seen_subcommand_from ${spellings}`);
+	}
+
+	// Negate any deeper subcommand on the leaf node so we don't suggest
+	// `prod`'s flags after the user has typed `prod something`.
+	const leaf = path[path.length - 1];
+	if (leaf === undefined) return undefined;
+	const childSpellings: string[] = [];
+	for (const sub of leaf.subCommands) {
+		childSpellings.push(sub.name);
+		if (sub.aliases !== undefined) childSpellings.push(...sub.aliases);
+	}
+
+	const parts = [...seenClauses];
+	if (childSpellings.length > 0) {
+		parts.push(`not __fish_seen_subcommand_from ${childSpellings.join(" ")}`);
+	}
+	return parts.join("; and ");
+}
+
+/**
+ * Recursively walk the command tree and emit:
+ *   1. one subcommand-listing rule per child of the current node, gated
+ *      on `inPathPredicate(path)` — these surface child names + aliases
+ *      with descriptions in the completion menu;
+ *   2. one rule per flag of the current node, also gated on the path
+ *      predicate, so flags only show up at the right depth.
+ */
+function emitRules(
+	binName: string,
+	path: readonly CompletionCommand[],
+	current: CompletionCommand,
+	out: string[],
+): void {
+	const condition = inPathPredicate(path);
+
+	// Subcommand rules: emit one rule per child spelling so each can carry
+	// its own description in the menu.
+	for (const sub of current.subCommands) {
+		const desc = sub.description ?? "";
+		const spellings = [sub.name, ...(sub.aliases ?? [])];
+		for (const spelling of spellings) {
+			out.push(
+				renderRule(binName, {
+					condition,
+					arguments: escSingleQuoted(spelling),
+					description: desc,
+					noFiles: true,
+				}),
+			);
+		}
+	}
+
+	// Flag rules.
+	for (const flag of current.flags) {
+		const desc = flag.description ?? "";
+		const baseRule: RuleParts = {
+			condition,
+			long: flag.name,
+			description: desc,
+		};
+		if (flag.short !== undefined) baseRule.short = flag.short;
+
+		if (flag.takesValue) {
+			if (flag.choices !== undefined && flag.choices.length > 0) {
+				// Choice flag: -x (require param + no files) + `-a`.
+				out.push(
+					renderRule(binName, {
+						...baseRule,
+						exclusive: true,
+						arguments: flag.choices.map(escSingleQuoted).join(" "),
+					}),
+				);
+			} else {
+				// Free-form value flag: -r so fish offers files after the flag.
+				out.push(renderRule(binName, { ...baseRule, requireParameter: true }));
+			}
+		} else {
+			// Boolean toggle: no -r/-x, no -a.
+			out.push(renderRule(binName, baseRule));
+		}
+
+		// Aliases — emit additional rules with the same condition/desc but
+		// using the alias as the long form. Aliases without a short alias
+		// get rendered as long-only rules.
+		if (flag.aliases !== undefined) {
+			for (const alias of flag.aliases) {
+				const aliasRule: RuleParts = {
+					condition,
+					long: alias,
+					description: desc,
+				};
+				if (flag.takesValue) {
+					if (flag.choices !== undefined && flag.choices.length > 0) {
+						out.push(
+							renderRule(binName, {
+								...aliasRule,
+								exclusive: true,
+								arguments: flag.choices.map(escSingleQuoted).join(" "),
+							}),
+						);
+					} else {
+						out.push(
+							renderRule(binName, {
+								...aliasRule,
+								requireParameter: true,
+							}),
+						);
+					}
+				} else {
+					out.push(renderRule(binName, aliasRule));
+				}
+			}
+		}
+	}
+
+	// Recurse into children.
+	for (const sub of current.subCommands) {
+		emitRules(binName, [...path, sub], sub, out);
+	}
+}
+
+/**
+ * Render a self-contained fish completion script for the given spec.
+ *
+ * The script is safe to drop into `~/.config/fish/completions/<bin>.fish`
+ * (auto-loaded the first time the user types `<bin>`) AND safe to source
+ * inline via `mycli completion fish | source` — both paths just register
+ * `complete` rules.
+ *
+ * @param spec     Walker output.
+ * @param binName  User-facing binary name.
+ * @param version  Free-form version string for the header comment.
+ */
+export function renderFish(
+	spec: CompletionSpec,
+	binName: string,
+	version: string,
+): string {
+	const lines: string[] = [];
+
+	lines.push(
+		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion fish`,
+	);
+	lines.push("");
+
+	// Disable file completion globally for the command. Individual rules
+	// re-enable filesystem completion via `-r` (free-form value flags) or
+	// stay file-less via `-x` (enum flags) as appropriate.
+	lines.push(`complete -c ${binName} -f`);
+	lines.push("");
+
+	const rules: string[] = [];
+	emitRules(binName, [], spec.root, rules);
+	lines.push(...rules);
+
+	return `${lines.join("\n")}\n`;
+}

--- a/packages/plugins/src/completion/templates/fish.ts
+++ b/packages/plugins/src/completion/templates/fish.ts
@@ -116,6 +116,36 @@ function pathPredicate(
 }
 
 /**
+ * Build the `-n` predicate for a positional-argument-choice rule.
+ *
+ * Calls `__<ident>_path_at_arg <spellings...> <pos_spec> <block>` where
+ * `pos_spec` is either `<N>` (exact: completion fires when exactly N
+ * positionals have been consumed past the path) or `*<N>` (variadic
+ * fallback: fires when N-or-more positionals have been consumed, used
+ * for variadic args with choices).
+ *
+ * Notes on layering: this helper is intentionally a parallel function
+ * to `__<ident>_path_is` rather than a generalisation of it — the two
+ * call sites (subcommand/flag rules vs positional-choice rules) want
+ * distinct semantics and the call surfaces are clearer when each helper
+ * does one thing.
+ */
+function posPredicate(
+	ident: string,
+	path: readonly CompletionCommand[],
+	leaf: CompletionCommand,
+	posSpec: string,
+): string {
+	const args: string[] = [];
+	for (const node of path) {
+		args.push(fishSingleQuote(spellingsOf(node)));
+	}
+	args.push(fishSingleQuote(posSpec));
+	args.push(fishSingleQuote(childSpellings(leaf)));
+	return `__${ident}_path_at_arg ${args.join(" ")}`;
+}
+
+/**
  * Recursively walk the command tree and emit:
  *   1. one subcommand-listing rule per child of the current node, gated
  *      on the path predicate — these surface child names + aliases with
@@ -240,23 +270,26 @@ function emitRules(
 		}
 	}
 
-	// Positional arg with choices: surface the first arg's choices as
-	// rules with no flag (so fish offers them when no flag context is
-	// active). Variadic args reuse the same rules and simply offer the
-	// list at every slot.
-	const firstArg = current.args[0];
-	if (firstArg !== undefined && firstArg.choices !== undefined) {
-		for (const choice of firstArg.choices) {
+	// Positional arg choices: emit one rule per (slot, choice value)
+	// gated on the per-slot predicate `__<ident>_path_at_arg`. Fixed
+	// slots fire only when the user is filling that exact slot; a
+	// variadic-with-choices arg fires for every slot from its declared
+	// index onwards (`*<N>` spec).
+	current.args.forEach((arg, idx) => {
+		if (arg.choices === undefined || arg.choices.length === 0) return;
+		const posSpec = arg.variadic ? `*${idx}` : String(idx);
+		const posCondition = posPredicate(ident, path, current, posSpec);
+		for (const choice of arg.choices) {
 			out.push(
 				renderRule(binName, {
-					condition,
+					condition: posCondition,
 					arguments: fishSingleQuote(choice),
-					description: firstArg.description ?? "",
+					description: arg.description ?? "",
 					noFiles: true,
 				}),
 			);
 		}
-	}
+	});
 
 	// Recurse.
 	for (const sub of current.subCommands) {
@@ -321,6 +354,78 @@ function emitHelper(ident: string): string[] {
 }
 
 /**
+ * Emit the per-script `__<ident>_path_at_arg` helper. Like
+ * {@link emitHelper} but takes an extra `pos_spec` argument before the
+ * block list. `pos_spec` is `<N>` (fires when exactly N positionals have
+ * been consumed past the path — the cursor is filling slot N) or
+ * `*<N>` (variadic; fires when N-or-more positionals have been
+ * consumed, used for variadic-with-choices args).
+ *
+ * The walking loop is identical to `__<ident>_path_is`; only the final
+ * test differs. Kept as a separate helper rather than a parameterised
+ * superset of the existing one so call sites stay declarative — a
+ * subcommand rule wants "we are at this path, nothing further typed",
+ * not "we are at this path with offset=0".
+ */
+function emitPosHelper(ident: string): string[] {
+	const fn = `__${ident}_path_at_arg`;
+	const lines: string[] = [];
+	lines.push(`function ${fn}`);
+	lines.push("\tset -l total_argv (count $argv)");
+	lines.push('\tset -l block (string split " " -- $argv[$total_argv])');
+	lines.push("\tset -l pos_spec $argv[(math $total_argv - 1)]");
+	lines.push("\tset -l n (math $total_argv - 2)");
+	lines.push("\tset -l variadic 0");
+	lines.push("\tset -l target $pos_spec");
+	lines.push("\tif string match -q -- '\\**' $pos_spec");
+	lines.push("\t\tset variadic 1");
+	lines.push("\t\tset target (string sub --start 2 -- $pos_spec)");
+	lines.push("\tend");
+	lines.push("\tset -l tokens (commandline -opc)");
+	lines.push("\tset -l total (count $tokens)");
+	lines.push("\tset -l j 2");
+	lines.push("\tset -l consumed 0");
+	lines.push("\tset -l end_of_options 0");
+	lines.push("\twhile test $j -le $total");
+	lines.push("\t\tset -l t $tokens[$j]");
+	lines.push('\t\tif test "$t" = "--"');
+	lines.push("\t\t\tset end_of_options 1");
+	lines.push("\t\t\tset j (math $j + 1)");
+	lines.push("\t\t\tcontinue");
+	lines.push("\t\tend");
+	lines.push(
+		"\t\tif test $end_of_options -eq 0; and string match -q -- '-*' $t",
+	);
+	lines.push("\t\t\tset j (math $j + 1)");
+	lines.push("\t\t\tcontinue");
+	lines.push("\t\tend");
+	lines.push("\t\tif test $consumed -lt $n");
+	lines.push(
+		'\t\t\tset -l alts (string split " " -- $argv[(math $consumed + 1)])',
+	);
+	lines.push("\t\t\tif not contains -- $t $alts");
+	lines.push("\t\t\t\treturn 1");
+	lines.push("\t\t\tend");
+	lines.push("\t\t\tset consumed (math $consumed + 1)");
+	lines.push("\t\telse");
+	lines.push("\t\t\tif contains -- $t $block");
+	lines.push("\t\t\t\treturn 1");
+	lines.push("\t\t\tend");
+	lines.push("\t\t\tset consumed (math $consumed + 1)");
+	lines.push("\t\tend");
+	lines.push("\t\tset j (math $j + 1)");
+	lines.push("\tend");
+	lines.push("\tset -l beyond (math $consumed - $n)");
+	lines.push("\tif test $variadic -eq 1");
+	lines.push("\t\ttest $beyond -ge $target");
+	lines.push("\telse");
+	lines.push("\t\ttest $beyond -eq $target");
+	lines.push("\tend");
+	lines.push("end");
+	return lines;
+}
+
+/**
  * Render a self-contained fish completion script for the given spec.
  *
  * The script is safe to drop into `~/.config/fish/completions/<bin>.fish`
@@ -347,8 +452,10 @@ export function renderFish(
 	);
 	lines.push("");
 
-	// Emit the path-resolution helper before any rules reference it.
+	// Emit the path-resolution helpers before any rules reference them.
 	lines.push(...emitHelper(ident));
+	lines.push("");
+	lines.push(...emitPosHelper(ident));
 	lines.push("");
 
 	// Disable file completion globally for the command. Individual rules

--- a/packages/plugins/src/completion/templates/fish.ts
+++ b/packages/plugins/src/completion/templates/fish.ts
@@ -1,3 +1,4 @@
+import { fishSingleQuote, sanitizeForComment } from "../escape.ts";
 import type { CompletionCommand, CompletionSpec } from "../spec.ts";
 
 /**
@@ -9,33 +10,35 @@ import type { CompletionCommand, CompletionSpec } from "../spec.ts";
  * them on every TAB; there's no entry-point function, no subprocess, and
  * no shell state to manage.
  *
- * Subcommand routing uses chained
- * `-n '__fish_seen_subcommand_from <parent-chain>; and not __fish_seen_subcommand_from <siblings>'`
- * predicates. That's slightly more verbose than the bash/zsh dispatch but
- * is fish's idiomatic shape and matches what `share/completions/git.fish`
- * and the Cobra/clap_complete fish output emit.
+ * **Subcommand routing.** We emit a single helper per script —
+ * `__<ident>_path_is` — that walks `commandline -opc` left-to-right,
+ * skips flags and the `--` end-of-options terminator, and verifies that
+ * each consumed positional matches the expected canonical-or-alias set
+ * for its depth in order. This replaces the stock
+ * `__fish_seen_subcommand_from` chain (which is order-insensitive and
+ * misroutes when the same name appears at different depths).
  */
 
-/**
- * Escape a string for inclusion inside a fish single-quoted string. Fish
- * single quotes only escape `\\` and `\'`; everything else is literal.
- */
-function escSingleQuoted(value: string): string {
-	return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+function toShellIdent(name: string): string {
+	return name.replace(/[^A-Za-z0-9_]/g, "_");
 }
 
-/**
- * Escape arbitrary text for inclusion in a fish description (`-d '...'`).
- * Same rules as a fish single-quoted string. We also collapse newlines.
- */
-function escDescription(value: string): string {
-	return escSingleQuoted(value.replace(/[\r\n]+/g, " "));
+/** Build the space-joined spelling list for a command (canonical + aliases). */
+function spellingsOf(node: CompletionCommand): string {
+	const all: string[] = [node.name, ...(node.aliases ?? [])];
+	return all.join(" ");
 }
 
-/**
- * Render a single `complete -c <bin> ...` rule line. Trailing flags omitted
- * when not applicable so the output stays readable.
- */
+/** Build the space-joined "block" list — direct children of `node`. */
+function childSpellings(node: CompletionCommand): string {
+	const out: string[] = [];
+	for (const sub of node.subCommands) {
+		out.push(sub.name);
+		if (sub.aliases !== undefined) out.push(...sub.aliases);
+	}
+	return out.join(" ");
+}
+
 interface RuleParts {
 	condition?: string;
 	short?: string;
@@ -47,101 +50,128 @@ interface RuleParts {
 	noFiles?: boolean;
 }
 
+/**
+ * Render a single `complete -c <bin> ...` rule line.
+ *
+ * `binName` was validated upstream via `assertSafeBinName`, but we still
+ * single-quote it as defence-in-depth so the line works even if a future
+ * caller bypasses validation.
+ */
 function renderRule(binName: string, parts: RuleParts): string {
-	const segments: string[] = [`complete -c ${binName}`];
+	const segments: string[] = [`complete -c ${fishSingleQuote(binName)}`];
 	if (parts.condition !== undefined) {
-		segments.push(`-n '${parts.condition}'`);
+		// The condition is fish code (one or more `; and` clauses); it is
+		// constructed in this file and only references our own helper plus
+		// validated identifiers, so we wrap it in single quotes so fish
+		// passes it as a single `-n` argument.
+		segments.push(`-n ${fishSingleQuote(parts.condition)}`);
 	}
 	if (parts.exclusive) segments.push("-x");
 	else if (parts.requireParameter) segments.push("-r");
 	else if (parts.noFiles) segments.push("-f");
-	if (parts.short !== undefined) segments.push(`-s ${parts.short}`);
-	if (parts.long !== undefined) segments.push(`-l ${parts.long}`);
+	if (parts.short !== undefined) {
+		segments.push(`-s ${fishSingleQuote(parts.short)}`);
+	}
+	if (parts.long !== undefined) {
+		segments.push(`-l ${fishSingleQuote(parts.long)}`);
+	}
 	if (parts.arguments !== undefined) {
-		segments.push(`-a '${parts.arguments}'`);
+		// `-a` takes a single shell-token that fish later re-tokenises into
+		// candidates. Embedding a multi-value list inside one shell-token
+		// requires double-escaping (single-quote nesting + fish's later
+		// re-tokenisation of the unwrapped string) which is fragile when
+		// candidates contain whitespace or quotes. We therefore emit
+		// **one rule per candidate** — each call passes a single
+		// fish-quoted shell-token via `arguments`. Fish accumulates rules
+		// with identical subjects/conditions into one candidate set.
+		segments.push(`-a ${parts.arguments}`);
 	}
 	if (parts.description !== undefined) {
-		segments.push(`-d '${escDescription(parts.description)}'`);
+		segments.push(`-d ${fishSingleQuote(parts.description)}`);
 	}
 	return segments.join(" ");
 }
 
 /**
- * Build the fish predicate that matches "we are currently inside the
- * command path `path`, and no further subcommand has been entered yet".
+ * Build the `-n` predicate expression that matches "we are currently at
+ * the command path `path` and no deeper subcommand has been entered".
  *
- * - Empty path  → `__fish_use_subcommand`
- *   (top level: no subcommand entered yet)
- * - `["build"]` → `__fish_seen_subcommand_from build; and not __fish_seen_subcommand_from <build's children>`
- *   …but if `build` has no subcommands, just the first half.
- *
- * The full chain matters for nested commands: at `mycli deploy prod` we
- * need `seen_subcommand_from deploy; and seen_subcommand_from prod`.
+ * Always uses the per-script helper `__<ident>_path_is`. The helper
+ * receives one argument per depth (space-joined acceptable spellings at
+ * that depth) plus a final "block" argument that lists the child
+ * spellings of the leaf — the helper rejects when any of those have
+ * already appeared past the path.
  */
-function inPathPredicate(
+function pathPredicate(
+	ident: string,
 	path: readonly CompletionCommand[],
-): string | undefined {
-	if (path.length === 0) {
-		return "__fish_use_subcommand";
-	}
-
-	// Build the chain of `seen_subcommand_from` clauses, one per depth
-	// step. Each clause must accept any spelling (canonical + aliases).
-	const seenClauses: string[] = [];
+	leaf: CompletionCommand,
+): string {
+	const args: string[] = [];
 	for (const node of path) {
-		const spellings = [node.name, ...(node.aliases ?? [])].join(" ");
-		seenClauses.push(`__fish_seen_subcommand_from ${spellings}`);
+		args.push(fishSingleQuote(spellingsOf(node)));
 	}
-
-	// Negate any deeper subcommand on the leaf node so we don't suggest
-	// `prod`'s flags after the user has typed `prod something`.
-	const leaf = path[path.length - 1];
-	if (leaf === undefined) return undefined;
-	const childSpellings: string[] = [];
-	for (const sub of leaf.subCommands) {
-		childSpellings.push(sub.name);
-		if (sub.aliases !== undefined) childSpellings.push(...sub.aliases);
-	}
-
-	const parts = [...seenClauses];
-	if (childSpellings.length > 0) {
-		parts.push(`not __fish_seen_subcommand_from ${childSpellings.join(" ")}`);
-	}
-	return parts.join("; and ");
+	args.push(fishSingleQuote(childSpellings(leaf)));
+	return `__${ident}_path_is ${args.join(" ")}`;
 }
 
 /**
  * Recursively walk the command tree and emit:
  *   1. one subcommand-listing rule per child of the current node, gated
- *      on `inPathPredicate(path)` — these surface child names + aliases
- *      with descriptions in the completion menu;
- *   2. one rule per flag of the current node, also gated on the path
- *      predicate, so flags only show up at the right depth.
+ *      on the path predicate — these surface child names + aliases with
+ *      descriptions in the completion menu;
+ *   2. one rule per flag of the current node;
+ *   3. one rule per positional arg that declares choices (only the first
+ *      slot — fish's `complete -a` model is best at offering a single
+ *      candidate set; further slots fall through to filename completion
+ *      via `-r` on the rule).
  */
 function emitRules(
 	binName: string,
+	ident: string,
 	path: readonly CompletionCommand[],
 	current: CompletionCommand,
 	out: string[],
 ): void {
-	const condition = inPathPredicate(path);
+	const condition = pathPredicate(ident, path, current);
 
-	// Subcommand rules: emit one rule per child spelling so each can carry
-	// its own description in the menu.
+	// Subcommand rules: emit one rule per spelling so each can carry its
+	// own description in the menu. fishSingleQuote is applied via the
+	// `arguments` pre-tokenisation path.
 	for (const sub of current.subCommands) {
 		const desc = sub.description ?? "";
-		const spellings = [sub.name, ...(sub.aliases ?? [])];
+		const spellings: string[] = [sub.name, ...(sub.aliases ?? [])];
 		for (const spelling of spellings) {
 			out.push(
 				renderRule(binName, {
 					condition,
-					arguments: escSingleQuoted(spelling),
+					arguments: fishSingleQuote(spelling),
 					description: desc,
 					noFiles: true,
 				}),
 			);
 		}
 	}
+
+	/**
+	 * Emit choice values as a separate rule per candidate. See the note
+	 * on {@link renderRule}'s `arguments` handling for why we don't
+	 * pack them into one space-joined list.
+	 */
+	const emitChoiceFlag = (
+		rule: RuleParts,
+		choices: readonly string[],
+	): void => {
+		for (const choice of choices) {
+			out.push(
+				renderRule(binName, {
+					...rule,
+					exclusive: true,
+					arguments: fishSingleQuote(choice),
+				}),
+			);
+		}
+	};
 
 	// Flag rules.
 	for (const flag of current.flags) {
@@ -155,26 +185,16 @@ function emitRules(
 
 		if (flag.takesValue) {
 			if (flag.choices !== undefined && flag.choices.length > 0) {
-				// Choice flag: -x (require param + no files) + `-a`.
-				out.push(
-					renderRule(binName, {
-						...baseRule,
-						exclusive: true,
-						arguments: flag.choices.map(escSingleQuoted).join(" "),
-					}),
-				);
+				emitChoiceFlag(baseRule, flag.choices);
 			} else {
-				// Free-form value flag: -r so fish offers files after the flag.
 				out.push(renderRule(binName, { ...baseRule, requireParameter: true }));
 			}
 		} else {
-			// Boolean toggle: no -r/-x, no -a.
 			out.push(renderRule(binName, baseRule));
 		}
 
 		// Aliases — emit additional rules with the same condition/desc but
-		// using the alias as the long form. Aliases without a short alias
-		// get rendered as long-only rules.
+		// using the alias as the long form.
 		if (flag.aliases !== undefined) {
 			for (const alias of flag.aliases) {
 				const aliasRule: RuleParts = {
@@ -184,19 +204,10 @@ function emitRules(
 				};
 				if (flag.takesValue) {
 					if (flag.choices !== undefined && flag.choices.length > 0) {
-						out.push(
-							renderRule(binName, {
-								...aliasRule,
-								exclusive: true,
-								arguments: flag.choices.map(escSingleQuoted).join(" "),
-							}),
-						);
+						emitChoiceFlag(aliasRule, flag.choices);
 					} else {
 						out.push(
-							renderRule(binName, {
-								...aliasRule,
-								requireParameter: true,
-							}),
+							renderRule(binName, { ...aliasRule, requireParameter: true }),
 						);
 					}
 				} else {
@@ -204,12 +215,109 @@ function emitRules(
 				}
 			}
 		}
+
+		// `--no-<name>` for boolean toggles.
+		if (flag.type === "boolean" && flag.noNegate !== true) {
+			const negDesc = `disable: ${desc}`.trim();
+			out.push(
+				renderRule(binName, {
+					condition,
+					long: `no-${flag.name}`,
+					description: negDesc,
+				}),
+			);
+			if (flag.aliases !== undefined) {
+				for (const alias of flag.aliases) {
+					out.push(
+						renderRule(binName, {
+							condition,
+							long: `no-${alias}`,
+							description: negDesc,
+						}),
+					);
+				}
+			}
+		}
 	}
 
-	// Recurse into children.
-	for (const sub of current.subCommands) {
-		emitRules(binName, [...path, sub], sub, out);
+	// Positional arg with choices: surface the first arg's choices as
+	// rules with no flag (so fish offers them when no flag context is
+	// active). Variadic args reuse the same rules and simply offer the
+	// list at every slot.
+	const firstArg = current.args[0];
+	if (firstArg !== undefined && firstArg.choices !== undefined) {
+		for (const choice of firstArg.choices) {
+			out.push(
+				renderRule(binName, {
+					condition,
+					arguments: fishSingleQuote(choice),
+					description: firstArg.description ?? "",
+					noFiles: true,
+				}),
+			);
+		}
 	}
+
+	// Recurse.
+	for (const sub of current.subCommands) {
+		emitRules(binName, ident, [...path, sub], sub, out);
+	}
+}
+
+/**
+ * Emit the per-script `__<ident>_path_is` helper. See
+ * {@link pathPredicate} for the calling convention.
+ *
+ * The helper walks `commandline -opc` (the line tokens up to the cursor),
+ * skipping the program name, all `-*` tokens, and everything after `--`.
+ * It then checks each consumed positional matches the expected
+ * spelling-list at depth `i`, in order. Past the path, it returns 1 if
+ * any of the leaf's children have been entered (so deeper paths win and
+ * shallower predicates stop matching).
+ */
+function emitHelper(ident: string): string[] {
+	const fn = `__${ident}_path_is`;
+	const lines: string[] = [];
+	lines.push(`function ${fn}`);
+	lines.push("\tset -l n (math (count $argv) - 1)");
+	lines.push('\tset -l block (string split " " -- $argv[-1])');
+	lines.push("\tset -l tokens (commandline -opc)");
+	lines.push("\tset -l total (count $tokens)");
+	// Skip the program name (token 1).
+	lines.push("\tset -l j 2");
+	lines.push("\tset -l consumed 0");
+	lines.push("\tset -l end_of_options 0");
+	lines.push("\twhile test $j -le $total");
+	lines.push("\t\tset -l t $tokens[$j]");
+	lines.push('\t\tif test "$t" = "--"');
+	lines.push("\t\t\tset end_of_options 1");
+	lines.push("\t\t\tset j (math $j + 1)");
+	lines.push("\t\t\tcontinue");
+	lines.push("\t\tend");
+	lines.push(
+		"\t\tif test $end_of_options -eq 0; and string match -q -- '-*' $t",
+	);
+	lines.push("\t\t\tset j (math $j + 1)");
+	lines.push("\t\t\tcontinue");
+	lines.push("\t\tend");
+	lines.push("\t\tif test $consumed -lt $n");
+	lines.push(
+		'\t\t\tset -l alts (string split " " -- $argv[(math $consumed + 1)])',
+	);
+	lines.push("\t\t\tif not contains -- $t $alts");
+	lines.push("\t\t\t\treturn 1");
+	lines.push("\t\t\tend");
+	lines.push("\t\t\tset consumed (math $consumed + 1)");
+	lines.push("\t\telse");
+	lines.push("\t\t\tif contains -- $t $block");
+	lines.push("\t\t\t\treturn 1");
+	lines.push("\t\t\tend");
+	lines.push("\t\tend");
+	lines.push("\t\tset j (math $j + 1)");
+	lines.push("\tend");
+	lines.push("\ttest $consumed -eq $n");
+	lines.push("end");
+	return lines;
 }
 
 /**
@@ -221,7 +329,7 @@ function emitRules(
  * `complete` rules.
  *
  * @param spec     Walker output.
- * @param binName  User-facing binary name.
+ * @param binName  User-facing binary name; validated upstream.
  * @param version  Free-form version string for the header comment.
  */
 export function renderFish(
@@ -229,21 +337,28 @@ export function renderFish(
 	binName: string,
 	version: string,
 ): string {
+	const ident = toShellIdent(binName);
 	const lines: string[] = [];
 
+	const safeBin = sanitizeForComment(binName);
+	const safeVersion = sanitizeForComment(version);
 	lines.push(
-		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion fish`,
+		`# completion script for ${safeBin} v${safeVersion} — regenerate with: ${safeBin} completion fish`,
 	);
+	lines.push("");
+
+	// Emit the path-resolution helper before any rules reference it.
+	lines.push(...emitHelper(ident));
 	lines.push("");
 
 	// Disable file completion globally for the command. Individual rules
 	// re-enable filesystem completion via `-r` (free-form value flags) or
 	// stay file-less via `-x` (enum flags) as appropriate.
-	lines.push(`complete -c ${binName} -f`);
+	lines.push(`complete -c ${fishSingleQuote(binName)} -f`);
 	lines.push("");
 
 	const rules: string[] = [];
-	emitRules(binName, [], spec.root, rules);
+	emitRules(binName, ident, [], spec.root, rules);
 	lines.push(...rules);
 
 	return `${lines.join("\n")}\n`;

--- a/packages/plugins/src/completion/templates/zsh.test.ts
+++ b/packages/plugins/src/completion/templates/zsh.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CompletionSpec } from "../spec.ts";
+import { renderZsh } from "./zsh.ts";
+
+/**
+ * Same fixture shape as the bash tests so the snapshots line up.
+ */
+const fixture: CompletionSpec = {
+	root: {
+		name: "mycli",
+		description: "Test CLI",
+		flags: [
+			{ name: "help", short: "h", type: "boolean", takesValue: false },
+			{ name: "version", short: "v", type: "boolean", takesValue: false },
+		],
+		args: [],
+		subCommands: [
+			{
+				name: "build",
+				description: "Build artifact",
+				flags: [
+					{ name: "release", type: "boolean", takesValue: false },
+					{
+						name: "target",
+						type: "string",
+						takesValue: true,
+						choices: ["browser", "bun", "node"],
+					},
+				],
+				args: [],
+				subCommands: [],
+			},
+			{
+				name: "deploy",
+				aliases: ["dep"],
+				description: "Deploy",
+				flags: [],
+				args: [],
+				subCommands: [
+					{
+						name: "prod",
+						description: "Production deploy",
+						flags: [
+							{
+								name: "env",
+								type: "string",
+								takesValue: true,
+								choices: ["dev", "staging", "prod"],
+							},
+						],
+						args: [],
+						subCommands: [],
+					},
+				],
+			},
+		],
+	},
+};
+
+describe("renderZsh", () => {
+	it("first line is `#compdef <bin>` (required by zsh autoload)", () => {
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		const firstLine = script.split("\n")[0];
+		expect(firstLine).toBe("#compdef mycli");
+	});
+
+	it("emits a header comment with bin + version + regenerate hint on line 2", () => {
+		const script = renderZsh(fixture, "mycli", "2.0.0-beta");
+		const lines = script.split("\n");
+		expect(lines[1]).toBe(
+			"# completion script for mycli v2.0.0-beta — regenerate with: mycli completion zsh",
+		);
+	});
+
+	it("uses _arguments -C with ->state routing for non-leaf commands", () => {
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		expect(script).toContain("_arguments -C");
+		expect(script).toContain("'1: :->cmds'");
+		expect(script).toContain("'*::arg:->args'");
+		expect(script).toContain("_describe 'subcommand' subcmds");
+	});
+
+	it("emits choices via :NAME:(opt1 opt2 opt3) form on string flags", () => {
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		expect(script).toContain(":target:(browser bun node)");
+		expect(script).toContain(":env:(dev staging prod)");
+	});
+
+	it("emits a mutex group {-h,--help} for flags with a short alias", () => {
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		// Short + long form for `--help`. Spec format is
+		// `'(-h --help)'{-h,--help}'[desc]'` — single-quote delimited.
+		expect(script).toContain("'(-h --help)'{-h,--help}");
+	});
+
+	it("aliases (TP-016) are dispatched to the same child helper", () => {
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		// `deploy|dep) _mycli_deploy ;;` — both spellings hit the same helper.
+		expect(script).toMatch(/deploy\|dep\)/);
+		// Subcommand menu surfaces both spellings.
+		expect(script).toContain("'deploy:Deploy'");
+		expect(script).toContain("'dep:Deploy'");
+	});
+
+	it("derives helper function names from bin name with non-alpha mapped to _", () => {
+		const script = renderZsh(fixture, "my-cli", "1.0.0");
+		// Function is `_my_cli`, but `#compdef` and `compdef` retain the
+		// real binary name.
+		expect(script).toContain("_my_cli() {");
+		expect(script).toContain("compdef _my_cli my-cli");
+	});
+
+	it("escapes special characters in descriptions", () => {
+		const spec: CompletionSpec = {
+			root: {
+				name: "x",
+				flags: [
+					{
+						name: "fancy",
+						type: "string",
+						takesValue: true,
+						description: "value: do [thing] now",
+					},
+				],
+				args: [],
+				subCommands: [],
+			},
+		};
+		const script = renderZsh(spec, "x", "1.0.0");
+		// `[`, `]`, and `:` in descriptions are backslash-escaped so the
+		// `_arguments` parser keeps the description intact.
+		expect(script).toContain("[value\\: do \\[thing\\] now]");
+	});
+});
+
+/**
+ * Behavioural tests: parse the generated script under `zsh -n` (syntax
+ * check) at minimum. If a richer behavioural check is feasible (sourcing
+ * the script and asking compsys directly), we attempt it; otherwise the
+ * syntax check is the gate.
+ */
+const zshAvailable = await isZshAvailable();
+const describeIfZsh = zshAvailable ? describe : describe.skip;
+
+describeIfZsh("renderZsh · zsh -n syntax check", () => {
+	let scriptPath: string;
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "tp010-zsh-"));
+		scriptPath = join(tmpDir, "_mycli");
+		const script = renderZsh(fixture, "mycli", "1.0.0");
+		await writeFile(scriptPath, script, "utf8");
+	});
+
+	afterAll(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("parses cleanly under `zsh -n`", async () => {
+		const proc = Bun.spawn(["zsh", "-n", scriptPath], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		expect(err).toBe("");
+		expect(code).toBe(0);
+	});
+
+	it("sources cleanly under interactive zsh with compsys initialised", async () => {
+		// Drive completion the way zsh does: load compinit, source the
+		// generated function file, then probe the candidate list with
+		// `_main_complete` is impractical without a TTY; the next-best
+		// gate is to confirm the script `source`s without errors when
+		// compinit is active.
+		const driver = `
+emulate -L zsh
+autoload -Uz compinit
+compinit -u -d $TMPDIR/zcompdump 2>/dev/null
+fpath=(${shQuoteForZsh(tmpDir)} $fpath)
+source ${shQuoteForZsh(scriptPath)}
+echo OK
+`;
+		const proc = Bun.spawn(["zsh", "-c", driver], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				TMPDIR: tmpDir,
+			},
+		});
+		const [out, err] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		const code = await proc.exited;
+		if (code !== 0) {
+			throw new Error(
+				`zsh failed: code=${code}\nstdout:\n${out}\nstderr:\n${err}`,
+			);
+		}
+		expect(out).toContain("OK");
+	});
+});
+
+if (!zshAvailable) {
+	describe("renderZsh · zsh behavioural tests", () => {
+		it.skip("zsh not available on PATH — skipping behavioural tests", () => {});
+	});
+}
+
+async function isZshAvailable(): Promise<boolean> {
+	try {
+		const proc = Bun.spawn(["zsh", "--version"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		return proc.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+function shQuoteForZsh(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/plugins/src/completion/templates/zsh.test.ts
+++ b/packages/plugins/src/completion/templates/zsh.test.ts
@@ -85,6 +85,8 @@ describe("renderZsh", () => {
 
 	it("emits choices via :NAME:(opt1 opt2 opt3) form on string flags", () => {
 		const script = renderZsh(fixture, "mycli", "1.0.0");
+		// Choice values are validated to a safe character set and emitted
+		// bare inside the `(…)` action list.
 		expect(script).toContain(":target:(browser bun node)");
 		expect(script).toContain(":env:(dev staging prod)");
 	});
@@ -98,8 +100,10 @@ describe("renderZsh", () => {
 
 	it("aliases (TP-016) are dispatched to the same child helper", () => {
 		const script = renderZsh(fixture, "mycli", "1.0.0");
-		// `deploy|dep) _mycli_deploy ;;` — both spellings hit the same helper.
-		expect(script).toMatch(/deploy\|dep\)/);
+		// Both spellings hit the same helper. Each alternative is single-
+		// quoted so glob metacharacters in command names are matched
+		// literally rather than as zsh `case` patterns.
+		expect(script).toMatch(/'deploy'\|'dep'\)/);
 		// Subcommand menu surfaces both spellings.
 		expect(script).toContain("'deploy:Deploy'");
 		expect(script).toContain("'dep:Deploy'");
@@ -108,9 +112,10 @@ describe("renderZsh", () => {
 	it("derives helper function names from bin name with non-alpha mapped to _", () => {
 		const script = renderZsh(fixture, "my-cli", "1.0.0");
 		// Function is `_my_cli`, but `#compdef` and `compdef` retain the
-		// real binary name.
+		// real binary name. The `compdef` argument is single-quoted as
+		// defence-in-depth.
 		expect(script).toContain("_my_cli() {");
-		expect(script).toContain("compdef _my_cli my-cli");
+		expect(script).toContain("compdef _my_cli 'my-cli'");
 	});
 
 	it("escapes special characters in descriptions", () => {

--- a/packages/plugins/src/completion/templates/zsh.ts
+++ b/packages/plugins/src/completion/templates/zsh.ts
@@ -1,3 +1,9 @@
+import {
+	sanitizeForComment,
+	zshArgsDescription,
+	zshDescribeField,
+	zshSingleQuote,
+} from "../escape.ts";
 import type {
 	CompletionCommand,
 	CompletionFlag,
@@ -17,35 +23,17 @@ import type {
  * and the entry-point function is invoked with `"$@"` at the end so the
  * script works both when dropped into `$fpath` and when sourced directly
  * (e.g. via `eval "$(mycli completion zsh)"`).
+ *
+ * **Quoting model.** Every spec string is wrapped via {@link zshSingleQuote}
+ * so it survives any character (description text, choice values) by going
+ * through the standard `'foo'\''bar'` close-and-reopen idiom. The spec
+ * **contents** are independently escaped via {@link zshArgsDescription}
+ * (for `_arguments` description brackets) and {@link zshDescribeField}
+ * (for the colon-separated `_describe` items).
  */
 
 function toShellIdent(name: string): string {
 	return name.replace(/[^A-Za-z0-9_]/g, "_");
-}
-
-/**
- * Escape a string for inclusion inside a zsh `_arguments` spec's `[desc]`
- * bracket. Per `man zshcompsys`, description text in `_arguments` runs
- * until the matching `]`, and `:` is the field separator, so we backslash
- * those plus backslash itself. We also drop newlines defensively.
- */
-function escZshDesc(text: string): string {
-	return text
-		.replace(/\\/g, "\\\\")
-		.replace(/\[/g, "\\[")
-		.replace(/]/g, "\\]")
-		.replace(/:/g, "\\:")
-		.replace(/[\r\n]+/g, " ");
-}
-
-/**
- * Escape a value for inclusion in a zsh single-quoted string.
- * Single quotes have no escape sequence; close-and-concat is the standard
- * idiom (`'foo'\''bar'` for `foo'bar`). Choice/subcommand values rarely
- * carry quotes in practice, but we are defensive.
- */
-function escSingleQuoted(value: string): string {
-	return value.replace(/'/g, "'\\''");
 }
 
 /**
@@ -63,43 +51,131 @@ function renderFlagSpecs(node: CompletionCommand): string[] {
 
 function flagSpecs(flag: CompletionFlag): string[] {
 	const desc = flag.description ?? "";
-	const descPart = `[${escZshDesc(desc)}]`;
+	const descPart = `[${zshArgsDescription(desc)}]`;
 
 	// Build the value-action suffix once: empty for booleans, ` :NAME:`
-	// for free-form values, ` :NAME:(opt1 opt2)` for choice flags.
+	// (with `_files` for free-form strings) for value-takers.
 	let valueSuffix = "";
 	if (flag.takesValue) {
 		const valueLabel = flag.name; // shown as the prompt placeholder
 		if (flag.choices !== undefined && flag.choices.length > 0) {
-			const opts = flag.choices.map(escSingleQuoted).join(" ");
+			// Choice values are validated by `assertSafeChoiceValue` to
+			// contain only `[A-Za-z0-9_.+:@/-]`, so they can be emitted bare
+			// inside the `(…)` action list without further escaping.
+			const opts = flag.choices.join(" ");
 			valueSuffix = `:${valueLabel}:(${opts})`;
+		} else if (flag.type === "string") {
+			valueSuffix = `:${valueLabel}:_files`;
 		} else {
-			valueSuffix = `:${valueLabel}:`;
+			valueSuffix = `:${valueLabel}: `;
 		}
 	}
+
+	// Repeatable flags: prefix with `*` per zshcompsys so the spec can
+	// match more than once (otherwise zsh hides used options after the
+	// first occurrence). Boolean negation candidates (`--no-foo`) are
+	// emitted as separate single-form specs further down.
+	const repeat = flag.multiple === true ? "*" : "";
 
 	// Pre-compute the alias spellings list for the mutual-exclusion prefix.
 	const allLong = [flag.name, ...(flag.aliases ?? [])];
 	const allShort = flag.short !== undefined ? [flag.short] : [];
 
+	const specs: string[] = [];
+
 	if (allShort.length === 0 && allLong.length === 1) {
 		// Single long form — simplest spec.
 		const eq = flag.takesValue ? "=" : "";
-		return [`'--${flag.name}${eq}${descPart}${valueSuffix}'`];
+		const body = `${repeat}--${flag.name}${eq}${descPart}${valueSuffix}`;
+		specs.push(zshSingleQuote(body));
+	} else {
+		// Multiple spellings — emit a mutex group. The standard zsh idiom
+		// (per `man zshcompsys`) is:
+		//   `(-h --help)'{-h,--help}'[desc]`
+		// with the mutex names listed in parentheses and the brace
+		// alternation expanding to one option per spelling. We
+		// single-quote-wrap each piece so flag names with `-` survive
+		// shell tokenisation cleanly.
+		const mutex = [
+			...allShort.map((s) => `-${s}`),
+			...allLong.map((l) => `--${l}`),
+		].join(" ");
+		const altGroup = [
+			...allShort.map((s) => `-${s}`),
+			...allLong.map((l) => `--${l}${flag.takesValue ? "=" : ""}`),
+		].join(",");
+		// Repeat marker in the brace alternation: `*{-h,--help}` ensures
+		// each member of the alternation can repeat. The mutex prefix
+		// `(...)` is only meaningful for non-repeatable specs.
+		const headPrefix = flag.multiple === true ? "" : `(${mutex})`;
+		const repeatBrace = flag.multiple === true ? "*" : "";
+		// The spec is built without an outer wrapper so we can wrap the
+		// whole thing in zsh single quotes after the brace alternation.
+		// Example: '(--help -h)'{-h,--help}'[desc]' — three single-quoted
+		// fragments concatenated. Each fragment is independently safe
+		// because none of the quoted contents contain a single quote
+		// (description quotes are escaped by zshArgsDescription).
+		const fragments = [
+			zshSingleQuote(headPrefix),
+			`${repeatBrace}{${altGroup}}`,
+			zshSingleQuote(`${descPart}${valueSuffix}`),
+		];
+		specs.push(fragments.join(""));
 	}
 
-	// Multiple spellings — emit a mutex group. The standard zsh idiom:
-	// `'(-h --help)'{-h,--help}'[desc]'`
-	const mutex = [
-		...allShort.map((s) => `-${s}`),
-		...allLong.map((l) => `--${l}`),
-	].join(" ");
-	const altGroup = [
-		...allShort.map((s) => `-${s}`),
-		...allLong.map((l) => `--${l}${flag.takesValue ? "=" : ""}`),
-	].join(",");
+	// `--no-<name>` for boolean toggles (matches the parser's
+	// negation-acceptance contract). Emitted as a separate spec so it
+	// shows up alongside `--<name>` in the menu.
+	if (flag.type === "boolean" && flag.noNegate !== true) {
+		const negDesc = `[${zshArgsDescription(`disable: ${desc}`.trim())}]`;
+		const negNames = allLong.map((l) => `--no-${l}`);
+		if (negNames.length === 1) {
+			specs.push(zshSingleQuote(`${repeat}${negNames[0]}${negDesc}`));
+		} else {
+			const negMutex = negNames.join(" ");
+			const negAlt = negNames.join(",");
+			const headPrefix = flag.multiple === true ? "" : `(${negMutex})`;
+			const repeatBrace = flag.multiple === true ? "*" : "";
+			specs.push(
+				[
+					zshSingleQuote(headPrefix),
+					`${repeatBrace}{${negAlt}}`,
+					zshSingleQuote(negDesc),
+				].join(""),
+			);
+		}
+	}
 
-	return [`'(${mutex})'{${altGroup}}'${descPart}${valueSuffix}'`];
+	return specs;
+}
+
+/**
+ * Render the positional-argument specs for a single command.
+ *
+ * Uses the same `'<idx>:NAME:<action>'` shape across leaf and non-leaf
+ * helpers. Variadic args expand the `<idx>` to `*` and run the action
+ * for every remaining word. Choice-bearing args use `(a b c)`; free-form
+ * string args fall through to `_files` so users get filesystem
+ * completion. Number/boolean positional args (rare) use a noop action
+ * so zsh doesn't try to file-complete them.
+ */
+function renderArgSpecs(node: CompletionCommand): string[] {
+	const specs: string[] = [];
+	node.args.forEach((arg, idx) => {
+		const idxToken = arg.variadic ? "*" : String(idx + 1);
+		const label = arg.name;
+		let action: string;
+		if (arg.choices !== undefined && arg.choices.length > 0) {
+			// Validated bare values — see comment in flagSpecs.
+			action = `(${arg.choices.join(" ")})`;
+		} else if (arg.type === "string") {
+			action = "_files";
+		} else {
+			action = " ";
+		}
+		specs.push(zshSingleQuote(`${idxToken}:${label}:${action}`));
+	});
+	return specs;
 }
 
 /**
@@ -115,12 +191,18 @@ function helperName(rootIdent: string, path: readonly string[]): string {
 /**
  * Render a single command's helper function.
  *
- * - Leaf commands: declare flag specs and an optional final `*: :_files`
- *   for free positional arguments.
+ * - Leaf commands: declare flag specs and any positional arg specs.
  * - Non-leaf commands: add the standard `->state` routing and a `case`
  *   over `$line[1]` (the first non-option positional) that dispatches to
  *   each child helper. Aliases reuse the same helper as their canonical
  *   sibling.
+ *
+ * Non-leaf commands with positional args are uncommon but supported:
+ * the routing emits `'1: :->cmds'` so the first slot is treated as a
+ * subcommand, plus any *additional* positional specs (slots 2+) for the
+ * declared args. If a CLI uses arg slot 1 AND has subcommands, the
+ * subcommand wins for that slot — matches the parser's behaviour where
+ * a known subcommand takes precedence over a positional value.
  */
 function renderHelper(
 	rootIdent: string,
@@ -130,6 +212,7 @@ function renderHelper(
 ): void {
 	const fnName = helperName(rootIdent, path);
 	const flagSpecLines = renderFlagSpecs(node);
+	const argSpecLines = renderArgSpecs(node);
 	const hasChildren = node.subCommands.length > 0;
 
 	out.push(`${fnName}() {`);
@@ -150,11 +233,15 @@ function renderHelper(
 		out.push("\t\t\tlocal -a subcmds");
 		out.push("\t\t\tsubcmds=(");
 		for (const sub of node.subCommands) {
-			const desc = escSingleQuoted(sub.description ?? "");
-			out.push(`\t\t\t\t'${escSingleQuoted(sub.name)}:${desc}'`);
+			const desc = zshDescribeField(sub.description ?? "");
+			out.push(
+				`\t\t\t\t${zshSingleQuote(`${zshDescribeField(sub.name)}:${desc}`)}`,
+			);
 			if (sub.aliases !== undefined) {
 				for (const alias of sub.aliases) {
-					out.push(`\t\t\t\t'${escSingleQuoted(alias)}:${desc}'`);
+					out.push(
+						`\t\t\t\t${zshSingleQuote(`${zshDescribeField(alias)}:${desc}`)}`,
+					);
 				}
 			}
 		}
@@ -165,10 +252,12 @@ function renderHelper(
 		out.push('\t\t\tcase "$line[1]" in');
 		for (const sub of node.subCommands) {
 			const childFn = helperName(rootIdent, [...path, sub.name]);
-			const names = [sub.name, ...(sub.aliases ?? [])]
-				.map(escSingleQuoted)
-				.join("|");
-			out.push(`\t\t\t\t${names})`);
+			// Each spelling becomes its own quoted case alternative — we
+			// avoid `|`-joined patterns because a quoted alternation list
+			// is simpler to keep literal (no glob metacharacter risk).
+			const allSpellings = [sub.name, ...(sub.aliases ?? [])];
+			const alts = allSpellings.map(zshSingleQuote).join("|");
+			out.push(`\t\t\t\t${alts})`);
 			out.push(`\t\t\t\t\t${childFn}`);
 			out.push("\t\t\t\t\t;;");
 		}
@@ -176,34 +265,16 @@ function renderHelper(
 		out.push("\t\t\t;;");
 		out.push("\tesac");
 	} else {
-		// Leaf — flat _arguments call. If the command declares positional
-		// args we emit `*: :_files` so files are offered for free-form
-		// positional slots; otherwise we omit it to keep the menu clean.
-		if (flagSpecLines.length === 0 && node.args.length === 0) {
+		// Leaf — flat _arguments call.
+		if (flagSpecLines.length === 0 && argSpecLines.length === 0) {
 			// Pure noop helper — keep an empty body so the caller's `case`
 			// dispatch still has a target to jump to.
 			out.push("\t:");
 		} else {
 			out.push("\t_arguments \\");
-			const lines: string[] = [...flagSpecLines];
-			if (node.args.length > 0) {
-				// Surface choices on positional args via positional spec
-				// `1:NAME:(a b c)`. Variadic args use the trailing `*:`.
-				node.args.forEach((arg, idx) => {
-					const idxToken = arg.variadic ? "*" : String(idx + 1);
-					const label = arg.name;
-					if (arg.choices !== undefined && arg.choices.length > 0) {
-						const opts = arg.choices.map(escSingleQuoted).join(" ");
-						lines.push(`'${idxToken}:${label}:(${opts})'`);
-					} else if (arg.type === "string") {
-						lines.push(`'${idxToken}:${label}:_files'`);
-					} else {
-						lines.push(`'${idxToken}:${label}:'`);
-					}
-				});
-			}
-			lines.forEach((spec, idx) => {
-				const trailing = idx === lines.length - 1 ? "" : " \\";
+			const allSpecs: string[] = [...flagSpecLines, ...argSpecLines];
+			allSpecs.forEach((spec, idx) => {
+				const trailing = idx === allSpecs.length - 1 ? "" : " \\";
 				out.push(`\t\t${spec}${trailing}`);
 			});
 		}
@@ -226,8 +297,8 @@ function renderHelper(
  * inline form actually invoke completion when the file is sourced.
  *
  * @param spec     Walker output.
- * @param binName  User-facing binary name. The `#compdef` line and the
- *                 entry-point function name derive from it.
+ * @param binName  User-facing binary name; validated upstream via
+ *                 {@link assertSafeBinName}.
  * @param version  Free-form version string for the header comment.
  */
 export function renderZsh(
@@ -238,10 +309,16 @@ export function renderZsh(
 	const ident = toShellIdent(binName);
 	const lines: string[] = [];
 
+	const safeBin = sanitizeForComment(binName);
+	const safeVersion = sanitizeForComment(version);
+
 	// `#compdef` MUST be the first line for zsh's autoload mechanism.
+	// `binName` was validated upstream; only the safe identifier set
+	// reaches here, so a quoted compdef target is unnecessary (and `zsh`
+	// itself rejects unusual `#compdef` arguments).
 	lines.push(`#compdef ${binName}`);
 	lines.push(
-		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion zsh`,
+		`# completion script for ${safeBin} v${safeVersion} — regenerate with: ${safeBin} completion zsh`,
 	);
 	lines.push("");
 
@@ -254,10 +331,12 @@ export function renderZsh(
 	// file by hand (the inline `eval` install), nothing has called the
 	// entry function yet. Guard with `compdef` so the autoload path doesn't
 	// double-invoke. Pattern adapted from yargs (research zsh.md §5.2).
+	// `binName` is validated, so the bare form is safe; we still single-
+	// quote it for readability and as defence-in-depth.
 	lines.push(`if [ "$funcstack[1]" = "_${ident}" ]; then`);
 	lines.push(`\t_${ident} "$@"`);
 	lines.push("else");
-	lines.push(`\tcompdef _${ident} ${binName}`);
+	lines.push(`\tcompdef _${ident} ${zshSingleQuote(binName)}`);
 	lines.push("fi");
 
 	return `${lines.join("\n")}\n`;

--- a/packages/plugins/src/completion/templates/zsh.ts
+++ b/packages/plugins/src/completion/templates/zsh.ts
@@ -1,0 +1,264 @@
+import type {
+	CompletionCommand,
+	CompletionFlag,
+	CompletionSpec,
+} from "../spec.ts";
+
+/**
+ * Pure-static zsh completion script renderer.
+ *
+ * Strategy: emit one `_<bin>_<path>` helper per command in the tree.
+ * Helpers for non-leaf commands declare an `_arguments -C` spec with
+ * `1: :->cmds` and `*::arg:->args`, then dispatch via `case "$line[1]"`
+ * into the child helper — the canonical `->state` routing pattern from
+ * `man zshcompsys` (and used by oclif's `ZshCompWithSpaces`).
+ *
+ * The first line is `#compdef <bin>` (required by zsh's autoload mechanism)
+ * and the entry-point function is invoked with `"$@"` at the end so the
+ * script works both when dropped into `$fpath` and when sourced directly
+ * (e.g. via `eval "$(mycli completion zsh)"`).
+ */
+
+function toShellIdent(name: string): string {
+	return name.replace(/[^A-Za-z0-9_]/g, "_");
+}
+
+/**
+ * Escape a string for inclusion inside a zsh `_arguments` spec's `[desc]`
+ * bracket. Per `man zshcompsys`, description text in `_arguments` runs
+ * until the matching `]`, and `:` is the field separator, so we backslash
+ * those plus backslash itself. We also drop newlines defensively.
+ */
+function escZshDesc(text: string): string {
+	return text
+		.replace(/\\/g, "\\\\")
+		.replace(/\[/g, "\\[")
+		.replace(/]/g, "\\]")
+		.replace(/:/g, "\\:")
+		.replace(/[\r\n]+/g, " ");
+}
+
+/**
+ * Escape a value for inclusion in a zsh single-quoted string.
+ * Single quotes have no escape sequence; close-and-concat is the standard
+ * idiom (`'foo'\''bar'` for `foo'bar`). Choice/subcommand values rarely
+ * carry quotes in practice, but we are defensive.
+ */
+function escSingleQuoted(value: string): string {
+	return value.replace(/'/g, "'\\''");
+}
+
+/**
+ * Render the `_arguments` specs for every flag on a given command. Each
+ * flag becomes one or more spec strings depending on whether it has a
+ * short alias (we use the `(-x --name){-x,--name}` mutex+alias pattern).
+ */
+function renderFlagSpecs(node: CompletionCommand): string[] {
+	const specs: string[] = [];
+	for (const flag of node.flags) {
+		specs.push(...flagSpecs(flag));
+	}
+	return specs;
+}
+
+function flagSpecs(flag: CompletionFlag): string[] {
+	const desc = flag.description ?? "";
+	const descPart = `[${escZshDesc(desc)}]`;
+
+	// Build the value-action suffix once: empty for booleans, ` :NAME:`
+	// for free-form values, ` :NAME:(opt1 opt2)` for choice flags.
+	let valueSuffix = "";
+	if (flag.takesValue) {
+		const valueLabel = flag.name; // shown as the prompt placeholder
+		if (flag.choices !== undefined && flag.choices.length > 0) {
+			const opts = flag.choices.map(escSingleQuoted).join(" ");
+			valueSuffix = `:${valueLabel}:(${opts})`;
+		} else {
+			valueSuffix = `:${valueLabel}:`;
+		}
+	}
+
+	// Pre-compute the alias spellings list for the mutual-exclusion prefix.
+	const allLong = [flag.name, ...(flag.aliases ?? [])];
+	const allShort = flag.short !== undefined ? [flag.short] : [];
+
+	if (allShort.length === 0 && allLong.length === 1) {
+		// Single long form — simplest spec.
+		const eq = flag.takesValue ? "=" : "";
+		return [`'--${flag.name}${eq}${descPart}${valueSuffix}'`];
+	}
+
+	// Multiple spellings — emit a mutex group. The standard zsh idiom:
+	// `'(-h --help)'{-h,--help}'[desc]'`
+	const mutex = [
+		...allShort.map((s) => `-${s}`),
+		...allLong.map((l) => `--${l}`),
+	].join(" ");
+	const altGroup = [
+		...allShort.map((s) => `-${s}`),
+		...allLong.map((l) => `--${l}${flag.takesValue ? "=" : ""}`),
+	].join(",");
+
+	return [`'(${mutex})'{${altGroup}}'${descPart}${valueSuffix}'`];
+}
+
+/**
+ * Build the function name for the helper that handles a given command
+ * path. The root is `_<ident>`; nested children append `_<segment>` for
+ * each step.
+ */
+function helperName(rootIdent: string, path: readonly string[]): string {
+	if (path.length === 0) return `_${rootIdent}`;
+	return `_${rootIdent}_${path.map(toShellIdent).join("_")}`;
+}
+
+/**
+ * Render a single command's helper function.
+ *
+ * - Leaf commands: declare flag specs and an optional final `*: :_files`
+ *   for free positional arguments.
+ * - Non-leaf commands: add the standard `->state` routing and a `case`
+ *   over `$line[1]` (the first non-option positional) that dispatches to
+ *   each child helper. Aliases reuse the same helper as their canonical
+ *   sibling.
+ */
+function renderHelper(
+	rootIdent: string,
+	path: readonly string[],
+	node: CompletionCommand,
+	out: string[],
+): void {
+	const fnName = helperName(rootIdent, path);
+	const flagSpecLines = renderFlagSpecs(node);
+	const hasChildren = node.subCommands.length > 0;
+
+	out.push(`${fnName}() {`);
+
+	if (hasChildren) {
+		out.push("\tlocal context state state_descr line");
+		out.push("\ttypeset -A opt_args");
+		out.push("");
+		out.push("\t_arguments -C \\");
+		for (const spec of flagSpecLines) {
+			out.push(`\t\t${spec} \\`);
+		}
+		out.push("\t\t'1: :->cmds' \\");
+		out.push("\t\t'*::arg:->args'");
+		out.push("");
+		out.push('\tcase "$state" in');
+		out.push("\t\tcmds)");
+		out.push("\t\t\tlocal -a subcmds");
+		out.push("\t\t\tsubcmds=(");
+		for (const sub of node.subCommands) {
+			const desc = escSingleQuoted(sub.description ?? "");
+			out.push(`\t\t\t\t'${escSingleQuoted(sub.name)}:${desc}'`);
+			if (sub.aliases !== undefined) {
+				for (const alias of sub.aliases) {
+					out.push(`\t\t\t\t'${escSingleQuoted(alias)}:${desc}'`);
+				}
+			}
+		}
+		out.push("\t\t\t)");
+		out.push("\t\t\t_describe 'subcommand' subcmds");
+		out.push("\t\t\t;;");
+		out.push("\t\targs)");
+		out.push('\t\t\tcase "$line[1]" in');
+		for (const sub of node.subCommands) {
+			const childFn = helperName(rootIdent, [...path, sub.name]);
+			const names = [sub.name, ...(sub.aliases ?? [])]
+				.map(escSingleQuoted)
+				.join("|");
+			out.push(`\t\t\t\t${names})`);
+			out.push(`\t\t\t\t\t${childFn}`);
+			out.push("\t\t\t\t\t;;");
+		}
+		out.push("\t\t\tesac");
+		out.push("\t\t\t;;");
+		out.push("\tesac");
+	} else {
+		// Leaf — flat _arguments call. If the command declares positional
+		// args we emit `*: :_files` so files are offered for free-form
+		// positional slots; otherwise we omit it to keep the menu clean.
+		if (flagSpecLines.length === 0 && node.args.length === 0) {
+			// Pure noop helper — keep an empty body so the caller's `case`
+			// dispatch still has a target to jump to.
+			out.push("\t:");
+		} else {
+			out.push("\t_arguments \\");
+			const lines: string[] = [...flagSpecLines];
+			if (node.args.length > 0) {
+				// Surface choices on positional args via positional spec
+				// `1:NAME:(a b c)`. Variadic args use the trailing `*:`.
+				node.args.forEach((arg, idx) => {
+					const idxToken = arg.variadic ? "*" : String(idx + 1);
+					const label = arg.name;
+					if (arg.choices !== undefined && arg.choices.length > 0) {
+						const opts = arg.choices.map(escSingleQuoted).join(" ");
+						lines.push(`'${idxToken}:${label}:(${opts})'`);
+					} else if (arg.type === "string") {
+						lines.push(`'${idxToken}:${label}:_files'`);
+					} else {
+						lines.push(`'${idxToken}:${label}:'`);
+					}
+				});
+			}
+			lines.forEach((spec, idx) => {
+				const trailing = idx === lines.length - 1 ? "" : " \\";
+				out.push(`\t\t${spec}${trailing}`);
+			});
+		}
+	}
+
+	out.push("}");
+	out.push("");
+
+	for (const sub of node.subCommands) {
+		renderHelper(rootIdent, [...path, sub.name], sub, out);
+	}
+}
+
+/**
+ * Render a self-contained zsh completion script for the given spec.
+ *
+ * The script is safe to drop into `$fpath` as `_<bin>` (autoloaded via the
+ * `#compdef` magic line) AND safe to source inline via
+ * `eval "$(mycli completion zsh)"` — the trailing `_<bin> "$@"` makes the
+ * inline form actually invoke completion when the file is sourced.
+ *
+ * @param spec     Walker output.
+ * @param binName  User-facing binary name. The `#compdef` line and the
+ *                 entry-point function name derive from it.
+ * @param version  Free-form version string for the header comment.
+ */
+export function renderZsh(
+	spec: CompletionSpec,
+	binName: string,
+	version: string,
+): string {
+	const ident = toShellIdent(binName);
+	const lines: string[] = [];
+
+	// `#compdef` MUST be the first line for zsh's autoload mechanism.
+	lines.push(`#compdef ${binName}`);
+	lines.push(
+		`# completion script for ${binName} v${version} — regenerate with: ${binName} completion zsh`,
+	);
+	lines.push("");
+
+	const helpers: string[] = [];
+	renderHelper(ident, [], spec.root, helpers);
+	lines.push(...helpers);
+
+	// Bootstrap line. When zsh's autoload machinery sources the file via
+	// `compdef`, it also calls the function — but if the user `source`s the
+	// file by hand (the inline `eval` install), nothing has called the
+	// entry function yet. Guard with `compdef` so the autoload path doesn't
+	// double-invoke. Pattern adapted from yargs (research zsh.md §5.2).
+	lines.push(`if [ "$funcstack[1]" = "_${ident}" ]; then`);
+	lines.push(`\t_${ident} "$@"`);
+	lines.push("else");
+	lines.push(`\tcompdef _${ident} ${binName}`);
+	lines.push("fi");
+
+	return `${lines.join("\n")}\n`;
+}

--- a/packages/plugins/src/completion/walker.test.ts
+++ b/packages/plugins/src/completion/walker.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "bun:test";
+import type { CommandNode, FlagsDef } from "@crustjs/core";
+import { walkCommandNode } from "./walker.ts";
+
+/**
+ * Build a `CommandNode` tree directly via object literals.
+ *
+ * `createCommandNode`/`computeEffectiveFlags` are not exported from
+ * `@crustjs/core`. Constructing literal nodes is the cleanest way to keep
+ * walker tests focused on the walker — we don't want to be coupled to the
+ * `Crust` builder's internal flag-inheritance plumbing here. For each node
+ * we set `effectiveFlags` explicitly so the walker observes exactly the set
+ * of flags we intend.
+ */
+function makeNode(
+	partial: Partial<CommandNode> & { name: string },
+): CommandNode {
+	const flags: FlagsDef = partial.localFlags ?? {};
+	return {
+		meta: { name: partial.name, ...(partial.meta ?? {}) },
+		localFlags: flags,
+		effectiveFlags: partial.effectiveFlags ?? flags,
+		args: partial.args,
+		subCommands: partial.subCommands ?? {},
+		plugins: [],
+		preRun: undefined,
+		run: undefined,
+		postRun: undefined,
+	};
+}
+
+describe("walkCommandNode", () => {
+	it("walks a leaf command with no flags, args, or children", () => {
+		const root = makeNode({
+			name: "mycli",
+			meta: { name: "mycli", description: "Top-level CLI" },
+		});
+
+		const spec = walkCommandNode(root);
+
+		expect(spec.root.name).toBe("mycli");
+		expect(spec.root.description).toBe("Top-level CLI");
+		expect(spec.root.flags).toEqual([]);
+		expect(spec.root.args).toEqual([]);
+		expect(spec.root.subCommands).toEqual([]);
+	});
+
+	it("captures flat flags with type, short, aliases, description, multiple, and takesValue", () => {
+		const root = makeNode({
+			name: "mycli",
+			localFlags: {
+				verbose: {
+					type: "boolean",
+					short: "v",
+					description: "Verbose output",
+				},
+				name: {
+					type: "string",
+					description: "Name to greet",
+					aliases: ["nm"],
+				},
+				tag: { type: "string", multiple: true },
+			},
+		});
+
+		const spec = walkCommandNode(root);
+		const byName = Object.fromEntries(spec.root.flags.map((f) => [f.name, f]));
+
+		expect(byName.verbose).toEqual({
+			name: "verbose",
+			type: "boolean",
+			short: "v",
+			description: "Verbose output",
+			takesValue: false,
+		});
+		expect(byName.name).toEqual({
+			name: "name",
+			type: "string",
+			aliases: ["nm"],
+			description: "Name to greet",
+			takesValue: true,
+		});
+		expect(byName.tag).toEqual({
+			name: "tag",
+			type: "string",
+			takesValue: true,
+			multiple: true,
+		});
+	});
+
+	it("captures positional args with required, variadic, type, and description", () => {
+		const root = makeNode({
+			name: "mycli",
+			args: [
+				{
+					name: "input",
+					type: "string",
+					required: true,
+					description: "Input file",
+				},
+				{ name: "extra", type: "string", variadic: true },
+			],
+		});
+
+		const spec = walkCommandNode(root);
+
+		expect(spec.root.args).toEqual([
+			{
+				name: "input",
+				type: "string",
+				required: true,
+				variadic: false,
+				description: "Input file",
+			},
+			{
+				name: "extra",
+				type: "string",
+				required: false,
+				variadic: true,
+			},
+		]);
+	});
+
+	it("captures choices on string flags and string args (TP-009)", () => {
+		const root = makeNode({
+			name: "mycli",
+			localFlags: {
+				target: { type: "string", choices: ["browser", "bun", "node"] },
+			},
+			args: [
+				{
+					name: "shell",
+					type: "string",
+					required: true,
+					choices: ["bash", "zsh", "fish"],
+				},
+			],
+		});
+
+		const spec = walkCommandNode(root);
+		const targetFlag = spec.root.flags.find((f) => f.name === "target");
+		expect(targetFlag?.choices).toEqual(["browser", "bun", "node"]);
+		expect(spec.root.args[0]?.choices).toEqual(["bash", "zsh", "fish"]);
+	});
+
+	it("walks nested subcommands recursively, surfacing inherited flags via effectiveFlags", () => {
+		const child = makeNode({
+			name: "child",
+			meta: { name: "child", description: "Child command" },
+			// Local flag plus an *inherited* parent flag pre-merged into effectiveFlags
+			// (mimics what `computeEffectiveFlags` does at build time).
+			localFlags: { local: { type: "boolean" } },
+			effectiveFlags: {
+				verbose: { type: "boolean", short: "v", inherit: true },
+				local: { type: "boolean" },
+			},
+		});
+
+		const root = makeNode({
+			name: "mycli",
+			localFlags: { verbose: { type: "boolean", short: "v", inherit: true } },
+			effectiveFlags: {
+				verbose: { type: "boolean", short: "v", inherit: true },
+			},
+			subCommands: { child },
+		});
+
+		const spec = walkCommandNode(root);
+
+		expect(spec.root.subCommands).toHaveLength(1);
+		const childSpec = spec.root.subCommands[0];
+		if (!childSpec) throw new Error("missing child");
+		expect(childSpec.name).toBe("child");
+		expect(childSpec.description).toBe("Child command");
+		// Inherited "verbose" must surface on the child too.
+		const flagNames = childSpec.flags.map((f) => f.name).sort();
+		expect(flagNames).toEqual(["local", "verbose"]);
+	});
+
+	it("filters subcommands marked meta.hidden recursively", () => {
+		const hiddenSub = makeNode({
+			name: "secret",
+			meta: { name: "secret", hidden: true },
+		});
+		const visibleSub = makeNode({
+			name: "build",
+			meta: { name: "build", description: "Build artifact" },
+		});
+		const root = makeNode({
+			name: "mycli",
+			subCommands: { secret: hiddenSub, build: visibleSub },
+		});
+
+		const spec = walkCommandNode(root);
+
+		const subNames = spec.root.subCommands.map((s) => s.name);
+		expect(subNames).toEqual(["build"]);
+	});
+
+	it("preserves command aliases (TP-016)", () => {
+		const child = makeNode({
+			name: "issue",
+			meta: { name: "issue", aliases: ["issues", "i"] },
+		});
+		const root = makeNode({
+			name: "mycli",
+			subCommands: { issue: child },
+		});
+
+		const spec = walkCommandNode(root);
+		expect(spec.root.subCommands[0]?.aliases).toEqual(["issues", "i"]);
+	});
+
+	it("strips ANSI escape sequences from descriptions", () => {
+		// Build descriptions with raw SGR codes so the test does not depend
+		// on `@crustjs/style` being importable here.
+		const ESC = "\x1b";
+		const colored = `${ESC}[1m${ESC}[36mcolored desc${ESC}[0m`;
+		const root = makeNode({
+			name: "mycli",
+			meta: { name: "mycli", description: colored },
+			localFlags: {
+				verbose: { type: "boolean", description: `${ESC}[2mverbose${ESC}[0m` },
+			},
+			args: [
+				{
+					name: "input",
+					type: "string",
+					description: `${ESC}[33minput desc${ESC}[0m`,
+				},
+			],
+			subCommands: {
+				kid: makeNode({
+					name: "kid",
+					meta: { name: "kid", description: `${ESC}[31mred kid${ESC}[0m` },
+				}),
+			},
+		});
+
+		const spec = walkCommandNode(root);
+
+		expect(spec.root.description).toBe("colored desc");
+		expect(spec.root.flags[0]?.description).toBe("verbose");
+		expect(spec.root.args[0]?.description).toBe("input desc");
+		expect(spec.root.subCommands[0]?.description).toBe("red kid");
+	});
+
+	it("drops empty descriptions instead of emitting empty strings", () => {
+		const root = makeNode({
+			name: "mycli",
+			meta: { name: "mycli", description: "  " },
+			localFlags: { foo: { type: "string", description: "" } },
+		});
+
+		const spec = walkCommandNode(root);
+		expect(spec.root.description).toBeUndefined();
+		expect(spec.root.flags[0]?.description).toBeUndefined();
+	});
+
+	it("does not emit choices on number/boolean flags or args", () => {
+		const root = makeNode({
+			name: "mycli",
+			// number/boolean flags can't carry choices per the type system,
+			// but the walker should still leave choices off the spec for them
+			// even if a misuser were to pass an extra field.
+			localFlags: {
+				port: { type: "number" },
+				force: { type: "boolean" },
+			},
+			args: [{ name: "n", type: "number" }],
+		});
+
+		const spec = walkCommandNode(root);
+		for (const flag of spec.root.flags) {
+			expect(flag.choices).toBeUndefined();
+		}
+		expect(spec.root.args[0]?.choices).toBeUndefined();
+	});
+});

--- a/packages/plugins/src/completion/walker.ts
+++ b/packages/plugins/src/completion/walker.ts
@@ -1,4 +1,9 @@
 import type { ArgDef, CommandNode, FlagDef } from "@crustjs/core";
+import {
+	assertSafeChoiceValue,
+	assertSafeIdentifier,
+	sanitizeFreeText,
+} from "./escape.ts";
 import type {
 	CompletionArg,
 	CompletionCommand,
@@ -47,7 +52,7 @@ function stripAnsi(value: string): string {
  */
 function normaliseDescription(value: string | undefined): string | undefined {
 	if (value === undefined) return undefined;
-	const stripped = stripAnsi(value).trim();
+	const stripped = sanitizeFreeText(stripAnsi(value)).trim();
 	return stripped.length === 0 ? undefined : stripped;
 }
 
@@ -58,7 +63,14 @@ function normaliseDescription(value: string | undefined): string | undefined {
  * depth.
  */
 function walkFlag(name: string, def: FlagDef): CompletionFlag {
+	assertSafeIdentifier(name, "flag name");
 	const aliases = def.aliases?.filter((alias) => alias.length > 0);
+	if (aliases !== undefined) {
+		for (const alias of aliases) assertSafeIdentifier(alias, "flag alias");
+	}
+	if (def.short !== undefined && def.short.length > 0) {
+		assertSafeIdentifier(def.short, "flag short alias");
+	}
 
 	const flag: CompletionFlag = {
 		name,
@@ -83,13 +95,20 @@ function walkFlag(name: string, def: FlagDef): CompletionFlag {
 		flag.multiple = true;
 	}
 
+	// `noNegate` is a `boolean`-flag-only opt-out from auto `--no-<name>`
+	// rendering; it lives on both single and multi boolean variants in
+	// core's `FlagDef` discriminated union.
+	if (def.type === "boolean" && def.noNegate === true) {
+		flag.noNegate = true;
+	}
+
 	// `choices` lives only on string-typed flags (TP-009 — see `types.ts`).
 	// We accept the field via discriminated narrowing rather than an `as`
 	// cast to keep the reader honest about which branches actually carry it.
 	if (def.type === "string") {
 		const choices = def.choices;
 		if (choices !== undefined && choices.length > 0) {
-			flag.choices = choices;
+			flag.choices = choices.map(assertSafeChoiceValue);
 		}
 	}
 
@@ -98,6 +117,7 @@ function walkFlag(name: string, def: FlagDef): CompletionFlag {
 
 /** Project a single `ArgDef` onto a `CompletionArg`. */
 function walkArg(def: ArgDef): CompletionArg {
+	assertSafeIdentifier(def.name, "arg name");
 	const arg: CompletionArg = {
 		name: def.name,
 		type: def.type,
@@ -114,7 +134,7 @@ function walkArg(def: ArgDef): CompletionArg {
 	if (def.type === "string") {
 		const choices = def.choices;
 		if (choices !== undefined && choices.length > 0) {
-			arg.choices = choices;
+			arg.choices = choices.map(assertSafeChoiceValue);
 		}
 	}
 
@@ -128,6 +148,13 @@ function walkArg(def: ArgDef): CompletionArg {
  * visible by construction.
  */
 function walkCommand(node: CommandNode): CompletionCommand {
+	assertSafeIdentifier(node.meta.name, "command name");
+	const nodeAliases = node.meta.aliases;
+	if (nodeAliases !== undefined) {
+		for (const alias of nodeAliases) {
+			assertSafeIdentifier(alias, "command alias");
+		}
+	}
 	const flags: CompletionFlag[] = [];
 	for (const [flagName, flagDef] of Object.entries(node.effectiveFlags)) {
 		flags.push(walkFlag(flagName, flagDef));

--- a/packages/plugins/src/completion/walker.ts
+++ b/packages/plugins/src/completion/walker.ts
@@ -1,0 +1,185 @@
+import type { ArgDef, CommandNode, FlagDef } from "@crustjs/core";
+import type {
+	CompletionArg,
+	CompletionCommand,
+	CompletionFlag,
+	CompletionSpec,
+} from "./spec.ts";
+
+/**
+ * Strip ANSI escape sequences (CSI + private-use SGR codes) from a string.
+ *
+ * Help-text descriptions can carry colour codes from `@crustjs/style` (e.g.
+ * `dim(...)`, `cyan(...)`). The completion templates inline descriptions
+ * verbatim into shell scripts; embedded `\x1b[...m` would corrupt the
+ * generated output (and would render as garbage in the completion menu of
+ * any terminal that did not interpret them).
+ *
+ * The pattern matches `ESC` followed by `[` (CSI) or `]` (OSC) plus any
+ * intermediate parameter/intermediate bytes terminated by a final byte in
+ * the conventional ranges. This is intentionally permissive: we strip more
+ * than strictly SGR because users who reach for ANSI in a description
+ * almost always mean "decoration", not "data".
+ */
+// Build the pattern via the `RegExp` constructor with a string assembled from
+// `String.fromCharCode` so the source has no embedded control characters —
+// Biome's `noControlCharactersInRegex` rule flags both regex literals and
+// string literals that contain raw `\x1b`/`\x07`. Behaviour is identical to
+// the equivalent regex literal.
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+const ANSI_PATTERN = new RegExp(
+	// CSI: ESC [ <params/intermediates> <final>
+	// OSC: ESC ] ... (BEL | ESC \)
+	// Two-byte simple sequences: ESC <0x40-0x5F>
+	`${ESC}(?:\\[[0-?]*[ -/]*[@-~]|\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)|[@-_])`,
+	"g",
+);
+
+function stripAnsi(value: string): string {
+	return value.replace(ANSI_PATTERN, "");
+}
+
+/**
+ * Normalise an optional description: strip ANSI, then drop empty results.
+ * Returning `undefined` (rather than `""`) makes templates' presence checks
+ * easy and keeps generated scripts tidy.
+ */
+function normaliseDescription(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	const stripped = stripAnsi(value).trim();
+	return stripped.length === 0 ? undefined : stripped;
+}
+
+/**
+ * Project a single `FlagDef` (keyed by `name` in `effectiveFlags`) onto a
+ * `CompletionFlag`. The walker calls this for every entry of every visible
+ * command's `effectiveFlags` map so inherited flags surface at the right
+ * depth.
+ */
+function walkFlag(name: string, def: FlagDef): CompletionFlag {
+	const aliases = def.aliases?.filter((alias) => alias.length > 0);
+
+	const flag: CompletionFlag = {
+		name,
+		type: def.type,
+		// Boolean flags are toggle-only; everything else takes a value.
+		takesValue: def.type !== "boolean",
+	};
+
+	if (def.short !== undefined && def.short.length > 0) {
+		flag.short = def.short;
+	}
+	if (aliases !== undefined && aliases.length > 0) {
+		flag.aliases = aliases;
+	}
+
+	const description = normaliseDescription(def.description);
+	if (description !== undefined) {
+		flag.description = description;
+	}
+
+	if (def.multiple === true) {
+		flag.multiple = true;
+	}
+
+	// `choices` lives only on string-typed flags (TP-009 — see `types.ts`).
+	// We accept the field via discriminated narrowing rather than an `as`
+	// cast to keep the reader honest about which branches actually carry it.
+	if (def.type === "string") {
+		const choices = def.choices;
+		if (choices !== undefined && choices.length > 0) {
+			flag.choices = choices;
+		}
+	}
+
+	return flag;
+}
+
+/** Project a single `ArgDef` onto a `CompletionArg`. */
+function walkArg(def: ArgDef): CompletionArg {
+	const arg: CompletionArg = {
+		name: def.name,
+		type: def.type,
+		required: def.required === true,
+		variadic: def.variadic === true,
+	};
+
+	const description = normaliseDescription(def.description);
+	if (description !== undefined) {
+		arg.description = description;
+	}
+
+	// `choices` is only present on string-typed args (TP-009).
+	if (def.type === "string") {
+		const choices = def.choices;
+		if (choices !== undefined && choices.length > 0) {
+			arg.choices = choices;
+		}
+	}
+
+	return arg;
+}
+
+/**
+ * Recursively walk a `CommandNode`. Hidden subcommands are filtered out at
+ * every level; the calling site (`walkCommandNode`) is responsible for
+ * passing in a node that should itself be visible — the root is always
+ * visible by construction.
+ */
+function walkCommand(node: CommandNode): CompletionCommand {
+	const flags: CompletionFlag[] = [];
+	for (const [flagName, flagDef] of Object.entries(node.effectiveFlags)) {
+		flags.push(walkFlag(flagName, flagDef));
+	}
+
+	const args: CompletionArg[] = [];
+	if (node.args !== undefined) {
+		for (const argDef of node.args) {
+			args.push(walkArg(argDef));
+		}
+	}
+
+	const subCommands: CompletionCommand[] = [];
+	for (const subNode of Object.values(node.subCommands)) {
+		// Mirror the help renderer's contract: skip listing-hidden nodes.
+		// Routing in `packages/core/src/router.ts` still resolves them by
+		// direct name (TP-009) — they are only invisible to enumeration.
+		if (subNode.meta.hidden === true) continue;
+		subCommands.push(walkCommand(subNode));
+	}
+
+	const result: CompletionCommand = {
+		name: node.meta.name,
+		flags,
+		args,
+		subCommands,
+	};
+
+	const aliases = node.meta.aliases;
+	if (aliases !== undefined && aliases.length > 0) {
+		// `CommandMeta.aliases` is `readonly string[] | undefined`. Preserve
+		// readonly-ness; template code only needs to enumerate.
+		result.aliases = aliases;
+	}
+
+	const description = normaliseDescription(node.meta.description);
+	if (description !== undefined) {
+		result.description = description;
+	}
+
+	return result;
+}
+
+/**
+ * Build a `CompletionSpec` from a root `CommandNode`.
+ *
+ * This is the single entry point used by the plugin's `run()` handler. It
+ * walks lazily — never at `setup()` time — so plugin order is irrelevant
+ * (other plugins may add subcommands or inject flags after this plugin
+ * registers; we only see the final tree when the user actually invokes the
+ * `completion` subcommand).
+ */
+export function walkCommandNode(root: CommandNode): CompletionSpec {
+	return { root: walkCommand(root) };
+}

--- a/packages/plugins/src/did-you-mean.test.ts
+++ b/packages/plugins/src/did-you-mean.test.ts
@@ -160,4 +160,57 @@ describe("didYouMeanPlugin", () => {
 		expect(stdout).toContain('Unknown command "issuee". Did you mean "issue"?');
 		expect(stdout).not.toContain('Did you mean "issues"');
 	});
+
+	it("never suggests a `meta.hidden: true` command, even on a close match", async () => {
+		// `__complete` is the textbook hidden-command scenario: it's a
+		// real, invocable command but should not surface in user-facing
+		// error output. A close typo of it must not produce a suggestion.
+		const app = new Crust("app")
+			.use(didYouMeanPlugin())
+			.command("build", (cmd) => cmd.run(() => {}))
+			.command("__complete", (cmd) => cmd.meta({ hidden: true }).run(() => {}));
+
+		// Typo distance(__complet -> __complete) = 1, well within the
+		// threshold. Distance(__complet -> build) is > 3, so without the
+		// hidden filter the only suggestion would be `__complete`.
+		await app.execute({ argv: ["__complet"] });
+
+		const stderr = stderrChunks.join("\n");
+		expect(stderr).toContain('Unknown command "__complet"');
+		expect(stderr).not.toContain("__complete");
+	});
+
+	it("never suggests a hidden command via one of its aliases", async () => {
+		// Hidden filtering must apply to alias matches too, not just the
+		// canonical name. If a hidden command has an alias that's close to
+		// the typo, it still must not leak.
+		const app = new Crust("app")
+			.use(didYouMeanPlugin())
+			.command("build", (cmd) => cmd.run(() => {}))
+			.command("__complete", (cmd) =>
+				cmd.meta({ hidden: true, aliases: ["__comp"] }).run(() => {}),
+			);
+
+		await app.execute({ argv: ["__cmp"] });
+
+		const stderr = stderrChunks.join("\n");
+		expect(stderr).toContain('Unknown command "__cmp"');
+		expect(stderr).not.toContain("__complete");
+		expect(stderr).not.toContain("__comp");
+	});
+
+	it("omits hidden commands from the 'Available commands' fallback list", async () => {
+		const app = new Crust("app")
+			.use(didYouMeanPlugin())
+			.command("build", (cmd) => cmd.run(() => {}))
+			.command("test", (cmd) => cmd.run(() => {}))
+			.command("__complete", (cmd) => cmd.meta({ hidden: true }).run(() => {}));
+
+		// No close match — we want the "Available commands" line.
+		await app.execute({ argv: ["zzzzz"] });
+
+		const stderr = stderrChunks.join("\n");
+		expect(stderr).toContain("Available commands: build, test");
+		expect(stderr).not.toContain("__complete");
+	});
 });

--- a/packages/plugins/src/did-you-mean.ts
+++ b/packages/plugins/src/did-you-mean.ts
@@ -43,6 +43,11 @@ function levenshtein(a: string, b: string): number {
  * within threshold, the better score wins for that command (a short alias
  * cannot lose to a more-distant canonical, and vice-versa).
  *
+ * Subcommands marked `meta.hidden: true` are excluded from the candidate
+ * set so internal commands (e.g. `__complete`) cannot leak into
+ * user-facing typo suggestions. They remain invocable by direct name —
+ * routing does not consult `meta.hidden`.
+ *
  * The matching is limited to: (a) `candidate.startsWith(input)` (a
  * forward-completion hint, useful when the user typed a prefix) and
  * (b) Levenshtein distance ≤ 3. The reverse `input.startsWith(candidate)`
@@ -67,6 +72,7 @@ function findSuggestions(
 	};
 
 	for (const [name, node] of Object.entries(subCommands)) {
+		if (node.meta.hidden === true) continue;
 		const d = score(name);
 		if (d !== null) record(name, d);
 		for (const alias of node.meta.aliases ?? []) {
@@ -115,8 +121,16 @@ export function didYouMeanPlugin(
 					return;
 				}
 
-				if (details.available.length > 0) {
-					message += `\n\nAvailable commands: ${details.available.join(", ")}`;
+				// `details.available` lists every canonical sibling name including
+				// those marked `meta.hidden: true`. The error message is user-
+				// facing, so filter the same way `findSuggestions` does — internal
+				// commands stay invocable but never surface in this list.
+				const visibleAvailable = details.available.filter(
+					(canonical) =>
+						details.parentCommand.subCommands[canonical]?.meta.hidden !== true,
+				);
+				if (visibleAvailable.length > 0) {
+					message += `\n\nAvailable commands: ${visibleAvailable.join(", ")}`;
 				}
 				console.error(message);
 				process.exitCode = 1;

--- a/packages/plugins/src/help.ts
+++ b/packages/plugins/src/help.ts
@@ -47,6 +47,42 @@ function formatDescription(
 	return `${description} ${defaultSuffix}`;
 }
 
+/**
+ * Render a `[choices: a, b, c]` hint when a non-empty `choices` list is
+ * present. The hint is colour-dimmed so it blends with the default-value
+ * suffix style. Returns the empty string when no choices are declared
+ * so the caller can unconditionally concatenate.
+ *
+ * Takes the raw `choices` array directly rather than a `def` object.
+ * `FlagDef` and `ArgDef` are discriminated unions whose number/boolean
+ * variants do not carry `choices` at all, so a structural `{ choices? }`
+ * parameter would fail TS excess-property checks at every call site.
+ * Each caller already has access to `def.choices` (typed as
+ * `readonly string[] | undefined`), so passing it directly is clearer
+ * and avoids the union narrowing.
+ */
+function formatChoicesSuffix(choices: readonly string[] | undefined): string {
+	if (!choices || choices.length === 0) return "";
+	return dim(`[choices: ${choices.join(", ")}]`);
+}
+
+/**
+ * Compose description + default + choices suffixes into a single help
+ * body line. Each segment is optional; separators collapse so we never
+ * emit a stray double-space when one piece is missing.
+ */
+function formatDescriptionWithChoices(
+	description: string | undefined,
+	defaultValue: unknown,
+	choices: readonly string[] | undefined,
+): string {
+	const base = formatDescription(description, defaultValue);
+	const suffix = formatChoicesSuffix(choices);
+	if (!suffix) return base;
+	if (!base) return suffix;
+	return `${base} ${suffix}`;
+}
+
 function formatUsage(
 	meta: CommandMeta,
 	command: CommandNode,
@@ -98,8 +134,12 @@ function formatFlagsSection(flagsDef: FlagsDef): string[] {
 	const lines = [bold(cyan("OPTIONS:"))];
 	for (const [name, def] of Object.entries(flagsDef)) {
 		const rendered = `${padEnd(formatFlagName(name, def), FLAG_COLUMN_WIDTH, " ")} `;
+		// `def.choices` only exists on string-typed flags; number/boolean
+		// variants narrow to `undefined`, which `formatChoicesSuffix`
+		// renders as the empty string.
+		const choices = def.type === "string" ? def.choices : undefined;
 		lines.push(
-			`  ${rendered}${formatDescription(def.description, def.default)}`.trimEnd(),
+			`  ${rendered}${formatDescriptionWithChoices(def.description, def.default, choices)}`.trimEnd(),
 		);
 	}
 
@@ -112,8 +152,9 @@ function formatArgsSection(command: CommandNode): string[] {
 	const lines = [bold(cyan("ARGS:"))];
 	for (const arg of command.args as readonly ArgDef[]) {
 		const rendered = `${padEnd(formatArgToken(arg), ARG_COLUMN_WIDTH, " ")} `;
+		const choices = arg.type === "string" ? arg.choices : undefined;
 		lines.push(
-			`  ${rendered}${formatDescription(arg.description, arg.default)}`.trimEnd(),
+			`  ${rendered}${formatDescriptionWithChoices(arg.description, arg.default, choices)}`.trimEnd(),
 		);
 	}
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -4,6 +4,11 @@ import {
 	didYouMeanPlugin,
 } from "./did-you-mean.ts";
 
+export type {
+	CompletionPluginOptions,
+	CompletionShell,
+} from "./completion/index.ts";
+export { completionPlugin } from "./completion/index.ts";
 export type { DidYouMeanPluginOptions } from "./did-you-mean.ts";
 export { didYouMeanPlugin } from "./did-you-mean.ts";
 

--- a/packages/plugins/src/plugins.test.ts
+++ b/packages/plugins/src/plugins.test.ts
@@ -620,4 +620,70 @@ describe("built-in plugins", () => {
 		await app.execute({ argv: ["__complete"] });
 		expect(didRun).toBe(true);
 	});
+
+	it("renderHelp surfaces flag `choices` as a `[choices: ...]` suffix", () => {
+		// The choices list is declared on the flag definition (TP-009);
+		// `helpPlugin` must surface it so users can discover the valid
+		// values from `--help` without resorting to shell completion or
+		// reading the source.
+		const command = new Crust("app")
+			.meta({ description: "Build artifact" })
+			.flags({
+				target: {
+					type: "string",
+					choices: ["browser", "bun", "node"],
+					description: "Build target",
+				},
+			})
+			.run(() => {})._node;
+		const plain = stripAnsi(renderHelp(command));
+		expect(plain).toContain("--target");
+		expect(plain).toContain("Build target");
+		expect(plain).toContain("[choices: browser, bun, node]");
+	});
+
+	it("renderHelp surfaces positional-arg `choices` in the ARGS section", () => {
+		const command = new Crust("app")
+			.meta({ description: "Deploy to an env" })
+			.args([
+				{
+					name: "env",
+					type: "string",
+					required: true,
+					choices: ["dev", "staging", "prod"],
+					description: "Target environment",
+				},
+			])
+			.run(() => {})._node;
+		const plain = stripAnsi(renderHelp(command));
+		// The ARGS section heading is the marker the rest of the
+		// assertions hang off; without it the test would silently miss
+		// rendering bugs that drop the section entirely.
+		expect(plain).toContain("ARGS:");
+		expect(plain).toContain("<env>");
+		expect(plain).toContain("[choices: dev, staging, prod]");
+	});
+
+	it("renderHelp composes `[default: ...]` and `[choices: ...]` when both are present", () => {
+		const command = new Crust("app")
+			.flags({
+				target: {
+					type: "string",
+					choices: ["a", "b"],
+					default: "a",
+					description: "Build target",
+				},
+			})
+			.run(() => {})._node;
+		const plain = stripAnsi(renderHelp(command));
+		// Both suffixes appear on the same flag line, in this order, so the
+		// `[default: ...]` reads before `[choices: ...]`.
+		const targetLine = plain.split("\n").find((l) => l.includes("--target"));
+		expect(targetLine).toBeDefined();
+		expect(targetLine).toContain('[default: "a"]');
+		expect(targetLine).toContain("[choices: a, b]");
+		expect((targetLine as string).indexOf("[default:")).toBeLessThan(
+			(targetLine as string).indexOf("[choices:"),
+		);
+	});
 });


### PR DESCRIPTION
Adds `completionPlugin` to `@crustjs/plugins`, registering a `completion <shell>` subcommand that emits self-contained tab-completion scripts for **bash**, **zsh**, and **fish**.

Tracks: TP-010. First consumer of PR #120's `choices` and `hidden` fields.

## Strategy: pure-static

The plugin walks the live command tree at run time and prints a fully-baked shell script. No runtime callbacks, no hidden `__complete` subcommand, no shell-out on TAB. The generated script is the artifact users install into their shell.

```ts
import { Crust } from "@crustjs/core";
import { completionPlugin } from "@crustjs/plugins";

new Crust("my-cli")
  .use(completionPlugin({ version: "1.0.0" }))
  .command("build", (cmd) =>
    cmd.flags({
      target: { type: "string", choices: ["browser", "bun", "node"] },
    }).run(() => {}),
  )
  .run(() => {});
```

```sh
# Print to stdout — pipe into the shell's auto-discovery directory
my-cli completion bash > ~/.local/share/bash-completion/completions/my-cli

# Or generate every supported shell at packaging time
my-cli completion bash --output-dir completions/
# → completions/my-cli, completions/_my-cli, completions/my-cli.fish
```

## Public surface

| Export | Type |
|---|---|
| `completionPlugin(options)` | factory function returning a `Plugin` |
| `CompletionPluginOptions` | `{ version, command?, shells?, outputDir?, ... }` |
| `CompletionShell` | `"bash" \| "zsh" \| "fish"` |

## Architecture

| File | Role |
|---|---|
| `walker.ts` | Walks `CommandNode` tree → `CompletionSpec` (shared by all 3 templates) |
| `templates/bash.ts` | Cobra-style init shim (works on macOS, Alpine, NixOS without `bash-completion`) |
| `templates/zsh.ts` | `_arguments -C` with `->state` subcommand routing + description-rich menus |
| `templates/fish.ts` | Declarative `complete -c` rules with chained `__fish_seen_subcommand_from` |

## End-to-end integration

This PR is the first consumer of fields landed earlier in this batch series:

- **`choices`** (PR #120) — static enums on `StringFlagDef` / `StringArgDef` become value lists in generated scripts
- **`meta.aliases`** (PR #116) — alias names are tab-completable and resolve to the canonical command's flags
- **`meta.hidden`** (PR #120) — hidden commands are filtered from the completion script

## `--output-dir` for distributors

Writes all configured shells with the canonical filenames Homebrew, Nix, AUR, and Debian expect:

| Shell | Filename |
|---|---|
| bash | `<bin>` |
| zsh  | `_<bin>` |
| fish | `<bin>.fish` |

## Versioned headers

Each generated script's first line embeds binary name + version, so users (and `diff`) spot stale completion files at a glance, with the regenerate command inline.

## Limitations (v1, intentional)

- **No dynamic value completion** (per-flag/per-arg `complete?:` callbacks). Deferred to a future minor bump — adding them is non-breaking, so v1 ships pure-static today and grows into a hybrid later.
- **No PowerShell template** (planned for v2).

## Verification

- `bun run check` ✅ 291 files, no fixes (was 280 → +11 new files)
- `bun run check:types --force` ✅ 21/21 (no cache)
- `packages/plugins` tests: **168 pass / 0 fail / 313 expect calls** (was 113 → +55 new tests covering walker, all 3 templates' snapshots + behavioral subprocess tests, plugin integration)
- All 10 packages: 2,300+ pass / 0 fail / 2 skip

## Changeset

`@crustjs/plugins` minor — purely additive (new `completionPlugin` factory + types). No breaking changes.