### PR TITLE
fix(skills): force rewrite same-version installs

### DIFF
--- a/.changeset/skills-force-rewrite.md
+++ b/.changeset/skills-force-rewrite.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Make `force: true` rewrite same-version generated skills and bundles in addition to overwriting conflicting install directories.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -426,7 +426,7 @@ consuming package's `package.json` `version` is the typical pattern.
 | `scope`       | `"global" \| "project"`         | `"global"` | Install scope. When `process.cwd()` is the home directory, `"project"` normalizes to `"global"`.                                   |
 | `installMode` | `"auto" \| "symlink" \| "copy"` | `"auto"`   | Same semantics as `generateSkill()`. `"auto"` symlinks from the canonical store, falling back to copy.                             |
 | `clean`       | `boolean`                       | `true`     | Remove the existing skill directory before writing.                                                                                |
-| `force`       | `boolean`                       | `false`    | Overwrite a conflicting directory (no `crust.json`, kind mismatch, or malformed manifest) instead of throwing.                     |
+| `force`       | `boolean`                       | `false`    | Rewrite even when the recorded version is unchanged, and overwrite a conflicting directory instead of throwing.                     |
 
 Crust copies bundle files as raw bytes, so supporting assets such as images,
 fonts, or scripts round-trip unchanged. `SKILL.md` is also parsed as UTF-8 to

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -403,9 +403,10 @@ description: Build a sales funnel
 ```
 
 `version` is required and recorded in `crust.json`; identical-version
-reinstalls report `up-to-date` and skip the canonical-store rewrite, so
-pass a fresh value whenever bundle contents change. Wiring it to the
-consuming package's `package.json` `version` is the typical pattern.
+reinstalls report `up-to-date` and skip the canonical-store rewrite
+(unless `force: true` is passed), so pass a fresh value whenever bundle
+contents change. Wiring it to the consuming package's `package.json`
+`version` is the typical pattern.
 
 <Callout type="info" title="`metadata.version` in SKILL.md is not read">
   The Agent Skills spec lets bundle authors record a version under

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -332,7 +332,7 @@ const result = await generateSkill({
   scope: "project", // default: "global"
   installMode: "auto", // default: "auto" — symlink first, fallback to copy
   clean: true, // default: true — removes existing skill dir first
-  force: false, // default: false — rewrite same-version output and overwrite conflicts
+  force: false, // default: false — set true to rewrite same-version output or overwrite conflicts
 });
 
 // result.agents — per-agent install results
@@ -618,8 +618,9 @@ UTF-8 to read its required frontmatter.
 
 Bundle content changes do not propagate without a `version` bump:
 identical-version reinstalls report `up-to-date` and leave the canonical
-store untouched. Pass a fresh `version` (typically wired to the consuming
-package's `package.json` `version`) whenever the bundle contents change.
+store untouched, unless `force: true` is passed. Pass a fresh `version`
+(typically wired to the consuming package's `package.json` `version`)
+whenever the bundle contents change.
 
 Bundle contents are copied as authored — no implicit name-based filtering.
 Dotfiles, `node_modules/`, `.DS_Store`, and editor cruft are all copied if

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -332,7 +332,7 @@ const result = await generateSkill({
   scope: "project", // default: "global"
   installMode: "auto", // default: "auto" — symlink first, fallback to copy
   clean: true, // default: true — removes existing skill dir first
-  force: false, // default: false — throws SkillConflictError if dir exists without crust.json
+  force: false, // default: false — rewrite same-version output and overwrite conflicts
 });
 
 // result.agents — per-agent install results
@@ -607,7 +607,7 @@ await installSkillBundle({
 | `scope`       | `"global" \| "project"`             | `"global"`  | Install scope. When `process.cwd()` is the home directory, `"project"` normalizes to `"global"`.                  |
 | `installMode` | `"auto" \| "symlink" \| "copy"`     | `"auto"`    | Same semantics as `generateSkill()`. `"auto"` symlinks from the canonical store, falling back to copy.            |
 | `clean`       | `boolean`                           | `true`      | Remove the existing skill directory before writing.                                                               |
-| `force`       | `boolean`                           | `false`     | Overwrite a conflicting directory (no `crust.json`, kind mismatch, or malformed manifest) instead of throwing.    |
+| `force`       | `boolean`                           | `false`     | Rewrite even when the recorded version is unchanged, and overwrite a conflicting directory instead of throwing.    |
 
 ### What gets copied
 

--- a/packages/skills/src/bundle.test.ts
+++ b/packages/skills/src/bundle.test.ts
@@ -426,6 +426,56 @@ describe("installSkillBundle", () => {
 		expect(agent.status).toBe("up-to-date");
 	});
 
+	it("force: true rewrites same-version bundle content", async () => {
+		const firstSource = join(tmpDir, "first-bundle");
+		const secondSource = join(tmpDir, "second-bundle");
+		await mkdir(firstSource, { recursive: true });
+		await mkdir(secondSource, { recursive: true });
+		await writeFile(
+			join(firstSource, "SKILL.md"),
+			"---\nname: funnel-builder\ndescription: Initial bundle\n---\n\nInitial content\n",
+		);
+		await writeFile(
+			join(secondSource, "SKILL.md"),
+			"---\nname: funnel-builder\ndescription: Forced bundle\n---\n\nForced content\n",
+		);
+
+		await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: firstSource,
+				agents: ["claude-code"],
+				scope: "project",
+				version: BUNDLE_VERSION,
+				installMode: "copy",
+			}),
+		);
+
+		const skillPath = join(
+			tmpDir,
+			".claude",
+			"skills",
+			"funnel-builder",
+			"SKILL.md",
+		);
+		expect(await readFile(skillPath, "utf-8")).toContain("Initial content");
+
+		const result = await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: secondSource,
+				agents: ["claude-code"],
+				scope: "project",
+				version: BUNDLE_VERSION,
+				force: true,
+				installMode: "copy",
+			}),
+		);
+
+		const agent = result.agents[0] as AgentResult;
+		expect(agent.status).toBe("updated");
+		expect(agent.previousVersion).toBe(BUNDLE_VERSION);
+		expect(await readFile(skillPath, "utf-8")).toContain("Forced content");
+	});
+
 	it("agents: [] validates the bundle before returning", async () => {
 		const dir = join(tmpDir, "missing-skill-md");
 		await mkdir(dir, { recursive: true });

--- a/packages/skills/src/bundle.test.ts
+++ b/packages/skills/src/bundle.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	lstat,
 	mkdir,
 	readdir,
 	readFile,
@@ -457,6 +458,13 @@ describe("installSkillBundle", () => {
 			"funnel-builder",
 			"SKILL.md",
 		);
+		const canonicalPath = join(
+			tmpDir,
+			".crust",
+			"skills",
+			"funnel-builder",
+			"SKILL.md",
+		);
 		expect(await readFile(skillPath, "utf-8")).toContain("Initial content");
 
 		const result = await withCwd(tmpDir, () =>
@@ -473,7 +481,67 @@ describe("installSkillBundle", () => {
 		const agent = result.agents[0] as AgentResult;
 		expect(agent.status).toBe("updated");
 		expect(agent.previousVersion).toBe(BUNDLE_VERSION);
-		expect(await readFile(skillPath, "utf-8")).toContain("Forced content");
+
+		const agentContent = await readFile(skillPath, "utf-8");
+		expect(agentContent).toContain("Forced content");
+		expect(agentContent).not.toContain("Initial content");
+
+		const canonicalContent = await readFile(canonicalPath, "utf-8");
+		expect(canonicalContent).toContain("Forced content");
+		expect(canonicalContent).not.toContain("Initial content");
+	});
+
+	it("force: true rewrites same-version bundle content in symlink mode", async () => {
+		if (process.platform === "win32") {
+			return;
+		}
+
+		const firstSource = join(tmpDir, "first-symlink-bundle");
+		const secondSource = join(tmpDir, "second-symlink-bundle");
+		await mkdir(firstSource, { recursive: true });
+		await mkdir(secondSource, { recursive: true });
+		await writeFile(
+			join(firstSource, "SKILL.md"),
+			"---\nname: funnel-builder\ndescription: Initial bundle\n---\n\nInitial content\n",
+		);
+		await writeFile(
+			join(secondSource, "SKILL.md"),
+			"---\nname: funnel-builder\ndescription: Forced bundle\n---\n\nForced content\n",
+		);
+
+		const first = await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: firstSource,
+				agents: ["claude-code"],
+				scope: "project",
+				version: BUNDLE_VERSION,
+				installMode: "symlink",
+			}),
+		);
+		const outputDir = (first.agents[0] as AgentResult).outputDir;
+		expect((await lstat(outputDir)).isSymbolicLink()).toBe(true);
+
+		const skillPath = join(outputDir, "SKILL.md");
+		expect(await readFile(skillPath, "utf-8")).toContain("Initial content");
+
+		const result = await withCwd(tmpDir, () =>
+			installSkillBundle({
+				sourceDir: secondSource,
+				agents: ["claude-code"],
+				scope: "project",
+				version: BUNDLE_VERSION,
+				force: true,
+				installMode: "symlink",
+			}),
+		);
+
+		const agent = result.agents[0] as AgentResult;
+		expect(agent.status).toBe("updated");
+		expect(agent.previousVersion).toBe(BUNDLE_VERSION);
+
+		const forcedContent = await readFile(skillPath, "utf-8");
+		expect(forcedContent).toContain("Forced content");
+		expect(forcedContent).not.toContain("Initial content");
 	});
 
 	it("agents: [] validates the bundle before returning", async () => {

--- a/packages/skills/src/bundle.ts
+++ b/packages/skills/src/bundle.ts
@@ -338,13 +338,15 @@ export async function loadBundleFiles(
  * consuming package's `package.json` `version`.
  *
  * Bundles and generated skills cannot share a name unless the existing
- * install is removed first. To overwrite a kind-mismatched install, pass
- * `force: true`.
+ * install is removed first. `force: true` overwrites a conflicting install
+ * (no `crust.json`, malformed `crust.json`, or kind mismatch) and also
+ * rewrites a same-version bundle.
  *
  * @param options - Bundle install options (see {@link InstallSkillBundleOptions})
  * @returns Per-agent install results
- * @throws {SkillConflictError} If the canonical store exists with a different
- *   kind or with no `crust.json` (and `force` is not set).
+ * @throws {SkillConflictError} If the canonical store exists with no
+ *   `crust.json`, a malformed `crust.json`, or a different kind (and `force`
+ *   is not set).
  * @throws {Error} If `SKILL.md` is missing, its frontmatter lacks `name:` or
  *   `description:`, the declared `name` is not a valid skill name, the
  *   declared `name` does not match `expectedName` when set, the source

--- a/packages/skills/src/errors.ts
+++ b/packages/skills/src/errors.ts
@@ -69,13 +69,15 @@ export interface SkillConflictDetails {
  * Thrown when an install entrypoint detects that the target skill directory
  * already exists but cannot be overwritten safely.
  *
- * Two flavours:
+ * Three flavours:
  * - **No `crust.json`** — directory exists but was not created by Crust.
  *   This prevents Crust from silently overwriting a skill that was manually
  *   created or installed by another tool.
+ * - **Malformed `crust.json`** — directory is Crust-owned but its manifest
+ *   cannot be interpreted (see {@link SkillConflictDetails.manifestMalformed}).
  * - **Kind mismatch** — directory was created by Crust but with a different
  *   {@link SkillKind} (e.g. an existing `generated` skill collides with an
- *   incoming `bundle` install). `force: true` bypasses both cases.
+ *   incoming `bundle` install). `force: true` bypasses all three cases.
  *
  * @example
  * ```ts

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -650,6 +650,90 @@ describe("generateSkill", () => {
 			expect((result.agents[0] as AgentResult).files.length).toBeGreaterThan(0);
 		});
 
+		it("force: true rewrites same-version generated content", async () => {
+			await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Initial description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					installMode: "copy",
+				}),
+			);
+
+			const skillPath = join(tmpDir, ".claude", "skills", "my-cli", "SKILL.md");
+			expect(await readText(skillPath)).toContain("Initial description");
+
+			const result = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Forced description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					force: true,
+					installMode: "copy",
+				}),
+			);
+
+			expect((result.agents[0] as AgentResult).status).toBe("updated");
+			expect((result.agents[0] as AgentResult).previousVersion).toBe("1.0.0");
+			expect((result.agents[0] as AgentResult).files.length).toBeGreaterThan(0);
+			expect(await readText(skillPath)).toContain("Forced description");
+		});
+
+		it("force: true rewrites same-version canonical content in symlink mode", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const first = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Initial description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					installMode: "symlink",
+				}),
+			);
+			const outputDir = (first.agents[0] as AgentResult).outputDir;
+			expect((await lstat(outputDir)).isSymbolicLink()).toBe(true);
+
+			const skillPath = join(outputDir, "SKILL.md");
+			expect(await readText(skillPath)).toContain("Initial description");
+
+			const result = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Forced description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					force: true,
+					installMode: "symlink",
+				}),
+			);
+
+			expect((result.agents[0] as AgentResult).status).toBe("updated");
+			expect((result.agents[0] as AgentResult).previousVersion).toBe("1.0.0");
+			expect((result.agents[0] as AgentResult).files.length).toBeGreaterThan(0);
+			expect(await readText(skillPath)).toContain("Forced description");
+		});
+
 		it("returns installed status for fresh install", async () => {
 			const result = await withCwd(tmpDir, () =>
 				generateSkill({

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -686,7 +686,9 @@ describe("generateSkill", () => {
 			expect((result.agents[0] as AgentResult).status).toBe("updated");
 			expect((result.agents[0] as AgentResult).previousVersion).toBe("1.0.0");
 			expect((result.agents[0] as AgentResult).files.length).toBeGreaterThan(0);
-			expect(await readText(skillPath)).toContain("Forced description");
+			const forced = await readText(skillPath);
+			expect(forced).toContain("Forced description");
+			expect(forced).not.toContain("Initial description");
 		});
 
 		it("force: true rewrites same-version canonical content in symlink mode", async () => {
@@ -731,7 +733,108 @@ describe("generateSkill", () => {
 			expect((result.agents[0] as AgentResult).status).toBe("updated");
 			expect((result.agents[0] as AgentResult).previousVersion).toBe("1.0.0");
 			expect((result.agents[0] as AgentResult).files.length).toBeGreaterThan(0);
-			expect(await readText(skillPath)).toContain("Forced description");
+			const forced = await readText(skillPath);
+			expect(forced).toContain("Forced description");
+			expect(forced).not.toContain("Initial description");
+		});
+
+		it("force: true rewrites same-version content while preserving extra files when clean is false", async () => {
+			const first = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Initial description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					installMode: "copy",
+				}),
+			);
+
+			const outputDir = (first.agents[0] as AgentResult).outputDir;
+			const extraFile = join(outputDir, "extra.txt");
+			await writeFile(extraFile, "extra content", "utf-8");
+
+			const skillPath = join(outputDir, "SKILL.md");
+			expect(await readText(skillPath)).toContain("Initial description");
+
+			const result = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Forced description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code"],
+					scope: "project",
+					force: true,
+					clean: false,
+					installMode: "copy",
+				}),
+			);
+
+			expect((result.agents[0] as AgentResult).status).toBe("updated");
+			const forced = await readText(skillPath);
+			expect(forced).toContain("Forced description");
+			expect(forced).not.toContain("Initial description");
+			expect(await listFiles(outputDir)).toContain("extra.txt");
+		});
+
+		it("force: true rewrites a stale agent copy when another agent is fresh", async () => {
+			const first = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Initial description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code", "opencode"],
+					scope: "project",
+					installMode: "copy",
+				}),
+			);
+
+			const claudeSkill = join(
+				(first.agents[0] as AgentResult).outputDir,
+				"SKILL.md",
+			);
+			const opencodeSkill = join(
+				(first.agents[1] as AgentResult).outputDir,
+				"SKILL.md",
+			);
+
+			// Manually corrupt one agent copy to simulate partial staleness.
+			await writeFile(opencodeSkill, "manually edited\n", "utf-8");
+
+			const result = await withCwd(tmpDir, () =>
+				generateSkill({
+					command: simpleCommand(),
+					meta: {
+						name: "my-cli",
+						description: "Forced description",
+						version: "1.0.0",
+					},
+					agents: ["claude-code", "opencode"],
+					scope: "project",
+					force: true,
+					installMode: "copy",
+				}),
+			);
+
+			expect((result.agents[0] as AgentResult).status).toBe("updated");
+			expect((result.agents[1] as AgentResult).status).toBe("updated");
+
+			const claudeContent = await readText(claudeSkill);
+			expect(claudeContent).toContain("Forced description");
+			expect(claudeContent).not.toContain("Initial description");
+
+			const opencodeContent = await readText(opencodeSkill);
+			expect(opencodeContent).toContain("Forced description");
+			expect(opencodeContent).not.toContain("manually edited");
 		});
 
 		it("returns installed status for fresh install", async () => {

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -380,7 +380,7 @@ async function installRenderedSkill(
 	const canonicalKindChanged =
 		canonicalManifest !== null && canonicalManifest.kind !== kind;
 	const canonicalChanged =
-		canonicalVersion !== meta.version || canonicalKindChanged;
+		force || canonicalVersion !== meta.version || canonicalKindChanged;
 	if (canonicalChanged) {
 		if (clean) {
 			await cleanDirectory(canonicalOutputDir);
@@ -451,6 +451,7 @@ async function installRenderedSkill(
 			inspection: state.current.inspection,
 			installedVersion: state.preferredVersion,
 			currentVersion: meta.version,
+			force,
 			// Per-output-path kind. Compared with the target `kind` so a
 			// `force` kind switch at the same version still rewrites copy-mode
 			// agent paths (the version-only `needsWrite` check would otherwise
@@ -696,6 +697,7 @@ interface EnsureAgentInstallPathOptions {
 	readonly inspection: InstallPathInspection;
 	readonly installedVersion: string | null;
 	readonly currentVersion: string;
+	readonly force: boolean;
 	readonly installedKind: SkillKind | null;
 	readonly currentKind: SkillKind;
 }
@@ -760,6 +762,7 @@ async function ensureAgentInstallPath(
 		inspection,
 		installedVersion,
 		currentVersion,
+		force,
 		installedKind,
 		currentKind,
 	} = options;
@@ -772,6 +775,7 @@ async function ensureAgentInstallPath(
 			inspection,
 			installedVersion,
 			currentVersion,
+			force,
 			installedKind,
 			currentKind,
 		});
@@ -803,6 +807,7 @@ async function ensureAgentInstallPath(
 			inspection: fallbackInspection,
 			installedVersion,
 			currentVersion,
+			force,
 			installedKind,
 			currentKind,
 		});
@@ -816,6 +821,7 @@ interface EnsureCopyInstallPathOptions {
 	readonly inspection: InstallPathInspection;
 	readonly installedVersion: string | null;
 	readonly currentVersion: string;
+	readonly force: boolean;
 	readonly installedKind: SkillKind | null;
 	readonly currentKind: SkillKind;
 }
@@ -830,6 +836,7 @@ async function ensureCopyInstallPath(
 		inspection,
 		installedVersion,
 		currentVersion,
+		force,
 		installedKind,
 		currentKind,
 	} = options;
@@ -842,6 +849,7 @@ async function ensureCopyInstallPath(
 	// agent fresh while another is stale — are repaired on the next `force`.
 	const kindChanged = installedKind !== null && installedKind !== currentKind;
 	const needsWrite =
+		force ||
 		!inspection.exists ||
 		inspection.isSymlink ||
 		installedVersion !== currentVersion ||

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -158,7 +158,7 @@ function resolveLegacySkillName(name: string): string {
  *
  * @param options - Generation options including command, metadata, agents, and scope
  * @returns Per-agent installation results
- * @throws {SkillConflictError} If the output directory exists but was not created by Crust
+ * @throws {SkillConflictError} If the output directory conflicts (no `crust.json`, malformed `crust.json`, or kind mismatch) and `force` is not set
  *
  * @example
  * ```ts

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -416,8 +416,8 @@ export interface InstallSkillBundleOptions {
 	 * Required. Typically wired to the consuming package's `package.json`
 	 * `version` (e.g. via `import pkg from "./package.json" with { type:
 	 * "json" }`). Identical-version reinstalls report `up-to-date` and skip
-	 * the canonical-store rewrite, so bump this whenever bundle contents
-	 * change.
+	 * the canonical-store rewrite (unless `force: true` is passed), so bump
+	 * this whenever bundle contents change.
 	 */
 	version: string;
 	/**

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -340,9 +340,10 @@ export interface GenerateOptions {
 	 */
 	clean?: boolean;
 	/**
-	 * When `true`, overwrite an existing skill directory even if it was not
-	 * created by Crust (i.e. has no `crust.json`). Without this flag, a
-	 * conflict throws a {@link SkillConflictError}.
+	 * When `true`, rewrite the generated skill even when the recorded version is
+	 * unchanged, and overwrite an existing conflicting directory (for example,
+	 * no `crust.json`, malformed `crust.json`, or a different skill kind)
+	 * instead of throwing {@link SkillConflictError}.
 	 * @default false
 	 */
 	force?: boolean;
@@ -435,8 +436,10 @@ export interface InstallSkillBundleOptions {
 	 */
 	clean?: boolean;
 	/**
-	 * When `true`, overwrite an existing skill directory even if it conflicts
-	 * (no `crust.json`, or a `crust.json` whose `kind` differs from `"bundle"`).
+	 * When `true`, rewrite the bundle even when the recorded version is
+	 * unchanged, and overwrite an existing conflicting directory (for example,
+	 * no `crust.json`, malformed `crust.json`, or a different skill kind)
+	 * instead of throwing {@link SkillConflictError}.
 	 * @default false
 	 */
 	force?: boolean;


### PR DESCRIPTION
## What changed

- Make `force: true` rewrite generated skills and bundled skills even when the recorded version is unchanged.
- Keep existing conflict-overwrite behavior for directories without valid Crust metadata or with mismatched skill kinds.
- Update `@crustjs/skills` docs and add a patch changeset.

## Why

`force` previously only bypassed conflict checks. Same-version installs still reported `up-to-date`, so changed generated or bundled skill content was not exported unless the caller bumped the recorded version.

## Affected areas

- `@crustjs/skills` generation/install behavior
- `generateSkill()` and `installSkillBundle()` `force` option docs

## Verification

- `bun test packages/skills/src/generate.test.ts packages/skills/src/bundle.test.ts`
- `bun run check:types`
- `bunx biome check packages/skills/src/generate.ts packages/skills/src/generate.test.ts packages/skills/src/bundle.test.ts packages/skills/src/types.ts packages/skills/README.md apps/docs/content/docs/modules/skills.mdx .changeset/skills-force-rewrite.md`

Note: `bun run check` currently fails on an unrelated pre-existing formatting issue in `.claude/settings.local.json`; the changed files pass Biome.