### PR TITLE
feat(prompts)!: injectable prompt IO and testing harness

### DIFF
--- a/.changeset/prompts-injectable-io.md
+++ b/.changeset/prompts-injectable-io.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/prompts": minor
+---
+
+Add injectable prompt IO through optional `io` parameters and `withPromptIO()`, plus `@crustjs/prompts/testing` helpers for fake TTY prompt tests.

--- a/apps/docs/content/docs/guide/development.mdx
+++ b/apps/docs/content/docs/guide/development.mdx
@@ -41,6 +41,27 @@ test("greets a name", async () => {
 await expect(app.run(["missing"])).rejects.toMatchObject({ code: "COMMAND_NOT_FOUND" });
 ```
 
+## Test custom prompts
+
+Prompt authors can drive `(options, io?)` prompt functions with fake TTY streams instead of patching process globals:
+
+```ts
+import { expect, test } from "bun:test";
+import { renderPrompt } from "@crustjs/prompts/testing";
+
+import { myPrompt } from "./my-prompt.ts";
+
+test("collects a name", async () => {
+  const prompt = renderPrompt(myPrompt, { message: "Name?" });
+  prompt.type("Ada");
+  prompt.keys("return");
+
+  expect(await prompt.answer).toBe("Ada");
+});
+```
+
+Use `prompt.screen()` to inspect the latest ANSI-stripped frame, or `createPromptIO({ isTTY: false })` to test a prompt's non-interactive fallback.
+
 ## Validate definitions
 
 ```sh

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -51,7 +51,7 @@ const addons = await multifilter({
 
 ## Injecting IO
 
-Every prompt accepts an optional second `io` argument. Prompt input and UI output resolve in this order: the explicit argument, the current `withPromptIO()` scope, then `process.stdin` and `process.stderr`. Prompt UI always writes to stderr.
+Every prompt accepts an optional second `io` argument. Prompt input and UI output resolve in this order: the explicit argument, the current `withPromptIO()` scope, then `process.stdin` and `process.stderr`. Prompt UI writes to the resolved output stream — stderr by default, keeping stdout clean for piped output.
 
 ```ts
 import { select, withPromptIO, type PromptIO } from "@crustjs/prompts";
@@ -381,7 +381,7 @@ if (edit) {
 
 `handleTextEdit` handles backspace, delete, left, right, home, end, and printable character insertion. It returns `null` for non-text-editing keys so you can handle them separately.
 
-Only one prompt can be active per input stream. Prompts on distinct input streams can run concurrently; a second prompt sharing an input stream rejects with an error.
+Only one prompt can be active per input or output stream. Prompts on fully distinct streams can run concurrently; a second prompt sharing an input or output stream rejects with an error.
 
 ## Exports
 
@@ -463,8 +463,8 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 
 Key design decisions:
 
-- **stderr rendering**: All prompt UI writes to stderr, keeping stdout clean for piped output.
+- **stderr rendering by default**: Prompt UI writes to the resolved output stream — `process.stderr` unless IO is injected — keeping stdout clean for piped output.
 - **`initial` escape hatch**: Every prompt accepts `initial` to skip interactivity in CI and scripted usage.
-- **Single active prompt per input stream**: Prompts on distinct input streams can run concurrently; concurrent calls sharing an input stream are rejected with a clear error.
+- **Single active prompt per stream**: Prompts on fully distinct input/output streams can run concurrently; concurrent calls sharing an input or output stream are rejected with a clear error.
 - **Composable themes**: Three-layer resolution with `StyleFn` slots from `@crustjs/style`.
 - **Shared text editing**: Common cursor-editing logic lives in `handleTextEdit` for consistency and reuse in custom prompts.

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -381,7 +381,7 @@ if (edit) {
 
 `handleTextEdit` handles backspace, delete, left, right, home, end, and printable character insertion. It returns `null` for non-text-editing keys so you can handle them separately.
 
-Only one prompt can be active at a time. Running a second prompt while one is already active rejects with an error.
+Only one prompt can be active per input stream. Prompts on distinct input streams can run concurrently; a second prompt sharing an input stream rejects with an error.
 
 ## Exports
 
@@ -465,6 +465,6 @@ Key design decisions:
 
 - **stderr rendering**: All prompt UI writes to stderr, keeping stdout clean for piped output.
 - **`initial` escape hatch**: Every prompt accepts `initial` to skip interactivity in CI and scripted usage.
-- **Single active prompt**: Only one prompt can run at a time; concurrent calls are rejected with a clear error.
+- **Single active prompt per input stream**: Prompts on distinct input streams can run concurrently; concurrent calls sharing an input stream are rejected with a clear error.
 - **Composable themes**: Three-layer resolution with `StyleFn` slots from `@crustjs/style`.
 - **Shared text editing**: Common cursor-editing logic lives in `handleTextEdit` for consistency and reuse in custom prompts.

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -49,9 +49,50 @@ const addons = await multifilter({
 });
 ```
 
+## Injecting IO
+
+Every prompt accepts an optional second `io` argument. Prompt input and UI output resolve in this order: the explicit argument, the current `withPromptIO()` scope, then `process.stdin` and `process.stderr`. Prompt UI always writes to stderr.
+
+```ts
+import { select, withPromptIO, type PromptIO } from "@crustjs/prompts";
+
+declare const io: PromptIO;
+
+const choice = await select({ message: "Pick one", choices: ["a", "b"] }, io);
+
+const scopedChoice = await withPromptIO(io, () =>
+  select({ message: "Pick one", choices: ["a", "b"] }),
+);
+```
+
+`io` is a `PromptIO` object with optional `input` and `output` streams. Omit it in normal CLI code.
+
+## Testing Custom Prompts
+
+Use the `@crustjs/prompts/testing` subpath to drive a prompt with fake TTY streams. `screen()` returns the latest ANSI-stripped terminal frame, while `answer` resolves after submission.
+
+```ts
+import { expect, test } from "bun:test";
+import { renderPrompt } from "@crustjs/prompts/testing";
+
+import { myPrompt } from "./my-prompt.ts";
+
+test("accepts a name", async () => {
+  const prompt = renderPrompt(myPrompt, { message: "Name?" });
+
+  prompt.type("Ada");
+  prompt.keys("return");
+
+  expect(prompt.screen()).toContain("Ada");
+  expect(await prompt.answer).toBe("Ada");
+});
+```
+
+Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks.
+
 ## Prompts
 
-### `input(options)`
+### `input(options, io?)`
 
 Single-line text input with cursor editing, placeholder, default value, and validation.
 
@@ -70,7 +111,7 @@ const name = await input({
 
 See [Validation](#validation) for the schema shape and typed return values.
 
-### `password(options)`
+### `password(options, io?)`
 
 Masked text input. Characters are displayed as the mask character, which defaults to `*`. After submission, a fixed-length mask is shown to avoid revealing password length.
 
@@ -120,7 +161,7 @@ const email = await input({ message: "Email?", validate: Email });
 //    ^? string
 ```
 
-### `confirm(options)`
+### `confirm(options, io?)`
 
 Yes/no boolean prompt. Toggle with arrow keys, `h`/`l`, `y`/`n`, or Tab. Confirm with Enter.
 
@@ -138,7 +179,7 @@ const proceed = await confirm({
   name="ConfirmOptions"
 />
 
-### `select(options)`
+### `select(options, io?)`
 
 Single selection from a list. Navigate with Up/Down or `k`/`j`, then confirm with Enter. Scrolls when the list exceeds `maxVisible`.
 
@@ -158,7 +199,7 @@ const port = await select({
   name="SelectOptions"
 />
 
-### `multiselect(options)`
+### `multiselect(options, io?)`
 
 Checkbox-style multi-selection. Use Space to toggle, `a` to toggle all, `i` to invert, and Enter to confirm.
 
@@ -183,7 +224,7 @@ const features = await multiselect({
   name="MultiselectOptions"
 />
 
-### `filter(options)`
+### `filter(options, io?)`
 
 Fuzzy-search selection. Type to filter, navigate with Up/Down, and confirm with Enter. Matched characters are highlighted in results.
 
@@ -202,7 +243,7 @@ const lang = await filter({
   name="FilterOptions"
 />
 
-### `multifilter(options)`
+### `multifilter(options, io?)`
 
 Fuzzy-search multi-selection. Type to filter, navigate with Up/Down, use Space to toggle the highlighted result, and confirm with Enter. Selected values are returned in original choice order.
 
@@ -299,7 +340,7 @@ For non-interactive async progress output, use [`@crustjs/progress`](/docs/modul
 
 ## Custom Prompts
 
-The low-level `runPrompt` API lets you build custom interactive prompts with full control over state, rendering, and keypress handling.
+The low-level `runPrompt(config, io?)` API lets you build custom interactive prompts with full control over state, rendering, and keypress handling.
 
 ```ts
 import { runPrompt, submit } from "@crustjs/prompts";
@@ -367,12 +408,14 @@ Only one prompt can be active at a time. Running a second prompt while one is al
 
 ### Renderer
 
-| Export                | Description                                       |
-| --------------------- | ------------------------------------------------- |
-| `runPrompt`           | Low-level prompt runner for custom prompts        |
-| `submit`              | Create a submit result to resolve a prompt        |
-| `assertTTY`           | Throw `NonInteractiveError` if stdin is not a TTY |
-| `NonInteractiveError` | Error thrown when a TTY is required but absent    |
+| Export                | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `runPrompt`           | Low-level prompt runner; accepts optional `PromptIO` |
+| `submit`              | Create a submit result to resolve a prompt           |
+| `assertTTY`           | Throw `NonInteractiveError` if stdin is not a TTY    |
+| `withPromptIO`        | Scope prompt IO for nested async prompt calls        |
+| `PromptIO`            | Optional input/output streams for prompts            |
+| `NonInteractiveError` | Error thrown when a TTY is required but absent       |
 
 Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` — check `err.name === "AbortError"`.
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -1,12 +1,46 @@
 # @crustjs/prompts
 
-Interactive terminal prompts for the Crust CLI ecosystem
+Interactive terminal prompts for the Crust CLI ecosystem.
 
 ## Install
 
 ```sh
 bun add @crustjs/prompts
 ```
+
+## Injectable IO
+
+All prompt functions accept an optional `io` argument with `input` and `output` streams. This keeps prompt UI on stderr while allowing applications and tests to provide their own streams.
+
+```ts
+import { input, withPromptIO, type PromptIO } from "@crustjs/prompts";
+
+declare const io: PromptIO;
+
+const name = await input({ message: "Name?" }, io);
+const scopedName = await withPromptIO(io, () => input({ message: "Name?" }));
+```
+
+## Testing Custom Prompts
+
+`@crustjs/prompts/testing` drives prompt functions against fake TTY streams:
+
+```ts
+import { expect, test } from "bun:test";
+import { renderPrompt } from "@crustjs/prompts/testing";
+
+import { myPrompt } from "./my-prompt.ts";
+
+test("submits a value", async () => {
+	const prompt = renderPrompt(myPrompt, { message: "Name?" });
+	prompt.type("Ada");
+	prompt.keys("return");
+
+	expect(await prompt.answer).toBe("Ada");
+});
+```
+
+Prompt functions passed to `renderPrompt` accept `(options, io?)`. Use `createPromptIO({ isTTY: false })` when testing non-interactive default fallbacks.
 
 ## Documentation
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -10,7 +10,7 @@ bun add @crustjs/prompts
 
 ## Injectable IO
 
-All prompt functions accept an optional `io` argument with `input` and `output` streams. This keeps prompt UI on stderr while allowing applications and tests to provide their own streams.
+All prompt functions accept an optional `io` argument with `input` and `output` streams. Prompt UI writes to the resolved output stream — stderr by default — while allowing applications and tests to provide their own streams.
 
 ```ts
 import { input, withPromptIO, type PromptIO } from "@crustjs/prompts";

--- a/packages/prompts/bunup.config.ts
+++ b/packages/prompts/bunup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/testing.ts"],
 	format: ["esm"],
 	target: "bun",
 	dts: true,

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -29,6 +29,10 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
+		},
+		"./testing": {
+			"types": "./dist/testing.d.ts",
+			"import": "./dist/testing.js"
 		}
 	},
 	"publishConfig": {

--- a/packages/prompts/src/core/renderer.test.ts
+++ b/packages/prompts/src/core/renderer.test.ts
@@ -226,6 +226,36 @@ describe("runPrompt", () => {
 		expect(output).toContain("prompt");
 	});
 
+	it("disables raw mode on a fake input without isRaw", async () => {
+		const input = new PassThrough() as PassThrough & {
+			isTTY: boolean;
+			setRawMode: (mode: boolean) => PassThrough;
+		};
+		input.isTTY = true;
+		const rawModes: boolean[] = [];
+		input.setRawMode = (mode) => {
+			rawModes.push(mode);
+			return input;
+		};
+		const output = new Writable({
+			write(_chunk, _encoding, callback) {
+				callback();
+			},
+		});
+		const config: PromptConfig<undefined, string> = {
+			render: () => "prompt",
+			handleKey: () => submit("done"),
+			initialState: undefined,
+			theme: defaultTheme,
+		};
+
+		const answer = runPrompt(config, { input, output });
+		input.write("x");
+
+		await answer;
+		expect(rawModes).toEqual([true, false]);
+	});
+
 	it("uses streams from withPromptIO", async () => {
 		const harness = createPromptIO();
 		const config: PromptConfig<{ value: string }, string> = {

--- a/packages/prompts/src/core/renderer.test.ts
+++ b/packages/prompts/src/core/renderer.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { PassThrough, Writable } from "node:stream";
 
+import { createPromptIO } from "../testing.ts";
 import {
 	assertTTY,
 	isTTY,
@@ -7,6 +9,7 @@ import {
 	type PromptConfig,
 	runPrompt,
 	submit,
+	withPromptIO,
 } from "./renderer.ts";
 import { defaultTheme } from "./theme.ts";
 
@@ -185,6 +188,92 @@ describe("runPrompt", () => {
 		process.stderr.write = originalStderrWrite;
 		// Remove any lingering keypress listeners added during tests
 		process.stdin.removeAllListeners("keypress");
+	});
+
+	it("uses supplied TTY streams instead of process globals", async () => {
+		const input = new PassThrough() as PassThrough & {
+			isTTY: boolean;
+			isRaw: boolean;
+			setRawMode: (mode: boolean) => PassThrough;
+		};
+		input.isTTY = true;
+		input.isRaw = false;
+		input.setRawMode = (mode) => {
+			input.isRaw = mode;
+			return input;
+		};
+
+		let output = "";
+		const stream = new Writable({
+			write(chunk, _encoding, callback) {
+				output += chunk.toString();
+				callback();
+			},
+		}) as Writable & { columns: number };
+		stream.columns = 80;
+
+		const config: PromptConfig<{ value: string }, string> = {
+			render: (state) => state.value,
+			handleKey: () => submit("done"),
+			initialState: { value: "prompt" },
+			theme: defaultTheme,
+		};
+
+		const answer = runPrompt(config, { input, output: stream });
+		input.write("x");
+
+		expect(await answer).toBe("done");
+		expect(output).toContain("prompt");
+	});
+
+	it("uses streams from withPromptIO", async () => {
+		const harness = createPromptIO();
+		const config: PromptConfig<{ value: string }, string> = {
+			render: (state) => state.value,
+			handleKey: () => submit("done"),
+			initialState: { value: "prompt" },
+			theme: defaultTheme,
+		};
+
+		const answer = withPromptIO(harness.io, () => runPrompt(config));
+		harness.type("x");
+
+		expect(await answer).toBe("done");
+		expect(harness.screen()).toContain("prompt");
+	});
+
+	it("permits concurrent prompts on distinct input streams", async () => {
+		const first = createPromptIO();
+		const second = createPromptIO();
+		const config: PromptConfig<undefined, string> = {
+			render: () => "prompt",
+			handleKey: () => submit("done"),
+			initialState: undefined,
+			theme: defaultTheme,
+		};
+
+		const firstAnswer = runPrompt(config, first.io);
+		const secondAnswer = runPrompt(config, second.io);
+		first.type("x");
+		second.type("x");
+
+		expect(await firstAnswer).toBe("done");
+		expect(await secondAnswer).toBe("done");
+	});
+
+	it("rejects concurrent prompts on the same input stream", async () => {
+		const harness = createPromptIO();
+		const config: PromptConfig<undefined, string> = {
+			render: () => "prompt",
+			handleKey: () => submit("done"),
+			initialState: undefined,
+			theme: defaultTheme,
+		};
+
+		const answer = runPrompt(config, harness.io);
+		await expect(runPrompt(config, harness.io)).rejects.toThrow("same input stream");
+		harness.type("x");
+		await answer;
 	});
 
 	it("rejects with NonInteractiveError when stdin is not a TTY", async () => {

--- a/packages/prompts/src/core/renderer.test.ts
+++ b/packages/prompts/src/core/renderer.test.ts
@@ -301,8 +301,26 @@ describe("runPrompt", () => {
 		};
 
 		const answer = runPrompt(config, harness.io);
-		await expect(runPrompt(config, harness.io)).rejects.toThrow("same input stream");
+		await expect(runPrompt(config, harness.io)).rejects.toThrow("same input or output stream");
 		harness.type("x");
+		await answer;
+	});
+
+	it("rejects concurrent prompts sharing an output stream", async () => {
+		const first = createPromptIO();
+		const second = createPromptIO();
+		const config: PromptConfig<undefined, string> = {
+			render: () => "prompt",
+			handleKey: () => submit("done"),
+			initialState: undefined,
+			theme: defaultTheme,
+		};
+
+		const answer = runPrompt(config, first.io);
+		await expect(
+			runPrompt(config, { input: second.io.input, output: first.io.output }),
+		).rejects.toThrow("same input or output stream");
+		first.type("x");
 		await answer;
 	});
 

--- a/packages/prompts/src/core/renderer.ts
+++ b/packages/prompts/src/core/renderer.ts
@@ -2,7 +2,9 @@
 // Renderer — Core terminal rendering engine for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as readline from "node:readline";
+import type { Readable, Writable } from "node:stream";
 
 import { visibleWidth } from "@crustjs/style";
 
@@ -11,6 +13,39 @@ import type { PromptTheme } from "./types.ts";
 // ────────────────────────────────────────────────────────────────────────────
 // Types
 // ────────────────────────────────────────────────────────────────────────────
+
+/** A readable stream that can drive an interactive terminal prompt. */
+export type PromptInput = Readable & {
+	readonly isTTY?: boolean;
+	readonly isRaw?: boolean;
+	setRawMode?: (mode: boolean) => unknown;
+};
+
+export type PromptOutput = Writable & {
+	readonly columns?: number;
+};
+
+/** Streams used to render and receive input for a prompt. */
+export interface PromptIO {
+	readonly input?: PromptInput;
+	readonly output?: PromptOutput;
+}
+
+const promptIOStorage = new AsyncLocalStorage<PromptIO>();
+
+/** Run a function with prompt streams available to prompts created in its async scope. */
+export function withPromptIO<T>(io: PromptIO, fn: () => T): T {
+	return promptIOStorage.run(io, fn);
+}
+
+/** Resolve explicit, ambient, then process-global prompt streams. */
+export function resolvePromptIO(io?: PromptIO): Required<PromptIO> {
+	const ambient = promptIOStorage.getStore();
+	return {
+		input: io?.input ?? ambient?.input ?? process.stdin,
+		output: io?.output ?? ambient?.output ?? process.stderr,
+	};
+}
 
 /**
  * Structured keypress event parsed from raw terminal input.
@@ -94,8 +129,8 @@ export interface PromptConfig<S, T> {
 // ANSI escape sequences
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Tracks whether a prompt is currently active to prevent concurrent prompts */
-let promptActive = false;
+/** Tracks active prompts so a stream can only drive one prompt at a time. */
+const activeInputs = new WeakSet<PromptInput>();
 
 const ESC = "\x1B[";
 const HIDE_CURSOR = `${ESC}?25l`;
@@ -149,17 +184,16 @@ export class NonInteractiveError extends Error {
  * Check whether stdin is an interactive TTY.
  * @returns `true` if stdin is a TTY, `false` otherwise
  */
-export function isTTY(): boolean {
-	// oxlint-disable-next-line typescript/no-unnecessary-type-conversion -- @types/node says boolean, but isTTY is undefined at runtime off-TTY; this API contract requires a real boolean
-	return !!process.stdin.isTTY;
+export function isTTY(input: Pick<PromptInput, "isTTY"> = process.stdin): boolean {
+	return !!input.isTTY;
 }
 
 /**
  * Check that stdin is an interactive TTY.
  * @throws {NonInteractiveError} when stdin is not a TTY
  */
-export function assertTTY(): void {
-	if (!isTTY()) {
+export function assertTTY(input: Pick<PromptInput, "isTTY"> = process.stdin): void {
+	if (!isTTY(input)) {
 		throw new NonInteractiveError();
 	}
 }
@@ -206,41 +240,38 @@ function isSubmit<S, T>(result: HandleKeyResult<S, T>): result is SubmitResult<T
  * });
  * ```
  */
-export function runPrompt<S, T>(config: PromptConfig<S, T>): Promise<T> {
+export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Promise<T> {
 	const { render, handleKey, initialState, theme, renderSubmitted } = config;
+	const { input: stdin, output } = resolvePromptIO(io);
 
 	return new Promise<T>((resolve, reject) => {
-		// Guard against concurrent prompts — only one prompt can be active at a time
-		if (promptActive) {
+		// Guard against concurrent prompts sharing an input stream.
+		if (activeInputs.has(stdin)) {
 			reject(
 				new Error(
-					"Cannot run multiple prompts concurrently. Await each prompt before starting the next.",
+					"Cannot run multiple prompts concurrently on the same input stream. Await each prompt before starting the next.",
 				),
 			);
 			return;
 		}
 
-		assertTTY();
-
-		promptActive = true;
+		assertTTY(stdin);
+		activeInputs.add(stdin);
 
 		let state = initialState;
 		let prevLineCount = 0;
 		let isCleanedUp = false;
 
-		const stdin = process.stdin;
-		const output = process.stderr;
-
 		// ── Cleanup helper ──────────────────────────────────────────────
 		function cleanup(): void {
 			if (isCleanedUp) return;
 			isCleanedUp = true;
-			promptActive = false;
+			activeInputs.delete(stdin);
 
 			stdin.removeListener("keypress", onKeypress);
 
 			if (stdin.isTTY && stdin.isRaw) {
-				stdin.setRawMode(false);
+				stdin.setRawMode?.(false);
 			}
 
 			stdin.pause();
@@ -364,7 +395,7 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>): Promise<T> {
 		// ── Initialize ──────────────────────────────────────────────────
 		try {
 			readline.emitKeypressEvents(stdin);
-			stdin.setRawMode(true);
+			stdin.setRawMode?.(true);
 			stdin.resume();
 			output.write(HIDE_CURSOR);
 

--- a/packages/prompts/src/core/renderer.ts
+++ b/packages/prompts/src/core/renderer.ts
@@ -131,6 +131,8 @@ export interface PromptConfig<S, T> {
 
 /** Tracks active prompts so a stream can only drive one prompt at a time. */
 const activeInputs = new WeakSet<PromptInput>();
+/** Tracks active outputs — concurrent frames on one stream would erase each other. */
+const activeOutputs = new WeakSet<PromptOutput>();
 
 const ESC = "\x1B[";
 const HIDE_CURSOR = `${ESC}?25l`;
@@ -246,10 +248,10 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 
 	return new Promise<T>((resolve, reject) => {
 		// Guard against concurrent prompts sharing an input stream.
-		if (activeInputs.has(stdin)) {
+		if (activeInputs.has(stdin) || activeOutputs.has(output)) {
 			reject(
 				new Error(
-					"Cannot run multiple prompts concurrently on the same input stream. Await each prompt before starting the next.",
+					"Cannot run multiple prompts concurrently on the same input or output stream. Await each prompt before starting the next.",
 				),
 			);
 			return;
@@ -257,6 +259,7 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 
 		assertTTY(stdin);
 		activeInputs.add(stdin);
+		activeOutputs.add(output);
 
 		let state = initialState;
 		let prevLineCount = 0;
@@ -268,6 +271,7 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 			if (isCleanedUp) return;
 			isCleanedUp = true;
 			activeInputs.delete(stdin);
+			activeOutputs.delete(output);
 
 			stdin.removeListener("keypress", onKeypress);
 

--- a/packages/prompts/src/core/renderer.ts
+++ b/packages/prompts/src/core/renderer.ts
@@ -261,6 +261,7 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 		let state = initialState;
 		let prevLineCount = 0;
 		let isCleanedUp = false;
+		let rawModeEnabled = false;
 
 		// ── Cleanup helper ──────────────────────────────────────────────
 		function cleanup(): void {
@@ -270,7 +271,7 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 
 			stdin.removeListener("keypress", onKeypress);
 
-			if (stdin.isTTY && stdin.isRaw) {
+			if (rawModeEnabled) {
 				stdin.setRawMode?.(false);
 			}
 
@@ -395,7 +396,10 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 		// ── Initialize ──────────────────────────────────────────────────
 		try {
 			readline.emitKeypressEvents(stdin);
-			stdin.setRawMode?.(true);
+			if (stdin.setRawMode) {
+				stdin.setRawMode(true);
+				rawModeEnabled = true;
+			}
 			stdin.resume();
 			output.write(HIDE_CURSOR);
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -24,9 +24,19 @@ export type {
 	HandleKeyResult,
 	KeypressEvent,
 	PromptConfig,
+	PromptIO,
+	PromptInput,
+	PromptOutput,
 	SubmitResult,
 } from "./core/renderer.ts";
-export { assertTTY, isTTY, NonInteractiveError, runPrompt, submit } from "./core/renderer.ts";
+export {
+	assertTTY,
+	isTTY,
+	NonInteractiveError,
+	runPrompt,
+	submit,
+	withPromptIO,
+} from "./core/renderer.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Prompts

--- a/packages/prompts/src/prompts/confirm.test.ts
+++ b/packages/prompts/src/prompts/confirm.test.ts
@@ -1,99 +1,51 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
-import { confirm } from "./confirm.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { confirm, type ConfirmOptions } from "./confirm.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start(options: ConfirmOptions): Promise<boolean> {
+	const prompt = renderPrompt<ConfirmOptions, boolean>(confirm, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
 // ────────────────────────────────────────────────────────────────────────────
 // Default value
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — default value", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("defaults to true when no default is specified", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		pressKey("", { name: "return" });
@@ -103,7 +55,7 @@ describe("confirm — default value", () => {
 	});
 
 	it("uses default: false when specified", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Continue?",
 			default: false,
 		});
@@ -116,7 +68,7 @@ describe("confirm — default value", () => {
 	});
 
 	it("uses default: true when specified", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Continue?",
 			default: true,
 		});
@@ -134,11 +86,8 @@ describe("confirm — default value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — toggle", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("left arrow toggles value", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		// Default is true, left should toggle to false
@@ -151,7 +100,7 @@ describe("confirm — toggle", () => {
 	});
 
 	it("right arrow toggles value", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		// Default is true, right should toggle to false
@@ -164,7 +113,7 @@ describe("confirm — toggle", () => {
 	});
 
 	it("tab toggles value", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		// Default is true, tab should toggle to false
@@ -177,7 +126,7 @@ describe("confirm — toggle", () => {
 	});
 
 	it("double toggle returns to original value", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		// Toggle twice — should be back to true
@@ -197,11 +146,8 @@ describe("confirm — toggle", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — shortcuts", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("y key sets value to true", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Continue?",
 			default: false,
 		});
@@ -216,7 +162,7 @@ describe("confirm — shortcuts", () => {
 	});
 
 	it("Y key sets value to true", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Continue?",
 			default: false,
 		});
@@ -231,7 +177,7 @@ describe("confirm — shortcuts", () => {
 	});
 
 	it("n key sets value to false", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		pressKey("n");
@@ -243,7 +189,7 @@ describe("confirm — shortcuts", () => {
 	});
 
 	it("N key sets value to false", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		pressKey("N", { name: "n", shift: true });
@@ -255,7 +201,7 @@ describe("confirm — shortcuts", () => {
 	});
 
 	it("h key sets value to true (yes/active)", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Continue?",
 			default: false,
 		});
@@ -270,7 +216,7 @@ describe("confirm — shortcuts", () => {
 	});
 
 	it("l key sets value to false (no/inactive)", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		pressKey("l", { name: "l" });
@@ -287,37 +233,34 @@ describe("confirm — shortcuts", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — custom labels", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders custom active and inactive labels", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Accept terms?",
 			active: "Agree",
 			inactive: "Decline",
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Agree");
-		expect(stderrOutput).toContain("Decline");
+		expect(screen()).toContain("Agree");
+		expect(screen()).toContain("Decline");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders default Yes/No labels when not customized", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
-		expect(stderrOutput).toContain("Yes");
-		expect(stderrOutput).toContain("No");
+		expect(screen()).toContain("Yes");
+		expect(screen()).toContain("No");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("shows selected custom label on submit", async () => {
-		const promise = confirm({
+		const promise = start({
 			message: "Accept?",
 			active: "Accept",
 			inactive: "Reject",
@@ -331,7 +274,7 @@ describe("confirm — custom labels", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Accept");
+		expect(screen()).toContain("Accept");
 	});
 });
 
@@ -340,31 +283,28 @@ describe("confirm — custom labels", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — rendering", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = confirm({ message: "Deploy to production?" });
+		const promise = start({ message: "Deploy to production?" });
 
 		await tick();
-		expect(stderrOutput).toContain("Deploy to production?");
+		expect(screen()).toContain("Deploy to production?");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders separator between options", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
-		expect(stderrOutput).toContain(" · ");
+		expect(screen()).toContain(" · ");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders submitted answer on confirm", async () => {
-		const promise = confirm({ message: "Continue?" });
+		const promise = start({ message: "Continue?" });
 
 		await tick();
 		pressKey("n");
@@ -373,7 +313,7 @@ describe("confirm — rendering", () => {
 
 		await promise;
 		// After submission, the selected answer should appear
-		expect(stderrOutput).toContain("No");
+		expect(screen()).toContain("No");
 	});
 });
 
@@ -382,17 +322,14 @@ describe("confirm — rendering", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = confirm({});
+		const promise = start({});
 
 		await tick();
-		expect(stderrOutput).toContain("Are you sure?");
-		expect(stderrOutput).not.toContain("undefined");
-		expect(stderrOutput).toContain("Yes");
-		expect(stderrOutput).toContain("No");
+		expect(screen()).toContain("Are you sure?");
+		expect(screen()).not.toContain("undefined");
+		expect(screen()).toContain("Yes");
+		expect(screen()).toContain("No");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -400,14 +337,14 @@ describe("confirm — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = confirm({});
+		const promise = start({});
 
 		await tick();
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Are you sure?");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Are you sure?");
+		expect(screen()).not.toContain("undefined");
 	});
 });
 
@@ -416,27 +353,16 @@ describe("confirm — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("confirm — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY(options: ConfirmOptions): Promise<boolean> {
+		return confirm(options, nonTTYIO());
+	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(confirm({ message: "Continue?" })).rejects.toThrow("interactive terminal");
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await confirm({
+		const result = await nonTTY({
 			message: "Continue?",
 			initial: false,
 		});
@@ -445,13 +371,7 @@ describe("confirm — non-TTY", () => {
 	});
 
 	it("returns explicit default value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await confirm({
+		const result = await nonTTY({
 			message: "Continue?",
 			default: false,
 		});
@@ -460,13 +380,7 @@ describe("confirm — non-TTY", () => {
 	});
 
 	it("returns explicit default true in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await confirm({
+		const result = await nonTTY({
 			message: "Continue?",
 			default: true,
 		});
@@ -475,23 +389,11 @@ describe("confirm — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no explicit default in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(confirm({ message: "Continue?" })).rejects.toThrow("interactive terminal");
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await confirm({
+		const result = await nonTTY({
 			message: "Continue?",
 			initial: true,
 			default: false,

--- a/packages/prompts/src/prompts/confirm.test.ts
+++ b/packages/prompts/src/prompts/confirm.test.ts
@@ -358,7 +358,7 @@ describe("confirm — non-TTY", () => {
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		await expect(confirm({ message: "Continue?" })).rejects.toThrow("interactive terminal");
+		await expect(nonTTY({ message: "Continue?" })).rejects.toThrow("interactive terminal");
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
@@ -389,7 +389,7 @@ describe("confirm — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no explicit default in non-TTY", async () => {
-		await expect(confirm({ message: "Continue?" })).rejects.toThrow("interactive terminal");
+		await expect(nonTTY({ message: "Continue?" })).rejects.toThrow("interactive terminal");
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {

--- a/packages/prompts/src/prompts/confirm.ts
+++ b/packages/prompts/src/prompts/confirm.ts
@@ -2,8 +2,8 @@
 // Confirm — Yes/no boolean confirmation prompt for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { resolveTheme } from "../core/theme.ts";
 import type { PartialPromptTheme, PromptTheme } from "../core/types.ts";
@@ -182,15 +182,17 @@ function renderSubmitted(
  * });
  * ```
  */
-export async function confirm(options: ConfirmOptions): Promise<boolean> {
+export async function confirm(options: ConfirmOptions, io?: PromptIO): Promise<boolean> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return options.initial;
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	// Non-interactive fallback: return default value when stdin is not a TTY
 	// Only triggers when user explicitly passed `default` (not the internal default of `true`)
-	if (!isTTY() && options.default !== undefined) {
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		return options.default;
 	}
 
@@ -203,12 +205,15 @@ export async function confirm(options: ConfirmOptions): Promise<boolean> {
 		value: defaultValue,
 	};
 
-	return runPrompt<ConfirmState, boolean>({
-		initialState,
-		theme,
-		render: (state, t) => renderConfirm(state, t, options.message, activeLabel, inactiveLabel),
-		handleKey,
-		renderSubmitted: (state, value, t) =>
-			renderSubmitted(state, value, t, options.message, activeLabel, inactiveLabel),
-	});
+	return runPrompt<ConfirmState, boolean>(
+		{
+			initialState,
+			theme,
+			render: (state, t) => renderConfirm(state, t, options.message, activeLabel, inactiveLabel),
+			handleKey,
+			renderSubmitted: (state, value, t) =>
+				renderSubmitted(state, value, t, options.message, activeLabel, inactiveLabel),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/filter.test.ts
+++ b/packages/prompts/src/prompts/filter.test.ts
@@ -1,89 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
-import { filter } from "./filter.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { filter, type FilterOptions } from "./filter.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start<T>(options: FilterOptions<T>): Promise<T> {
+	const prompt = renderPrompt<FilterOptions<T>, T>(filter, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
 // ────────────────────────────────────────────────────────────────────────────
 // Initial value — object-choice numeric value
 // ────────────────────────────────────────────────────────────────────────────
@@ -110,11 +65,8 @@ describe("filter — initial value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — default value", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("sets initial cursor to matching default value", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 			default: "Rust",
@@ -129,7 +81,7 @@ describe("filter — default value", () => {
 	});
 
 	it("defaults cursor to first item when no default is provided", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 		});
@@ -142,7 +94,7 @@ describe("filter — default value", () => {
 	});
 
 	it("defaults cursor to first item when default value is not found", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 			default: "Python",
@@ -161,26 +113,23 @@ describe("filter — default value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — typing filters the list", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("empty query shows all items", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("TypeScript");
-		expect(stderrOutput).toContain("JavaScript");
-		expect(stderrOutput).toContain("Rust");
+		expect(screen()).toContain("TypeScript");
+		expect(screen()).toContain("JavaScript");
+		expect(screen()).toContain("Rust");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("typing a character filters the results", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust", "Python", "Go"],
 		});
@@ -193,7 +142,7 @@ describe("filter — typing filters the list", () => {
 		await tick();
 
 		// "Python" should be visible, "Go" should not
-		expect(stderrOutput).toContain("Python");
+		expect(screen()).toContain("Python");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -201,7 +150,7 @@ describe("filter — typing filters the list", () => {
 	});
 
 	it("backspace removes filter character and re-filters", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 		});
@@ -224,7 +173,7 @@ describe("filter — typing filters the list", () => {
 	});
 
 	it("shows 'No matches' when nothing matches the query", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript", "JavaScript", "Rust"],
 		});
@@ -238,7 +187,7 @@ describe("filter — typing filters the list", () => {
 		pressKey("z", { name: "z" });
 		await tick();
 
-		expect(stderrOutput).toContain("No matches");
+		expect(screen()).toContain("No matches");
 
 		// Backspace to clear and get matches again, then submit
 		pressKey("", { name: "backspace" });
@@ -257,11 +206,8 @@ describe("filter — typing filters the list", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — navigation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("down arrow moves to next result", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -276,7 +222,7 @@ describe("filter — navigation", () => {
 	});
 
 	it("up arrow moves to previous result", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -295,7 +241,7 @@ describe("filter — navigation", () => {
 	});
 
 	it("wraps to last item when moving up from first", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -310,7 +256,7 @@ describe("filter — navigation", () => {
 	});
 
 	it("wraps to first item when moving down from last", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -330,7 +276,7 @@ describe("filter — navigation", () => {
 	});
 
 	it("Enter selects the highlighted result", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -347,7 +293,7 @@ describe("filter — navigation", () => {
 	});
 
 	it("ignores navigation when no results", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta"],
 		});
@@ -384,11 +330,8 @@ describe("filter — navigation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — query editing", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("left/right arrow moves cursor in query", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["abc", "xyz"],
 		});
@@ -413,7 +356,7 @@ describe("filter — query editing", () => {
 	});
 
 	it("delete key removes character at cursor", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["ab", "cd"],
 		});
@@ -442,7 +385,7 @@ describe("filter — query editing", () => {
 	});
 
 	it("home/end keys move cursor to start/end", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["xab", "other"],
 		});
@@ -471,66 +414,63 @@ describe("filter — query editing", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — rendering", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Find a language",
 			choices: ["TypeScript", "JavaScript"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Find a language");
+		expect(screen()).toContain("Find a language");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders placeholder when query is empty", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["TypeScript"],
 			placeholder: "Type to filter...",
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Type to filter...");
+		expect(screen()).toContain("Type to filter...");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders all choices initially", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("alpha");
-		expect(stderrOutput).toContain("beta");
-		expect(stderrOutput).toContain("gamma");
+		expect(screen()).toContain("alpha");
+		expect(screen()).toContain("beta");
+		expect(screen()).toContain("gamma");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders cursor indicator on active result", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("›");
+		expect(screen()).toContain("›");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders submitted answer on confirm", async () => {
-		const promise = filter({
+		const promise = start({
 			message: "Pick a fruit",
 			choices: ["apple", "banana", "cherry"],
 		});
@@ -541,11 +481,11 @@ describe("filter — rendering", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("banana");
+		expect(screen()).toContain("banana");
 	});
 
 	it("renders labels for object choices", async () => {
-		const promise = filter<number>({
+		const promise = start({
 			message: "Pick",
 			choices: [
 				{ label: "Option A", value: 1 },
@@ -554,8 +494,8 @@ describe("filter — rendering", () => {
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Option A");
-		expect(stderrOutput).toContain("Option B");
+		expect(screen()).toContain("Option A");
+		expect(screen()).toContain("Option B");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -567,12 +507,9 @@ describe("filter — rendering", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — viewport scrolling", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("limits visible results to maxVisible", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices,
 			maxVisible: 5,
@@ -580,9 +517,9 @@ describe("filter — viewport scrolling", () => {
 
 		await tick();
 		// Only first 5 items should be visible
-		expect(stderrOutput).toContain("item-0");
-		expect(stderrOutput).toContain("item-4");
-		expect(stderrOutput).not.toContain("item-5");
+		expect(screen()).toContain("item-0");
+		expect(screen()).toContain("item-4");
+		expect(screen()).not.toContain("item-5");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -590,14 +527,14 @@ describe("filter — viewport scrolling", () => {
 
 	it("shows scroll indicator when more items below", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices,
 			maxVisible: 5,
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("...");
+		expect(screen()).toContain("...");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -605,7 +542,7 @@ describe("filter — viewport scrolling", () => {
 
 	it("scrolls down when navigating past visible items", async () => {
 		const choices = Array.from({ length: 10 }, (_, i) => `item-${i}`);
-		const promise = filter({
+		const promise = start({
 			message: "Search",
 			choices,
 			maxVisible: 3,
@@ -621,7 +558,7 @@ describe("filter — viewport scrolling", () => {
 		await tick();
 
 		// item-3 should now be visible
-		expect(stderrOutput).toContain("item-3");
+		expect(screen()).toContain("item-3");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -634,18 +571,15 @@ describe("filter — viewport scrolling", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = filter({
+		const promise = start({
 			choices: ["apple", "banana", "cherry"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Search and select");
-		expect(stderrOutput).not.toContain("undefined");
-		expect(stderrOutput).toContain("apple");
+		expect(screen()).toContain("Search and select");
+		expect(screen()).not.toContain("undefined");
+		expect(screen()).toContain("apple");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -653,7 +587,7 @@ describe("filter — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = filter({
+		const promise = start({
 			choices: ["apple", "banana", "cherry"],
 		});
 
@@ -661,8 +595,8 @@ describe("filter — no message", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Search and select");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Search and select");
+		expect(screen()).not.toContain("undefined");
 	});
 });
 
@@ -671,18 +605,13 @@ describe("filter — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("filter — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY<T>(options: FilterOptions<T>): Promise<T> {
+		return filter(options, nonTTYIO());
+	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			filter({
+			nonTTY({
 				message: "Search",
 				choices: ["a", "b", "c"],
 			}),
@@ -690,13 +619,7 @@ describe("filter — non-TTY", () => {
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await filter({
+		const result = await nonTTY({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			initial: "b",
@@ -706,13 +629,7 @@ describe("filter — non-TTY", () => {
 	});
 
 	it("returns default value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await filter({
+		const result = await nonTTY({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			default: "b",
@@ -722,14 +639,8 @@ describe("filter — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no default or initial in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			filter({
+			nonTTY({
 				message: "Search",
 				choices: ["a", "b", "c"],
 			}),
@@ -737,13 +648,7 @@ describe("filter — non-TTY", () => {
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await filter({
+		const result = await nonTTY({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			initial: "a",

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -4,8 +4,8 @@
 
 import type { FuzzyFilterResult } from "../core/fuzzy.ts";
 import { fuzzyFilter, highlightMatches, refilter } from "../core/fuzzy.ts";
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import {
 	CURSOR_INDICATOR,
 	PREFIX_SUBMITTED,
@@ -273,14 +273,16 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-export async function filter<T>(options: FilterOptions<T>): Promise<T> {
+export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return options.initial;
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	// Non-interactive fallback: return default value when stdin is not a TTY
-	if (!isTTY() && options.default !== undefined) {
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		return options.default;
 	}
 
@@ -317,20 +319,23 @@ export async function filter<T>(options: FilterOptions<T>): Promise<T> {
 		scrollOffset: initialScrollOffset,
 	};
 
-	return runPrompt<FilterState<T>, T>({
-		initialState,
-		theme,
-		render: (state, resolvedTheme) =>
-			renderFilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
-		handleKey: createHandleKey<T>(maxVisible),
-		renderSubmitted: (state, value, resolvedTheme) =>
-			renderSubmitted(
-				state,
-				value,
-				resolvedTheme,
-				options.message,
-				state.results,
-				state.listCursor,
-			),
-	});
+	return runPrompt<FilterState<T>, T>(
+		{
+			initialState,
+			theme,
+			render: (state, resolvedTheme) =>
+				renderFilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
+			handleKey: createHandleKey<T>(maxVisible),
+			renderSubmitted: (state, value, resolvedTheme) =>
+				renderSubmitted(
+					state,
+					value,
+					resolvedTheme,
+					options.message,
+					state.results,
+					state.listCursor,
+				),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/input.test.ts
+++ b/packages/prompts/src/prompts/input.test.ts
@@ -1,103 +1,58 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { z } from "zod";
 
-import { input } from "./input.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { input, type InputOptions } from "./input.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start<Output>(options: InputOptions<Output>): Promise<Output | string> {
+	const prompt = renderPrompt<InputOptions<Output>, Output | string>(input, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
 	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Poll `stderrOutput` until it contains `needle`, or throw after `timeout`
- * ms. Use this instead of a fixed `tick(N)` whenever the assertion depends
- * on async work that may take a variable amount of time on slower runners
- * (notably async schema validation, which has its own internal delays).
- */
-async function waitForStderr(needle: string, timeout = 500): Promise<void> {
+async function waitForScreen(needle: string, timeout = 500): Promise<void> {
 	const start = Date.now();
-	while (!stderrOutput.includes(needle)) {
+	while (!screen().includes(needle)) {
 		if (Date.now() - start > timeout) {
 			throw new Error(
-				`stderr never contained ${JSON.stringify(needle)} within ${timeout}ms. ` +
-					`Got: ${JSON.stringify(stderrOutput)}`,
+				`screen never contained ${JSON.stringify(needle)} within ${timeout}ms. ` +
+					`Got: ${JSON.stringify(screen())}`,
 			);
 		}
 		await tick(5);
 	}
+}
+
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -123,14 +78,11 @@ describe("input — initial value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — interactive", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = input({ message: "Your name?" });
+		const promise = start({ message: "Your name?" });
 
 		await tick();
-		expect(stderrOutput).toContain("Your name?");
+		expect(screen()).toContain("Your name?");
 
 		// Submit empty to resolve
 		pressKey("", { name: "return" });
@@ -138,50 +90,50 @@ describe("input — interactive", () => {
 	});
 
 	it("renders placeholder when no value entered", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			placeholder: "Enter your name",
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Enter your name");
+		expect(screen()).toContain("Enter your name");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders default value as placeholder when no placeholder is set", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			default: "World",
 		});
 
 		await tick();
 		// Default is shown as placeholder text, not as a (hint)
-		expect(stderrOutput).toContain("World");
-		expect(stderrOutput).not.toContain("(World)");
+		expect(screen()).toContain("World");
+		expect(screen()).not.toContain("(World)");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders default hint when both placeholder and default are set", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			placeholder: "Enter your name",
 			default: "World",
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Enter your name");
-		expect(stderrOutput).toContain("(World)");
+		expect(screen()).toContain("Enter your name");
+		expect(screen()).toContain("(World)");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("submits typed value on Enter", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A", { name: "a" });
@@ -197,7 +149,7 @@ describe("input — interactive", () => {
 	});
 
 	it("uses default value when submitting empty input", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			default: "DefaultName",
 		});
@@ -210,7 +162,7 @@ describe("input — interactive", () => {
 	});
 
 	it("submits typed value even when default is set", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			default: "DefaultName",
 		});
@@ -225,7 +177,7 @@ describe("input — interactive", () => {
 	});
 
 	it("renders submitted value with success styling", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("O", { name: "o" });
@@ -236,7 +188,7 @@ describe("input — interactive", () => {
 
 		await promise;
 		// After submission, the confirmed value should appear in output
-		expect(stderrOutput).toContain("OK");
+		expect(screen()).toContain("OK");
 	});
 });
 
@@ -245,11 +197,8 @@ describe("input — interactive", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — keypress editing", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("backspace deletes character before cursor", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -265,7 +214,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("backspace at position 0 does nothing", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("", { name: "backspace" });
@@ -279,7 +228,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("delete removes character at cursor", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -303,7 +252,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("left arrow moves cursor left", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -322,7 +271,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("right arrow moves cursor right", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -345,7 +294,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("home key jumps to start", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -363,7 +312,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("end key jumps to end", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -383,7 +332,7 @@ describe("input — keypress editing", () => {
 	});
 
 	it("ignores ctrl+key combinations", async () => {
-		const promise = input({ message: "Name?" });
+		const promise = start({ message: "Name?" });
 
 		await tick();
 		pressKey("A");
@@ -403,11 +352,8 @@ describe("input — keypress editing", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — validation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("shows error message when validation fails", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Email?",
 			validate: (v) => {
 				if (!v.includes("@")) throw new Error("Must contain @");
@@ -424,7 +370,7 @@ describe("input — validation", () => {
 		await tick();
 
 		// Error should be displayed
-		expect(stderrOutput).toContain("Must contain @");
+		expect(screen()).toContain("Must contain @");
 
 		// Now type valid input and resubmit
 		pressKey("@");
@@ -438,7 +384,7 @@ describe("input — validation", () => {
 	it("accepts valid input after correction", async () => {
 		let validateCallCount = 0;
 
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			validate: (v) => {
 				validateCallCount++;
@@ -453,7 +399,7 @@ describe("input — validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Too short");
+		expect(screen()).toContain("Too short");
 
 		// Add more text and resubmit
 		pressKey("B");
@@ -466,7 +412,7 @@ describe("input — validation", () => {
 	});
 
 	it("supports async validation", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Code?",
 			validate: async (v) => {
 				await new Promise((r) => setTimeout(r, 5));
@@ -490,7 +436,7 @@ describe("input — validation", () => {
 	});
 
 	it("validates default value when used", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			default: "",
 			validate: (v) => {
@@ -503,7 +449,7 @@ describe("input — validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Required");
+		expect(screen()).toContain("Required");
 
 		// Type something and submit
 		pressKey("X");
@@ -520,15 +466,12 @@ describe("input — validation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = input({});
+		const promise = start({});
 
 		await tick();
-		expect(stderrOutput).toContain("Enter a value");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Enter a value");
+		expect(screen()).not.toContain("undefined");
 
 		pressKey("A");
 		await tick();
@@ -539,26 +482,26 @@ describe("input — no message", () => {
 	});
 
 	it("renders placeholder with default message", async () => {
-		const promise = input({ placeholder: "Enter name" });
+		const promise = start({ placeholder: "Enter name" });
 
 		await tick();
-		expect(stderrOutput).toContain("Enter a value");
-		expect(stderrOutput).toContain("Enter name");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Enter a value");
+		expect(screen()).toContain("Enter name");
+		expect(screen()).not.toContain("undefined");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders default as placeholder with default message", async () => {
-		const promise = input({ default: "World" });
+		const promise = start({ default: "World" });
 
 		await tick();
-		expect(stderrOutput).toContain("Enter a value");
+		expect(screen()).toContain("Enter a value");
 		// Default shown as placeholder, not hint
-		expect(stderrOutput).toContain("World");
-		expect(stderrOutput).not.toContain("(World)");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("World");
+		expect(screen()).not.toContain("(World)");
+		expect(screen()).not.toContain("undefined");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -566,7 +509,7 @@ describe("input — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = input({});
+		const promise = start({});
 
 		await tick();
 		pressKey("X");
@@ -574,9 +517,9 @@ describe("input — no message", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Enter a value");
-		expect(stderrOutput).not.toContain("undefined");
-		expect(stderrOutput).toContain("X");
+		expect(screen()).toContain("Enter a value");
+		expect(screen()).not.toContain("undefined");
+		expect(screen()).toContain("X");
 	});
 });
 
@@ -585,71 +528,31 @@ describe("input — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		await expect(input({ message: "Name?" })).rejects.toThrow("interactive terminal");
+		await expect(input({ message: "Name?" }, nonTTYIO())).rejects.toThrow("interactive terminal");
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await input({
-			message: "Name?",
-			initial: "Bob",
-		});
+		const result = await input({ message: "Name?", initial: "Bob" }, nonTTYIO());
 
 		expect(result).toBe("Bob");
 	});
 
 	it("returns default value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await input({
-			message: "Name?",
-			default: "untitled",
-		});
+		const result = await input({ message: "Name?", default: "untitled" }, nonTTYIO());
 
 		expect(result).toBe("untitled");
 	});
 
 	it("throws NonInteractiveError when no default or initial in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		await expect(input({ message: "Name?" })).rejects.toThrow("interactive terminal");
+		await expect(input({ message: "Name?" }, nonTTYIO())).rejects.toThrow("interactive terminal");
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await input({
-			message: "Name?",
-			initial: "from-flag",
-			default: "fallback",
-		});
+		const result = await input(
+			{ message: "Name?", initial: "from-flag", default: "fallback" },
+			nonTTYIO(),
+		);
 
 		expect(result).toBe("from-flag");
 	});
@@ -660,11 +563,8 @@ describe("input — non-TTY", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("input — schema validation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("resolves to string when a string schema accepts the input", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			validate: z.string().min(3),
 		});
@@ -684,7 +584,7 @@ describe("input — schema validation", () => {
 	});
 
 	it("resolves to the schema's transformed output (number from coerce)", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Port?",
 			validate: z.coerce.number().int().min(1),
 		});
@@ -702,7 +602,7 @@ describe("input — schema validation", () => {
 	});
 
 	it("renders the first issue's message and waits for retry on failure", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Name?",
 			validate: z.string().min(3, "Too short"),
 		});
@@ -714,7 +614,7 @@ describe("input — schema validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Too short");
+		expect(screen()).toContain("Too short");
 
 		// Add more characters and retry
 		pressKey("l");
@@ -740,7 +640,7 @@ describe("input — schema validation", () => {
 			},
 		};
 
-		const promise = input({
+		const promise = start({
 			message: "Word?",
 			validate: emptyMessageSchema,
 		});
@@ -751,7 +651,7 @@ describe("input — schema validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Validation failed");
+		expect(screen()).toContain("Validation failed");
 
 		// Clear field, type valid value, submit
 		pressKey("", { name: "backspace" });
@@ -781,7 +681,7 @@ describe("input — schema validation", () => {
 			},
 		};
 
-		const promise = input({ message: "Word?", validate: emptyIssuesSchema });
+		const promise = start({ message: "Word?", validate: emptyIssuesSchema });
 
 		await tick();
 		pressKey("o");
@@ -792,7 +692,7 @@ describe("input — schema validation", () => {
 
 		const result = await promise;
 		expect(result).toBe("ok");
-		expect(stderrOutput).not.toContain("Validation failed");
+		expect(screen()).not.toContain("Validation failed");
 	});
 
 	it("surfaces zod's built-in issue message (no custom .message override)", async () => {
@@ -804,7 +704,7 @@ describe("input — schema validation", () => {
 		const expectedMessage = schema.safeParse("a").error?.issues[0]?.message ?? "";
 		expect(expectedMessage).not.toBe("");
 
-		const promise = input({ message: "Code?", validate: schema });
+		const promise = start({ message: "Code?", validate: schema });
 
 		await tick();
 		pressKey("a");
@@ -812,7 +712,7 @@ describe("input — schema validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain(expectedMessage);
+		expect(screen()).toContain(expectedMessage);
 
 		pressKey("b");
 		await tick();
@@ -833,7 +733,7 @@ describe("input — schema validation", () => {
 			{ message: "must be yes" },
 		);
 
-		const promise = input({ message: "Confirm?", validate: asyncSchema });
+		const promise = start({ message: "Confirm?", validate: asyncSchema });
 
 		await tick();
 		pressKey("n");
@@ -841,9 +741,9 @@ describe("input — schema validation", () => {
 		pressKey("o");
 		await tick();
 		pressKey("", { name: "return" });
-		await waitForStderr("must be yes");
+		await waitForScreen("must be yes");
 
-		expect(stderrOutput).toContain("must be yes");
+		expect(screen()).toContain("must be yes");
 
 		// Clear and type valid value
 		pressKey("", { name: "backspace" });
@@ -894,61 +794,36 @@ describe("input — schema short-circuit", () => {
 	});
 
 	it("parses non-TTY `default` through the schema and returns transformed output", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		try {
-			const result = await input({
+		const result = await input(
+			{
 				message: "Port?",
 				default: "3000",
 				validate: z.coerce.number().int(),
-			});
+			},
+			nonTTYIO(),
+		);
 
-			expect(result).toBe(3000);
-			expect(typeof result).toBe("number");
-		} finally {
-			Object.defineProperty(process.stdin, "isTTY", {
-				value: originalIsTTY,
-				writable: true,
-				configurable: true,
-			});
-		}
+		expect(result).toBe(3000);
+		expect(typeof result).toBe("number");
 	});
 
 	it("throws when non-TTY `default` is rejected by the schema", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		try {
-			await expect(
-				input({
+		await expect(
+			input(
+				{
 					message: "Port?",
 					default: "abc",
 					validate: z.coerce.number().int(),
-				}),
-			).rejects.toThrow(/default value rejected by schema/);
-		} finally {
-			Object.defineProperty(process.stdin, "isTTY", {
-				value: originalIsTTY,
-				writable: true,
-				configurable: true,
-			});
-		}
+				},
+				nonTTYIO(),
+			),
+		).rejects.toThrow(/default value rejected by schema/);
 	});
 });
 
 describe("input — schema + interactive default", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("runs schema against the default value when user submits empty", async () => {
-		const promise = input({
+		const promise = start({
 			message: "Port?",
 			default: "4000",
 			validate: z.coerce.number().int(),
@@ -972,9 +847,6 @@ describe("input — schema + interactive default", () => {
 // callable function-objects. Our guard must accept both shapes.
 
 describe("input — callable Standard Schema", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("dispatches a callable schema through the schema branch", async () => {
 		// Build a callable function that also has a `~standard` property.
 		const callable = Object.assign((_value: unknown) => undefined, {
@@ -990,12 +862,12 @@ describe("input — callable Standard Schema", () => {
 			},
 		});
 
-		const promise = input({ message: "Word?", validate: callable });
+		const promise = start({ message: "Word?", validate: callable });
 
 		await tick();
 		pressKey("", { name: "return" });
 		await tick();
-		expect(stderrOutput).toContain("empty");
+		expect(screen()).toContain("empty");
 
 		pressKey("a");
 		await tick();

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -4,8 +4,8 @@
 
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { CURSOR_CHAR, handleTextEdit } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
@@ -262,14 +262,22 @@ export function input<Output>(
 	options: InputOptions<Output> & {
 		readonly validate: StandardSchemaV1<unknown, Output>;
 	},
+	io?: PromptIO,
 ): Promise<Output>;
 export function input(
 	options?: Omit<InputOptions, "validate"> & {
 		readonly validate?: ValidateFn<string>;
 	},
+	io?: PromptIO,
 ): Promise<string>;
-export function input<Output>(options: InputOptions<Output>): Promise<Output | string>;
-export async function input<Output>(options: InputOptions<Output> = {}): Promise<Output | string> {
+export function input<Output>(
+	options: InputOptions<Output>,
+	io?: PromptIO,
+): Promise<Output | string>;
+export async function input<Output>(
+	options: InputOptions<Output> = {},
+	io?: PromptIO,
+): Promise<Output | string> {
 	// Short-circuit: return initial value immediately without rendering.
 	// When `validate` is a Standard Schema we MUST parse the short-circuit
 	// value through it so the `Promise<Output>` overload stays sound — a raw
@@ -282,9 +290,11 @@ export async function input<Output>(options: InputOptions<Output> = {}): Promise
 		return options.initial;
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	// Non-interactive fallback: return default value when stdin is not a TTY.
 	// Same schema-soundness rule as above.
-	if (!isTTY() && options.default !== undefined) {
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		if (isStandardSchema(options.validate)) {
 			return parseShortCircuit(options.validate, options.default, "default");
 		}
@@ -299,12 +309,15 @@ export async function input<Output>(options: InputOptions<Output> = {}): Promise
 		error: null,
 	};
 
-	return runPrompt<InputState, Output | string>({
-		initialState,
-		theme,
-		render: (state, t) =>
-			renderInput(state, t, options.message, options.placeholder, options.default),
-		handleKey: createHandleKey<Output>(options.validate, options.default),
-		renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message),
-	});
+	return runPrompt<InputState, Output | string>(
+		{
+			initialState,
+			theme,
+			render: (state, t) =>
+				renderInput(state, t, options.message, options.placeholder, options.default),
+			handleKey: createHandleKey<Output>(options.validate, options.default),
+			renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -1,83 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
-import { multifilter } from "./multifilter.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { multifilter, type MultifilterOptions } from "./multifilter.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
-}
-
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
+function start<T>(options: MultifilterOptions<T>): Promise<T[]> {
+	const prompt = renderPrompt<MultifilterOptions<T>, T[]>(multifilter, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
+}
+
+function screen(): string {
+	return activePrompt.screen();
 }
 
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
 // ────────────────────────────────────────────────────────────────────────────
 // Initial/default short-circuits
 // ────────────────────────────────────────────────────────────────────────────
@@ -112,17 +73,12 @@ describe("multifilter — initial / default", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multifilter — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY<T>(options: MultifilterOptions<T>): Promise<T[]> {
+		return multifilter(options, nonTTYIO());
+	}
 
 	it("returns default array in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await multifilter({
+		const result = await nonTTY({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			default: ["b", "c"],
@@ -132,14 +88,8 @@ describe("multifilter — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no default or initial in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			multifilter({
+			nonTTY({
 				message: "Search",
 				choices: ["a", "b", "c"],
 			}),
@@ -147,13 +97,7 @@ describe("multifilter — non-TTY", () => {
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await multifilter({
+		const result = await nonTTY({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			initial: ["a"],
@@ -169,11 +113,8 @@ describe("multifilter — non-TTY", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multifilter — interactive", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("Space toggles selection; Enter submits values in choice order", async () => {
-		const promise = multifilter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -192,14 +133,14 @@ describe("multifilter — interactive", () => {
 	});
 
 	it("pre-selects from default", async () => {
-		const promise = multifilter({
+		const promise = start({
 			message: "Search",
 			choices: ["a", "b", "c"],
 			default: ["c"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("●");
+		expect(screen()).toContain("●");
 		pressKey("", { name: "return" });
 
 		const result = await promise;
@@ -207,7 +148,7 @@ describe("multifilter — interactive", () => {
 	});
 
 	it("Enter with required and no selection shows error", async () => {
-		const promise = multifilter({
+		const promise = start({
 			message: "Search",
 			choices: ["x", "y"],
 			required: true,
@@ -217,7 +158,7 @@ describe("multifilter — interactive", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("At least one");
+		expect(screen()).toContain("At least one");
 
 		pressKey("", { name: "space" });
 		await tick();
@@ -228,7 +169,7 @@ describe("multifilter — interactive", () => {
 	});
 
 	it("keeps selections when query filters the list", async () => {
-		const promise = multifilter({
+		const promise = start({
 			message: "Search",
 			choices: ["alpha", "beta", "gamma"],
 		});
@@ -247,7 +188,7 @@ describe("multifilter — interactive", () => {
 		pressKey("m", { name: "m" });
 		await tick();
 
-		expect(stderrOutput).toContain("gamma");
+		expect(screen()).toContain("gamma");
 		pressKey("", { name: "return" });
 
 		const result = await promise;

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -4,8 +4,8 @@
 
 import type { FuzzyFilterResult } from "../core/fuzzy.ts";
 import { fuzzyFilter, highlightMatches, refilter } from "../core/fuzzy.ts";
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import {
 	CHECKBOX_CHECKED,
 	CHECKBOX_UNCHECKED,
@@ -296,12 +296,14 @@ function renderSubmitted<T>(
  * In non-interactive environments (no TTY), the `default` values are returned
  * automatically if provided.
  */
-export async function multifilter<T>(options: MultifilterOptions<T>): Promise<T[]> {
+export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
 	if (options.initial !== undefined) {
 		return [...options.initial];
 	}
 
-	if (!isTTY() && options.default !== undefined) {
+	const promptIO = resolvePromptIO(io);
+
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		return [...options.default];
 	}
 
@@ -341,13 +343,16 @@ export async function multifilter<T>(options: MultifilterOptions<T>): Promise<T[
 		error: null,
 	};
 
-	return runPrompt<MultifilterState<T>, T[]>({
-		initialState,
-		theme,
-		render: (state, resolvedTheme) =>
-			renderMultifilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
-		handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),
-		renderSubmitted: (state, value, resolvedTheme) =>
-			renderSubmitted(state, value, resolvedTheme, options.message, choices, state.selected),
-	});
+	return runPrompt<MultifilterState<T>, T[]>(
+		{
+			initialState,
+			theme,
+			render: (state, resolvedTheme) =>
+				renderMultifilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
+			handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),
+			renderSubmitted: (state, value, resolvedTheme) =>
+				renderSubmitted(state, value, resolvedTheme, options.message, choices, state.selected),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -1,89 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
-import { multiselect } from "./multiselect.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { multiselect, type MultiselectOptions } from "./multiselect.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start<T>(options: MultiselectOptions<T>): Promise<T[]> {
+	const prompt = renderPrompt<MultiselectOptions<T>, T[]>(multiselect, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
 // ────────────────────────────────────────────────────────────────────────────
 // Initial value — object-choice numeric values
 // ────────────────────────────────────────────────────────────────────────────
@@ -110,11 +65,8 @@ describe("multiselect — initial value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — default value", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("pre-selects items matching default values", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select toppings",
 			choices: ["cheese", "pepperoni", "mushrooms"],
 			default: ["cheese", "mushrooms"],
@@ -129,7 +81,7 @@ describe("multiselect — default value", () => {
 	});
 
 	it("returns empty array when no defaults and nothing selected", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select toppings",
 			choices: ["cheese", "pepperoni", "mushrooms"],
 		});
@@ -142,7 +94,7 @@ describe("multiselect — default value", () => {
 	});
 
 	it("ignores default values that don't match any choice", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select toppings",
 			choices: ["cheese", "pepperoni", "mushrooms"],
 			default: ["cheese", "nonexistent"],
@@ -161,11 +113,8 @@ describe("multiselect — default value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — Space toggle", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("Space toggles selection on current item", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -181,7 +130,7 @@ describe("multiselect — Space toggle", () => {
 	});
 
 	it("Space toggles off a selected item", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a"],
@@ -198,7 +147,7 @@ describe("multiselect — Space toggle", () => {
 	});
 
 	it("can select multiple items", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -224,11 +173,8 @@ describe("multiselect — Space toggle", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — navigation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("down arrow moves cursor down", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -245,7 +191,7 @@ describe("multiselect — navigation", () => {
 	});
 
 	it("up arrow moves cursor up", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -265,7 +211,7 @@ describe("multiselect — navigation", () => {
 	});
 
 	it("j moves cursor down (vim)", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -282,7 +228,7 @@ describe("multiselect — navigation", () => {
 	});
 
 	it("k moves cursor up (vim)", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -301,7 +247,7 @@ describe("multiselect — navigation", () => {
 	});
 
 	it("wraps to last item when moving up from first", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -318,7 +264,7 @@ describe("multiselect — navigation", () => {
 	});
 
 	it("wraps to first item when moving down from last", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -346,11 +292,8 @@ describe("multiselect — navigation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — toggle all / invert", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("'a' selects all items when none are selected", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 		});
@@ -365,7 +308,7 @@ describe("multiselect — toggle all / invert", () => {
 	});
 
 	it("'a' deselects all items when all are selected", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a", "b", "c"],
@@ -381,7 +324,7 @@ describe("multiselect — toggle all / invert", () => {
 	});
 
 	it("'a' selects all when some are selected (not all)", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a"],
@@ -397,7 +340,7 @@ describe("multiselect — toggle all / invert", () => {
 	});
 
 	it("'i' inverts selection", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a"],
@@ -413,7 +356,7 @@ describe("multiselect — toggle all / invert", () => {
 	});
 
 	it("'i' inverts from all selected to none", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a", "b", "c"],
@@ -434,11 +377,8 @@ describe("multiselect — toggle all / invert", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — validation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("required blocks empty submit", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			required: true,
@@ -450,7 +390,7 @@ describe("multiselect — validation", () => {
 		await tick();
 
 		// Error should be shown
-		expect(stderrOutput).toContain("At least one item must be selected");
+		expect(screen()).toContain("At least one item must be selected");
 
 		// Select something and submit
 		pressKey(" ", { name: "space" });
@@ -462,7 +402,7 @@ describe("multiselect — validation", () => {
 	});
 
 	it("min validation blocks submit when too few selected", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			min: 2,
@@ -476,7 +416,7 @@ describe("multiselect — validation", () => {
 		await tick();
 
 		// Error should be shown
-		expect(stderrOutput).toContain("Select at least 2 items");
+		expect(screen()).toContain("Select at least 2 items");
 
 		// Select another item and submit
 		pressKey("", { name: "down" });
@@ -490,7 +430,7 @@ describe("multiselect — validation", () => {
 	});
 
 	it("max validation blocks submit when too many selected", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			max: 1,
@@ -502,7 +442,7 @@ describe("multiselect — validation", () => {
 		await tick();
 
 		// Error should be shown
-		expect(stderrOutput).toContain("Select at most 1 item");
+		expect(screen()).toContain("Select at most 1 item");
 
 		// Deselect one and submit
 		pressKey(" ", { name: "space" });
@@ -514,7 +454,7 @@ describe("multiselect — validation", () => {
 	});
 
 	it("error clears when user navigates", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			required: true,
@@ -524,15 +464,15 @@ describe("multiselect — validation", () => {
 		// Submit with nothing — triggers error
 		pressKey("", { name: "return" });
 		await tick();
-		expect(stderrOutput).toContain("At least one item must be selected");
+		expect(screen()).toContain("At least one item must be selected");
 
 		// Navigate — error should clear
-		stderrOutput = "";
+
 		pressKey("", { name: "down" });
 		await tick();
 
 		// The error should no longer appear in new output
-		expect(stderrOutput).not.toContain("At least one item must be selected");
+		expect(screen()).not.toContain("At least one item must be selected");
 
 		// Select and submit
 		pressKey(" ", { name: "space" });
@@ -549,81 +489,78 @@ describe("multiselect — validation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — rendering", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select toppings",
 			choices: ["cheese", "pepperoni", "mushrooms"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Select toppings");
+		expect(screen()).toContain("Select toppings");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders all choices with checkboxes", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["alpha", "beta", "gamma"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("alpha");
-		expect(stderrOutput).toContain("beta");
-		expect(stderrOutput).toContain("gamma");
-		expect(stderrOutput).toContain("○");
+		expect(screen()).toContain("alpha");
+		expect(screen()).toContain("beta");
+		expect(screen()).toContain("gamma");
+		expect(screen()).toContain("○");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders checked boxes for selected items", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["alpha", "beta", "gamma"],
 			default: ["alpha"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("●");
+		expect(screen()).toContain("●");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders cursor indicator on active item", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["alpha", "beta"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("›");
+		expect(screen()).toContain("›");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders hint line with keybindings", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices: ["alpha", "beta"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Space to toggle");
-		expect(stderrOutput).toContain("Enter to confirm");
+		expect(screen()).toContain("Space to toggle");
+		expect(screen()).toContain("Enter to confirm");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders submitted answer with comma-separated labels", async () => {
-		const promise = multiselect({
+		const promise = start({
 			message: "Select toppings",
 			choices: ["cheese", "pepperoni", "mushrooms"],
 			default: ["cheese", "mushrooms"],
@@ -634,11 +571,11 @@ describe("multiselect — rendering", () => {
 
 		await promise;
 		// After submit, should show comma-separated labels
-		expect(stderrOutput).toContain("cheese, mushrooms");
+		expect(screen()).toContain("cheese, mushrooms");
 	});
 
 	it("renders hints for object choices", async () => {
-		const promise = multiselect<string>({
+		const promise = start({
 			message: "Select features",
 			choices: [
 				{ label: "TypeScript", value: "ts", hint: "recommended" },
@@ -647,7 +584,7 @@ describe("multiselect — rendering", () => {
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("recommended");
+		expect(screen()).toContain("recommended");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -659,21 +596,18 @@ describe("multiselect — rendering", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — viewport scrolling", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("limits visible choices to maxVisible", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices,
 			maxVisible: 5,
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("item-0");
-		expect(stderrOutput).toContain("item-4");
-		expect(stderrOutput).not.toContain("item-5");
+		expect(screen()).toContain("item-0");
+		expect(screen()).toContain("item-4");
+		expect(screen()).not.toContain("item-5");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -681,14 +615,14 @@ describe("multiselect — viewport scrolling", () => {
 
 	it("shows scroll-down indicator when more items below", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices,
 			maxVisible: 5,
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("...");
+		expect(screen()).toContain("...");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -696,7 +630,7 @@ describe("multiselect — viewport scrolling", () => {
 
 	it("scrolls down when navigating past visible items", async () => {
 		const choices = Array.from({ length: 10 }, (_, i) => `item-${i}`);
-		const promise = multiselect({
+		const promise = start({
 			message: "Select",
 			choices,
 			maxVisible: 3,
@@ -712,7 +646,7 @@ describe("multiselect — viewport scrolling", () => {
 		await tick();
 
 		// item-3 should now be visible
-		expect(stderrOutput).toContain("item-3");
+		expect(screen()).toContain("item-3");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -724,18 +658,15 @@ describe("multiselect — viewport scrolling", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = multiselect({
+		const promise = start({
 			choices: ["a", "b", "c"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Pick one or more");
-		expect(stderrOutput).not.toContain("undefined");
-		expect(stderrOutput).toContain("a");
+		expect(screen()).toContain("Pick one or more");
+		expect(screen()).not.toContain("undefined");
+		expect(screen()).toContain("a");
 
 		// Select first item and submit
 		pressKey("", { name: "space" });
@@ -747,7 +678,7 @@ describe("multiselect — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = multiselect({
+		const promise = start({
 			choices: ["a", "b", "c"],
 		});
 
@@ -757,8 +688,8 @@ describe("multiselect — no message", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Pick one or more");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Pick one or more");
+		expect(screen()).not.toContain("undefined");
 	});
 });
 
@@ -767,18 +698,13 @@ describe("multiselect — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("multiselect — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY<T>(options: MultiselectOptions<T>): Promise<T[]> {
+		return multiselect(options, nonTTYIO());
+	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			multiselect({
+			nonTTY({
 				message: "Select",
 				choices: ["a", "b", "c"],
 			}),
@@ -786,13 +712,7 @@ describe("multiselect — non-TTY", () => {
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await multiselect({
+		const result = await nonTTY({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			initial: ["b"],
@@ -802,13 +722,7 @@ describe("multiselect — non-TTY", () => {
 	});
 
 	it("returns default values in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await multiselect({
+		const result = await nonTTY({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			default: ["a", "c"],
@@ -818,14 +732,8 @@ describe("multiselect — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no default or initial in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			multiselect({
+			nonTTY({
 				message: "Select",
 				choices: ["a", "b", "c"],
 			}),
@@ -833,13 +741,7 @@ describe("multiselect — non-TTY", () => {
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await multiselect({
+		const result = await nonTTY({
 			message: "Select",
 			choices: ["a", "b", "c"],
 			initial: ["a"],

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -2,8 +2,8 @@
 // Multiselect — Checkbox-style multi selection from a list for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import {
 	CHECKBOX_CHECKED,
 	CHECKBOX_UNCHECKED,
@@ -314,14 +314,16 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-export async function multiselect<T>(options: MultiselectOptions<T>): Promise<T[]> {
+export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return [...options.initial];
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	// Non-interactive fallback: return default values when stdin is not a TTY
-	if (!isTTY() && options.default !== undefined) {
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		return [...options.default];
 	}
 
@@ -348,12 +350,15 @@ export async function multiselect<T>(options: MultiselectOptions<T>): Promise<T[
 		error: null,
 	};
 
-	return runPrompt<MultiselectState<T>, T[]>({
-		initialState,
-		theme,
-		render: (state, t) => renderMultiselect(state, t, options.message, maxVisible),
-		handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),
-		renderSubmitted: (state, value, t) =>
-			renderSubmitted(state, value, t, options.message, choices, state.selected),
-	});
+	return runPrompt<MultiselectState<T>, T[]>(
+		{
+			initialState,
+			theme,
+			render: (state, t) => renderMultiselect(state, t, options.message, maxVisible),
+			handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),
+			renderSubmitted: (state, value, t) =>
+				renderSubmitted(state, value, t, options.message, choices, state.selected),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -1,110 +1,56 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { z } from "zod";
 
-import { password } from "./password.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { password, type PasswordOptions } from "./password.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start<Output>(options: PasswordOptions<Output>): Promise<Output | string> {
+	const prompt = renderPrompt<PasswordOptions<Output>, Output | string>(password, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Poll `stderrOutput` until it contains `needle`, or throw after `timeout`
- * ms. Use this instead of a fixed `tick(N)` whenever the assertion depends
- * on async work that may take a variable amount of time on slower runners
- * (notably async schema validation, which has its own internal delays).
- */
-async function waitForStderr(needle: string, timeout = 500): Promise<void> {
-	const start = Date.now();
-	while (!stderrOutput.includes(needle)) {
-		if (Date.now() - start > timeout) {
-			throw new Error(
-				`stderr never contained ${JSON.stringify(needle)} within ${timeout}ms. ` +
-					`Got: ${JSON.stringify(stderrOutput)}`,
-			);
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
+
+async function waitForScreen(needle: string, timeout = 500): Promise<void> {
+	const started = Date.now();
+	while (!screen().includes(needle)) {
+		if (Date.now() - started > timeout) {
+			throw new Error(`screen never contained ${JSON.stringify(needle)} within ${timeout}ms.`);
 		}
 		await tick(5);
 	}
 }
-
 // ────────────────────────────────────────────────────────────────────────────
 // Initial value — empty-string edge case
 // ────────────────────────────────────────────────────────────────────────────
@@ -128,21 +74,18 @@ describe("password — initial value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — masked rendering", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = password({ message: "Enter password:" });
+		const promise = start({ message: "Enter password:" });
 
 		await tick();
-		expect(stderrOutput).toContain("Enter password:");
+		expect(screen()).toContain("Enter password:");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders mask characters instead of actual value", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("a");
@@ -153,7 +96,7 @@ describe("password — masked rendering", () => {
 		await tick();
 
 		// Should see mask characters (***) but NOT the actual value "abc"
-		expect(stderrOutput).toContain("*");
+		expect(screen()).toContain("*");
 		// The actual characters should not appear in output
 		// (except potentially in keypress event data, not in rendered output)
 
@@ -164,7 +107,7 @@ describe("password — masked rendering", () => {
 	});
 
 	it("supports custom mask character", async () => {
-		const promise = password({ message: "Password?", mask: "●" });
+		const promise = start({ message: "Password?", mask: "●" });
 
 		await tick();
 		pressKey("x");
@@ -173,7 +116,7 @@ describe("password — masked rendering", () => {
 		await tick();
 
 		// Custom mask character should appear in output
-		expect(stderrOutput).toContain("●");
+		expect(screen()).toContain("●");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -181,7 +124,7 @@ describe("password — masked rendering", () => {
 	});
 
 	it("shows fixed-length mask on submission regardless of actual length", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		// Type a 10-character password
@@ -195,15 +138,15 @@ describe("password — masked rendering", () => {
 
 		// After submission, should show exactly 4 mask characters (SUBMITTED_MASK_LENGTH)
 		// The submitted line uses the success theme, so look for **** in output
-		expect(stderrOutput).toContain("****");
+		expect(screen()).toContain("****");
 	});
 
 	it("shows cursor indicator when input is empty", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		// U+2502 (│) is the cursor character
-		expect(stderrOutput).toContain("\u2502");
+		expect(screen()).toContain("\u2502");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -215,11 +158,8 @@ describe("password — masked rendering", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — keypress editing", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("submits typed value on Enter", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("s");
@@ -235,7 +175,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("backspace deletes character before cursor", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -253,7 +193,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("backspace at position 0 does nothing", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("", { name: "backspace" });
@@ -267,7 +207,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("delete removes character at cursor", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -291,7 +231,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("left/right arrow keys move cursor", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -310,7 +250,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("home key jumps to start", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -328,7 +268,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("end key jumps to end", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -348,7 +288,7 @@ describe("password — keypress editing", () => {
 	});
 
 	it("ignores ctrl+key combinations", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		pressKey("A");
@@ -367,11 +307,8 @@ describe("password — keypress editing", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — validation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("shows error message when validation fails", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Password?",
 			validate: (v) => {
 				if (v.length < 4) throw new Error("Password must be at least 4 characters");
@@ -387,7 +324,7 @@ describe("password — validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Password must be at least 4 characters");
+		expect(screen()).toContain("Password must be at least 4 characters");
 
 		// Type more and resubmit
 		pressKey("c");
@@ -401,7 +338,7 @@ describe("password — validation", () => {
 	});
 
 	it("supports async validation", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Token?",
 			validate: async (v) => {
 				await new Promise((r) => setTimeout(r, 5));
@@ -421,7 +358,7 @@ describe("password — validation", () => {
 	});
 
 	it("clears error on new character input", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Password?",
 			validate: (v) => {
 				if (v.length < 2) throw new Error("Too short");
@@ -435,7 +372,7 @@ describe("password — validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Too short");
+		expect(screen()).toContain("Too short");
 
 		// Type another character — error should be cleared from state
 		pressKey("b");
@@ -452,15 +389,12 @@ describe("password — validation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = password({});
+		const promise = start({});
 
 		await tick();
-		expect(stderrOutput).toContain("Enter a password");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Enter a password");
+		expect(screen()).not.toContain("undefined");
 
 		pressKey("s");
 		await tick();
@@ -475,7 +409,7 @@ describe("password — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = password({});
+		const promise = start({});
 
 		await tick();
 		pressKey("x");
@@ -483,8 +417,8 @@ describe("password — no message", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Enter a password");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Enter a password");
+		expect(screen()).not.toContain("undefined");
 	});
 });
 
@@ -493,27 +427,16 @@ describe("password — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY<Output>(options: PasswordOptions<Output>): Promise<Output | string> {
+		return password(options, nonTTYIO());
+	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		await expect(password({ message: "Password?" })).rejects.toThrow("interactive terminal");
+		await expect(nonTTY({ message: "Password?" })).rejects.toThrow("interactive terminal");
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await password({
+		const result = await nonTTY({
 			message: "Password?",
 			initial: "secret123",
 		});
@@ -527,11 +450,8 @@ describe("password — non-TTY", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("password — schema validation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("resolves to string when a string schema accepts the input", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Password?",
 			validate: z.string().min(3),
 		});
@@ -551,7 +471,7 @@ describe("password — schema validation", () => {
 	});
 
 	it("renders the first issue's message and waits for retry on failure", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Password?",
 			validate: z.string().min(3, "Too short"),
 		});
@@ -562,7 +482,7 @@ describe("password — schema validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Too short");
+		expect(screen()).toContain("Too short");
 
 		pressKey("b");
 		await tick();
@@ -575,7 +495,7 @@ describe("password — schema validation", () => {
 	});
 
 	it("resolves to the schema's transformed output (number from coerce)", async () => {
-		const promise = password({
+		const promise = start({
 			message: "PIN?",
 			validate: z.coerce.number().int().min(1000),
 		});
@@ -605,7 +525,7 @@ describe("password — schema validation", () => {
 			{ message: "wrong passphrase" },
 		);
 
-		const promise = password({
+		const promise = start({
 			message: "Passphrase?",
 			validate: asyncSchema,
 		});
@@ -616,9 +536,9 @@ describe("password — schema validation", () => {
 			await tick();
 		}
 		pressKey("", { name: "return" });
-		await waitForStderr("wrong passphrase");
+		await waitForScreen("wrong passphrase");
 
-		expect(stderrOutput).toContain("wrong passphrase");
+		expect(screen()).toContain("wrong passphrase");
 
 		// Clear and type the correct value.
 		for (let i = 0; i < 5; i++) {
@@ -647,7 +567,7 @@ describe("password — schema validation", () => {
 			},
 		};
 
-		const promise = password({
+		const promise = start({
 			message: "Word?",
 			validate: emptyMessageSchema,
 		});
@@ -658,7 +578,7 @@ describe("password — schema validation", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("Validation failed");
+		expect(screen()).toContain("Validation failed");
 
 		pressKey("", { name: "backspace" });
 		await tick();
@@ -737,15 +657,12 @@ describe("password — schema short-circuit", () => {
 // rejection and submission paths so a regression is loud.
 
 describe("password — secrecy", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	// A unique, unlikely-to-appear-in-prompt-chrome marker so any leak fails
 	// the assertion deterministically.
 	const SECRET = "hunter2-XYZ";
 
 	it("never renders the raw value while typing or after submission", async () => {
-		const promise = password({ message: "Password?" });
+		const promise = start({ message: "Password?" });
 
 		await tick();
 		for (const ch of SECRET) {
@@ -755,11 +672,11 @@ describe("password — secrecy", () => {
 		pressKey("", { name: "return" });
 		await promise;
 
-		expect(stderrOutput).not.toContain(SECRET);
+		expect(screen()).not.toContain(SECRET);
 	});
 
 	it("never renders the raw value when schema validation rejects", async () => {
-		const promise = password({
+		const promise = start({
 			message: "Password?",
 			validate: z.string().min(64, "too short"),
 		});
@@ -772,8 +689,8 @@ describe("password — secrecy", () => {
 		pressKey("", { name: "return" });
 		await tick();
 
-		expect(stderrOutput).toContain("too short");
-		expect(stderrOutput).not.toContain(SECRET);
+		expect(screen()).toContain("too short");
+		expect(screen()).not.toContain(SECRET);
 
 		// Resolve the prompt cleanly with a long-enough valid value.
 		for (let i = 0; i < SECRET.length; i++) {

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -4,8 +4,8 @@
 
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { CURSOR_CHAR, handleTextEdit } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
@@ -231,15 +231,21 @@ export function password<Output>(
 	options: PasswordOptions<Output> & {
 		readonly validate: StandardSchemaV1<unknown, Output>;
 	},
+	io?: PromptIO,
 ): Promise<Output>;
 export function password(
 	options?: Omit<PasswordOptions, "validate"> & {
 		readonly validate?: ValidateFn<string>;
 	},
+	io?: PromptIO,
 ): Promise<string>;
-export function password<Output>(options: PasswordOptions<Output>): Promise<Output | string>;
+export function password<Output>(
+	options: PasswordOptions<Output>,
+	io?: PromptIO,
+): Promise<Output | string>;
 export async function password<Output>(
 	options: PasswordOptions<Output> = {},
+	io?: PromptIO,
 ): Promise<Output | string> {
 	// Short-circuit: return initial value immediately without rendering.
 	// When `validate` is a Standard Schema we MUST parse the short-circuit
@@ -253,6 +259,8 @@ export async function password<Output>(
 		return options.initial;
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	const theme = resolveTheme(options.theme);
 	const mask = options.mask ?? "*";
 
@@ -262,11 +270,14 @@ export async function password<Output>(
 		error: null,
 	};
 
-	return runPrompt<PasswordState, Output | string>({
-		initialState,
-		theme,
-		render: (state, t) => renderPassword(state, t, options.message, mask),
-		handleKey: createHandleKey<Output>(options.validate),
-		renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message, mask),
-	});
+	return runPrompt<PasswordState, Output | string>(
+		{
+			initialState,
+			theme,
+			render: (state, t) => renderPassword(state, t, options.message, mask),
+			handleKey: createHandleKey<Output>(options.validate),
+			renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message, mask),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -1,89 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
-import { select } from "./select.ts";
+import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { select, type SelectOptions } from "./select.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-const originalIsTTY = process.stdin.isTTY;
-const originalSetRawMode = process.stdin.setRawMode;
-const originalIsRaw = process.stdin.isRaw;
-const originalStderrWrite = process.stderr.write;
+let activePrompt: Pick<RenderedPrompt<unknown>, "type" | "keys" | "screen">;
 
-let stderrOutput: string;
-
-function setupMocks(): void {
-	stderrOutput = "";
-
-	process.stderr.write = (chunk: string | Uint8Array) => {
-		if (typeof chunk === "string") {
-			stderrOutput += chunk;
-		}
-		return true;
-	};
-
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: true,
-		writable: true,
-		configurable: true,
-	});
-
-	(process.stdin as any).setRawMode = (mode: boolean) => {
-		Object.defineProperty(process.stdin, "isRaw", {
-			value: mode,
-			writable: true,
-			configurable: true,
-		});
-		return process.stdin;
-	};
+function start<T>(options: SelectOptions<T>): Promise<T> {
+	const prompt = renderPrompt<SelectOptions<T>, T>(select, options);
+	activePrompt = prompt;
+	return prompt.answer;
 }
 
-function restoreMocks(): void {
-	Object.defineProperty(process.stdin, "isTTY", {
-		value: originalIsTTY,
-		writable: true,
-		configurable: true,
-	});
-	Object.defineProperty(process.stdin, "isRaw", {
-		value: originalIsRaw,
-		writable: true,
-		configurable: true,
-	});
-	if (originalSetRawMode) {
-		process.stdin.setRawMode = originalSetRawMode;
-	}
-	process.stderr.write = originalStderrWrite;
-	process.stdin.removeAllListeners("keypress");
-}
-
-/**
- * Emit a keypress event on stdin.
- */
 function pressKey(
 	char: string,
-	key?: Partial<{
-		name: string;
-		ctrl: boolean;
-		meta: boolean;
-		shift: boolean;
-	}>,
+	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
 ): void {
-	process.stdin.emit("keypress", char, {
-		name: key?.name ?? char,
-		ctrl: key?.ctrl ?? false,
-		meta: key?.meta ?? false,
-		shift: key?.shift ?? false,
-	});
+	if (key?.ctrl) {
+		activePrompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		activePrompt.keys(key?.name ?? "");
+	} else {
+		activePrompt.type(char);
+	}
 }
 
-/**
- * Wait briefly for async event processing.
- */
+function screen(): string {
+	return activePrompt.screen();
+}
+
 function tick(ms = 10): Promise<void> {
-	return new Promise((r) => setTimeout(r, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function nonTTYIO() {
+	return createPromptIO({ isTTY: false }).io;
+}
 // ────────────────────────────────────────────────────────────────────────────
 // Initial value — object-choice numeric value
 // ────────────────────────────────────────────────────────────────────────────
@@ -110,11 +65,8 @@ describe("select — initial value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — default value", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("sets initial cursor to matching default value", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick a color",
 			choices: ["red", "green", "blue"],
 			default: "green",
@@ -129,7 +81,7 @@ describe("select — default value", () => {
 	});
 
 	it("defaults cursor to first item when no default is provided", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick a color",
 			choices: ["red", "green", "blue"],
 		});
@@ -142,7 +94,7 @@ describe("select — default value", () => {
 	});
 
 	it("defaults cursor to first item when default value is not found", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick a color",
 			choices: ["red", "green", "blue"],
 			default: "yellow",
@@ -161,11 +113,8 @@ describe("select — default value", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — navigation", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("down arrow moves cursor down", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 		});
@@ -180,7 +129,7 @@ describe("select — navigation", () => {
 	});
 
 	it("up arrow moves cursor up", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			default: "b",
@@ -196,7 +145,7 @@ describe("select — navigation", () => {
 	});
 
 	it("j moves cursor down (vim)", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 		});
@@ -211,7 +160,7 @@ describe("select — navigation", () => {
 	});
 
 	it("k moves cursor up (vim)", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			default: "c",
@@ -227,7 +176,7 @@ describe("select — navigation", () => {
 	});
 
 	it("wraps to last item when moving up from first", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 		});
@@ -243,7 +192,7 @@ describe("select — navigation", () => {
 	});
 
 	it("wraps to first item when moving down from last", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			default: "c",
@@ -260,7 +209,7 @@ describe("select — navigation", () => {
 	});
 
 	it("Enter selects the highlighted item", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 		});
@@ -282,11 +231,8 @@ describe("select — navigation", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — choice types", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("handles string choices correctly", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick a color",
 			choices: ["red", "green", "blue"],
 		});
@@ -299,7 +245,7 @@ describe("select — choice types", () => {
 	});
 
 	it("handles object choices with label and value", async () => {
-		const promise = select<number>({
+		const promise = start({
 			message: "Pick a port",
 			choices: [
 				{ label: "HTTP", value: 80 },
@@ -317,7 +263,7 @@ describe("select — choice types", () => {
 	});
 
 	it("handles object choices with hints", async () => {
-		const promise = select<number>({
+		const promise = start({
 			message: "Pick a port",
 			choices: [
 				{ label: "HTTP", value: 80 },
@@ -327,7 +273,7 @@ describe("select — choice types", () => {
 
 		await tick();
 		// Verify hint text is rendered
-		expect(stderrOutput).toContain("recommended");
+		expect(screen()).toContain("recommended");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -339,52 +285,49 @@ describe("select — choice types", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — rendering", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders message on initial display", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Choose your favorite",
 			choices: ["apple", "banana", "cherry"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Choose your favorite");
+		expect(screen()).toContain("Choose your favorite");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders all visible choices", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["alpha", "beta", "gamma"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("alpha");
-		expect(stderrOutput).toContain("beta");
-		expect(stderrOutput).toContain("gamma");
+		expect(screen()).toContain("alpha");
+		expect(screen()).toContain("beta");
+		expect(screen()).toContain("gamma");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders cursor indicator on active item", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["alpha", "beta"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("›");
+		expect(screen()).toContain("›");
 
 		pressKey("", { name: "return" });
 		await promise;
 	});
 
 	it("renders submitted answer on confirm", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick a fruit",
 			choices: ["apple", "banana", "cherry"],
 		});
@@ -396,11 +339,11 @@ describe("select — rendering", () => {
 
 		await promise;
 		// After submit, the selected label should appear in the output
-		expect(stderrOutput).toContain("banana");
+		expect(screen()).toContain("banana");
 	});
 
 	it("renders labels for object choices", async () => {
-		const promise = select<number>({
+		const promise = start({
 			message: "Pick",
 			choices: [
 				{ label: "Option A", value: 1 },
@@ -409,8 +352,8 @@ describe("select — rendering", () => {
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Option A");
-		expect(stderrOutput).toContain("Option B");
+		expect(screen()).toContain("Option A");
+		expect(screen()).toContain("Option B");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -422,12 +365,9 @@ describe("select — rendering", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — viewport scrolling", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("limits visible choices to maxVisible", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices,
 			maxVisible: 5,
@@ -435,9 +375,9 @@ describe("select — viewport scrolling", () => {
 
 		await tick();
 		// Only first 5 items should be visible
-		expect(stderrOutput).toContain("item-0");
-		expect(stderrOutput).toContain("item-4");
-		expect(stderrOutput).not.toContain("item-5");
+		expect(screen()).toContain("item-0");
+		expect(screen()).toContain("item-4");
+		expect(screen()).not.toContain("item-5");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -445,14 +385,14 @@ describe("select — viewport scrolling", () => {
 
 	it("shows scroll-down indicator when more items below", async () => {
 		const choices = Array.from({ length: 20 }, (_, i) => `item-${i}`);
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices,
 			maxVisible: 5,
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("...");
+		expect(screen()).toContain("...");
 
 		pressKey("", { name: "return" });
 		await promise;
@@ -460,7 +400,7 @@ describe("select — viewport scrolling", () => {
 
 	it("scrolls down when navigating past visible items", async () => {
 		const choices = Array.from({ length: 10 }, (_, i) => `item-${i}`);
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices,
 			maxVisible: 3,
@@ -476,7 +416,7 @@ describe("select — viewport scrolling", () => {
 		await tick();
 
 		// item-3 should now be visible
-		expect(stderrOutput).toContain("item-3");
+		expect(screen()).toContain("item-3");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -484,7 +424,7 @@ describe("select — viewport scrolling", () => {
 	});
 
 	it("does not show scroll indicators when all items fit", async () => {
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			maxVisible: 10,
@@ -493,7 +433,7 @@ describe("select — viewport scrolling", () => {
 		await tick();
 		// With only 3 items and maxVisible=10, no scroll indicators
 		// Count "..." occurrences — should not appear as a scroll indicator line
-		const lines = stderrOutput.split("\n");
+		const lines = screen().split("\n");
 		const scrollLines = lines.filter((l) => l.trim() === "...");
 		expect(scrollLines.length).toBe(0);
 
@@ -503,7 +443,7 @@ describe("select — viewport scrolling", () => {
 
 	it("wrapping from last item scrolls viewport back to top", async () => {
 		const choices = Array.from({ length: 10 }, (_, i) => `item-${i}`);
-		const promise = select({
+		const promise = start({
 			message: "Pick",
 			choices,
 			maxVisible: 3,
@@ -516,7 +456,7 @@ describe("select — viewport scrolling", () => {
 		await tick();
 
 		// Should now show the first items
-		expect(stderrOutput).toContain("item-0");
+		expect(screen()).toContain("item-0");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -529,18 +469,15 @@ describe("select — viewport scrolling", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — no message", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
 	it("renders default message when message is omitted", async () => {
-		const promise = select({
+		const promise = start({
 			choices: ["a", "b", "c"],
 		});
 
 		await tick();
-		expect(stderrOutput).toContain("Pick an option");
-		expect(stderrOutput).not.toContain("undefined");
-		expect(stderrOutput).toContain("a");
+		expect(screen()).toContain("Pick an option");
+		expect(screen()).not.toContain("undefined");
+		expect(screen()).toContain("a");
 
 		pressKey("", { name: "return" });
 		const result = await promise;
@@ -548,7 +485,7 @@ describe("select — no message", () => {
 	});
 
 	it("submitted output shows default message", async () => {
-		const promise = select({
+		const promise = start({
 			choices: ["a", "b", "c"],
 		});
 
@@ -556,8 +493,8 @@ describe("select — no message", () => {
 		pressKey("", { name: "return" });
 
 		await promise;
-		expect(stderrOutput).toContain("Pick an option");
-		expect(stderrOutput).not.toContain("undefined");
+		expect(screen()).toContain("Pick an option");
+		expect(screen()).not.toContain("undefined");
 	});
 });
 
@@ -566,18 +503,13 @@ describe("select — no message", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("select — non-TTY", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
+	function nonTTY<T>(options: SelectOptions<T>): Promise<T> {
+		return select(options, nonTTYIO());
+	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			select({
+			nonTTY({
 				message: "Pick",
 				choices: ["a", "b", "c"],
 			}),
@@ -585,13 +517,7 @@ describe("select — non-TTY", () => {
 	});
 
 	it("returns initial value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await select({
+		const result = await nonTTY({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			initial: "b",
@@ -601,13 +527,7 @@ describe("select — non-TTY", () => {
 	});
 
 	it("returns default value in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await select({
+		const result = await nonTTY({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			default: "b",
@@ -617,14 +537,8 @@ describe("select — non-TTY", () => {
 	});
 
 	it("throws NonInteractiveError when no default or initial in non-TTY", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
 		await expect(
-			select({
+			nonTTY({
 				message: "Pick",
 				choices: ["a", "b", "c"],
 			}),
@@ -632,13 +546,7 @@ describe("select — non-TTY", () => {
 	});
 
 	it("prefers initial over default in non-TTY environment", async () => {
-		Object.defineProperty(process.stdin, "isTTY", {
-			value: false,
-			writable: true,
-			configurable: true,
-		});
-
-		const result = await select({
+		const result = await nonTTY({
 			message: "Pick",
 			choices: ["a", "b", "c"],
 			initial: "a",

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -2,8 +2,8 @@
 // Select — Single selection from a list of choices for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
-import type { KeypressEvent, SubmitResult } from "../core/renderer.ts";
-import { isTTY, runPrompt, submit } from "../core/renderer.ts";
+import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
+import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import {
 	CURSOR_INDICATOR,
 	PREFIX_SUBMITTED,
@@ -235,14 +235,16 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-export async function select<T>(options: SelectOptions<T>): Promise<T> {
+export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {
 		return options.initial;
 	}
 
+	const promptIO = resolvePromptIO(io);
+
 	// Non-interactive fallback: return default value when stdin is not a TTY
-	if (!isTTY() && options.default !== undefined) {
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
 		return options.default;
 	}
 
@@ -268,12 +270,15 @@ export async function select<T>(options: SelectOptions<T>): Promise<T> {
 		scrollOffset: initialScrollOffset,
 	};
 
-	return runPrompt<SelectState<T>, T>({
-		initialState,
-		theme,
-		render: (state, t) => renderSelect(state, t, options.message, maxVisible),
-		handleKey: createHandleKey<T>(maxVisible),
-		renderSubmitted: (state, value, t) =>
-			renderSubmitted(state, value, t, options.message, choices, state.cursor),
-	});
+	return runPrompt<SelectState<T>, T>(
+		{
+			initialState,
+			theme,
+			render: (state, t) => renderSelect(state, t, options.message, maxVisible),
+			handleKey: createHandleKey<T>(maxVisible),
+			renderSubmitted: (state, value, t) =>
+				renderSubmitted(state, value, t, options.message, choices, state.cursor),
+		},
+		promptIO,
+	);
 }

--- a/packages/prompts/src/testing.test.ts
+++ b/packages/prompts/src/testing.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { encodeKey } from "./testing.ts";
+
+describe("encodeKey", () => {
+	it("encodes named keys", () => {
+		expect(encodeKey("return")).toBe("\r");
+		expect(encodeKey("up")).toBe("\x1B[A");
+		expect(encodeKey("space")).toBe(" ");
+	});
+
+	it("encodes ctrl combinations", () => {
+		expect(encodeKey("ctrl+c")).toBe("\x03");
+	});
+
+	it("passes single printable characters through", () => {
+		expect(encodeKey("y")).toBe("y");
+	});
+
+	it("throws on unsupported key names instead of typing them", () => {
+		expect(() => encodeKey("pageup")).toThrow("Unsupported key name");
+		expect(() => encodeKey("")).toThrow("Unsupported key name");
+	});
+});

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -7,29 +7,40 @@ export function stripAnsi(text: string): string {
 	return text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
-/** Encode a named terminal key as its raw input sequence. */
+const namedKeys: Record<string, string> = {
+	return: "\r",
+	enter: "\r",
+	backspace: "\x7f",
+	delete: "\x1B[3~",
+	up: "\x1B[A",
+	down: "\x1B[B",
+	right: "\x1B[C",
+	left: "\x1B[D",
+	home: "\x1B[H",
+	end: "\x1B[F",
+	tab: "\t",
+	space: " ",
+	escape: "\x1B",
+};
+
+/**
+ * Encode a named terminal key as its raw input sequence.
+ *
+ * Accepts names from the key table, `ctrl+<letter>` combinations, and single
+ * printable characters. Anything else throws — silently typing a misspelled
+ * key name (e.g. `"pageup"`) into the prompt would corrupt the test input.
+ */
 export function encodeKey(key: string): string {
-	const namedKeys: Record<string, string> = {
-		return: "\r",
-		enter: "\r",
-		backspace: "\x7f",
-		delete: "\x1B[3~",
-		up: "\x1B[A",
-		down: "\x1B[B",
-		right: "\x1B[C",
-		left: "\x1B[D",
-		home: "\x1B[H",
-		end: "\x1B[F",
-		tab: "\t",
-		space: " ",
-		escape: "\x1B",
-	};
 	if (key in namedKeys) return namedKeys[key] ?? "";
 
 	const ctrl = /^ctrl\+([a-z])$/i.exec(key);
 	if (ctrl?.[1]) return String.fromCharCode(ctrl[1].toUpperCase().charCodeAt(0) & 0x1f);
 
-	return key;
+	if (key.length === 1) return key;
+
+	throw new Error(
+		`Unsupported key name: ${JSON.stringify(key)}. Use one of ${Object.keys(namedKeys).join(", ")}, ctrl+<letter>, a single character, or type() for literal text.`,
+	);
 }
 
 class FakeTerminal {

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -1,0 +1,160 @@
+import { PassThrough, Writable } from "node:stream";
+
+import type { PromptIO } from "./core/renderer.ts";
+
+/** Remove ANSI control sequences from terminal output. */
+export function stripAnsi(text: string): string {
+	return text.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+/** Encode a named terminal key as its raw input sequence. */
+export function encodeKey(key: string): string {
+	const namedKeys: Record<string, string> = {
+		return: "\r",
+		enter: "\r",
+		backspace: "\x7f",
+		delete: "\x1B[3~",
+		up: "\x1B[A",
+		down: "\x1B[B",
+		right: "\x1B[C",
+		left: "\x1B[D",
+		home: "\x1B[H",
+		end: "\x1B[F",
+		tab: "\t",
+		space: " ",
+		escape: "\x1B",
+	};
+	if (key in namedKeys) return namedKeys[key] ?? "";
+
+	const ctrl = /^ctrl\+([a-z])$/i.exec(key);
+	if (ctrl?.[1]) return String.fromCharCode(ctrl[1].toUpperCase().charCodeAt(0) & 0x1f);
+
+	return key;
+}
+
+class FakeTerminal {
+	private readonly lines = [""];
+	private row = 0;
+	private column = 0;
+
+	write(text: string): void {
+		let index = 0;
+		while (index < text.length) {
+			const escape = /^\x1B\[([0-?]*)([ -/]*)([@-~])/.exec(text.slice(index));
+			if (escape) {
+				this.handleEscape(escape[1] ?? "", escape[3] ?? "");
+				index += escape[0].length;
+				continue;
+			}
+
+			const char = text[index] ?? "";
+			index++;
+			if (char === "\r") {
+				this.column = 0;
+			} else if (char === "\n") {
+				this.row++;
+				this.column = 0;
+				this.ensureLine();
+			} else {
+				this.writeChar(char);
+			}
+		}
+	}
+
+	screen(): string {
+		let last = this.lines.length - 1;
+		while (last > 0 && this.lines[last] === "") last--;
+		return this.lines.slice(0, last + 1).join("\n");
+	}
+
+	private handleEscape(parameters: string, command: string): void {
+		const count = Number(parameters.replace(/[^0-9]/g, "")) || 1;
+		if (command === "A") {
+			this.row = Math.max(0, this.row - count);
+		} else if (command === "B") {
+			this.row += count;
+			this.ensureLine();
+		} else if (command === "K") {
+			this.lines[this.row] = "";
+		}
+	}
+
+	private writeChar(char: string): void {
+		this.ensureLine();
+		const line = this.lines[this.row] ?? "";
+		const padding = " ".repeat(Math.max(0, this.column - line.length));
+		this.lines[this.row] =
+			`${line.slice(0, this.column)}${padding}${char}${line.slice(this.column + 1)}`;
+		this.column++;
+	}
+
+	private ensureLine(): void {
+		while (this.lines.length <= this.row) this.lines.push("");
+	}
+}
+
+export interface PromptTestIO {
+	readonly io: PromptIO;
+	type(text: string): void;
+	keys(...namedKeys: string[]): void;
+	screen(): string;
+	output(): string;
+}
+
+/** Create fake TTY streams for testing prompts or applications that render prompts. */
+export function createPromptIO({ isTTY = true }: { isTTY?: boolean } = {}): PromptTestIO {
+	const input = new PassThrough() as PassThrough & {
+		isTTY: boolean;
+		isRaw: boolean;
+		setRawMode: (mode: boolean) => PassThrough;
+	};
+	input.isTTY = isTTY;
+	input.isRaw = false;
+	input.setRawMode = (mode) => {
+		input.isRaw = mode;
+		return input;
+	};
+
+	const terminal = new FakeTerminal();
+	let transcript = "";
+	const output = new Writable({
+		write(chunk, _encoding, callback) {
+			const text = chunk.toString();
+			transcript += text;
+			terminal.write(text);
+			callback();
+		},
+	}) as Writable & { columns: number };
+	output.columns = 80;
+
+	return {
+		io: { input, output },
+		type: (text) => input.write(text),
+		keys: (...namedKeys) => {
+			for (const key of namedKeys) input.write(encodeKey(key));
+		},
+		screen: () => stripAnsi(terminal.screen()),
+		output: () => transcript,
+	};
+}
+
+export interface RenderedPrompt<Answer> {
+	type(text: string): void;
+	keys(...namedKeys: string[]): void;
+	screen(): string;
+	readonly answer: Promise<Answer>;
+}
+
+/** Run a prompt function against fake TTY streams and expose terminal-style controls. */
+export function renderPrompt<Options, Answer>(
+	prompt: (options: Options, io?: PromptIO) => Promise<Answer>,
+	options: Options,
+): RenderedPrompt<Answer> {
+	const harness = createPromptIO();
+	return {
+		type: harness.type,
+		keys: harness.keys,
+		screen: harness.screen,
+		answer: prompt(options, harness.io),
+	};
+}


### PR DESCRIPTION
## Summary

- Add injectable IO to `@crustjs/prompts`: `PromptIO = { input?, output? }` as a trailing optional param on `runPrompt` and all 8 prompts, mirroring core's `run(argv, io?)`.
- IO resolution order: explicit `io` arg → ambient IO via `AsyncLocalStorage` scope (`withPromptIO(io, fn)`) → process globals.
- `isTTY()`/`assertTTY()` now duck-type an optional injected stream; the non-TTY `default`/`initial` fallback paths are testable without touching globals.
- Replace the module-global `promptActive` lock with a per-input-stream `WeakSet` — one prompt per input stream; distinct streams can run concurrently.
- New `@crustjs/prompts/testing` subpath: `renderPrompt(promptFn, options)` → `{ type(), keys(), screen(), answer }` with fake TTY streams, named-key encoding, and ANSI-stripped frames — for custom-prompt authors and crust's own tests.
- Rewrite all 8 prompt test files on the harness; delete the `process.stdin`/`process.stderr` monkey-patch boilerplate.
- Prompt UI still writes to stderr (stdout stays pipeable). Docs and changeset (minor) included.

## Verification

`bun run check && bun run check:types && bun test` — green (2,320 pass, 8 skip, 0 fail).

Sets up #<follow-up>: `@crustjs/testing` (app-level `captureRun`/`interactiveRun`) is stacked on this branch.