### PR TITLE
refactor!: replace extension intercept with named lifecycle hooks

### DIFF
--- a/.changeset/extension-named-hooks.md
+++ b/.changeset/extension-named-hooks.md
@@ -1,0 +1,9 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": minor
+"@crustjs/skills": minor
+---
+
+Replace Extension `intercept(ctx, next)` and `handleError(error, ctx, next)` with named `hooks`: `preRun(ctx)`, `postRun(ctx, outcome)`, and `onError(error, ctx)`. `preRun` returns `ctx.finish()` to short-circuit successfully; `postRun` runs in reverse extension order after every settled invocation; `onError` returns `true` after rendering an `execute()` failure.
+
+Command Handlers now receive `rootCommand`, including handlers for Extension-owned commands. Migrate Extension-owned routing work into real `.handle()` callbacks.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -240,17 +240,17 @@ handle(
 ): Crust
 ```
 
-Defines the Command Handler. It runs after routing, parsing, validation, Extension interception, and Context construction.
+Defines the Command Handler. It runs after routing, parsing, `preRun` hooks, validation, and Context construction.
 
 ```ts
 const app = new Crust("greet")
   .args({ name: "name", type: "string", required: true })
-  .handle(({ args, flags, ctx, rawArgs, command, stdout, stderr }) => {
+  .handle(({ args, flags, ctx, rawArgs, command, rootCommand, stdout, stderr }) => {
     stdout(`Hello, ${args.name}!`);
   });
 ```
 
-The context contains typed `args`, typed effective `flags`, typed Context values in `ctx`, `rawArgs` after `--`, the resolved `CommandSnapshot`, and injectable `stdout(text)` and `stderr(text)` callbacks.
+The context contains typed `args`, typed effective `flags`, typed Context values in `ctx`, `rawArgs` after `--`, the resolved `command` and application `rootCommand` snapshots, and injectable `stdout(text)` and `stderr(text)` callbacks.
 
 ## `.mount(...definitions)`
 
@@ -314,7 +314,7 @@ await app.run(["Ada"], {
 });
 ```
 
-`run()` resolves after successful cleanup. It does not render errors, run Extension `handleError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Handler, and cancellation failures are thrown unchanged.
+`run()` resolves after successful cleanup. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Handler, and cancellation failures are thrown unchanged.
 
 ## `.execute(options?)`
 
@@ -328,7 +328,7 @@ Runs the terminal boundary. By default it parses `process.argv.slice(2)`; `optio
 await app.execute();
 ```
 
-`execute()` renders a failure once through the Extension `handleError` chain ending in Core's renderer, sets `process.exitCode` to `1`, and resolves. A standard `AbortError` cancellation is silent and sets exit code `130`.
+`execute()` renders a failure once through Extension `onError` hooks ending in Core's renderer, sets `process.exitCode` to `1`, and resolves. A standard `AbortError` cancellation is silent and sets exit code `130`.
 
 <Callout type="warn">
   Use `.handle(handler)` to define behavior. `.run(argv, io)` is only programmatic invocation;

--- a/apps/docs/content/docs/api/errors.mdx
+++ b/apps/docs/content/docs/api/errors.mdx
@@ -105,7 +105,7 @@ const app = new Crust("my-cli").handle(() => {
 await app.run([]); // throws the same `failure` object
 ```
 
-`.execute()` renders a failure once, sets `process.exitCode = 1`, and resolves. Extension `handleError` hooks can replace or delegate presentation but cannot turn the invocation into success.
+`.execute()` renders a failure once, sets `process.exitCode = 1`, and resolves. Extension `onError` hooks can render or delegate presentation but cannot turn the invocation into success.
 
 A prompt cancellation is a standard `DOMException` named `AbortError`. Programmatic `.run()` throws it; terminal `.execute()` handles it silently and sets exit code `130`.
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -139,7 +139,7 @@ Snapshots omit schemas and parse functions. `URL` defaults become strings, and a
   name="CrustCommandContext"
 />
 
-`InferArgs` and `InferFlags` are internal type plumbing, not root exports. `.args()`, `.flags()`, and `.provide()` infer these fields without explicit generic arguments.
+`rootCommand` is the readonly serializable snapshot of the application root, including Extension contributions. `InferArgs` and `InferFlags` are internal type plumbing, not root exports. `.args()`, `.flags()`, and `.provide()` infer these fields without explicit generic arguments.
 
 ## Context types
 
@@ -225,23 +225,29 @@ A structural type satisfied by a configured `Crust` builder. Extension commands 
 
 `args` and `flags` are syntax-parsed values. Extension hooks do not alter application Command Handler types.
 
-### Hook types
+### `ExtensionHooks`
 
-```ts
-type ExtensionNext = () => Promise<void>;
+<auto-type-table
+  path="../../../../../packages/core/src/api/extension.ts"
+  name="ExtensionHooks"
+/>
 
-type ExtensionIntercept = (context: ExtensionContext, next: ExtensionNext) => void | Promise<void>;
+`preRun` runs in `.extend()` order after routing and syntax parsing, before validation. Return `ctx.finish()` to end successfully. `postRun` is the LIFO `finally` hook: it runs for every Extension after a completed, finished, or failed invocation. `onError` is used by `.execute()` only; return `true` after rendering to stop the chain, or a falsy value to continue to Core's renderer.
 
-type ExtensionErrorHandler = (
-  error: unknown,
-  context: ExtensionContext,
-  next: ExtensionNext,
-) => void | Promise<void>;
-```
+### `Finished`
 
-`intercept` runs after routing and syntax parsing but before application value validation and Context construction. It short-circuits by not calling `next()`; calling `next()` more than once is a `DEFINITION` error. Extension-owned command inputs are validated before interception.
+<auto-type-table path="../../../../../packages/core/src/api/extension.ts" name="Finished" />
 
-`handleError` is a terminal presentation chain used by `.execute()` only. Render the error or call `next()` to delegate. Core preserves a nonzero failure outcome either way.
+`ctx.finish()` returns this opaque token. Return that exact value from `preRun`; do not construct one yourself.
+
+### `InvocationOutcome`
+
+<auto-type-table
+  path="../../../../../packages/core/src/api/extension.ts"
+  name="InvocationOutcome"
+/>
+
+`postRun` receives `completed` after a Command Handler completes, `finished` when an Extension short-circuits with `ctx.finish()`, or `failed` with the thrown value.
 
 ## Error types
 

--- a/apps/docs/content/docs/guide/commands.mdx
+++ b/apps/docs/content/docs/guide/commands.mdx
@@ -68,7 +68,7 @@ await app.run(["Ada"], {
 });
 ```
 
-`run()` throws the original error. `execute()` presents errors through the Extension `handleError` chain, sets `process.exitCode`, and resolves. See [Execution Model](/docs/guide/lifecycle).
+`run()` throws the original error. `execute()` presents errors through Extension `onError` hooks, sets `process.exitCode`, and resolves. See [Execution Model](/docs/guide/lifecycle).
 
 <Callout type="info">
   A command without a Command Handler is valid when it owns subcommands. Invoking it directly

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -30,7 +30,7 @@ const app = new Crust("app").provide(clock());
 
 ## Lazy construction and inheritance
 
-Context values are constructed only after a command is routed, parsed, intercepted, and validated — and only for the resolved command path. A short-circuiting Extension does not construct them.
+Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
 
 Contexts are inherited by descendant commands. A mounted command declares the factories it depends on in `requirements.ctx`, which types `ctx` in its handler:
 
@@ -174,6 +174,6 @@ const database = defineContext("db", async ({ options }: { options: { url: strin
 Crust disposes constructed Context values in reverse construction order after success or failure — with topological construction, dependents are always disposed before their dependencies. Prefer `Symbol.asyncDispose` when cleanup is asynchronous.
 
 <Callout type="info">
-  Use Contexts for command setup and cleanup. Use an Extension `intercept` only for app-wide
-  cross-cutting behavior around invocation.
+  Use Contexts for command setup and cleanup. Use Extension `preRun` and `postRun` hooks only for
+  app-wide cross-cutting behavior around an invocation.
 </Callout>

--- a/apps/docs/content/docs/guide/error-handling.mdx
+++ b/apps/docs/content/docs/guide/error-handling.mdx
@@ -51,25 +51,25 @@ Use ordinary application error classes when callers need to distinguish domain f
 
 ## Terminal presentation
 
-Extension `handleError` hooks form the presentation chain for `execute()`:
+Extension `onError` hooks present failures for `execute()`:
 
 ```ts
 import { defineExtension } from "@crustjs/core";
 
 const serviceErrors = defineExtension("service-errors", {
-  async handleError(error, ctx, next) {
-    if (error instanceof Error && error.name === "ServiceUnavailableError") {
+  hooks: {
+    onError(error, ctx) {
+      if (!(error instanceof Error) || error.name !== "ServiceUnavailableError") return;
       ctx.stderr(error.message);
-      return;
-    }
-    await next();
+      return true;
+    },
   },
 });
 ```
 
-A hook renders and returns, or delegates with `next()`. Core's default renderer is last. Core establishes a nonzero status before invoking the chain, so presentation cannot turn a failure into success.
+A hook returns `true` after rendering, or a falsy value to delegate to the next hook. Core's default renderer is last. Core establishes a nonzero status before invoking the chain, so presentation cannot turn a failure into success.
 
-`run()` never invokes this chain. It throws the original error and leaves rendering and exit status to its caller.
+`run()` never invokes these hooks. It throws the original error and leaves rendering and exit status to its caller.
 
 ## Cancellation
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -39,10 +39,12 @@ Mounted definitions are materialized into ordinary command nodes before root Ext
 
 ## Author an Extension
 
-`defineExtension(name, config)` returns a frozen plain value:
+`defineExtension(name, config)` returns a frozen plain value. The config can contain `flags`, `commands`, and `hooks`:
 
 ```ts
-import { Crust, defineExtension } from "@crustjs/core";
+import { Crust, type ExtensionContext, defineExtension } from "@crustjs/core";
+
+const timers = new WeakMap<ExtensionContext, number>();
 
 export const diagnostics = defineExtension("diagnostics", {
   flags: {
@@ -55,66 +57,89 @@ export const diagnostics = defineExtension("diagnostics", {
   commands: [
     new Crust("doctor")
       .meta({ description: "Check the installation" })
-      .handle(({ stdout }) => stdout("ok")),
+      .handle(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
   ],
-  async intercept(ctx, next) {
-    const start = performance.now();
-    await next();
-    if (ctx.flags.trace) ctx.stderr(`completed in ${performance.now() - start}ms`);
-  },
-  async handleError(error, ctx, next) {
-    if (error instanceof Error && error.name === "NetworkError") {
-      ctx.stderr(`Network error: ${error.message}`);
-      return;
-    }
-    await next();
+  hooks: {
+    preRun(ctx) {
+      if (ctx.flags.trace === true) timers.set(ctx, performance.now());
+    },
+    postRun(ctx, outcome) {
+      const started = timers.get(ctx);
+      if (started === undefined) return;
+      timers.delete(ctx);
+      ctx.stderr(`${outcome.status} in ${performance.now() - started}ms`);
+    },
   },
 });
 ```
-
-The config can contain `flags`, `commands`, `intercept`, and `handleError`.
 
 ## Owned flags and commands
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `inherit` controls ordinary command inheritance and remains available on the flag definition.
 
-Extension commands remain configured `Crust` builders attached at the root; this surface is unchanged by reusable command definitions. Their input definitions are validated before an intercept runs.
+Extension commands are configured `Crust` builders attached at the root. Their `.handle()` callbacks are real Command Handlers: validation, schemas, and Context construction complete before they run, and they receive the same typed handler context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide either. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 
-## Interception
+## Hooks
 
-`intercept(ctx, next)` runs after routing and syntax parsing but before application validation, schemas, Context construction, and the Command Handler.
+Hooks run after routing and syntax parsing. Routing and syntax failures skip `preRun` and `postRun`.
 
-Extensions run in `.extend()` order. Calling `await next()` enters the rest of the chain; code after it runs as the chain unwinds. Do not call `next()` to short-circuit:
+### `preRun`
+
+`preRun(ctx)` runs before value validation, schemas, Context construction, and the Command Handler, in `.extend()` order. Return `ctx.finish()` to end the invocation successfully: later `preRun` hooks and the remaining invocation work do not run.
 
 ```ts
 const cached = defineExtension("cached", {
-  async intercept(ctx, next) {
-    if (ctx.flags.cached) {
+  hooks: {
+    preRun(ctx) {
+      if (ctx.flags.cached !== true) return;
       ctx.stdout("cached result");
-      return;
-    }
-    await next();
+      return ctx.finish();
+    },
   },
 });
 ```
 
-Routing and syntax errors happen before interception and skip the intercept chain.
+### `postRun`
 
-## Error presentation
+`postRun(ctx, outcome)` runs after every invocation that reached the hooks, including a failure or `ctx.finish()` short-circuit. Hooks run in reverse `.extend()` order (LIFO), making this the cleanup and post-run side-effect slot.
 
-`handleError(error, ctx, next)` is a presentation chain used only by `execute()`. Render a known error and return, or call `next()` to delegate. The last handler is Core's default renderer.
+`outcome` is one of:
 
-Core sets a nonzero outcome before this chain. Handling presentation cannot turn a failure into success. Programmatic `run()` skips the chain and throws the original error.
+- `{ status: "completed" }` after the Command Handler completes
+- `{ status: "finished", by: string }` after an Extension returns `ctx.finish()`
+- `{ status: "failed", error: unknown }` after a `preRun` hook or the command pipeline throws
+
+A failing `postRun` cannot mask an existing invocation failure. After a completed or finished invocation, the first `postRun` failure is thrown after the remaining cleanup hooks run.
+
+Use a module-level `WeakMap<ExtensionContext, State>` for state shared by a hook pair. The same context identity reaches all hooks for one invocation, and entries can be removed in `postRun`; the diagnostics timer above follows this pattern.
+
+### `onError`
+
+`onError(error, ctx)` presents failures for `execute()` only, in `.extend()` order. Return `true` after rendering to stop presentation; return nothing (or `false`) to delegate to the next Extension and ultimately Core's default renderer.
+
+```ts
+const serviceErrors = defineExtension("service-errors", {
+  hooks: {
+    onError(error, ctx) {
+      if (!(error instanceof Error) || error.name !== "ServiceUnavailableError") return;
+      ctx.stderr(error.message);
+      return true;
+    },
+  },
+});
+```
+
+Core sets a nonzero exit status before `onError` hooks run, so rendering cannot turn a failure into success. Programmatic `run()` never invokes `onError`; it throws the original error. `AbortError` cancellation renders nothing and also skips `onError`.
 
 ## Extension context
 
-Both hooks receive an `ExtensionContext` containing:
+Hooks receive an `ExtensionContext` containing:
 
 - `argv`, syntax-parsed `args` and `flags`, and `rawArgs`
 - `rootCommand` and `command` as readonly serializable Command Snapshots
-- `commandPath`
+- `commandPath` and `finish()`
 - injectable `stdout(text)` and `stderr(text)` writers
 
 The values are invocation data, not mutable command definitions.

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -11,7 +11,7 @@ Use `execute()` at a CLI entrypoint:
 await app.execute();
 ```
 
-It reads `process.argv.slice(2)` by default, presents failures through Extension `handleError` hooks, sets `process.exitCode` to `1` (or `130` for cancellation), and resolves.
+It reads `process.argv.slice(2)` by default, presents failures through Extension `onError` hooks, sets `process.exitCode` to `1` (or `130` for cancellation), and resolves.
 
 Use `run()` for programmatic invocation:
 
@@ -29,22 +29,21 @@ It requires explicit argv, honors injected writers, throws the original error, d
 1. **Prepare definitions** — apply Extensions and reject command, flag, and alias collisions (duplicate Context names are rejected earlier, at the `.provide()` call).
 2. **Route** — resolve the command path.
 3. **Parse syntax** — consume positional and flag tokens.
-4. **Intercept** — run Extension intercepts in `.extend()` order. An intercept can stop here by not calling `next()`.
+4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Handler.
 5. **Validate structure** — enforce required values, choices, and other core rules.
 6. **Apply schemas** — validate and transform every schema-backed input, aggregating issues.
 7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared ctx requirements (registration order among independent Contexts), passing each setup the validated flags it declared.
 8. **Run the Command Handler**.
 9. **Dispose Contexts** — run `Symbol.dispose` or `Symbol.asyncDispose` in reverse construction order, including after failure.
-
-Code after `await next()` in an intercept runs while the chain unwinds, after the Command Handler and Context disposal beneath it.
+10. **Run `postRun` hooks** — invoke every Extension hook in reverse `.extend()` order with the completed, finished, or failed outcome. This is the invocation-level `finally` slot.
 
 ## Error flow
 
-Definition, routing, and parse failures occur before intercepts. Validation, schema, Context, and Command Handler failures can unwind through intercepts that called `next()`.
+Definition, routing, and parse failures occur before `preRun` and `postRun`. A failure from `preRun`, validation, schema application, Context construction or disposal, or the Command Handler still runs every `postRun` hook. The original failure wins over cleanup failures; after a successful or finished invocation, the first cleanup failure fails the invocation after remaining hooks run.
 
 With `run()`, the original value is thrown to the caller. Handler and Context failures are never wrapped in `CrustError`.
 
-With `execute()`, Crust first establishes a nonzero status, then invokes Extension `handleError` hooks in `.extend()` order. A hook can render and return or call `next()`; Core's default renderer terminates the chain.
+With `execute()`, Crust first establishes a nonzero status, then invokes Extension `onError` hooks in `.extend()` order. A hook returns `true` when it rendered the failure; falsy results continue to the next hook and then Core's default renderer. `onError` is presentation only and never runs for `run()`.
 
 A `DOMException` whose name is `"AbortError"` is cancellation. `execute()` sets status `130` and renders nothing. `run()` still throws it.
 
@@ -53,7 +52,7 @@ A `DOMException` whose name is `"AbortError"` is cancellation. `execute()` sets 
 Choose the mechanism that matches the setup's scope:
 
 - use a Context for command-specific setup and native disposal
-- use Extension `intercept` for app-wide behavior around invocation
+- use Extension `preRun` and `postRun` for app-wide behavior around an invocation
 - keep ordinary local setup in the Command Handler when it is not reusable
 
 This keeps dependency construction lazy and guarantees reverse-order cleanup.

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -65,12 +65,12 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Command boundary types
 
-| Type                  | Description                                |
-| --------------------- | ------------------------------------------ |
-| `CrustCommandContext` | Typed context passed to a Command Handler  |
-| `CommandSnapshot`     | Readonly, serializable command description |
-| `ArgSnapshot`         | Serializable argument projection           |
-| `FlagSnapshot`        | Serializable flag projection               |
+| Type                  | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `CrustCommandContext` | Typed context passed to a Command Handler, including `rootCommand` |
+| `CommandSnapshot`     | Readonly, serializable command description                         |
+| `ArgSnapshot`         | Serializable argument projection                                   |
+| `FlagSnapshot`        | Serializable flag projection                                       |
 
 ## Context types
 
@@ -85,16 +85,16 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Extension types
 
-| Type                    | Description                                              |
-| ----------------------- | -------------------------------------------------------- |
-| `Extension`             | Named frozen Extension value                             |
-| `ExtensionConfig`       | Owned flags/commands and `intercept`/`handleError` hooks |
-| `ExtensionCommand`      | Structural configured-command contribution               |
-| `ExtensionFlagDef`      | Extension-owned flag with optional `recursive` scope     |
-| `ExtensionContext`      | Readonly invocation view passed to Extension hooks       |
-| `ExtensionNext`         | `() => Promise<void>` chain continuation                 |
-| `ExtensionIntercept`    | Cross-cutting interception hook                          |
-| `ExtensionErrorHandler` | Terminal error-presentation hook                         |
+| Type                | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| `Extension`         | Named frozen Extension value                            |
+| `ExtensionConfig`   | Owned flags, commands, and named hooks                  |
+| `ExtensionCommand`  | Structural configured-command contribution              |
+| `ExtensionFlagDef`  | Extension-owned flag with optional `recursive` scope    |
+| `ExtensionContext`  | Readonly invocation view, including `finish()`          |
+| `ExtensionHooks`    | `preRun`, `postRun`, and `onError` hook slots           |
+| `Finished`          | Opaque token returned by `ExtensionContext.finish()`    |
+| `InvocationOutcome` | Completed, short-circuited, or failed invocation result |
 
 ## Error types
 

--- a/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
+++ b/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
@@ -36,6 +36,6 @@ function didYouMean(options?: DidYouMeanOptions): Extension;
 
 Suggestions compare the unknown token with visible sibling command names and aliases. Alias matches are reported as canonical command names. Hidden commands are omitted.
 
-`didYouMean()` is a presentation-only `handleError` Extension. It handles only `CrustError` values with code `COMMAND_NOT_FOUND` and delegates every other failure to the next presenter. Core sets and preserves the nonzero terminal exit code independently of the selected mode.
+`didYouMean()` is a presentation-only `onError` Extension. It handles only `CrustError` values with code `COMMAND_NOT_FOUND`, returns `true` when it renders a suggestion, and delegates every other failure to the next presenter. Core sets and preserves the nonzero terminal exit code independently of the selected mode.
 
 `app.run(argv)` does not run presentation hooks; it throws the original `COMMAND_NOT_FOUND` error instead.

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -27,7 +27,7 @@ my-cli deploy --help
 function help(): Extension;
 ```
 
-`help()` owns an inherited boolean `help` flag with short name `h`. Its `intercept` hook writes help through `ctx.stdout` and short-circuits the Command Handler when `--help` is present. A container command with no Command Handler also displays help.
+`help()` owns an inherited boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Handler also displays help.
 
 The renderer includes usage, visible subcommands, positional arguments, effective flags, aliases, defaults, and choices. Commands with `meta.hidden: true` stay routable but are omitted from listings.
 

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -33,7 +33,7 @@ function updateNotifier(options: UpdateNotifierOptions): Extension;
   name="UpdateNotifierOptions"
 />
 
-The `intercept` hook first awaits the Command Handler, then checks for an update. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. The notice is written to process stderr. Version comparison uses stable `major.minor.patch` values and ignores prerelease/build suffixes.
+The `postRun` hook checks for an update only after a Command Handler completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written to process stderr. Version comparison uses stable `major.minor.patch` values and ignores prerelease/build suffixes.
 
 Without `cache`, the check occurs once per process execution. With `cache`, a fresh cached result is reused for `intervalMs` and duplicate notices for the same version are suppressed.
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -178,7 +178,7 @@ uninstall the existing skill first.
 
 | Context                         | Conflict behavior                                             |
 | ------------------------------- | ------------------------------------------------------------- |
-| **Auto-update intercept**       | Logs a warning and skips — the CLI continues running normally |
+| **Auto-update hook**            | Logs a warning and skips — the CLI continues running normally |
 | **Interactive `skill` command** | Prompts the user to confirm overwriting the conflicting skill |
 | **`skill update` command**      | Logs a warning and skips the conflicting agent                |
 | **`generateSkill()` API**       | Throws `SkillConflictError`. Pass `force: true` to overwrite  |

--- a/packages/core/bunup.config.ts
+++ b/packages/core/bunup.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
 	entry: ["src/index.ts", "src/tooling.ts"],
 	format: ["esm"],
 	target: "bun",
-	dts: true,
+	dts: { splitting: true },
 	minify: false,
 });

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -65,9 +65,10 @@ describe("public beta API", () => {
 			flags: {
 				version: { type: "boolean" },
 			},
-			async intercept(_context, next) {
-				wrapperCalled = true;
-				await next();
+			hooks: {
+				preRun() {
+					wrapperCalled = true;
+				},
 			},
 		});
 

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -8,6 +8,25 @@ import type { Awaitable } from "./context.ts";
 // Extension — the public integration contract (ADR-0001)
 // ────────────────────────────────────────────────────────────────────────────
 
+const finishedBrand: unique symbol = Symbol("crust.finished");
+
+/** Opaque token returned by {@link ExtensionContext.finish} to end an invocation successfully. */
+export interface Finished {
+	readonly [finishedBrand]: true;
+}
+
+const FINISHED: Finished = Object.freeze({ [finishedBrand]: true as const });
+
+/** @internal */
+export function finishInvocation(): Finished {
+	return FINISHED;
+}
+
+export type InvocationOutcome =
+	| { readonly status: "completed" }
+	| { readonly status: "finished"; readonly by: string }
+	| { readonly status: "failed"; readonly error: unknown };
+
 /**
  * Readonly invocation view passed to Extension hooks.
  *
@@ -26,37 +45,32 @@ export interface ExtensionContext {
 	/** Syntax-parsed flag values for the resolved command */
 	readonly flags: Readonly<Record<string, unknown>>;
 	readonly rawArgs: readonly string[];
+	/** End the invocation successfully before validation, Context construction, and the handler. */
+	readonly finish: () => Finished;
 	/** Write a line of standard output (honors io injected via `run()`) */
 	readonly stdout: (text: string) => void;
 	/** Write a line of diagnostic output (honors io injected via `run()`) */
 	readonly stderr: (text: string) => void;
 }
 
-export type ExtensionNext = () => Promise<void>;
-
-/**
- * The one interception primitive. Executes after routing and syntax parsing
- * but before application value validation and Context construction, so an
- * Extension can short-circuit (by not calling `next()`) without exposing
- * nullable parser state. Extension-owned inputs are validated before the
- * hook; routing and syntax failures flow directly to error handling.
- */
-export type ExtensionIntercept = (
-	context: ExtensionContext,
-	next: ExtensionNext,
-) => Awaitable<void>;
-
-/**
- * Presentation-only error hook. Hooks form a chain ending in Core's default
- * renderer: render the failure yourself, or call `next()` to delegate to the
- * next handler. Core always preserves a nonzero failure outcome regardless
- * of what a handler does.
- */
-export type ExtensionErrorHandler = (
-	error: unknown,
-	context: ExtensionContext,
-	next: ExtensionNext,
-) => Awaitable<void>;
+export interface ExtensionHooks {
+	/**
+	 * Runs after routing and syntax parsing, before validation, in `.extend()` order.
+	 * Return `ctx.finish()` to end the invocation successfully; later pre-run hooks,
+	 * validation, schemas, Contexts, and the Command Handler do not run.
+	 */
+	readonly preRun?: (ctx: ExtensionContext) => Awaitable<void | Finished>;
+	/**
+	 * Runs after the invocation settles, in reverse `.extend()` order. This is the
+	 * `finally` slot for cleanup and post-run side effects.
+	 */
+	readonly postRun?: (ctx: ExtensionContext, outcome: InvocationOutcome) => Awaitable<void>;
+	/**
+	 * Renders a failure in `execute()` only. Return true when rendered to stop the
+	 * chain; falsy values delegate to the next Extension and then Core's renderer.
+	 */
+	readonly onError?: (error: unknown, ctx: ExtensionContext) => Awaitable<boolean | void>;
+}
 
 /**
  * A flag owned by an Extension. `recursive` (default `true`) contributes the
@@ -78,8 +92,7 @@ export interface ExtensionConfig {
 	readonly flags?: Readonly<Record<string, ExtensionFlagDef>>;
 	/** Root commands this Extension owns and contributes to the application */
 	readonly commands?: readonly ExtensionCommand[];
-	readonly intercept?: ExtensionIntercept;
-	readonly handleError?: ExtensionErrorHandler;
+	readonly hooks?: ExtensionHooks;
 }
 
 /**

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { defineContext } from "../api/context.ts";
-import { defineExtension, type ExtensionContext } from "../api/extension.ts";
+import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
 import type { FlagsDef } from "../types.ts";
@@ -995,30 +994,22 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
 
-	it("Extension commands are routable and their inputs validated before hooks", async () => {
+	it("Extension commands are routable, validated, and receive the root snapshot", async () => {
 		const lines: string[] = [];
 		const completion = defineExtension("completion", {
 			commands: [
 				new Crust("completion")
 					.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh"] })
-					.handle(() => {}),
+					.handle(({ args, rootCommand }) => {
+						lines.push(`completion:${args.shell}:${rootCommand.meta.name}`);
+					}),
 			],
-			async intercept(context, next) {
-				if (context.commandPath[1] === "completion") {
-					lines.push(`completion:${String(context.args.shell)}`);
-					return; // short-circuit — owned command handled here
-				}
-				await next();
-			},
 		});
 
 		const app = new Crust("cli").extend(completion).handle(() => {});
 
 		await app.run(["completion", "bash"]);
-		expect(lines).toEqual(["completion:bash"]);
-
-		// Owned inputs are checked BEFORE the intercept hook runs: bad choice
-		// values fail at syntax parsing, missing required args at validation
+		expect(lines).toEqual(["completion:bash:cli"]);
 		await expect(app.run(["completion", "fish"])).rejects.toMatchObject({ code: "PARSE" });
 		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
 	});
@@ -1049,122 +1040,194 @@ describe("Extension application at prepare time", () => {
 	});
 });
 
-describe("Extension intercept chain", () => {
-	it("runs intercepts in registration order around the Command Handler", async () => {
+describe("Extension named hooks", () => {
+	it("runs pre-run hooks in extension order and finish skips later hooks and the handler", async () => {
 		const order: string[] = [];
 		const first = defineExtension("first", {
-			async intercept(_context, next) {
-				order.push("first:before");
-				await next();
-				order.push("first:after");
+			hooks: {
+				preRun: () => {
+					order.push("first");
+				},
+			},
+		});
+		const gate = defineExtension("gate", {
+			hooks: {
+				preRun(ctx) {
+					order.push("gate");
+					return ctx.finish();
+				},
+			},
+		});
+		const last = defineExtension("last", {
+			hooks: {
+				preRun: () => {
+					order.push("last");
+				},
+			},
+		});
+		const app = new Crust("cli")
+			.args({ name: "file", type: "string", required: true })
+			.extend(first, gate, last)
+			.handle(() => {
+				order.push("handler");
+			});
+
+		await app.run([]);
+		expect(order).toEqual(["first", "gate"]);
+	});
+
+	it("runs post-run hooks LIFO for completed, failed, and finished invocations", async () => {
+		const outcomes: string[] = [];
+		const first = defineExtension("first", {
+			hooks: {
+				postRun: (_ctx, outcome) => {
+					outcomes.push(`first:${outcome.status}`);
+				},
 			},
 		});
 		const second = defineExtension("second", {
-			async intercept(_context, next) {
-				order.push("second:before");
-				await next();
-				order.push("second:after");
+			hooks: {
+				postRun: (_ctx, outcome) => {
+					outcomes.push(`second:${outcome.status}`);
+				},
 			},
 		});
 
-		const app = new Crust("cli").extend(first, second).handle(() => {
-			order.push("run");
+		await new Crust("cli")
+			.extend(first, second)
+			.handle(() => {})
+			.run([]);
+		expect(outcomes).toEqual(["second:completed", "first:completed"]);
+
+		outcomes.length = 0;
+		await expect(
+			new Crust("cli")
+				.extend(first, second)
+				.handle(() => {
+					throw new Error("boom");
+				})
+				.run([]),
+		).rejects.toThrow("boom");
+		expect(outcomes).toEqual(["second:failed", "first:failed"]);
+
+		outcomes.length = 0;
+		const gate = defineExtension("gate", { hooks: { preRun: (ctx) => ctx.finish() } });
+		await new Crust("cli")
+			.extend(first, gate, second)
+			.handle(() => {})
+			.run([]);
+		expect(outcomes).toEqual(["second:finished", "first:finished"]);
+	});
+
+	it("reports the finishing Extension and exposes parsed snapshots before validation", async () => {
+		let outcomeBy = "";
+		let seenPort: unknown;
+		const gate = defineExtension("gate", {
+			hooks: {
+				preRun(ctx) {
+					seenPort = ctx.flags.port;
+					return ctx.finish();
+				},
+				postRun(_ctx, outcome) {
+					outcomeBy = outcome.status === "finished" ? outcome.by : "";
+				},
+			},
+		});
+		await new Crust("cli")
+			.flags({ name: "port", type: "number", required: true })
+			.extend(gate)
+			.handle(() => {})
+			.run(["--port", "8080"]);
+
+		expect(seenPort).toBe(8080);
+		expect(outcomeBy).toBe("gate");
+	});
+
+	it("does not run hooks for routing failures and exposes frozen snapshots with injected io", async () => {
+		let preRunCalled = false;
+		const lines: string[] = [];
+		const probe = defineExtension("probe", {
+			hooks: {
+				preRun(ctx) {
+					preRunCalled = true;
+					expect(Object.isFrozen(ctx.rootCommand)).toBe(true);
+					expect(Object.isFrozen(ctx.command)).toBe(true);
+					expect(() => structuredClone(ctx.rootCommand)).not.toThrow();
+					ctx.stdout(`probe:${ctx.command.meta.name}`);
+				},
+			},
+		});
+		const app = new Crust("cli")
+			.extend(probe)
+			.mount(defineCommand("known", (cmd) => cmd.handle(() => {})));
+
+		await app.run(["known"], { stdout: (line) => lines.push(line) });
+		expect(lines).toEqual(["probe:known"]);
+		preRunCalled = false;
+		await expect(app.run(["unknown"])).rejects.toMatchObject({ code: "COMMAND_NOT_FOUND" });
+		expect(preRunCalled).toBe(false);
+	});
+
+	it("preserves a failed invocation over post-run errors and fails success with the first cleanup error", async () => {
+		const original = new Error("original");
+		const cleanup = defineExtension("cleanup", {
+			hooks: {
+				postRun() {
+					throw new Error("cleanup");
+				},
+			},
+		});
+		await expect(
+			new Crust("cli")
+				.extend(cleanup)
+				.handle(() => {
+					throw original;
+				})
+				.run([]),
+		).rejects.toBe(original);
+
+		const calls: string[] = [];
+		const first = defineExtension("first", {
+			hooks: {
+				postRun() {
+					calls.push("first");
+					throw new Error("first cleanup");
+				},
+			},
+		});
+		const second = defineExtension("second", {
+			hooks: {
+				postRun() {
+					calls.push("second");
+					throw new Error("second cleanup");
+				},
+			},
+		});
+		await expect(
+			new Crust("cli")
+				.extend(first, second)
+				.handle(() => {})
+				.run([]),
+		).rejects.toThrow("second cleanup");
+		expect(calls).toEqual(["second", "first"]);
+	});
+
+	it("passes the application root snapshot to app and Extension command handlers", async () => {
+		const roots: string[] = [];
+		const extension = defineExtension("extension", {
+			commands: [
+				new Crust("owned").handle(({ rootCommand }) => {
+					roots.push(rootCommand.meta.name);
+				}),
+			],
+		});
+		const app = new Crust("cli").extend(extension).handle(({ rootCommand }) => {
+			roots.push(rootCommand.meta.name);
 		});
 
 		await app.run([]);
-
-		expect(order).toEqual(["first:before", "second:before", "run", "second:after", "first:after"]);
-	});
-
-	it("short-circuiting an intercept skips validation and the Command Handler", async () => {
-		let ran = false;
-		const gate = defineExtension("gate", {
-			intercept() {
-				// no next() — short-circuit
-			},
-		});
-
-		// Required arg missing would normally fail validation
-		const app = new Crust("cli")
-			.args({ name: "file", type: "string", required: true })
-			.extend(gate)
-			.handle(() => {
-				ran = true;
-			});
-
-		await expect(app.run([])).resolves.toBeUndefined();
-		expect(ran).toBe(false);
-	});
-
-	it("intercept runs before application value validation but after parsing", async () => {
-		const observed: unknown[] = [];
-		const observer = defineExtension("observer", {
-			async intercept(context, next) {
-				observed.push(context.flags.port);
-				await next();
-			},
-		});
-
-		const app = new Crust("cli")
-			.flags({ name: "port", type: "number", required: true })
-			.extend(observer)
-			.handle(() => {});
-
-		// Parsed (coerced) value visible in the hook even though validation
-		// later fails on the missing required flag when absent
-		await app.run(["--port", "8080"]);
-		expect(observed).toEqual([8080]);
-
-		await expect(app.run([])).rejects.toMatchObject({ code: "VALIDATION" });
-		expect(observed).toEqual([8080, undefined]);
-	});
-
-	it("routing failures flow directly to the caller — intercepts never observe them", async () => {
-		let intercepted = false;
-		const watcher = defineExtension("watcher", {
-			async intercept(_context, next) {
-				intercepted = true;
-				await next();
-			},
-		});
-
-		const app = new Crust("cli")
-			.extend(watcher)
-			.mount(defineCommand("known", (cmd) => cmd.handle(() => {})));
-
-		await expect(app.run(["unknown"])).rejects.toMatchObject({ code: "COMMAND_NOT_FOUND" });
-		expect(intercepted).toBe(false);
-	});
-
-	it("intercept receives readonly serializable snapshots and injected io", async () => {
-		const lines: string[] = [];
-		const probe = defineExtension("probe", {
-			async intercept(context, next) {
-				expect(Object.isFrozen(context.rootCommand)).toBe(true);
-				expect(Object.isFrozen(context.command)).toBe(true);
-				expect(() => structuredClone(context.rootCommand)).not.toThrow();
-				context.stdout(`probe:${context.command.meta.name}`);
-				await next();
-			},
-		});
-
-		const app = new Crust("cli").extend(probe).handle(() => {});
-
-		await app.run([], { stdout: (t) => lines.push(t) });
-		expect(lines).toEqual(["probe:cli"]);
-	});
-
-	it("calling next() twice is a DEFINITION error", async () => {
-		const rogue = defineExtension("rogue", {
-			async intercept(_context, next) {
-				await next();
-				await next();
-			},
-		});
-
-		const app = new Crust("cli").extend(rogue).handle(() => {});
-
-		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
+		await app.run(["owned"]);
+		expect(roots).toEqual(["cli", "cli"]);
 	});
 });
 
@@ -1172,7 +1235,7 @@ describe("Extension intercept chain", () => {
 // .execute() — Full execution pipeline tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Extension handleError chain", () => {
+describe("Extension onError hooks", () => {
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
 	let originalExitCode: number | string | null | undefined;
@@ -1200,175 +1263,53 @@ describe("Extension handleError chain", () => {
 			throw new Error("boom");
 		});
 
-	it("handlers run in registration order and next() reaches Core's default renderer", async () => {
+	it("stops at the first truthy result and retains the nonzero exit status", async () => {
 		const order: string[] = [];
 		const first = defineExtension("first", {
-			async handleError(_error, _ctx, next) {
-				order.push("first");
-				await next();
-			},
+			hooks: { onError: () => (order.push("first"), undefined) },
 		});
-		const second = defineExtension("second", {
-			async handleError(_error, _ctx, next) {
-				order.push("second");
-				await next();
-			},
-		});
-
-		await failing().extend(first, second).execute({ argv: [] });
-
-		expect(order).toEqual(["first", "second"]);
-		// Chain end = Core's default renderer
-		expect(stderrChunks.join("\n")).toContain("boom");
-		expect(process.exitCode).toBe(1);
-	});
-
-	it("a handler that renders and returns replaces the default renderer but keeps a nonzero exit", async () => {
-		const lines: string[] = [];
 		const presenter = defineExtension("presenter", {
-			handleError(error, ctx) {
-				ctx.stderr(`pretty: ${(error as Error).message}`);
-				lines.push("rendered");
+			hooks: {
+				onError(error, ctx) {
+					order.push("presenter");
+					ctx.stderr(`pretty: ${(error as Error).message}`);
+					return true;
+				},
+			},
+		});
+		const never = defineExtension("never", {
+			hooks: {
+				onError: () => {
+					order.push("never");
+				},
 			},
 		});
 
-		await failing().extend(presenter).execute({ argv: [] });
-
-		expect(lines).toEqual(["rendered"]);
+		await failing().extend(first, presenter, never).execute({ argv: [] });
+		expect(order).toEqual(["first", "presenter"]);
 		expect(stderrChunks.join("\n")).toContain("pretty: boom");
-		// Default renderer did not run on top
 		expect(stderrChunks.join("\n")).not.toContain("Error: boom");
-		// Core always preserves the nonzero failure outcome (fixes the old
-		// onError-swallows-errors exit-0 bug)
 		expect(process.exitCode).toBe(1);
 	});
 
-	it("a handler that throws falls back to default rendering of the original error", async () => {
-		const broken = defineExtension("broken", {
-			handleError() {
-				throw new Error("renderer exploded");
+	it("falls through to Core's default renderer and never runs for run()", async () => {
+		let onErrorRan = false;
+		const observer = defineExtension("observer", {
+			hooks: {
+				onError() {
+					onErrorRan = true;
+				},
 			},
 		});
 
-		await failing().extend(broken).execute({ argv: [] });
+		await failing().extend(observer).execute({ argv: [] });
+		expect(stderrChunks.join("\n")).toContain("Error: boom");
+		expect(onErrorRan).toBe(true);
 
-		expect(stderrChunks.join("\n")).toContain("boom");
-		expect(process.exitCode).toBe(1);
-	});
-
-	it("receives routing failures (COMMAND_NOT_FOUND) with the original error object", async () => {
-		let received: unknown;
-		const catcher = defineExtension("catcher", {
-			handleError(error, ctx) {
-				received = error;
-				ctx.stderr("handled");
-			},
-		});
-
-		const app = new Crust("cli")
-			.extend(catcher)
-			.mount(defineCommand("known", (cmd) => cmd.handle(() => {})));
-
-		await app.execute({ argv: ["unknown"] });
-
-		expect(received).toBeInstanceOf(CrustError);
-		expect((received as CrustError).is("COMMAND_NOT_FOUND")).toBe(true);
-		expect(process.exitCode).toBe(1);
-	});
-
-	it("preserves resolved parsed context for schema, Context, and handler failures", async () => {
-		let received: ExtensionContext | undefined;
-		const catcher = defineExtension("catcher", {
-			handleError(_error, ctx) {
-				received = ctx;
-			},
-		});
-		const expectResolvedContext = () => {
-			expect(received?.command.meta.name).toBe("deploy");
-			expect(received?.commandPath).toEqual(["cli", "deploy"]);
-			expect(received?.args).toEqual({ target: "production" });
-			expect(received?.flags).toEqual({ force: true });
-			expect(received?.rawArgs).toEqual(["manifest.json"]);
-			received = undefined;
-		};
-		const command = (handler: () => void) =>
-			new Crust("cli")
-				.extend(catcher)
-				.mount(
-					defineCommand("deploy", (cmd) =>
-						cmd
-							.args({ name: "target", type: "string", required: true })
-							.flags({ name: "force", type: "boolean" })
-							.handle(handler),
-					),
-				);
-		const argv = ["deploy", "production", "--force", "--", "manifest.json"];
-
-		await command(() => {
-			throw new Error("handler failed");
-		}).execute({ argv });
-		expectResolvedContext();
-
-		const brokenContext = defineContext("broken", () => {
-			throw new Error("Context failed");
-		});
-		await new Crust("cli")
-			.extend(catcher)
-			.mount(
-				defineCommand("deploy", (cmd) =>
-					cmd
-						.args({ name: "target", type: "string", required: true })
-						.flags({ name: "force", type: "boolean" })
-						.provide(brokenContext(undefined))
-						.handle(() => {}),
-				),
-			)
-			.execute({ argv });
-		expectResolvedContext();
-
-		await new Crust("cli")
-			.extend(catcher)
-			.mount(
-				defineCommand("deploy", (cmd) =>
-					cmd
-						.args({ name: "target", type: "string", required: true })
-						.flags(
-							{ name: "force", type: "boolean" },
-							{
-								name: "mode",
-								type: "string",
-								schema: {
-									"~standard": {
-										version: 1,
-										vendor: "test",
-										validate: () => ({ issues: [{ message: "schema failed" }] }),
-									},
-								},
-							},
-						)
-						.handle(() => {}),
-				),
-			)
-			.execute({
-				argv: ["deploy", "production", "--force", "--mode", "fast", "--", "manifest.json"],
-			});
-		expect(received?.command.meta.name).toBe("deploy");
-		expect(received?.commandPath).toEqual(["cli", "deploy"]);
-		expect(received?.flags).toEqual({ force: true, mode: "fast" });
-		expect(received?.args).toEqual({ target: "production" });
-		expect(received?.rawArgs).toEqual(["manifest.json"]);
-	});
-
-	it("never runs for run() — the original error propagates unrendered", async () => {
-		let handlerRan = false;
-		const presenter = defineExtension("presenter", {
-			handleError() {
-				handlerRan = true;
-			},
-		});
-
-		await expect(failing().extend(presenter).run([])).rejects.toThrow("boom");
-		expect(handlerRan).toBe(false);
+		onErrorRan = false;
+		stderrChunks = [];
+		await expect(failing().extend(observer).run([])).rejects.toThrow("boom");
+		expect(onErrorRan).toBe(false);
 		expect(stderrChunks).toEqual([]);
 	});
 });
@@ -1581,54 +1522,24 @@ describe("Crust .execute()", () => {
 		expect(receivedDir).toBe("custom-dir");
 	});
 
-	it("runs the intercept chain around the handler", async () => {
+	it("runs pre-run then post-run hooks around the handler", async () => {
 		const order: string[] = [];
-
 		const wrap = defineExtension("wrap", {
-			async intercept(_ctx, next) {
-				order.push("intercept:before");
-				await next();
-				order.push("intercept:after");
+			hooks: {
+				preRun: () => {
+					order.push("pre");
+				},
+				postRun: () => {
+					order.push("post");
+				},
 			},
 		});
-
 		const app = new Crust("test").extend(wrap).handle(() => {
 			order.push("run");
 		});
 
 		await app.execute({ argv: [] });
-
-		expect(order).toEqual(["intercept:before", "run", "intercept:after"]);
-	});
-
-	it("runs multiple intercepts in registration order", async () => {
-		const order: string[] = [];
-
-		const e1 = defineExtension("e1", {
-			async intercept(_ctx, next) {
-				order.push("e1:before");
-				await next();
-				order.push("e1:after");
-			},
-		});
-		const e2 = defineExtension("e2", {
-			async intercept(_ctx, next) {
-				order.push("e2:before");
-				await next();
-				order.push("e2:after");
-			},
-		});
-
-		const app = new Crust("test")
-			.extend(e1)
-			.extend(e2)
-			.handle(() => {
-				order.push("run");
-			});
-
-		await app.execute({ argv: [] });
-
-		expect(order).toEqual(["e1:before", "e2:before", "run", "e2:after", "e1:after"]);
+		expect(order).toEqual(["pre", "run", "post"]);
 	});
 
 	it("catches errors and sets exitCode", async () => {
@@ -1782,15 +1693,16 @@ describe("Crust .execute()", () => {
 		expect(receivedRawArgs).toEqual(["extra1", "extra2"]);
 	});
 
-	it("intercept receives the resolved command and parsed input", async () => {
-		let interceptedName = "";
-		let interceptedFlags: Record<string, unknown> = {};
+	it("pre-run receives the resolved command and parsed input", async () => {
+		let preRunName = "";
+		let preRunFlags: Record<string, unknown> = {};
 
 		const inspect = defineExtension("inspect", {
-			async intercept(ctx, next) {
-				interceptedName = ctx.command.meta.name;
-				interceptedFlags = { ...ctx.flags };
-				await next();
+			hooks: {
+				preRun(ctx) {
+					preRunName = ctx.command.meta.name;
+					preRunFlags = { ...ctx.flags };
+				},
 			},
 		});
 
@@ -1804,25 +1716,20 @@ describe("Crust .execute()", () => {
 
 		await app.execute({ argv: ["sub", "--output", "file.txt"] });
 
-		expect(interceptedName).toBe("sub");
-		expect(interceptedFlags.output).toBe("file.txt");
+		expect(preRunName).toBe("sub");
+		expect(preRunFlags.output).toBe("file.txt");
 	});
 
-	it("intercept can short-circuit execution", async () => {
+	it("pre-run can finish execution", async () => {
 		let handlerRan = false;
-
 		const gate = defineExtension("short-circuit", {
-			intercept: async (_ctx, _next) => {
-				// Don't call next() — short circuit
-			},
+			hooks: { preRun: (ctx) => ctx.finish() },
 		});
-
 		const app = new Crust("test").extend(gate).handle(() => {
 			handlerRan = true;
 		});
 
 		await app.execute({ argv: [] });
-
 		expect(handlerRan).toBe(false);
 	});
 
@@ -1888,10 +1795,12 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks.join("\n")).toContain("collides");
 	});
 
-	it("treats intercept-time prompt cancellation as a silent user abort", async () => {
+	it("treats pre-run prompt cancellation as a silent user abort", async () => {
 		const cancel = defineExtension("cancel", {
-			intercept: () => {
-				throw new DOMException("Prompt was cancelled.", "AbortError");
+			hooks: {
+				preRun: () => {
+					throw new DOMException("Prompt was cancelled.", "AbortError");
+				},
 			},
 		});
 

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -8,11 +8,11 @@ import {
 	type RequirementCtxOf,
 	type RequirementFlagsOf,
 } from "../api/context.ts";
-import type {
-	Extension,
-	ExtensionContext,
-	ExtensionErrorHandler,
-	ExtensionIntercept,
+import {
+	finishInvocation,
+	type Extension,
+	type ExtensionContext,
+	type InvocationOutcome,
 } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
 import { parseArgs, validateParsed } from "../parsing/parser.ts";
@@ -64,6 +64,8 @@ export interface CrustCommandContext<
 	rawArgs: string[];
 	/** Readonly, serializable snapshot of the resolved command */
 	command: CommandSnapshot;
+	/** Readonly snapshot of the application root, including Extension contributions */
+	rootCommand: CommandSnapshot;
 	/** Write a line of standard output (injectable text callback) */
 	stdout: (text: string) => void;
 	/** Write a line of diagnostic output (injectable text callback) */
@@ -86,8 +88,6 @@ const DEFAULT_IO: InvocationIO = {
 interface PreparedInvocation {
 	rootNode: CommandNode;
 	extensions: readonly Extension[];
-	/** Names of Extension-owned root commands (inputs validated pre-hook) */
-	ownedCommands: ReadonlySet<string>;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -886,11 +886,11 @@ export class Crust<
 
 	/**
 	 * Invoke this application programmatically: resolve, parse, run the
-	 * Extension intercept chain and the Command Handler for `argv`.
+	 * Extension hooks and the Command Handler for `argv`.
 	 *
 	 * Unlike {@link Crust.execute}, `run()` throws the original definition,
 	 * parse, Context, or handler failure without rendering it (Extension
-	 * `handleError` hooks are a terminal presentation concern and never run
+	 * `onError` hooks are a terminal presentation concern and never run
 	 * here) and without changing process status. It resolves with no value
 	 * after successful cleanup. Prompt cancellation surfaces as a standard
 	 * `AbortError`.
@@ -916,8 +916,8 @@ export class Crust<
 	 * execute the matched Command Handler.
 	 *
 	 * This is the terminal CLI boundary — call it on the root builder. It
-	 * renders a failure once (through the Extension `handleError` chain,
-	 * ending in Core's default renderer), sets `process.exitCode` (`1`, or
+	 * renders a failure once (through Extension `onError` hooks, ending in
+	 * Core's default renderer), sets `process.exitCode` (`1`, or
 	 * `130` for an `AbortError` cancellation), and resolves.
 	 *
 	 * @param options - Optional overrides (e.g. custom `argv` for testing)
@@ -930,8 +930,8 @@ export class Crust<
 		try {
 			prepared = prepareInvocation(this._node);
 		} catch (error) {
-			// Extension-application failures render directly: the handleError
-			// chain belongs to Extensions that just failed to apply.
+			// Extension-application failures render directly: hooks belong to
+			// Extensions that just failed to apply.
 			if (isAbortError(error)) {
 				process.exitCode = EXIT_CODE_CANCELLED;
 				return;
@@ -971,18 +971,17 @@ export class Crust<
 				return;
 			}
 			// Core always preserves a nonzero failure outcome, regardless of
-			// what Extension handleError hooks do (ADR-0001).
+			// what Extension onError hooks do (ADR-0001).
 			process.exitCode = 1;
 			await renderFailure(error, argv, prepared, io, extensionContext);
 		}
 	}
 
 	/**
-	 * Resolve, parse, run the Extension intercept chain and the Command
-	 * Handler for one invocation. Throws the original failure (definition,
-	 * parse, Context, or handler error) without rendering it or touching
-	 * `process.exitCode`. Routing and syntax failures throw directly —
-	 * intercept hooks never observe them.
+	 * Resolve and parse one invocation, then run Extension hooks and the
+	 * Command Handler. Throws the original failure without rendering it or
+	 * touching `process.exitCode`. Routing and syntax failures throw directly
+	 * before hooks observe the invocation.
 	 */
 	private async _dispatch(
 		argv: readonly string[],
@@ -990,7 +989,7 @@ export class Crust<
 		io: InvocationIO,
 		onExtensionContext?: (context: ExtensionContext) => void,
 	): Promise<void> {
-		const { rootNode, extensions, ownedCommands } = prepared;
+		const { rootNode, extensions } = prepared;
 
 		// Routing and syntax parsing — failures flow directly to the caller
 		const resolved = resolveCommand(rootNode, [...argv]);
@@ -1007,16 +1006,11 @@ export class Crust<
 			args: parsed.args as Readonly<Record<string, unknown>>,
 			flags: parsed.flags as Readonly<Record<string, unknown>>,
 			rawArgs: parsed.rawArgs,
+			finish: finishInvocation,
 			stdout: io.stdout,
 			stderr: io.stderr,
 		});
 		onExtensionContext?.(extensionContext);
-
-		// Extension-owned inputs are validated before the hooks run (ADR-0001)
-		const routedRoot = resolved.commandPath[1];
-		if (routedRoot !== undefined && ownedCommands.has(routedRoot)) {
-			validateParsed(resolvedNode, parsed);
-		}
 
 		const terminal = async (): Promise<void> => {
 			validateParsed(resolvedNode, parsed);
@@ -1044,6 +1038,7 @@ export class Crust<
 				),
 				rawArgs: parsed.rawArgs,
 				command: extensionContext.command,
+				rootCommand: rootSnapshot,
 				stdout: io.stdout,
 				stderr: io.stderr,
 			};
@@ -1051,45 +1046,41 @@ export class Crust<
 			await resolvedNode.run(context);
 		};
 
-		await runInterceptChain(
-			extensions
-				.map((ext) => ext.intercept)
-				.filter((hook): hook is ExtensionIntercept => hook !== undefined),
-			extensionContext,
-			terminal,
-		);
+		let outcome: InvocationOutcome = { status: "completed" };
+		try {
+			for (const extension of extensions) {
+				if ((await extension.hooks?.preRun?.(extensionContext)) === finishInvocation()) {
+					outcome = { status: "finished", by: extension.name };
+					break;
+				}
+			}
+			if (outcome.status !== "finished") {
+				await terminal();
+				outcome = { status: "completed" };
+			}
+		} catch (error) {
+			outcome = { status: "failed", error };
+		}
+
+		let postRunFailed = false;
+		let postRunError: unknown;
+		for (const extension of extensions.toReversed()) {
+			try {
+				await extension.hooks?.postRun?.(extensionContext, outcome);
+			} catch (error) {
+				if (outcome.status !== "failed" && !postRunFailed) {
+					postRunFailed = true;
+					postRunError = error;
+				}
+			}
+		}
+
+		if (outcome.status === "failed") throw outcome.error;
+		if (postRunFailed) throw postRunError;
 	}
 }
 
-/** Run the Extension intercept chain, terminating in `terminal`. */
-async function runInterceptChain(
-	hooks: readonly ExtensionIntercept[],
-	context: ExtensionContext,
-	terminal: () => Promise<void>,
-): Promise<void> {
-	let index = -1;
-	const dispatch = async (i: number): Promise<void> => {
-		if (i <= index) {
-			throw new CrustError("DEFINITION", "Extension intercept called next() multiple times", {
-				subject: "extension",
-				reason: "duplicate-next",
-			});
-		}
-		index = i;
-		if (i === hooks.length) {
-			await terminal();
-			return;
-		}
-		await (hooks[i] as ExtensionIntercept)(context, () => dispatch(i + 1));
-	};
-	await dispatch(0);
-}
-
-/**
- * Render one failure through the Extension handleError chain, ending in
- * Core's default renderer. Presentation only — the caller has already set
- * the nonzero exit code.
- */
+/** Render one failure through Extension onError hooks, ending in Core's default renderer. */
 async function renderFailure(
 	error: unknown,
 	argv: readonly string[],
@@ -1102,51 +1093,30 @@ async function renderFailure(
 		io.stderr(`Error: ${message}`);
 	};
 
-	const handlers = prepared.extensions
-		.map((ext) => ext.handleError)
-		.filter((hook): hook is ExtensionErrorHandler => hook !== undefined);
-	if (handlers.length === 0) {
-		renderDefault();
-		return;
-	}
-
 	// Routing or parsing may have failed before an invocation context existed.
-	let context = extensionContext;
-	if (context === undefined) {
-		const rootSnapshot = snapshotCommand(prepared.rootNode);
-		context = Object.freeze({
+	const context =
+		extensionContext ??
+		Object.freeze({
 			argv: [...argv] as readonly string[],
-			rootCommand: rootSnapshot,
-			command: rootSnapshot,
+			rootCommand: snapshotCommand(prepared.rootNode),
+			command: snapshotCommand(prepared.rootNode),
 			commandPath: Object.freeze([prepared.rootNode.meta.name]),
 			args: Object.freeze({}),
 			flags: Object.freeze({}),
 			rawArgs: [],
+			finish: finishInvocation,
 			stdout: io.stdout,
 			stderr: io.stderr,
 		} satisfies ExtensionContext);
-	}
-
-	let index = -1;
-	const dispatch = async (i: number): Promise<void> => {
-		// Unlike the intercept chain, duplicate next() is ignored rather than
-		// thrown: the presentation chain must never create new failures.
-		if (i <= index) return;
-		index = i;
-		if (i === handlers.length) {
-			renderDefault();
-			return;
-		}
-		await (handlers[i] as ExtensionErrorHandler)(error, context, () => dispatch(i + 1));
-	};
 
 	try {
-		await dispatch(0);
+		for (const extension of prepared.extensions) {
+			if (await extension.hooks?.onError?.(error, context)) return;
+		}
 	} catch {
-		// The presentation chain itself failed — fall back to the default
-		// rendering of the original failure so it is never lost.
-		renderDefault();
+		// Rendering must not hide the original invocation failure.
 	}
+	renderDefault();
 }
 
 /** Shared prepare step: clone, apply Extensions, freeze. */
@@ -1163,16 +1133,9 @@ function prepareInvocation(node: CommandNode): PreparedInvocation {
 		applyExtensionFlags(rootNode, ext);
 	}
 
-	const ownedCommands = new Set<string>();
-	for (const ext of extensions) {
-		for (const builder of ext.commands ?? []) {
-			ownedCommands.add(builder._node.meta.name);
-		}
-	}
-
 	freezeTree(rootNode);
 
-	return { rootNode, extensions, ownedCommands };
+	return { rootNode, extensions };
 }
 
 /**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1062,6 +1062,10 @@ export class Crust<
 			outcome = { status: "failed", error };
 		}
 
+		// Frozen so a mutating post-run hook cannot rewrite the outcome Core
+		// trusts below (e.g. flipping "failed" to "completed" to mask an error).
+		Object.freeze(outcome);
+
 		let postRunFailed = false;
 		let postRunError: unknown;
 		for (const extension of extensions.toReversed()) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,10 +13,10 @@ export type {
 	ExtensionCommand,
 	ExtensionConfig,
 	ExtensionContext,
-	ExtensionErrorHandler,
 	ExtensionFlagDef,
-	ExtensionIntercept,
-	ExtensionNext,
+	ExtensionHooks,
+	Finished,
+	InvocationOutcome,
 } from "./api/extension.ts";
 export { defineExtension } from "./api/extension.ts";
 export { defineArg, defineFlag } from "./api/flags.ts";

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -495,7 +495,7 @@ function validateCanonicalNegationUsage(
  *
  * This is a pure parse+coerce function — it never throws for missing required
  * values. Use {@link validateParsed} to enforce required constraints after
- * middleware has had a chance to intercept (e.g. `--help`).
+ * extensions have had a chance to finish an invocation (e.g. `--help`).
  *
  * @param command - The command whose arg/flag definitions drive the parsing
  * @param argv - The argv array to parse (typically `process.argv.slice(2)`)

--- a/packages/core/src/parsing/schema.test.ts
+++ b/packages/core/src/parsing/schema.test.ts
@@ -166,15 +166,16 @@ describe("Standard Schema on flag definitions", () => {
 });
 
 describe("schema interaction with Extensions", () => {
-	it("intercepts observe raw values while the handler sees schema outputs", async () => {
+	it("pre-run hooks observe raw values while the handler sees schema outputs", async () => {
 		const { defineExtension } = await import("../api/extension.ts");
-		let interceptSaw: unknown;
+		let preRunSaw: unknown;
 		let handlerSaw: unknown;
 
 		const probe = defineExtension("probe", {
-			async intercept(ctx, next) {
-				interceptSaw = ctx.flags.port;
-				await next();
+			hooks: {
+				preRun(ctx) {
+					preRunSaw = ctx.flags.port;
+				},
 			},
 		});
 
@@ -187,18 +188,18 @@ describe("schema interaction with Extensions", () => {
 
 		await app.run(["--port", "8080"]);
 
-		expect(interceptSaw).toBe("8080"); // raw, pre-validation
+		expect(preRunSaw).toBe("8080"); // raw, pre-validation
 		expect(handlerSaw).toBe(8080); // schema output
 	});
 
-	it("an intercept short-circuit skips schema validation entirely", async () => {
+	it("a pre-run finish skips schema validation entirely", async () => {
 		let validated = false;
 		const spy = schema<string | undefined, string>((raw) => {
 			validated = true;
 			return { value: String(raw) };
 		});
 		const { defineExtension } = await import("../api/extension.ts");
-		const gate = defineExtension("gate", { intercept() {} });
+		const gate = defineExtension("gate", { hooks: { preRun: (ctx) => ctx.finish() } });
 
 		const app = new Crust("cli")
 			.flags({ name: "x", type: "string", schema: spy })

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -458,17 +458,18 @@ describe("integration: Extension adds flag visible to subcommand handler", () =>
 		expect(result.exitCode).toBe(0);
 	});
 
-	it("Extension intercept wraps subcommand execution", async () => {
+	it("Extension hooks run around subcommand execution", async () => {
 		const order: string[] = [];
-
 		const logging = defineExtension("logging", {
-			async intercept(ctx, next) {
-				order.push(`intercept:before:${ctx.command.meta.name}`);
-				await next();
-				order.push(`intercept:after:${ctx.command.meta.name}`);
+			hooks: {
+				preRun: (ctx) => {
+					order.push(`pre:${ctx.command.meta.name}`);
+				},
+				postRun: (ctx) => {
+					order.push(`post:${ctx.command.meta.name}`);
+				},
 			},
 		});
-
 		const app = new Crust("cli").extend(logging).mount(
 			defineCommand("sub", (cmd) =>
 				cmd.handle(() => {
@@ -478,7 +479,7 @@ describe("integration: Extension adds flag visible to subcommand handler", () =>
 		);
 
 		await executeCrust(app, ["sub"]);
-		expect(order).toEqual(["intercept:before:sub", "sub:run", "intercept:after:sub"]);
+		expect(order).toEqual(["pre:sub", "sub:run", "post:sub"]);
 	});
 });
 
@@ -723,9 +724,10 @@ describe("integration: complex real-world CLI scenario", () => {
 		const order: string[] = [];
 
 		const auditExtension = defineExtension("audit", {
-			async intercept(ctx, next) {
-				order.push(`audit:${ctx.command.meta.name}`);
-				await next();
+			hooks: {
+				preRun: (ctx) => {
+					order.push(`audit:${ctx.command.meta.name}`);
+				},
 			},
 		});
 

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -65,31 +65,26 @@ function filenameForShell(shell: CompletionShell, binName: string): string {
 }
 
 function renderForShell(
-	shell: CompletionShell,
+	shell: string,
 	spec: ReturnType<typeof walkCommandNode>,
 	binName: string,
 	version: string,
 ): string {
-	switch (shell) {
-		case "bash":
-			return renderBash(spec, binName, version);
-		case "zsh":
-			return renderZsh(spec, binName, version);
-		case "fish":
-			return renderFish(spec, binName, version);
-	}
+	if (shell === "bash") return renderBash(spec, binName, version);
+	if (shell === "zsh") return renderZsh(spec, binName, version);
+	return renderFish(spec, binName, version);
 }
 
 /**
  * Build an Extension that contributes a `completion <shell>` command
  * which emits a tab-completion script for bash, zsh, or fish.
  *
- * **Strategy: pure-static.** The walk happens lazily in the intercept hook
- * against the final root snapshot, so registration order is irrelevant —
- * any commands or inherited flags added by other Extensions are visible by
- * the time we generate the script. The walker projects the root snapshot to
- * a small `CompletionSpec`; per-shell renderers turn that into a
- * self-contained shell script with no runtime callbacks.
+ * **Strategy: pure-static.** The handler walks the final root snapshot, so
+ * registration order is irrelevant — any commands or inherited flags added
+ * by other Extensions are visible by the time we generate the script. The
+ * walker projects the root snapshot to a small `CompletionSpec`; per-shell
+ * renderers turn that into a self-contained shell script with no runtime
+ * callbacks.
  *
  * **Print vs `--output-dir`.**
  * - With no `--output-dir`: print the script for the requested `<shell>`
@@ -107,9 +102,6 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 	const shells = options.shells ?? SUPPORTED_SHELLS;
 	const version = options.version ?? "0.0.0";
 
-	// The owned command declares the CLI grammar; the work happens in the
-	// intercept hook, which is the only place with access to the final root
-	// snapshot (needed for the lazy walk).
 	const completionCommand = new Crust(subcommandName)
 		.meta({
 			description: "Generate shell tab-completion scripts",
@@ -127,18 +119,7 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 			description:
 				"Write all configured shells' scripts into this directory instead of printing to stdout",
 		})
-		.handle(() => {
-			// Never reached — the extension intercept short-circuits first.
-		});
-
-	return defineExtension("completion", {
-		commands: [completionCommand],
-		async intercept(context, next) {
-			if (context.commandPath[1] !== subcommandName) {
-				await next();
-				return;
-			}
-
+		.handle(async (context) => {
 			const rootCommand = context.rootCommand;
 			// Validate `binName` before emitting anything so misconfigured
 			// CLIs fail loudly. The walker also re-validates command/flag
@@ -149,9 +130,9 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 			// out of the comment line in the emitted script.
 			const safeVersion = sanitizeFreeText(version);
 
-			const requestedShell = context.args.shell as CompletionShell;
+			const { shell: requestedShell } = context.args;
 			const spec = walkCommandNode(rootCommand);
-			const outputDir = context.flags["output-dir"] as string | undefined;
+			const outputDir = context.flags["output-dir"];
 
 			if (outputDir === undefined) {
 				const script = renderForShell(requestedShell, spec, binName, safeVersion);
@@ -185,6 +166,7 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 				}
 				await writeFile(targetPath, script, "utf8");
 			}
-		},
-	});
+		});
+
+	return defineExtension("completion", { commands: [completionCommand] });
 }

--- a/packages/extensions/src/did-you-mean.ts
+++ b/packages/extensions/src/did-you-mean.ts
@@ -96,39 +96,39 @@ export function didYouMeanExtension(options: DidYouMeanOptions = {}): Extension 
 	const mode = options.mode ?? "error";
 
 	return defineExtension("did-you-mean", {
-		async handleError(error, context, next) {
-			if (!(error instanceof CrustError) || !error.is("COMMAND_NOT_FOUND")) {
-				await next();
-				return;
-			}
+		hooks: {
+			onError(error, context) {
+				if (!(error instanceof CrustError) || !error.is("COMMAND_NOT_FOUND")) return;
 
-			const details = error.details;
-			const suggestions = findSuggestions(details.input, details.parentCommand.subCommands);
+				const details = error.details;
+				const suggestions = findSuggestions(details.input, details.parentCommand.subCommands);
 
-			let message = `Unknown command "${details.input}".`;
-			if (suggestions.length > 0) {
-				message += ` Did you mean "${suggestions[0]}"?`;
-			}
+				let message = `Unknown command "${details.input}".`;
+				if (suggestions.length > 0) {
+					message += ` Did you mean "${suggestions[0]}"?`;
+				}
 
-			if (mode === "help") {
-				context.stdout(message);
-				context.stdout("");
-				context.stdout(renderHelp(details.parentCommand, details.commandPath));
-				return;
-			}
+				if (mode === "help") {
+					context.stdout(message);
+					context.stdout("");
+					context.stdout(renderHelp(details.parentCommand, details.commandPath));
+					return true;
+				}
 
-			// `details.available` lists every canonical sibling name including
-			// those marked `meta.hidden: true`. The error message is user-
-			// facing, so filter the same way `findSuggestions` does — internal
-			// commands stay invocable but never surface in this list.
-			const visibleAvailable = details.available.filter(
-				(canonical) => details.parentCommand.subCommands[canonical]?.meta.hidden !== true,
-			);
-			if (visibleAvailable.length > 0) {
-				message += `\n\nAvailable commands: ${visibleAvailable.join(", ")}`;
-			}
-			context.stderr(message);
-			// Core preserves the nonzero exit code — rendering only here.
+				// `details.available` lists every canonical sibling name including
+				// those marked `meta.hidden: true`. The error message is user-
+				// facing, so filter the same way `findSuggestions` does — internal
+				// commands stay invocable but never surface in this list.
+				const visibleAvailable = details.available.filter(
+					(canonical) => details.parentCommand.subCommands[canonical]?.meta.hidden !== true,
+				);
+				if (visibleAvailable.length > 0) {
+					message += `\n\nAvailable commands: ${visibleAvailable.join(", ")}`;
+				}
+				context.stderr(message);
+				// Core preserves the nonzero exit code — rendering only here.
+				return true;
+			},
 		},
 	});
 }

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -239,16 +239,14 @@ export function helpExtension(): Extension {
 				description: "Show help",
 			},
 		},
-		async intercept(context, next) {
-			const shouldShowHelp = context.flags.help === true;
+		hooks: {
+			preRun(context) {
+				if (context.flags.help !== true && context.command.hasHandler) return;
 
-			if (!shouldShowHelp && context.command.hasHandler) {
-				await next();
-				return;
-			}
-
-			// Explicit --help, or a container command without a handler
-			context.stdout(renderHelp(context.command, context.commandPath));
+				// Explicit --help, or a container command without a handler
+				context.stdout(renderHelp(context.command, context.commandPath));
+				return context.finish();
+			},
 		},
 	});
 }

--- a/packages/extensions/src/no-color.ts
+++ b/packages/extensions/src/no-color.ts
@@ -1,4 +1,4 @@
-import { type Extension, defineExtension } from "@crustjs/core";
+import { type Extension, type ExtensionContext, defineExtension } from "@crustjs/core";
 
 function setEnv(name: string, value: string | undefined): void {
 	if (value === undefined) {
@@ -34,6 +34,7 @@ function setEnv(name: string, value: string | undefined): void {
 let activeRuns = 0;
 let baseForceColor: string | undefined;
 let baseNoColor: string | undefined;
+const colorRuns = new WeakMap<ExtensionContext, true>();
 
 export function noColorExtension(): Extension {
 	return defineExtension("no-color", {
@@ -44,30 +45,29 @@ export function noColorExtension(): Extension {
 				description: "Enable colored output",
 			},
 		},
-		async intercept(context, next) {
-			const flagValue = context.flags.color;
-			if (typeof flagValue !== "boolean") {
-				await next();
-				return;
-			}
+		hooks: {
+			preRun(context) {
+				const flagValue = context.flags.color;
+				if (typeof flagValue !== "boolean") return;
 
-			if (activeRuns === 0) {
-				baseForceColor = process.env.FORCE_COLOR;
-				baseNoColor = process.env.NO_COLOR;
-			}
-			activeRuns++;
+				if (activeRuns === 0) {
+					baseForceColor = process.env.FORCE_COLOR;
+					baseNoColor = process.env.NO_COLOR;
+				}
+				activeRuns++;
+				colorRuns.set(context, true);
 
-			if (flagValue) {
-				delete process.env.NO_COLOR;
-				process.env.FORCE_COLOR = "3";
-			} else {
-				delete process.env.FORCE_COLOR;
-				process.env.NO_COLOR = "1";
-			}
-
-			try {
-				await next();
-			} finally {
+				if (flagValue) {
+					delete process.env.NO_COLOR;
+					process.env.FORCE_COLOR = "3";
+				} else {
+					delete process.env.FORCE_COLOR;
+					process.env.NO_COLOR = "1";
+				}
+			},
+			postRun(context) {
+				if (!colorRuns.has(context)) return;
+				colorRuns.delete(context);
 				activeRuns--;
 				// ponytail: last-writer-wins while runs overlap; only the ambient
 				// env is guaranteed restored once all runs finish.
@@ -75,7 +75,7 @@ export function noColorExtension(): Extension {
 					setEnv("FORCE_COLOR", baseForceColor);
 					setEnv("NO_COLOR", baseNoColor);
 				}
-			}
+			},
 		},
 	});
 }

--- a/packages/extensions/src/update-notifier.test.ts
+++ b/packages/extensions/src/update-notifier.test.ts
@@ -320,10 +320,10 @@ describe("fetchLatestVersion", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// updateNotifierExtension — middleware integration tests
+// updateNotifierExtension — post-run integration tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("updateNotifierExtension middleware", () => {
+describe("updateNotifierExtension post-run hook", () => {
 	const originalFetch = globalThis.fetch;
 	const originalProcessArgv = [...process.argv];
 	const originalUserAgent = process.env.npm_config_user_agent;
@@ -410,9 +410,7 @@ describe("updateNotifierExtension middleware", () => {
 		return snapshotCommand(new Crust(name).handle(() => {})._node);
 	}
 
-	/**
-	 * Helper to invoke the extension intercept directly with controlled context.
-	 */
+	/** Helper to invoke the extension post-run hook with a completed outcome. */
 	async function runPluginMiddleware(
 		options: {
 			currentVersion: string;
@@ -446,11 +444,6 @@ describe("updateNotifierExtension middleware", () => {
 		};
 		const plugin = updateNotifierExtension(pluginOptions);
 
-		if (!plugin.intercept) {
-			return { plugin, ran: false };
-		}
-
-		let commandRan = false;
 		const rootCommand = makeCommandSnapshot(overrides?.commandName ?? options.packageName);
 
 		const context = {
@@ -461,17 +454,16 @@ describe("updateNotifierExtension middleware", () => {
 			args: {},
 			flags: {},
 			rawArgs: [] as readonly string[],
+			finish: () => undefined as never,
 			stdout: () => {},
 			stderr: (text: string) => stderrChunks.push(text),
 		};
 
-		const next = async () => {
-			commandRan = true;
-		};
+		const postRun = plugin.hooks?.postRun;
+		if (!postRun) throw new Error("update notifier must define a post-run hook");
+		await postRun(context, { status: "completed" });
 
-		await plugin.intercept(context, next);
-
-		return { plugin, ran: commandRan };
+		return { plugin };
 	}
 
 	// ── Update available flow ─────────────────────────────────────────────
@@ -727,8 +719,7 @@ describe("updateNotifierExtension middleware", () => {
 			});
 			const elapsed = Date.now() - start;
 
-			// Command should have run
-			expect(result.ran).toBe(true);
+			expect(result.plugin.hooks?.postRun).toBeDefined();
 			// Should complete quickly (timeout + overhead), not hang
 			expect(elapsed).toBeLessThan(5000);
 			// No notice on timeout
@@ -1049,58 +1040,42 @@ describe("updateNotifierExtension middleware", () => {
 		});
 	});
 
-	// ── Middleware ordering ────────────────────────────────────────────────
+	// ── Post-run ordering ─────────────────────────────────────────────────
 
-	describe("middleware ordering", () => {
-		it("runs command handler (next) before emitting update notice", async () => {
+	describe("post-run ordering", () => {
+		it("runs after the command handler", async () => {
 			const pkgName = uniquePackageName("ordering");
 			mockRegistryResponse("2.0.0");
-
 			const executionOrder: string[] = [];
+			const app = new Crust(pkgName)
+				.extend(updateNotifierExtension({ currentVersion: "1.0.0", packageName: pkgName }))
+				.handle(() => {
+					executionOrder.push("command");
+				});
 
-			const plugin = updateNotifierExtension({
-				currentVersion: "1.0.0",
-				packageName: pkgName,
-			});
+			await app.run([], { stderr: () => executionOrder.push("notice") });
 
-			const rootCommand = makeCommandSnapshot(pkgName);
-
-			const context = {
-				argv: [] as readonly string[],
-				rootCommand,
-				command: rootCommand,
-				commandPath: [rootCommand.meta.name] as readonly string[],
-				args: {},
-				flags: {},
-				rawArgs: [] as readonly string[],
-				stdout: () => {},
-				stderr: () => executionOrder.push("notice"),
-			};
-
-			await plugin.intercept?.(context, async () => {
-				executionOrder.push("command");
-			});
-
-			// Command must run before notice
-			expect(executionOrder).toContain("command");
-			expect(executionOrder).toContain("notice");
-			expect(executionOrder.indexOf("command")).toBeLessThan(executionOrder.indexOf("notice"));
+			expect(executionOrder).toEqual(["command", "notice"]);
 		});
 
-		it("calls next() even if notifier work would fail", async () => {
-			const pkgName = uniquePackageName("next-on-fail");
-			// Throw from fetch to simulate a broken state
+		it("does not run after a failed command", async () => {
+			const pkgName = uniquePackageName("failed-command");
+			let fetchCalled = false;
 			mockFetch(() => {
-				throw new Error("Catastrophic failure");
+				fetchCalled = true;
+				return Promise.resolve(
+					new Response(JSON.stringify({ "dist-tags": { latest: "2.0.0" } }), { status: 200 }),
+				);
 			});
+			const app = new Crust(pkgName)
+				.extend(updateNotifierExtension({ currentVersion: "1.0.0", packageName: pkgName }))
+				.handle(() => {
+					throw new Error("command failed");
+				});
 
-			const result = await runPluginMiddleware({
-				currentVersion: "1.0.0",
-				packageName: pkgName,
-			});
+			await expect(app.run([])).rejects.toThrow("command failed");
 
-			// Command should still have run via next()
-			expect(result.ran).toBe(true);
+			expect(fetchCalled).toBe(false);
 		});
 	});
 
@@ -1138,11 +1113,7 @@ describe("updateNotifierExtension middleware", () => {
 			let commandExecuted = false;
 
 			// Combine with a custom no-op extension
-			const otherPlugin = defineExtension("test-other", {
-				async intercept(_ctx, next) {
-					await next();
-				},
-			});
+			const otherPlugin = defineExtension("test-other");
 
 			const app = new Crust(pkgName)
 				.meta({ description: "Test" })

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -523,78 +523,79 @@ export function updateNotifierExtension(options: UpdateNotifierOptions): Extensi
 	const cacheAdapter = cache?.adapter ?? NO_CACHE_ADAPTER;
 
 	return defineExtension("update-notifier", {
-		async intercept(context, next) {
-			// Always let the command execute first
-			await next();
+		hooks: {
+			async postRun(context, outcome) {
+				if (outcome.status !== "completed") return;
 
-			try {
-				// ── Resolve package name ─────────────────────────────────
-				const state = normalizeNotifierState(await cacheAdapter.read());
-				const resolvedUpdateCommand = resolveUpdateCommand(
-					packageName,
-					packageManager,
-					installScope,
-					updateCommand,
-				);
+				try {
+					// ── Resolve package name ─────────────────────────────────
+					const state = normalizeNotifierState(await cacheAdapter.read());
+					const resolvedUpdateCommand = resolveUpdateCommand(
+						packageName,
+						packageManager,
+						installScope,
+						updateCommand,
+					);
 
-				// ── Cache gate: skip network if within interval ──────────
-				const now = Date.now();
-				const elapsed = now - state.lastCheckedAt;
+					// ── Cache gate: skip network if within interval ──────────
+					const now = Date.now();
+					const elapsed = now - state.lastCheckedAt;
 
-				if (hasCache && elapsed < intervalMs) {
-					// Cache is still fresh — use cached version if available
-					if (
-						state.latestVersion &&
-						isNewerVersion(currentVersion, state.latestVersion) &&
-						state.lastNotifiedVersion !== state.latestVersion
-					) {
-						emitUpdateNotice(
-							currentVersion,
-							state.latestVersion,
-							resolvedUpdateCommand,
-							context.stderr,
-						);
+					if (hasCache && elapsed < intervalMs) {
+						// Cache is still fresh — use cached version if available
+						if (
+							state.latestVersion &&
+							isNewerVersion(currentVersion, state.latestVersion) &&
+							state.lastNotifiedVersion !== state.latestVersion
+						) {
+							emitUpdateNotice(
+								currentVersion,
+								state.latestVersion,
+								resolvedUpdateCommand,
+								context.stderr,
+							);
+							await cacheAdapter.write({
+								...state,
+								lastNotifiedVersion: state.latestVersion,
+							});
+						}
+						return;
+					}
+
+					// ── Network check: fetch latest version ──────────────────
+					const latestVersion = await fetchLatestVersion(packageName, registryUrl, timeoutMs);
+
+					if (latestVersion === null) {
+						// Soft failure — update timestamp to avoid retrying too soon
 						await cacheAdapter.write({
 							...state,
-							lastNotifiedVersion: state.latestVersion,
+							lastCheckedAt: now,
 						});
+						return;
 					}
-					return;
-				}
 
-				// ── Network check: fetch latest version ──────────────────
-				const latestVersion = await fetchLatestVersion(packageName, registryUrl, timeoutMs);
-
-				if (latestVersion === null) {
-					// Soft failure — update timestamp to avoid retrying too soon
-					await cacheAdapter.write({
+					// ── Persist fetched version and timestamp ─────────────────
+					const nextState: UpdateNotifierState = {
 						...state,
 						lastCheckedAt: now,
-					});
-					return;
+						latestVersion,
+					};
+
+					// ── Emit notice if newer and not already notified ─────────
+					if (
+						isNewerVersion(currentVersion, latestVersion) &&
+						state.lastNotifiedVersion !== latestVersion
+					) {
+						emitUpdateNotice(currentVersion, latestVersion, resolvedUpdateCommand, context.stderr);
+						nextState.lastNotifiedVersion = latestVersion;
+					}
+
+					await cacheAdapter.write(nextState);
+				} catch {
+					// All notifier internal errors are silently swallowed.
+					// The extension must never affect command exit codes or output.
 				}
-
-				// ── Persist fetched version and timestamp ─────────────────
-				const nextState: UpdateNotifierState = {
-					...state,
-					lastCheckedAt: now,
-					latestVersion,
-				};
-
-				// ── Emit notice if newer and not already notified ─────────
-				if (
-					isNewerVersion(currentVersion, latestVersion) &&
-					state.lastNotifiedVersion !== latestVersion
-				) {
-					emitUpdateNotice(currentVersion, latestVersion, resolvedUpdateCommand, context.stderr);
-					nextState.lastNotifiedVersion = latestVersion;
-				}
-
-				await cacheAdapter.write(nextState);
-			} catch {
-				// All notifier internal errors are silently swallowed.
-				// The extension must never affect command exit codes or output.
-			}
+			},
 		},
 	});
 }

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -13,15 +13,15 @@ export function versionExtension(versionValue: VersionValue = "0.0.0"): Extensio
 				recursive: false,
 			},
 		},
-		async intercept(context, next) {
-			// Root invocation with --version only
-			if (context.commandPath.length !== 1 || context.flags.version !== true) {
-				await next();
-				return;
-			}
+		hooks: {
+			preRun(context) {
+				// Root invocation with --version only
+				if (context.commandPath.length !== 1 || context.flags.version !== true) return;
 
-			const version = typeof versionValue === "function" ? versionValue() : versionValue;
-			context.stdout(`${context.rootCommand.meta.name} v${version}`);
+				const version = typeof versionValue === "function" ? versionValue() : versionValue;
+				context.stdout(`${context.rootCommand.meta.name} v${version}`);
+				return context.finish();
+			},
 		},
 	});
 }

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -39,9 +39,7 @@ function restoreHomedir(): void {
 
 function shortCircuitExtension() {
 	return defineExtension("short-circuit", {
-		async intercept() {
-			// Intentionally stop the chain without calling next()
-		},
+		hooks: { preRun: (context) => context.finish() },
 	});
 }
 
@@ -247,7 +245,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("auto-updates before a later extension short-circuits (registration order matters)", async () => {
-		// Intercepts run in registration order; registering skills first means
+		// Pre-run hooks run in registration order; registering skills first means
 		// its auto-update work happens before any later short-circuit.
 		const app = new Crust("order-test")
 			.meta({ description: "test" })

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -526,12 +526,14 @@ export function skillExtension(options: SkillOptions): Extension {
 		commands: [buildSkillCommandGrammar(skillCommandName, options)],
 		hooks: {
 			async preRun(context) {
-				if (context.commandPath[1] === skillCommandName || options.autoUpdate === false) return;
-
+				// Validate at the boundary on every invocation so misconfiguration
+				// surfaces at setup time even when auto-update is disabled.
 				const customSkills = validateCustomSkillsConfig(
 					context.rootCommand.meta.name,
 					options.customSkills,
 				);
+				if (context.commandPath[1] === skillCommandName || options.autoUpdate === false) return;
+
 				await autoUpdateSkills(context.rootCommand, options, customSkills);
 			},
 		},

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -38,6 +38,15 @@ const DEFAULT_SKILL_COMMAND_NAME = "skill";
 const DEFAULT_SKILL_SCOPE = "global";
 const UNIVERSAL_GROUP = "__universal__";
 
+interface SkillInstallFlags {
+	readonly scope?: string;
+	readonly all?: boolean;
+}
+
+interface SkillUpdateFlags {
+	readonly scope?: string;
+}
+
 function isScope(value: unknown): value is Scope {
 	return value === "global" || value === "project";
 }
@@ -514,33 +523,17 @@ export function skillExtension(options: SkillOptions): Extension {
 	const skillCommandName = options.command ?? DEFAULT_SKILL_COMMAND_NAME;
 
 	return defineExtension("skills", {
-		commands: [buildSkillCommandGrammar(skillCommandName)],
-		async intercept(context, next) {
-			const rootCmd = context.rootCommand;
+		commands: [buildSkillCommandGrammar(skillCommandName, options)],
+		hooks: {
+			async preRun(context) {
+				if (context.commandPath[1] === skillCommandName || options.autoUpdate === false) return;
 
-			// Validate customSkills config at the boundary so misconfiguration
-			// surfaces before any auto-update or interactive run.
-			const customSkills = validateCustomSkillsConfig(rootCmd.meta.name, options.customSkills);
-
-			// The owned skill command's work happens here — the intercept is
-			// the only hook with access to the final root snapshot.
-			if (context.commandPath[1] === skillCommandName) {
-				if (context.commandPath[2] === "update") {
-					await runSkillUpdateFlow(rootCmd, options, customSkills, context.flags);
-				} else {
-					await runSkillInstallFlow(rootCmd, options, customSkills, context.flags);
-				}
-				return;
-			}
-
-			// Auto-update already-installed skills when version changes.
-			// Build-validation mode never reaches intercepts, so it can never
-			// mutate user environments.
-			if (options.autoUpdate !== false) {
-				await autoUpdateSkills(rootCmd, options, customSkills);
-			}
-
-			await next();
+				const customSkills = validateCustomSkillsConfig(
+					context.rootCommand.meta.name,
+					options.customSkills,
+				);
+				await autoUpdateSkills(context.rootCommand, options, customSkills);
+			},
 		},
 	});
 }
@@ -731,45 +724,53 @@ async function reconcileSkillInteractively(opts: {
  * are prompted to choose between project and global. In non-interactive mode,
  * scope falls back to global.
  */
-function buildSkillCommandGrammar(commandName: string) {
-	return (
-		new Crust(commandName)
-			.meta({ description: "Manage agent skill installations" })
-			.flags(
-				{
-					name: "scope",
-					type: "string",
-					description: "Install scope (project or global)",
-				},
-				{
-					name: "all",
-					type: "boolean",
-					description: "Install for all detected agents non-interactively (universal + detected)",
-				},
-			)
-			.mount(
-				defineCommand("update", (cmd) =>
-					cmd
-						.meta({ description: "Update installed skills to latest version" })
-						.flags({
-							name: "scope",
-							type: "string",
-							description: "Update scope (project or global)",
-						})
-						// Never reached — the skills extension intercept short-circuits
-						.handle(() => {}),
-				),
-			)
-			// Never reached — the skills extension intercept short-circuits
-			.handle(() => {})
-	);
+function buildSkillCommandGrammar(commandName: string, options: SkillOptions) {
+	return new Crust(commandName)
+		.meta({ description: "Manage agent skill installations" })
+		.flags(
+			{
+				name: "scope",
+				type: "string",
+				description: "Install scope (project or global)",
+			},
+			{
+				name: "all",
+				type: "boolean",
+				description: "Install for all detected agents non-interactively (universal + detected)",
+			},
+		)
+		.mount(
+			defineCommand("update", (cmd) =>
+				cmd
+					.meta({ description: "Update installed skills to latest version" })
+					.flags({
+						name: "scope",
+						type: "string",
+						description: "Update scope (project or global)",
+					})
+					.handle(async (context) => {
+						const customSkills = validateCustomSkillsConfig(
+							context.rootCommand.meta.name,
+							options.customSkills,
+						);
+						await runSkillUpdateFlow(context.rootCommand, options, customSkills, context.flags);
+					}),
+			),
+		)
+		.handle(async (context) => {
+			const customSkills = validateCustomSkillsConfig(
+				context.rootCommand.meta.name,
+				options.customSkills,
+			);
+			await runSkillInstallFlow(context.rootCommand, options, customSkills, context.flags);
+		});
 }
 
 async function runSkillInstallFlow(
 	rootCmd: CommandSnapshot,
 	options: SkillOptions,
 	customSkills: readonly CustomSkillConfig[],
-	flags: Readonly<Record<string, unknown>>,
+	flags: SkillInstallFlags,
 ): Promise<void> {
 	const meta = deriveSkillMeta(rootCmd, options);
 	const installAll = flags.all === true;
@@ -777,10 +778,8 @@ async function runSkillInstallFlow(
 	// `--scope` always wins when set; `--all` skips only the interactive
 	// prompt fallback, falling back to `defaultScope` or `"global"`.
 	const scope = installAll
-		? (parseScopeFlag(flags.scope as string | undefined) ??
-			options.defaultScope ??
-			DEFAULT_SKILL_SCOPE)
-		: await resolveScopeForCommand(flags.scope as string | undefined, options);
+		? (parseScopeFlag(flags.scope) ?? options.defaultScope ?? DEFAULT_SKILL_SCOPE)
+		: await resolveScopeForCommand(flags.scope, options);
 
 	await reconcileSkillInteractively({
 		name: meta.name,
@@ -853,9 +852,9 @@ async function runSkillUpdateFlow(
 	rootCmd: CommandSnapshot,
 	options: SkillOptions,
 	customSkills: readonly CustomSkillConfig[],
-	flags: Readonly<Record<string, unknown>>,
+	flags: SkillUpdateFlags,
 ): Promise<void> {
-	const scope = await resolveScopeForCommand(flags.scope as string | undefined, options);
+	const scope = await resolveScopeForCommand(flags.scope, options);
 	const effectiveScope = resolveEffectiveScope(scope);
 	// The default status sweep checks all known agents without PATH probing.
 	const meta = deriveSkillMeta(rootCmd, options);


### PR DESCRIPTION
## Summary

Stacked on `refactor/style-surface-trim`.

This breaking change replaces onion-style Extension interception and error middleware with explicit lifecycle hooks.

### Before

```ts
defineExtension("example", {
  async intercept(ctx, next) {
    await next();
  },
  async handleError(error, ctx, next) {
    await next();
  },
});
```

### After

```ts
defineExtension("example", {
  hooks: {
    async preRun(ctx) {
      if (shouldStop) return ctx.finish();
    },
    async postRun(ctx, outcome) {
      // cleanup or post-run work
    },
    async onError(error, ctx) {
      return false; // delegate to the next renderer
    },
  },
});
```

`preRun` executes in `.extend()` order before validation; `postRun` always executes in reverse extension order after the invocation settles; `onError` is an `execute()`-only error presentation chain. Command handlers now receive the final `rootCommand` snapshot.

## Built-in migration

| Extension | Migration |
| --- | --- |
| `help` | `preRun` renders help and finishes |
| `version` | `preRun` prints the version and finishes |
| `no-color` | `preRun` scopes color env; `postRun` restores it |
| `did-you-mean` | `onError` renders handled suggestions |
| `completion` | Owned command uses a real handler and `ctx.rootCommand` |
| `update-notifier` | `postRun` runs only for completed invocations |
| `skills` | Owned commands use real handlers; auto-update uses `preRun` |

## Behavior notes

- Extension-owned commands are validated in the terminal pipeline, exactly like application commands; invalid input retains identical UX.
- The update notifier does not run after command failures, unchanged from prior semantics.
- `postRun` always runs. If the invocation failed, its original error wins and post-run errors are suppressed. For a completed or finished invocation, the first post-run error fails the invocation after all post-run hooks have run.

## Breaking change

`ExtensionConfig.intercept`, `ExtensionConfig.handleError`, and their `next()` middleware types are removed outright. Migrate Extensions to `hooks.preRun`, `hooks.postRun`, and/or `hooks.onError`; use `ctx.finish()` to short-circuit successfully.

## Gates

- `bun run check` — passed (pre-existing lint warnings)
- `bun run check:types` — passed
- `bun run test` — passed (five Fish-dependent tests skipped because Fish is unavailable)
