### PR TITLE
feat(testing): add @crustjs/testing package

### DIFF
--- a/.changeset/testing-package.md
+++ b/.changeset/testing-package.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/testing": minor
+---
+
+Add application testing helpers with captured output and fake interactive terminals.

--- a/apps/docs/content/docs/guide/development.mdx
+++ b/apps/docs/content/docs/guide/development.mdx
@@ -18,49 +18,7 @@ await app.execute();
 
 ## Test programmatically
 
-Use `run(argv, io)` to avoid global console and exit-state changes:
-
-```ts
-import { expect, test } from "bun:test";
-
-const output: string[] = [];
-
-test("greets a name", async () => {
-  await app.run(["Ada"], {
-    stdout: (line) => output.push(line),
-    stderr: (line) => output.push(line),
-  });
-
-  expect(output).toEqual(["Hello, Ada!"]);
-});
-```
-
-`run()` throws the original error, so tests can assert identity or application error classes directly:
-
-```ts
-await expect(app.run(["missing"])).rejects.toMatchObject({ code: "COMMAND_NOT_FOUND" });
-```
-
-## Test custom prompts
-
-Prompt authors can drive `(options, io?)` prompt functions with fake TTY streams instead of patching process globals:
-
-```ts
-import { expect, test } from "bun:test";
-import { renderPrompt } from "@crustjs/prompts/testing";
-
-import { myPrompt } from "./my-prompt.ts";
-
-test("collects a name", async () => {
-  const prompt = renderPrompt(myPrompt, { message: "Name?" });
-  prompt.type("Ada");
-  prompt.keys("return");
-
-  expect(await prompt.answer).toBe("Ada");
-});
-```
-
-Use `prompt.screen()` to inspect the latest ANSI-stripped frame, or `createPromptIO({ isTTY: false })` to test a prompt's non-interactive fallback.
+Use the [Testing guide](/docs/guide/testing) for `captureRun()` and `interactiveRun()` helpers. It also explains when custom prompt authors should use `@crustjs/prompts/testing` directly.
 
 ## Validate definitions
 

--- a/apps/docs/content/docs/guide/meta.json
+++ b/apps/docs/content/docs/guide/meta.json
@@ -14,6 +14,7 @@
     "environment",
     "error-handling",
     "build",
-    "development"
+    "development",
+    "testing"
   ]
 }

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -13,7 +13,7 @@ bun add -d @crustjs/testing
 
 ## Capture command output
 
-Use `captureRun()` for commands that write ordinary stdout or stderr. It returns joined strings and returns a thrown application error instead of discarding output that occurred before it.
+Use `captureRun()` for commands that write ordinary stdout or stderr. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults), and a thrown application error is returned instead of discarding output that occurred before it.
 
 ```ts
 import { expect, test } from "bun:test";
@@ -52,7 +52,7 @@ test("collects a name", async () => {
 });
 ```
 
-`done` rejects with the original application error, matching `app.run()`.
+`done` rejects with the original application error, matching `app.run()`. `waitFor()` never hangs on a failed or finished run: it rethrows the application error, or throws with the current screen when the pattern can no longer match or its timeout (default 5000ms) elapses.
 
 ## For custom prompt authors
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -1,0 +1,79 @@
+---
+title: Testing
+description: Test Crust applications and custom prompts without process-global stream patches.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+`@crustjs/testing` runs a Crust application with captured output or fake terminal streams. It is for application developers; install it alongside `@crustjs/core`.
+
+```sh
+bun add -d @crustjs/testing
+```
+
+## Capture command output
+
+Use `captureRun()` for commands that write ordinary stdout or stderr. It returns joined strings and returns a thrown application error instead of discarding output that occurred before it.
+
+```ts
+import { expect, test } from "bun:test";
+import { captureRun } from "@crustjs/testing";
+
+import { app } from "./cli.ts";
+
+test("greets a name", async () => {
+  const result = await captureRun(app, ["Ada"]);
+
+  expect(result.stdout).toBe("Hello, Ada!");
+  expect(result.stderr).toBe("");
+  expect(result.error).toBeUndefined();
+});
+```
+
+## Test interactive commands
+
+Use `interactiveRun()` when a handler renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
+
+```ts
+import { expect, test } from "bun:test";
+import { interactiveRun } from "@crustjs/testing";
+
+import { app } from "./cli.ts";
+
+test("collects a name", async () => {
+  const run = interactiveRun(app, []);
+  await run.waitFor(/Name\?/);
+
+  run.type("Ada");
+  run.keys("return");
+  await run.done;
+
+  expect(run.screen()).toContain("Hello, Ada!");
+});
+```
+
+`done` rejects with the original application error, matching `app.run()`.
+
+## For custom prompt authors
+
+<Callout type="warn" title="Built-in prompts are already covered">
+  You do not test built-in prompts. The library covers them. Use this only when authoring a custom
+  `(options, io?)` prompt.
+</Callout>
+
+Use `@crustjs/prompts/testing` directly for custom prompt functions:
+
+```ts
+import { expect, test } from "bun:test";
+import { renderPrompt } from "@crustjs/prompts/testing";
+
+import { myPrompt } from "./my-prompt.ts";
+
+test("collects a name", async () => {
+  const prompt = renderPrompt(myPrompt, { message: "Name?" });
+  prompt.type("Ada");
+  prompt.keys("return");
+
+  expect(await prompt.answer).toBe("Ada");
+});
+```

--- a/apps/docs/content/docs/modules/index.mdx
+++ b/apps/docs/content/docs/modules/index.mdx
@@ -23,5 +23,6 @@ Install [`@crustjs/core`](/docs/modules/core) and the capabilities your applicat
 | [`@crustjs/create`](/docs/modules/create)     | Headless scaffolding engine for create-\* tools |
 | [`@crustjs/progress`](/docs/modules/progress) | Non-interactive progress indicators             |
 | [`@crustjs/prompts`](/docs/modules/prompts)   | Interactive terminal prompts                    |
+| [`@crustjs/testing`](/docs/modules/testing)   | Test helpers for Crust applications             |
 | [`@crustjs/store`](/docs/modules/store)       | Typed configuration persistence                 |
 | [`@crustjs/style`](/docs/modules/style)       | Terminal styling and layout utilities           |

--- a/apps/docs/content/docs/modules/meta.json
+++ b/apps/docs/content/docs/modules/meta.json
@@ -8,6 +8,7 @@
     "create",
     "progress",
     "prompts",
+    "testing",
     "style",
     "store",
     "skills",

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -13,7 +13,7 @@ bun add -d @crustjs/testing
 
 ## `captureRun(app, argv)`
 
-Run an application with captured output. The returned `stdout` and `stderr` fields are joined strings. If the application throws, `error` contains that value and output written before the failure is retained.
+Run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. If the application throws, `error` contains that value and output written before the failure is retained.
 
 ```ts
 import { captureRun } from "@crustjs/testing";
@@ -27,6 +27,8 @@ console.log(result.stdout);
 ## `interactiveRun(app, argv)`
 
 Run an application against a fake TTY. Use `waitFor()` before sending input with `type()` or `keys()`, then await `done`.
+
+`waitFor(pattern, timeoutMs?)` polls the terminal (default timeout 5000ms). It fails fast instead of hanging: if the application throws before the pattern matches, `waitFor()` rethrows that error; if the application completes without matching, or the timeout elapses, it throws with the current screen contents.
 
 ```ts
 import { interactiveRun } from "@crustjs/testing";

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -1,0 +1,45 @@
+---
+title: Testing
+description: Test Crust applications with captured output and fake interactive terminals.
+---
+
+`@crustjs/testing` provides application-level test helpers for `@crustjs/core`. It captures ordinary command output and drives handlers that use built-in `@crustjs/prompts` prompts.
+
+## Install
+
+```sh
+bun add -d @crustjs/testing
+```
+
+## `captureRun(app, argv)`
+
+Run an application with captured output. The returned `stdout` and `stderr` fields are joined strings. If the application throws, `error` contains that value and output written before the failure is retained.
+
+```ts
+import { captureRun } from "@crustjs/testing";
+
+const result = await captureRun(app, ["build"]);
+
+if (result.error) throw result.error;
+console.log(result.stdout);
+```
+
+## `interactiveRun(app, argv)`
+
+Run an application against a fake TTY. Use `waitFor()` before sending input with `type()` or `keys()`, then await `done`.
+
+```ts
+import { interactiveRun } from "@crustjs/testing";
+
+const run = interactiveRun(app, []);
+await run.waitFor(/Project name/);
+run.type("my-app");
+run.keys("return");
+await run.done;
+```
+
+`screen()` returns the ANSI-stripped terminal screen. Prompt frames and `ctx.stderr()` output share that screen and the transcript scanned by `waitFor()`.
+
+## Custom prompts
+
+This package intentionally does not re-export prompt-author helpers. For a custom `(options, io?)` prompt, use `renderPrompt()` from [`@crustjs/prompts/testing`](/docs/modules/prompts#testing-custom-prompts). Built-in prompts are covered by the library.

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -151,9 +151,9 @@ const MODULES: Array<{
     doc: "modules/man",
   },
   {
-    pkg: "@crustjs/test",
+    pkg: "@crustjs/testing",
     desc: "CLI testing helpers",
-    upcoming: true,
+    doc: "modules/testing",
   },
   {
     pkg: "@crustjs/render",

--- a/bun.lock
+++ b/bun.lock
@@ -192,6 +192,20 @@
         "bunup": "catalog:",
       },
     },
+    "packages/testing": {
+      "name": "@crustjs/testing",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@crustjs/config": "workspace:*",
+        "@crustjs/core": "workspace:*",
+        "@crustjs/prompts": "workspace:*",
+        "bunup": "catalog:",
+      },
+      "peerDependencies": {
+        "@crustjs/core": "workspace:0.x",
+        "@crustjs/prompts": "workspace:0.x",
+      },
+    },
     "packages/utils": {
       "name": "@crustjs/utils",
       "version": "0.0.0",
@@ -323,6 +337,8 @@
     "@crustjs/store": ["@crustjs/store@workspace:packages/store"],
 
     "@crustjs/style": ["@crustjs/style@workspace:packages/style"],
+
+    "@crustjs/testing": ["@crustjs/testing@workspace:packages/testing"],
 
     "@crustjs/utils": ["@crustjs/utils@workspace:packages/utils"],
 

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -105,7 +105,7 @@ class FakeTerminal {
 }
 
 export interface PromptTestIO {
-	readonly io: PromptIO;
+	readonly io: Required<PromptIO>;
 	type(text: string): void;
 	keys(...namedKeys: string[]): void;
 	screen(): string;

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,13 @@
+# @crustjs/testing
+
+Testing helpers for Crust CLI applications
+
+## Install
+
+```sh
+bun add -d @crustjs/testing
+```
+
+## Documentation
+
+Full docs: [crustjs.com/docs/modules/testing](https://crustjs.com/docs/modules/testing)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -8,6 +8,36 @@ Testing helpers for Crust CLI applications
 bun add -d @crustjs/testing
 ```
 
+## Exports
+
+- `captureRun(app, argv)` — run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line, joined with `"\n"`; a thrown application error is returned as `error` instead of discarding earlier output.
+- `interactiveRun(app, argv)` — run an application against a fake TTY for handlers that render built-in prompts: `waitFor(pattern, timeoutMs?)`, `type(text)`, `keys(...names)`, `screen()`, and `done`.
+
+## Quick example
+
+```ts
+import { expect, test } from "bun:test";
+import { captureRun, interactiveRun } from "@crustjs/testing";
+
+import { app } from "./cli.ts";
+
+test("greets a name", async () => {
+	const result = await captureRun(app, ["Ada"]);
+	expect(result.stdout).toBe("Hello, Ada!");
+});
+
+test("prompts for a name", async () => {
+	const run = interactiveRun(app, []);
+	await run.waitFor(/Name\?/);
+	run.type("Ada");
+	run.keys("return");
+	await run.done;
+	expect(run.screen()).toContain("Hello, Ada!");
+});
+```
+
+Testing a custom `(options, io?)` prompt? Use `renderPrompt()` from `@crustjs/prompts/testing` — built-in prompts are already covered by the library.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/testing](https://crustjs.com/docs/modules/testing)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -8,36 +8,6 @@ Testing helpers for Crust CLI applications
 bun add -d @crustjs/testing
 ```
 
-## Exports
-
-- `captureRun(app, argv)` — run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line, joined with `"\n"`; a thrown application error is returned as `error` instead of discarding earlier output.
-- `interactiveRun(app, argv)` — run an application against a fake TTY for handlers that render built-in prompts: `waitFor(pattern, timeoutMs?)`, `type(text)`, `keys(...names)`, `screen()`, and `done`.
-
-## Quick example
-
-```ts
-import { expect, test } from "bun:test";
-import { captureRun, interactiveRun } from "@crustjs/testing";
-
-import { app } from "./cli.ts";
-
-test("greets a name", async () => {
-	const result = await captureRun(app, ["Ada"]);
-	expect(result.stdout).toBe("Hello, Ada!");
-});
-
-test("prompts for a name", async () => {
-	const run = interactiveRun(app, []);
-	await run.waitFor(/Name\?/);
-	run.type("Ada");
-	run.keys("return");
-	await run.done;
-	expect(run.screen()).toContain("Hello, Ada!");
-});
-```
-
-Testing a custom `(options, io?)` prompt? Use `renderPrompt()` from `@crustjs/prompts/testing` — built-in prompts are already covered by the library.
-
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/testing](https://crustjs.com/docs/modules/testing)

--- a/packages/testing/bunup.config.ts
+++ b/packages/testing/bunup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "bunup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: ["esm"],
+	target: "bun",
+	dts: true,
+	minify: false,
+});

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,58 @@
+{
+	"name": "@crustjs/testing",
+	"version": "0.0.1",
+	"description": "Testing helpers for Crust CLI applications",
+	"type": "module",
+	"license": "MIT",
+	"author": "chenxin-yan",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/chenxin-yan/crust.git",
+		"directory": "packages/testing"
+	},
+	"homepage": "https://crustjs.com",
+	"bugs": {
+		"url": "https://github.com/chenxin-yan/crust/issues"
+	},
+	"keywords": [
+		"cli",
+		"testing",
+		"crust",
+		"bun",
+		"typescript"
+	],
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"build": "bunup",
+		"dev": "bunup --watch",
+		"check:types": "tsc --noEmit",
+		"test": "bun test",
+		"publish": "bun publish --no-git-checks",
+		"prepack": "cp ../../LICENSE LICENSE",
+		"postpack": "rm -f LICENSE"
+	},
+	"devDependencies": {
+		"@crustjs/config": "workspace:*",
+		"@crustjs/core": "workspace:*",
+		"@crustjs/prompts": "workspace:*",
+		"bunup": "catalog:"
+	},
+	"peerDependencies": {
+		"@crustjs/core": "workspace:0.x",
+		"@crustjs/prompts": "workspace:0.x"
+	},
+	"engines": {
+		"bun": ">=1.3.14"
+	}
+}

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -6,15 +6,15 @@ import { input } from "@crustjs/prompts";
 import { captureRun, interactiveRun } from "./index.ts";
 
 describe("captureRun", () => {
-	it("captures joined output", async () => {
+	it("captures output as lines, matching core's console.log defaults", async () => {
 		const app = new Crust("test").handle(({ stdout, stderr }) => {
-			stdout("hello ");
-			stdout("world");
+			stdout("first");
+			stdout("second");
 			stderr("warning");
 		});
 
 		expect(await captureRun(app, [])).toEqual({
-			stdout: "hello world",
+			stdout: "first\nsecond",
 			stderr: "warning",
 		});
 	});
@@ -37,7 +37,7 @@ describe("captureRun", () => {
 describe("interactiveRun", () => {
 	it("drives prompts and merges application stderr with prompt frames", async () => {
 		const app = new Crust("test").handle(async ({ stderr }) => {
-			stderr("Starting\n");
+			stderr("Starting");
 			const name = await input({ message: "Name?" });
 			stderr(`Hello, ${name}!`);
 		});
@@ -50,5 +50,25 @@ describe("interactiveRun", () => {
 
 		expect(run.screen()).toContain("Starting");
 		expect(run.screen()).toContain("Hello, Ada!");
+	});
+
+	it("waitFor rethrows the application error instead of hanging", async () => {
+		const error = new Error("boom");
+		const app = new Crust("test").handle(() => {
+			throw error;
+		});
+
+		const run = interactiveRun(app, []);
+		await expect(run.waitFor(/never rendered/)).rejects.toBe(error);
+	});
+
+	it("waitFor fails when the application completes without matching", async () => {
+		const app = new Crust("test").handle(({ stderr }) => {
+			stderr("done");
+		});
+
+		const run = interactiveRun(app, []);
+		await expect(run.waitFor(/never rendered/)).rejects.toThrow("already completed");
+		await run.done;
 	});
 });

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import { Crust } from "@crustjs/core";
+import { input } from "@crustjs/prompts";
+
+import { captureRun, interactiveRun } from "./index.ts";
+
+describe("captureRun", () => {
+	it("captures joined output", async () => {
+		const app = new Crust("test").handle(({ stdout, stderr }) => {
+			stdout("hello ");
+			stdout("world");
+			stderr("warning");
+		});
+
+		expect(await captureRun(app, [])).toEqual({
+			stdout: "hello world",
+			stderr: "warning",
+		});
+	});
+
+	it("returns errors after preserving output", async () => {
+		const error = new Error("failed");
+		const app = new Crust("test").handle(({ stdout, stderr }) => {
+			stdout("before");
+			stderr("problem");
+			throw error;
+		});
+
+		const result = await captureRun(app, []);
+		expect(result.stdout).toBe("before");
+		expect(result.stderr).toBe("problem");
+		expect(result.error).toBe(error);
+	});
+});
+
+describe("interactiveRun", () => {
+	it("drives prompts and merges application stderr with prompt frames", async () => {
+		const app = new Crust("test").handle(async ({ stderr }) => {
+			stderr("Starting\n");
+			const name = await input({ message: "Name?" });
+			stderr(`Hello, ${name}!`);
+		});
+
+		const run = interactiveRun(app, []);
+		await run.waitFor(/Name\?/);
+		run.type("Ada");
+		run.keys("return");
+		await run.done;
+
+		expect(run.screen()).toContain("Starting");
+		expect(run.screen()).toContain("Hello, Ada!");
+	});
+});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,68 @@
+import type { Crust } from "@crustjs/core";
+import { withPromptIO } from "@crustjs/prompts";
+import { createPromptIO } from "@crustjs/prompts/testing";
+
+export interface CapturedRun {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly error?: unknown;
+}
+
+/** Run an application and capture its text output without throwing invocation errors. */
+export async function captureRun(app: Crust, argv: readonly string[]): Promise<CapturedRun> {
+	let stdout = "";
+	let stderr = "";
+	let failed = false;
+	let error: unknown;
+
+	try {
+		await app.run(argv, {
+			stdout: (text) => {
+				stdout += text;
+			},
+			stderr: (text) => {
+				stderr += text;
+			},
+		});
+	} catch (caught) {
+		failed = true;
+		error = caught;
+	}
+
+	return failed ? { stdout, stderr, error } : { stdout, stderr };
+}
+
+export interface InteractiveRun {
+	waitFor(pattern: RegExp): Promise<void>;
+	type(text: string): void;
+	keys(...namedKeys: string[]): void;
+	screen(): string;
+	readonly done: Promise<void>;
+}
+
+/** Run an application with fake terminal streams for its prompts and stderr output. */
+export function interactiveRun(app: Crust, argv: readonly string[]): InteractiveRun {
+	const harness = createPromptIO();
+	const output = harness.io.output!;
+	const done = withPromptIO(harness.io, () =>
+		app.run(argv, {
+			stdout: () => {},
+			stderr: (text) => {
+				output.write(text);
+			},
+		}),
+	);
+
+	return {
+		waitFor: async (pattern) => {
+			const matcher = new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
+			while (!matcher.test(harness.screen())) {
+				await Bun.sleep(1);
+			}
+		},
+		type: (text) => harness.type(text),
+		keys: (...namedKeys) => harness.keys(...namedKeys),
+		screen: () => harness.screen(),
+		done,
+	};
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -10,18 +10,20 @@ export interface CapturedRun {
 
 /** Run an application and capture its text output without throwing invocation errors. */
 export async function captureRun(app: Crust, argv: readonly string[]): Promise<CapturedRun> {
-	let stdout = "";
-	let stderr = "";
+	// Each io callback invocation is one line in a real terminal (core's
+	// defaults are console.log/console.error), so join captured calls with "\n".
+	const stdoutLines: string[] = [];
+	const stderrLines: string[] = [];
 	let failed = false;
 	let error: unknown;
 
 	try {
 		await app.run(argv, {
 			stdout: (text) => {
-				stdout += text;
+				stdoutLines.push(text);
 			},
 			stderr: (text) => {
-				stderr += text;
+				stderrLines.push(text);
 			},
 		});
 	} catch (caught) {
@@ -29,11 +31,13 @@ export async function captureRun(app: Crust, argv: readonly string[]): Promise<C
 		error = caught;
 	}
 
+	const stdout = stdoutLines.join("\n");
+	const stderr = stderrLines.join("\n");
 	return failed ? { stdout, stderr, error } : { stdout, stderr };
 }
 
 export interface InteractiveRun {
-	waitFor(pattern: RegExp): Promise<void>;
+	waitFor(pattern: RegExp, timeoutMs?: number): Promise<void>;
 	type(text: string): void;
 	keys(...namedKeys: string[]): void;
 	screen(): string;
@@ -48,15 +52,47 @@ export function interactiveRun(app: Crust, argv: readonly string[]): Interactive
 		app.run(argv, {
 			stdout: () => {},
 			stderr: (text) => {
-				output.write(text);
+				// Line-oriented like core's console.error default.
+				output.write(`${text}\n`);
 			},
 		}),
 	);
 
+	// Observe settlement so waitFor can stop polling; the handler also keeps an
+	// unawaited rejected `done` from surfacing as an unhandled rejection.
+	let settled = false;
+	let failed = false;
+	let failure: unknown;
+	done.then(
+		() => {
+			settled = true;
+		},
+		(caught: unknown) => {
+			settled = true;
+			failed = true;
+			failure = caught;
+		},
+	);
+
 	return {
-		waitFor: async (pattern) => {
+		waitFor: async (pattern, timeoutMs = 5000) => {
 			const matcher = new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
+			const deadline = Date.now() + timeoutMs;
 			while (!matcher.test(harness.screen())) {
+				if (settled) {
+					// All writes land before settlement; re-test once in case the
+					// loop condition ran before the final frame was written.
+					if (matcher.test(harness.screen())) return;
+					if (failed) throw failure;
+					throw new Error(
+						`waitFor(${matcher}) never matched; the application already completed. Screen:\n${harness.screen()}`,
+					);
+				}
+				if (Date.now() > deadline) {
+					throw new Error(
+						`waitFor(${matcher}) timed out after ${timeoutMs}ms. Screen:\n${harness.screen()}`,
+					);
+				}
 				await Bun.sleep(1);
 			}
 		},

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@crustjs/config/tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"isolatedDeclarations": true
+	},
+	"include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary

Stacked on #141 — merge that first, then retarget/merge this.

- New `@crustjs/testing` package for **app developers** testing their CLIs:
  - `captureRun(app, argv)` → `{ stdout, stderr, error? }` — buffered `run()` with error-as-value so pre-failure output survives.
  - `interactiveRun(app, argv)` → `{ waitFor(regex), type(), keys(), screen(), done }` — tests commands that prompt mid-handler by wrapping `run()` in `withPromptIO`; handler stderr and prompt frames merge into one transcript.
- Peer-deps on `@crustjs/core` and `@crustjs/prompts` (`workspace:0.x`) — the ambient-IO `AsyncLocalStorage` is module-scoped, so a second prompts copy would silently break `interactiveRun`.
- Independently versioned (not in the changesets `fixed` group). No `renderPrompt` re-export — custom-prompt authors use `@crustjs/prompts/testing` directly.
- Testing guide in docs framed by audience, with an explicit "you don't test built-in prompts — the library covers that" callout. Changeset included.

## Verification

`bun run check && bun run check:types && bun test` — green (2,320 pass, 8 skip, 0 fail).