### PR TITLE
feat(store): persist schema transforms with read-stability guard

### DIFF
--- a/.changeset/store-transform-persistence.md
+++ b/.changeset/store-transform-persistence.md
@@ -1,0 +1,51 @@
+---
+"@crustjs/store": minor
+---
+
+Schema-driven transforms in `field()` now persist on `write`, `update`,
+and `patch`. Reads return the on-disk value verbatim (no transform on
+read). Closes the long-standing command/store asymmetry — the store path
+now mirrors the command path's "parse and use `result.value`" semantics
+for the Standard Schema flow.
+
+### What changed
+
+- `field(z.string().transform(s => s.trim()))` now writes the **trimmed**
+  value to disk on `store.write({ name: "  hi  " })` instead of the
+  original input. Same applies to `update` and `patch`.
+- A new write-time **read-stability guard** rejects transforms whose
+  output the schema itself would reject on a subsequent read. For
+  example, `field(z.string().transform(s => s.length))` (string in,
+  number out) is rejected with `CrustStoreError("VALIDATION")` and an
+  issue message tagged `read-unstable transform`. Nothing is written to
+  disk when a transform is read-unstable.
+- `read()` never transforms. Reads return the on-disk JSON verbatim.
+  Schema validation still runs on read and rejects invalid persisted
+  config (unchanged).
+- Hand-rolled `validate: (v) => { ... }` callbacks that return `void`
+  are unaffected — they remain validation-only.
+
+### Behavior change (pre-1.0 minor break)
+
+If you use `field(schemaWithTransform)` today, existing on-disk values
+**survive unchanged** on the next `read()` — no automatic migration.
+The first subsequent `write` / `update` / `patch` canonicalizes the
+value through the transform and persists the new shape.
+
+Concrete: a store with `field(z.string().transform(s => s.trim()))` that
+has `{ name: "  hi  " }` on disk will:
+
+1. `await store.read()` → `{ name: "  hi  " }` (untouched)
+2. `await store.write({ name: "  hi  " })` → file becomes `{ name: "hi" }`
+
+### Type contract widening
+
+`FieldDef.validate` widens from `(value: V) => void | Promise<void>` to
+`(value: V) => void | Promise<void> | { value: V } | Promise<{ value: V }>`.
+Plain-literal users who write `validate: (v) => { if (...) throw }`
+returning `void` are unaffected — the new shapes are additive.
+
+### No surface contraction
+
+No public types removed. No new exports. `field()`, `createStore`,
+`FieldOptions`, and the `Store<TConfig>` interface are all unchanged.

--- a/.changeset/store-transform-persistence.md
+++ b/.changeset/store-transform-persistence.md
@@ -3,34 +3,27 @@
 ---
 
 Schema-driven transforms in `field()` now persist on `write`, `update`,
-and `patch`. Reads return the on-disk value verbatim (no transform on
-read). Closes the long-standing command/store asymmetry — the store path
-now mirrors the command path's "parse and use `result.value`" semantics
-for the Standard Schema flow.
-
-### What changed
+and `patch`. On `read`, the schema still validates the persisted value
+but its transform output is discarded — the returned value matches what
+is on disk.
 
 - `field(z.string().transform(s => s.trim()))` now writes the **trimmed**
-  value to disk on `store.write({ name: "  hi  " })` instead of the
-  original input. Same applies to `update` and `patch`.
-- A new write-time **read-stability guard** rejects transforms whose
-  output the schema itself would reject on a subsequent read. For
-  example, `field(z.string().transform(s => s.length))` (string in,
-  number out) is rejected with `CrustStoreError("VALIDATION")` and an
-  issue message tagged `read-unstable transform`. Nothing is written to
-  disk when a transform is read-unstable.
-- `read()` never transforms. Reads return the on-disk JSON verbatim.
-  Schema validation still runs on read and rejects invalid persisted
-  config (unchanged).
+  value to disk on `store.write({ name: "  hi  " })`. Same for `update`
+  and `patch`.
+- A write-time **read-stability guard** rejects transforms whose output
+  the schema would reject on a subsequent read. For example,
+  `field(z.string().transform(s => s.length))` (string in, number out)
+  fails with `CrustStoreError("VALIDATION")` tagged
+  `read-unstable transform`. Nothing is written.
 - Hand-rolled `validate: (v) => { ... }` callbacks that return `void`
-  are unaffected — they remain validation-only.
+  remain validation-only and are unaffected.
 
 ### Behavior change (pre-1.0 minor break)
 
 If you use `field(schemaWithTransform)` today, existing on-disk values
 **survive unchanged** on the next `read()` — no automatic migration.
 The first subsequent `write` / `update` / `patch` canonicalizes the
-value through the transform and persists the new shape.
+value through the transform.
 
 Concrete: a store with `field(z.string().transform(s => s.trim()))` that
 has `{ name: "  hi  " }` on disk will:
@@ -41,11 +34,5 @@ has `{ name: "  hi  " }` on disk will:
 ### Type contract widening
 
 `FieldDef.validate` widens from `(value: V) => void | Promise<void>` to
-`(value: V) => void | Promise<void> | { value: V } | Promise<{ value: V }>`.
-Plain-literal users who write `validate: (v) => { if (...) throw }`
-returning `void` are unaffected — the new shapes are additive.
-
-### No surface contraction
-
-No public types removed. No new exports. `field()`, `createStore`,
-`FieldOptions`, and the `Store<TConfig>` interface are all unchanged.
+`(value: V) => void | Promise<void> | { value: unknown } | Promise<{ value: unknown }>`.
+The new shapes are additive — `void`-returning validators are unchanged.

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -350,10 +350,11 @@ whose output the schema would itself reject (e.g.
 write time with `CrustStoreError("VALIDATION")` and an issue message
 tagged `read-unstable transform`.
 
-Reads always return the on-disk value verbatim. Existing on-disk values
-for schema-using stores survive unchanged across upgrades; the first
-subsequent `write` / `update` / `patch` canonicalizes them through the
-transform.
+On `read`, the schema still validates the persisted value but its
+transform output is discarded — the returned value matches what is on
+disk. Existing on-disk values for schema-using stores survive unchanged
+across upgrades; the first subsequent `write` / `update` / `patch`
+canonicalizes them through the transform.
 
 Hand-rolled `validate: (v) => { ... }` callbacks that return `void` are
 unaffected — they remain validation-only (throw to reject, return `void`

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -342,8 +342,22 @@ const store = createStore({
 `reset`. If a validator throws, the operation is aborted and a
 `CrustStoreError` with `VALIDATION` code is thrown with structured issues.
 
-Store field validators are validation-only. Schema transforms/coercions
-in the schema passed to `field()` are not written back into store state.
+Schema transforms in fields built via `field()` are applied on `write`,
+`update`, and `patch` — never on `read`. The transformed output replaces
+the input before persistence and is then re-validated once: a transform
+whose output the schema would itself reject (e.g.
+`z.string().transform(Number)` — string in, number out) is rejected at
+write time with `CrustStoreError("VALIDATION")` and an issue message
+tagged `read-unstable transform`.
+
+Reads always return the on-disk value verbatim. Existing on-disk values
+for schema-using stores survive unchanged across upgrades; the first
+subsequent `write` / `update` / `patch` canonicalizes them through the
+transform.
+
+Hand-rolled `validate: (v) => { ... }` callbacks that return `void` are
+unaffected — they remain validation-only (throw to reject, return `void`
+to accept) and cannot transform the persisted value.
 
 #### Schema-derived defaults and TypeScript
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -410,18 +410,35 @@ const store = createStore({
 });
 ```
 
-The per-field `validate` function's contract is
-`(value: V) => void | Promise<void>`. Return `void` (or `Promise<void>`) for
-a valid value; throw an `Error` to reject. Validators are side-effect only —
-they cannot transform the persisted value. Use the built-in `field()` factory
-(above) when you need schema-driven validation.
+Hand-rolled `validate` callbacks are `(value: V) => void | Promise<void>`.
+Return `void` (or `Promise<void>`) to accept; throw an `Error` to reject.
+These remain validation-only — they cannot transform the persisted value.
+
+Fields built via the `field()` factory carry a Standard Schema and DO
+persist transforms on `write` / `update` / `patch` (e.g.
+`field(z.string().transform(s => s.trim()))` writes the trimmed value to
+disk). Reads always return the on-disk value verbatim — transforms never
+run on `read`. Existing on-disk values survive unchanged; the first
+subsequent write canonicalizes them through the transform.
+
+A write-time **read-stability guard** rejects cross-type transforms whose
+output would fail the schema's own re-validation. For example,
+`field(z.string().transform(Number))` (string in, number out) is rejected
+with `CrustStoreError("VALIDATION")` and an issue message tagged
+`read-unstable transform`. No on-disk write occurs.
 
 ### Validation behavior
 
-- **Write**: Validates each field before persisting. The persisted value is the input value unchanged — custom validators cannot transform.
-- **Read**: Validates each field after applying defaults. Invalid persisted config fails loudly — no silent fallback to defaults.
-- **Update**: Reads raw config (no validation), applies updater, validates each field, then persists.
-- **Patch**: Reads raw config, applies shallow partial merge, validates each field, then persists.
+- **Write**: Validates each field before persisting. Schema-driven
+  transforms (via `field()`) replace the input value with the transformed
+  output; hand-rolled validators cannot transform.
+- **Read**: Validates each field after applying defaults. Invalid persisted
+  config fails loudly — no silent fallback to defaults. Schema transforms
+  do NOT run on read; the on-disk value is returned verbatim.
+- **Update**: Reads raw config (no validation), applies updater, validates
+  each field (persisting any schema-transformed outputs), then persists.
+- **Patch**: Reads raw config, applies shallow partial merge, validates each
+  field (persisting any schema-transformed outputs), then persists.
 - **Reset**: No validation — just removes the persisted file.
 
 ### Catching validation errors

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -417,8 +417,9 @@ These remain validation-only — they cannot transform the persisted value.
 Fields built via the `field()` factory carry a Standard Schema and DO
 persist transforms on `write` / `update` / `patch` (e.g.
 `field(z.string().transform(s => s.trim()))` writes the trimmed value to
-disk). Reads always return the on-disk value verbatim — transforms never
-run on `read`. Existing on-disk values survive unchanged; the first
+disk). On `read`, the schema still validates the persisted value but its
+transform output is discarded — the on-disk value is returned unchanged.
+Existing on-disk values survive unchanged across upgrades; the first
 subsequent write canonicalizes them through the transform.
 
 A write-time **read-stability guard** rejects cross-type transforms whose
@@ -433,8 +434,8 @@ with `CrustStoreError("VALIDATION")` and an issue message tagged
   transforms (via `field()`) replace the input value with the transformed
   output; hand-rolled validators cannot transform.
 - **Read**: Validates each field after applying defaults. Invalid persisted
-  config fails loudly — no silent fallback to defaults. Schema transforms
-  do NOT run on read; the on-disk value is returned verbatim.
+  config fails loudly — no silent fallback to defaults. Schema transform
+  output is discarded on read; the returned value matches what is on disk.
 - **Update**: Reads raw config (no validation), applies updater, validates
   each field (persisting any schema-transformed outputs), then persists.
 - **Patch**: Reads raw config, applies shallow partial merge, validates each

--- a/packages/store/src/field.test.ts
+++ b/packages/store/src/field.test.ts
@@ -285,9 +285,11 @@ describe("default extraction — vendor-neutral fallback", () => {
 describe("field() — type-level integration with FieldDef", () => {
 	it("returns a value structurally compatible with store FieldDef.validate", async () => {
 		const def = field(z.string());
-		// Structural check: validate signature aligns with the widened
-		// FieldDef.validate union (TP-018) — schema-driven validators emit
-		// `{ value: unknown }` on success so the store can persist transforms.
+		// Structural check: schema-driven validators emit `{ value: unknown }`
+		// on success so the store can persist transforms. The parameter is
+		// typed as `unknown` here because `FieldDef.validate` narrows its
+		// argument per-discriminant (string vs number vs …) and the public
+		// `field()` factory has to accept any input shape.
 		const validate: (
 			value: unknown,
 		) =>

--- a/packages/store/src/field.test.ts
+++ b/packages/store/src/field.test.ts
@@ -107,9 +107,17 @@ describe("field() — runtime shape", () => {
 });
 
 describe("field() — validate adapter", () => {
-	it("returns a validate function that resolves on valid input", async () => {
+	it("returns a validate function that resolves to { value } on valid input", async () => {
+		// Schema-driven validators return `{ value: result.value }` so the
+		// store can persist transformed outputs (TP-018). For non-
+		// transforming schemas the value round-trips unchanged.
 		const def = field(z.string());
-		await expect(def.validate("hello")).resolves.toBeUndefined();
+		await expect(def.validate("hello")).resolves.toEqual({ value: "hello" });
+	});
+
+	it("returns a validate function that resolves to the transformed value", async () => {
+		const def = field(z.string().transform((s) => s.trim()));
+		await expect(def.validate("  hi  ")).resolves.toEqual({ value: "hi" });
 	});
 
 	it("returns a validate function that rejects on invalid input", async () => {
@@ -277,8 +285,16 @@ describe("default extraction — vendor-neutral fallback", () => {
 describe("field() — type-level integration with FieldDef", () => {
 	it("returns a value structurally compatible with store FieldDef.validate", async () => {
 		const def = field(z.string());
-		// Structural check: validate signature aligns with FieldDef.validate
-		const validate: (value: unknown) => void | Promise<void> = def.validate;
+		// Structural check: validate signature aligns with the widened
+		// FieldDef.validate union (TP-018) — schema-driven validators emit
+		// `{ value: unknown }` on success so the store can persist transforms.
+		const validate: (
+			value: unknown,
+		) =>
+			| void
+			| Promise<void>
+			| { value: unknown }
+			| Promise<{ value: unknown }> = def.validate;
 		await validate("hello");
 	});
 });

--- a/packages/store/src/field.ts
+++ b/packages/store/src/field.ts
@@ -58,10 +58,19 @@ export interface FieldOptions<T = unknown> {
 // Schema → field validate adapter
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Build the per-field async validate function from a Standard Schema. */
+/**
+ * Build the per-field async validate function from a Standard Schema.
+ *
+ * On success returns `{ value: result.value }` so the store can persist
+ * schema-transformed values (e.g. `z.string().transform(s => s.trim())`).
+ * On issues, throws an `Error` whose message contains the schema's
+ * normalized issues. The store treats `{ value }` returns as
+ * "persist on write/update/patch, discard on read" — see
+ * `FieldDef.validate` in `./types.ts`.
+ */
 function makeValidator<S extends StandardSchema>(
 	schema: S,
-): (value: unknown) => Promise<void> {
+): (value: unknown) => Promise<{ value: unknown }> {
 	return async (value: unknown) => {
 		const result = await schema["~standard"].validate(value);
 		if (result.issues) {
@@ -71,6 +80,7 @@ function makeValidator<S extends StandardSchema>(
 			);
 			throw new Error(messages.join("; "));
 		}
+		return { value: result.value };
 	};
 }
 
@@ -120,7 +130,7 @@ type ResolveScalarType<S> =
 type ScalarFieldDef<T extends ValueType> = {
 	readonly type: T;
 	readonly description?: string;
-	readonly validate: (value: unknown) => Promise<void>;
+	readonly validate: (value: unknown) => Promise<{ value: unknown }>;
 };
 
 /** A scalar `FieldDef` with a narrowed default. */
@@ -128,7 +138,7 @@ type ScalarFieldDefWithDefault<T extends ValueType, D> = {
 	readonly type: T;
 	readonly description?: string;
 	readonly default: D;
-	readonly validate: (value: unknown) => Promise<void>;
+	readonly validate: (value: unknown) => Promise<{ value: unknown }>;
 };
 
 /** An array `FieldDef` with no narrowed default. */
@@ -136,7 +146,7 @@ type ArrayFieldDef<T extends ValueType> = {
 	readonly type: T;
 	readonly array: true;
 	readonly description?: string;
-	readonly validate: (value: unknown) => Promise<void>;
+	readonly validate: (value: unknown) => Promise<{ value: unknown }>;
 };
 
 /** An array `FieldDef` with a narrowed default. */
@@ -145,7 +155,7 @@ type ArrayFieldDefWithDefault<T extends ValueType, D> = {
 	readonly array: true;
 	readonly description?: string;
 	readonly default: D;
-	readonly validate: (value: unknown) => Promise<void>;
+	readonly validate: (value: unknown) => Promise<{ value: unknown }>;
 };
 
 /**

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -4,7 +4,9 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import { CrustStoreError } from "./errors.ts";
+import { field } from "./field.ts";
 import { createStore } from "./store.ts";
 import type { FieldsDef } from "./types.ts";
 
@@ -1156,6 +1158,187 @@ describe("FieldDef.validate contract", () => {
 				expect(e.details.issues).toHaveLength(1);
 				expect(e.details.issues[0]?.path).toBe("name");
 				expect(e.details.issues[0]?.message).toBe("name rejected by user code");
+			}
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Schema-driven transform persistence + read-stability guard (TP-018)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Closes the command/store asymmetry: schema transforms (e.g.
+// `z.string().transform(s => s.trim())`) MUST persist on write/update/
+// patch operations. Reads return on-disk values verbatim (no transform on
+// read). A write-time read-stability guard rejects cross-type transforms
+// whose output would fail the schema's own re-validation on the next
+// read.
+
+describe("schema transform persistence", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = createTempDir();
+		await mkdir(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	// RED: today the store discards `result.value` and persists the
+	// untransformed input. After TP-018 the trimmed value is written.
+	it("persists Zod transform output on write (trim example)", async () => {
+		const fields = {
+			name: field(z.string().transform((s) => s.trim())),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.write({ name: "  hi  " });
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ name: "hi" });
+	});
+
+	it("persists Zod transform output on update", async () => {
+		const fields = {
+			name: field(z.string().transform((s) => s.trim())),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.update(() => ({ name: "  spaced  " }));
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ name: "spaced" });
+	});
+
+	it("persists Zod transform output on patch", async () => {
+		const fields = {
+			name: field(z.string().transform((s) => s.trim())),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.patch({ name: "  patched  " });
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ name: "patched" });
+	});
+
+	// Pin: reads MUST NOT mutate on-disk state, even when the schema would
+	// transform the persisted value. Existing on-disk values survive
+	// untouched until the next write canonicalizes them.
+	it("read does NOT transform — pre-seeded file survives unchanged", async () => {
+		const filePath = join(tempDir, "config.json");
+		await writeFile(filePath, JSON.stringify({ name: "  hi  " }));
+
+		const fields = {
+			name: field(z.string().transform((s) => s.trim())),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		const result = await store.read();
+		expect(result.name).toBe("  hi  ");
+
+		const rawAfter = await readFile(filePath, "utf-8");
+		expect(JSON.parse(rawAfter)).toEqual({ name: "  hi  " });
+	});
+
+	// RED: cross-type transform (string → number) succeeds the first
+	// validation but its output fails the schema on re-validation. Must
+	// surface as `read-unstable transform` at write time and never touch
+	// disk. Today this either persists the raw string or surfaces as a
+	// regular validation issue depending on coercion; after TP-018 it is
+	// always rejected with the read-unstable message.
+	it("rejects read-unstable cross-type transform at write time", async () => {
+		const fields = {
+			x: field(z.string().transform((s) => s.length)),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		let caught: unknown;
+		try {
+			await store.write({ x: "hello" as unknown as number });
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(CrustStoreError);
+		const e = caught as CrustStoreError;
+		expect(e.is("VALIDATION")).toBe(true);
+		if (e.is("VALIDATION")) {
+			expect(e.details.operation).toBe("write");
+			expect(e.details.issues).toHaveLength(1);
+			expect(e.details.issues[0]?.path).toBe("x");
+			expect(e.details.issues[0]?.message).toContain("read-unstable transform");
+		}
+
+		// Nothing should have been persisted.
+		const filePath = join(tempDir, "config.json");
+		expect(existsSync(filePath)).toBe(false);
+	});
+
+	// Pin: literal fields with the discriminated-union shape are
+	// unaffected by transform persistence. The written JSON matches the
+	// input value byte-for-byte (after coercion, which is unchanged).
+	it("plain literal FieldDef is unaffected (end-to-end pin)", async () => {
+		const fields = {
+			theme: { type: "string", default: "x" },
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.write({ theme: "dark" });
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ theme: "dark" });
+
+		const result = await store.read();
+		expect(result.theme).toBe("dark");
+	});
+
+	// Pin: hand-rolled void-returning `validate` callbacks keep their
+	// current contract — accept on no-throw, reject on throw. The widened
+	// FieldDef.validate signature must remain backward-compatible.
+	it("hand-rolled void-return validate keeps current contract", async () => {
+		const fields = {
+			port: {
+				type: "number",
+				default: 3000,
+				validate: (v: number) => {
+					if (v < 1 || v > 65535) throw new Error("invalid port");
+				},
+			},
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		// Accept on no-throw: writes 8080 successfully.
+		await store.write({ port: 8080 });
+		const filePath = join(tempDir, "config.json");
+		expect(JSON.parse(await readFile(filePath, "utf-8"))).toEqual({
+			port: 8080,
+		});
+
+		// Reject on throw: 0 is out of range → CrustStoreError(VALIDATION).
+		try {
+			await store.write({ port: 0 });
+			expect.unreachable("should have thrown");
+		} catch (__err) {
+			const e = __err as CrustStoreError;
+			expect(e).toBeInstanceOf(CrustStoreError);
+			expect(e.is("VALIDATION")).toBe(true);
+			if (e.is("VALIDATION")) {
+				expect(e.details.issues[0]?.message).toBe("invalid port");
 			}
 		}
 	});

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -1095,6 +1095,38 @@ describe("FieldDef.validate contract", () => {
 		await rm(tempDir, { recursive: true, force: true });
 	});
 
+	// Regression: previously the migration guard accepted any object with
+	// a `"value" in result` key, so `{ ok: false, value: "bad" }` was
+	// silently persisted as `"bad"` instead of throwing TypeError. The
+	// guard now rejects any return shape carrying an `ok` key.
+	it("surfaces legacy { ok, value } validator return as TypeError", async () => {
+		const fields = {
+			name: {
+				type: "string",
+				default: "ok",
+				validate: ((_v: string) => ({ ok: false, value: "bad" }) as never) as (
+					v: string,
+				) => void,
+			},
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		let caught: unknown;
+		try {
+			await store.write({ name: "input" });
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(TypeError);
+		expect(caught).not.toBeInstanceOf(CrustStoreError);
+		// Critically: the legacy `value: "bad"` was NOT persisted.
+		const filePath = join(tempDir, "config.json");
+		expect(existsSync(filePath)).toBe(false);
+	});
+
 	it("surfaces a buggy validator (returns a value) as TypeError, not CrustStoreError", async () => {
 		// Regression: previously the migration guard `throw new TypeError`
 		// ran inside the same try/catch that captures legitimate validation
@@ -1186,8 +1218,6 @@ describe("schema transform persistence", () => {
 		await rm(tempDir, { recursive: true, force: true });
 	});
 
-	// RED: today the store discards `result.value` and persists the
-	// untransformed input. After TP-018 the trimmed value is written.
 	it("persists Zod transform output on write (trim example)", async () => {
 		const fields = {
 			name: field(z.string().transform((s) => s.trim())),
@@ -1250,12 +1280,10 @@ describe("schema transform persistence", () => {
 		expect(JSON.parse(rawAfter)).toEqual({ name: "  hi  " });
 	});
 
-	// RED: cross-type transform (string → number) succeeds the first
-	// validation but its output fails the schema on re-validation. Must
+	// Cross-type transform (string → number) succeeds the first
+	// validation but its output fails the schema on re-validation — must
 	// surface as `read-unstable transform` at write time and never touch
-	// disk. Today this either persists the raw string or surfaces as a
-	// regular validation issue depending on coercion; after TP-018 it is
-	// always rejected with the read-unstable message.
+	// disk.
 	it("rejects read-unstable cross-type transform at write time", async () => {
 		const fields = {
 			x: field(z.string().transform((s) => s.length)),
@@ -1289,6 +1317,42 @@ describe("schema transform persistence", () => {
 	// Pin: literal fields with the discriminated-union shape are
 	// unaffected by transform persistence. The written JSON matches the
 	// input value byte-for-byte (after coercion, which is unchanged).
+	// Regression: the read-stability guard previously used reference
+	// identity (`Object.is`), so Standard Schema parsers that return fresh
+	// references for identical content (Zod arrays/objects) tripped the
+	// guard and made `field(z.array(...))` unwritable.
+	it("writes array field without tripping read-stability guard", async () => {
+		const fields = {
+			tags: field(z.array(z.string())),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.write({ tags: ["a", "b"] });
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ tags: ["a", "b"] });
+	});
+
+	// Regression: an array schema whose elements transform (e.g.
+	// `z.array(z.string().transform(s => s.trim()))`) must still persist
+	// the transformed array — the structural compare must accept the
+	// recheck output as stable when contents match by value.
+	it("persists Zod array-of-transforms output on write", async () => {
+		const fields = {
+			tags: field(z.array(z.string().transform((s) => s.trim()))),
+		} as const satisfies FieldsDef;
+
+		const store = createStore({ dirPath: tempDir, fields });
+
+		await store.write({ tags: ["  a  ", "b "] });
+
+		const filePath = join(tempDir, "config.json");
+		const raw = await readFile(filePath, "utf-8");
+		expect(JSON.parse(raw)).toEqual({ tags: ["a", "b"] });
+	});
+
 	it("plain literal FieldDef is unaffected (end-to-end pin)", async () => {
 		const fields = {
 			theme: { type: "string", default: "x" },

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -134,18 +134,74 @@ export function createStore<const F extends FieldsDef>(
 				continue;
 			}
 
-			// Fail-fast migration guard runs OUTSIDE the try block so it
-			// cannot be caught and re-wrapped as `CrustStoreError("VALIDATION")`.
-			// FieldDef.validate is contractually `void | Promise<void>` — any
-			// return value is a caller bug (e.g. the legacy `{ ok, value }`
-			// shape that earlier docs incorrectly showed), not a validation
-			// failure. Letting `TypeError` propagate keeps user-thrown errors
-			// (including `TypeError`) inside the try as legitimate rejections.
-			if (result !== undefined) {
-				throw new TypeError(
-					`FieldDef.validate must return void. Throw an Error to reject the value (see @crustjs/store validation docs).`,
-				);
+			// `FieldDef.validate` is contractually `void | { value }` — anything
+			// else is a caller bug (e.g. the legacy `{ ok, value }` shape).
+			// The fail-fast migration guard runs OUTSIDE the try block so the
+			// resulting `TypeError` cannot be caught and re-wrapped as a
+			// `CrustStoreError("VALIDATION")`.
+
+			// Validation-only: validator returned no transformed value.
+			if (result === undefined) continue;
+
+			// Transform path: validator returned `{ value }`.
+			if (typeof result === "object" && result !== null && "value" in result) {
+				const transformed = (result as { value: unknown }).value;
+
+				// On read, transforms are discarded — reads always return the
+				// on-disk value verbatim (canonicalization happens on the
+				// next write/update/patch).
+				if (operation === "read") continue;
+
+				// Persist-time path: if the transform changed the value,
+				// re-validate the output once. This catches cross-type
+				// transforms like `z.string().transform(Number)` whose output
+				// would fail the schema on the next read.
+				if (!Object.is(transformed, value)) {
+					let recheck: unknown;
+					try {
+						recheck = await def.validate(transformed as never);
+					} catch (cause) {
+						const message =
+							cause instanceof Error ? cause.message : "re-validation failed";
+						issues.push({
+							message: `read-unstable transform: ${message}`,
+							path: key,
+						});
+						continue;
+					}
+
+					// Recheck must accept the transformed value: either `void`
+					// (validation-only contract) or `{ value }` that is
+					// stable under another round of the same transform (i.e.
+					// `Object.is(recheck.value, transformed)`). Anything else
+					// means the next read would see a different value than the
+					// one we'd persist now.
+					if (recheck !== undefined) {
+						if (
+							typeof recheck !== "object" ||
+							recheck === null ||
+							!("value" in recheck) ||
+							!Object.is((recheck as { value: unknown }).value, transformed)
+						) {
+							issues.push({
+								message: `read-unstable transform: output would be transformed again on re-read`,
+								path: key,
+							});
+							continue;
+						}
+					}
+
+					record[key] = transformed;
+				}
+				continue;
 			}
+
+			// Any other return shape (e.g. legacy `{ ok, issues }`) is a
+			// caller bug — surface as a TypeError so it isn't misclassified
+			// as a `VALIDATION` failure.
+			throw new TypeError(
+				`FieldDef.validate must return void or { value } (see @crustjs/store validation docs).`,
+			);
 		}
 
 		if (issues.length > 0) {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -16,6 +16,16 @@ import type {
 	StoreValidatorIssue,
 } from "./types.ts";
 
+/**
+ * Narrow a `FieldDef.validate` return to the transform-result shape
+ * `{ value: unknown }`. Rejects the legacy `{ ok, value }` and
+ * `{ ok, issues }` shapes so they fall through to the fail-fast
+ * `TypeError` migration guard instead of being silently persisted.
+ */
+function isFieldValueResult(r: unknown): r is { value: unknown } {
+	return typeof r === "object" && r !== null && "value" in r && !("ok" in r);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // createStore — Public factory
 // ────────────────────────────────────────────────────────────────────────────
@@ -134,18 +144,17 @@ export function createStore<const F extends FieldsDef>(
 				continue;
 			}
 
-			// `FieldDef.validate` is contractually `void | { value }` — anything
-			// else is a caller bug (e.g. the legacy `{ ok, value }` shape).
-			// The fail-fast migration guard runs OUTSIDE the try block so the
-			// resulting `TypeError` cannot be caught and re-wrapped as a
-			// `CrustStoreError("VALIDATION")`.
+			// `FieldDef.validate` is contractually `void | { value }`. Anything
+			// else (notably the legacy `{ ok, value }` shape) is a caller bug
+			// and is surfaced below as a `TypeError` OUTSIDE the try/catch so
+			// it cannot be re-wrapped as `CrustStoreError("VALIDATION")`.
 
 			// Validation-only: validator returned no transformed value.
 			if (result === undefined) continue;
 
 			// Transform path: validator returned `{ value }`.
-			if (typeof result === "object" && result !== null && "value" in result) {
-				const transformed = (result as { value: unknown }).value;
+			if (isFieldValueResult(result)) {
+				const transformed = result.value;
 
 				// On read, transforms are discarded — reads always return the
 				// on-disk value verbatim (canonicalization happens on the
@@ -155,8 +164,10 @@ export function createStore<const F extends FieldsDef>(
 				// Persist-time path: if the transform changed the value,
 				// re-validate the output once. This catches cross-type
 				// transforms like `z.string().transform(Number)` whose output
-				// would fail the schema on the next read.
-				if (!Object.is(transformed, value)) {
+				// would fail the schema on the next read. Compare structurally
+				// because Standard Schema parsers (e.g. Zod arrays/objects)
+				// return fresh references even when contents are identical.
+				if (!Bun.deepEquals(transformed, value)) {
 					let recheck: unknown;
 					try {
 						recheck = await def.validate(transformed as never);
@@ -172,23 +183,19 @@ export function createStore<const F extends FieldsDef>(
 
 					// Recheck must accept the transformed value: either `void`
 					// (validation-only contract) or `{ value }` that is
-					// stable under another round of the same transform (i.e.
-					// `Object.is(recheck.value, transformed)`). Anything else
-					// means the next read would see a different value than the
-					// one we'd persist now.
-					if (recheck !== undefined) {
-						if (
-							typeof recheck !== "object" ||
-							recheck === null ||
-							!("value" in recheck) ||
-							!Object.is((recheck as { value: unknown }).value, transformed)
-						) {
-							issues.push({
-								message: `read-unstable transform: output would be transformed again on re-read`,
-								path: key,
-							});
-							continue;
-						}
+					// structurally stable under another round of the same
+					// transform. Anything else means the next read would see a
+					// different value than the one we'd persist now.
+					if (
+						recheck !== undefined &&
+						(!isFieldValueResult(recheck) ||
+							!Bun.deepEquals(recheck.value, transformed))
+					) {
+						issues.push({
+							message: `read-unstable transform: output would be transformed again on re-read`,
+							path: key,
+						});
+						continue;
 					}
 
 					record[key] = transformed;
@@ -196,9 +203,9 @@ export function createStore<const F extends FieldsDef>(
 				continue;
 			}
 
-			// Any other return shape (e.g. legacy `{ ok, issues }`) is a
-			// caller bug — surface as a TypeError so it isn't misclassified
-			// as a `VALIDATION` failure.
+			// Any other return shape (e.g. legacy `{ ok, value }` or
+			// `{ ok, issues }`) is a caller bug — surface as a TypeError so
+			// it isn't misclassified as a `VALIDATION` failure.
 			throw new TypeError(
 				`FieldDef.validate must return void or { value } (see @crustjs/store validation docs).`,
 			);

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -37,14 +37,29 @@ interface FieldDefBase<V> {
 	 * Optional per-field validation function.
 	 *
 	 * Called during `read`, `write`, `update`, and `patch` operations when
-	 * the field has a value (not `undefined`). Throw an error to reject the
-	 * value.
+	 * the field has a value (not `undefined`).
+	 *
+	 * Return shapes:
+	 * - `void` (or `Promise<void>`) — validation-only; the input value is
+	 *   persisted as-is. This is the contract for hand-rolled validators.
+	 * - `{ value }` (or `Promise<{ value }>`) — the schema (or transform)
+	 *   produced an output value (typed as `unknown` because schema
+	 *   transforms may emit a value of a different runtime type than
+	 *   `V`; the read-stability guard enforces shape correctness at
+	 *   write time). On `write` / `update` / `patch`, the transformed
+	 *   value replaces the input before persistence and is re-validated
+	 *   once to catch read-unstable transforms (cross-type transforms
+	 *   whose output would fail the schema on the next read). On `read`,
+	 *   the transformed value is discarded — reads always return the
+	 *   on-disk value verbatim.
+	 * - Throwing an error — the value is rejected; the error message is
+	 *   captured as a validation issue with the field name as `path`.
 	 *
 	 * @param value - The field value to validate.
-	 * @throws When the value is invalid — the error message is captured as a
-	 *   validation issue with the field name as `path`.
 	 */
-	validate?: (value: V) => void | Promise<void>;
+	validate?: (
+		value: V,
+	) => void | Promise<void> | { value: unknown } | Promise<{ value: unknown }>;
 }
 
 // ── Scalar fields ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the command/store asymmetry for Standard Schema validation. The store path now mirrors the command path's parse-and-use-`result.value` semantics: schema-driven transforms persist on `write` / `update` / `patch`, while reads return the on-disk value verbatim.

## What changes

- **Transform persistence:** `field(z.string().transform(s => s.trim()))` now writes the trimmed value to disk on `store.write({ name: "  hi  " })`. Same for `update` and `patch`.
- **Read-stability guard:** transforms whose output the schema itself would reject on a subsequent read (e.g. `z.string().transform(Number)` — string in, number out) are rejected at write time with `CrustStoreError("VALIDATION")` tagged `read-unstable transform`. Nothing is persisted when a transform is read-unstable.
- **Reads never transform.** `read()` returns the on-disk JSON verbatim. Schema validation still runs on read (unchanged).
- **`FieldDef.validate` type widened** from `void | Promise<void>` to `void | Promise<void> | { value } | Promise<{ value }>`. Plain-literal users with `validate: (v) => { if (...) throw }` returning `void` are unaffected — the new shapes are additive.

## Behavior change (pre-1.0 minor)

For stores using `field(schemaWithTransform)`: existing on-disk values **survive unchanged on read**. The first subsequent `write` / `update` / `patch` canonicalizes the value through the transform. No automatic migration.

Concrete: a store with `field(z.string().transform(s => s.trim()))` and `{ name: "  hi  " }` on disk will:

1. `await store.read()` → `{ name: "  hi  " }` (untouched)
2. `await store.write({ name: "  hi  " })` → file becomes `{ name: "hi" }`

## What does **not** change

- No public types removed; no new exports.
- `field()`, `createStore`, `FieldOptions`, and the `Store<TConfig>` interface are unchanged.
- `@crustjs/validate` is untouched (PR #123 already locked its surface).
- Plain-literal field coercion (`normalizeStateTypes` / `coerceByType`) preserved as-is.

## Test coverage

- 3 new RED-then-GREEN tests in `packages/store/src/store.test.ts`:
  - Zod transform persists on write
  - read does NOT transform (file unchanged on disk)
  - read-stability guard rejects cross-type transforms at write
- 2 GREEN/pin tests preserve existing literal + hand-rolled validate behavior
- Existing 30 `field.test.ts` tests + 259 store tests all pass

## Verification

`bun run check && bun run check:types --force && bun run test --force` — all green; store suite 259 tests, 0 fail.

## Docs

- `apps/docs/content/docs/modules/store.mdx` — the "validation-only" / "not written back" paragraph is inverted to document the new contract + read-stability requirement.
- `packages/store/README.md` mirrors the mdx change.
- Single `@crustjs/store` minor changeset committed.