### PR TITLE
refactor!: defineCommand-based extension commands + v0.2 docs overhaul

### DIFF
--- a/.changeset/extension-command-definitions.md
+++ b/.changeset/extension-command-definitions.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": minor
+"@crustjs/skills": minor
+---
+
+`ExtensionConfig.commands` now accepts only `defineCommand()` definitions. Migrate extension-owned `new Crust("name")` builders to `defineCommand("name", (command) => ...)`; `ExtensionCommand` is removed. Definition Context requirements are checked when the application prepares and report `DEFINITION` errors.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -35,7 +35,7 @@ Requirements are arrays of defined values describing what a mount site must supp
 - `flags` lists named flag definitions (from `defineFlag()`) the parent must provide as inheritable flags. Every required flag must have `inherit: true`.
 - `ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
 
-The same shape types `defineContext()` requirements. Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus a runtime check that each Context requirement name is provided on the parent path.
+The same shape types `defineContext()` requirements. Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required inheritable flags and Context names are provided on the parent path.
 
 ### `CommandDefinitionBuilder`
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -169,7 +169,7 @@ const app = new Crust("serve").flags(
 
 Repeated `.flags()` calls replace the local flags. A duplicate name within one call throws `DEFINITION`.
 
-`inherit: true` exposes a flag to descendant commands and allows it to satisfy mounted definition and Context requirements. Boolean flags support generated `--no-name` negation unless `noNegate: true` is set. Names and aliases beginning with `no-` are reserved.
+`inherit: true` exposes a flag to descendant commands and allows it to satisfy mounted definition and Context requirements. Boolean flags support generated `--no-name` negation; `noNegate: true` hides the generated label from help, completion, and man output (the parser still accepts `--no-name`). Names and aliases beginning with `no-` are reserved.
 
 Schema-backed flags require `type: "string" | "boolean"` only to declare whether the flag consumes a token. Their schema owns the value rules and receives the raw parsed value.
 
@@ -226,7 +226,7 @@ import { help, version } from "@crustjs/extensions";
 const app = new Crust("my-cli").extend(help(), version("1.2.3"));
 ```
 
-Mounted definitions become ordinary command nodes before root Extensions prepare the application, so root Extensions apply to them. Extension-owned command builders remain unchanged.
+Mounted definitions become ordinary command nodes before root Extensions prepare the application, so root Extensions apply to them. Extension-contributed definitions are materialized when the application prepares.
 
 Extension-owned command or flag name and alias collisions throw `DEFINITION` when the application is prepared.
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -198,6 +198,8 @@ The map shape used for inferred `ctx` values.
   name="ExtensionConfig"
 />
 
+`commands` entries are `defineCommand()` definitions contributed at the application root — see [Extensions](/docs/guide/extensions).
+
 ### `Extension`
 
 <auto-type-table path="../../../../../packages/core/src/api/extension.ts" name="Extension" />
@@ -211,10 +213,6 @@ type ExtensionFlagDef = FlagDef & { readonly recursive?: boolean };
 ```
 
 An Extension owns contributed flags. `recursive` defaults to `true`; `false` contributes the flag only to the root.
-
-### `ExtensionCommand`
-
-A structural type satisfied by a configured `Crust` builder. Extension commands are contributed at the application root.
 
 ### `ExtensionContext`
 

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -3,11 +3,11 @@ title: Arguments
 description: Define typed positional inputs for a command.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
-
 `.args(...defs)` maps positional tokens to names in the order the definitions are passed. Pass values from `defineArg(name, def)` or inline literals:
 
 ```ts
+import { Crust } from "@crustjs/core";
+
 const command = new Crust("serve")
   .args(
     { name: "port", type: "number", default: 3000 },
@@ -69,12 +69,7 @@ new Crust("serve")
   });
 ```
 
-<Callout type="warn">
-  Schema-backed arguments cannot also use core value options such as `type`, `default`, `required`,
-  `choices`, or `parse`. The schema owns coercion, defaults, requiredness, choices, and validation.
-</Callout>
-
-See [Schema-backed definitions](/docs/guide/types#schema-backed-definitions).
+A schema cannot be combined with core value options — see [Schema-backed definitions](/docs/guide/types#schema-backed-definitions) for the full rule.
 
 ## Forwarding raw tokens
 

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -155,17 +155,10 @@ crust build --no-minify
 
 ## Environment Variables
 
-`crust build` keeps **runtime env** and **build-time constants** separate.
-
-- compiled executables continue to use Bun's runtime env behavior
-- Bun's auto-loaded cwd env can provide build-time constants by default
-- `--env-file` lets you override that with explicit env files
-- only `PUBLIC_*` values are eligible to be embedded as build-time constants
+Only `PUBLIC_*` values are embedded as build-time constants; `--env-file` (repeatable, also with `--package`) selects explicit env files.
 
 ```sh
 crust build --env-file .env.production
-crust build --env-file .env --env-file .env.local
-crust build --package --env-file .env.production
 ```
 
 <Callout type="warn">
@@ -334,20 +327,15 @@ The `bin` field points to the resolver script, which handles platform detection 
 ```json title="package.json"
 {
   "name": "my-cli",
-  "files": ["dist"],
-  "bin": {
-    "my-cli": "dist/cli"
-  },
+  "private": true,
   "scripts": {
-    "build": "crust build",
     "package": "crust build --package",
-    "publish": "crust publish --stage-dir dist/npm",
-    "prepack": "bun run build"
+    "publish": "crust publish --stage-dir dist/npm"
   }
 }
 ```
 
-After building and staging, publish all platform packages:
+In this mode the package users install is the **staged root package** (`dist/npm/root/package.json`), which `crust build --package` generates with its own `bin` entry and platform `optionalDependencies` — your local `package.json` needs no `bin`, `files`, or `prepack` wiring. After building and staging, publish all platform packages:
 
 ```sh
 # Stage npm packages

--- a/apps/docs/content/docs/guide/commands.mdx
+++ b/apps/docs/content/docs/guide/commands.mdx
@@ -35,13 +35,12 @@ This permits safe composition and preserves input inference through the chain.
 
 ## Command Handler context
 
-`.handle()` receives:
+`.handle()` receives a typed `CrustCommandContext`:
 
-- `args` and `flags`: validated, transformed inputs
-- `ctx`: constructed [Contexts](/docs/guide/contexts)
-- `rawArgs`: tokens after `--`
-- `command`: the resolved readonly `CommandSnapshot`
-- `stdout(text)` and `stderr(text)`: injectable line writers
+<auto-type-table
+  path="../../../../../packages/core/src/command/crust.ts"
+  name="CrustCommandContext"
+/>
 
 ```ts
 const command = new Crust("inspect").handle(({ command, stdout }) => {

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -146,7 +146,7 @@ const status = defineCommand("status", { ctx: [database] }, (command) =>
 const app = new Crust("app").flags(verbose).provide(config(), database()).mount(status);
 ```
 
-Call `.provide()` before `.mount()`: a Context provided on a later builder does not backfill an earlier mount, and a missing requirement name is a `DEFINITION` error at the mount.
+Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).
 
 ## One name per command path
 

--- a/apps/docs/content/docs/guide/error-handling.mdx
+++ b/apps/docs/content/docs/guide/error-handling.mdx
@@ -53,19 +53,7 @@ Use ordinary application error classes when callers need to distinguish domain f
 
 Extension `onError` hooks present failures for `execute()`:
 
-```ts
-import { defineExtension } from "@crustjs/core";
-
-const serviceErrors = defineExtension("service-errors", {
-  hooks: {
-    onError(error, ctx) {
-      if (!(error instanceof Error) || error.name !== "ServiceUnavailableError") return;
-      ctx.stderr(error.message);
-      return true;
-    },
-  },
-});
-```
+<include lang="ts">../../../examples/extensions/hooks.ts#service-errors</include>
 
 A hook returns `true` after rendering, or a falsy value to delegate to the next hook. Core's default renderer is last. Core establishes a nonzero status before invoking the chain, so presentation cannot turn a failure into success.
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -7,26 +7,9 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 An Extension is an app-wide capability that owns any flags and commands it contributes. Attach Extensions once, on the root builder:
 
-```ts
-import { Crust } from "@crustjs/core";
-import {
-  completion,
-  didYouMean,
-  help,
-  noColor,
-  updateNotifier,
-  version,
-} from "@crustjs/extensions";
-
-const app = new Crust("my-cli").extend(
-  help(),
-  version("0.2.0"),
-  completion(),
-  didYouMean(),
-  noColor(),
-  updateNotifier({ packageName: "my-cli", currentVersion: "0.2.0" }),
-);
-```
+<include lang="ts" meta='title="cli.ts"'>
+  ../../../examples/extensions/install.ts
+</include>
 
 See the [Extensions module](/docs/modules/extensions) for each capability's options.
 
@@ -35,111 +18,60 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
   registered inside `defineCommand()` callbacks.
 </Callout>
 
-Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application. Root Extensions therefore apply to mounted and inline commands alike. Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's compile-time flag requirements; declare required inheritable flags on the root itself.
+Two consequences of the root-only model:
+
+- Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to mounted and inline commands alike.
+- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's compile-time flag requirements; declare required inheritable flags on the root itself.
 
 ## Author an Extension
 
 `defineExtension(name, config)` returns a frozen plain value. The config can contain `flags`, `commands`, and `hooks`:
 
-```ts
-import { Crust, type ExtensionContext, defineExtension } from "@crustjs/core";
-
-const timers = new WeakMap<ExtensionContext, number>();
-
-export const diagnostics = defineExtension("diagnostics", {
-  flags: {
-    trace: {
-      type: "boolean",
-      description: "Print diagnostic timing",
-      inherit: true,
-    },
-  },
-  commands: [
-    new Crust("doctor")
-      .meta({ description: "Check the installation" })
-      .handle(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
-  ],
-  hooks: {
-    preRun(ctx) {
-      if (ctx.flags.trace === true) timers.set(ctx, performance.now());
-    },
-    postRun(ctx, outcome) {
-      const started = timers.get(ctx);
-      if (started === undefined) return;
-      timers.delete(ctx);
-      ctx.stderr(`${outcome.status} in ${performance.now() - started}ms`);
-    },
-  },
-});
-```
+<include lang="ts" meta='title="diagnostics.ts"'>
+  ../../../examples/extensions/diagnostics.ts
+</include>
 
 ## Owned flags and commands
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `inherit` controls ordinary command inheritance and remains available on the flag definition.
 
-Extension commands are configured `Crust` builders attached at the root. Their `.handle()` callbacks are real Command Handlers: validation, schemas, and Context construction complete before they run, and they receive the same typed handler context as application commands, including `rootCommand`.
+Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare Context requirements; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide either. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 
 ## Hooks
 
-Hooks run after routing and syntax parsing. Routing and syntax failures skip `preRun` and `postRun`.
+Hooks run after routing and syntax parsing. Where each hook sits in the invocation, and how failures flow through them, is defined once in the [Execution Model](/docs/guide/lifecycle).
 
 ### `preRun`
 
-`preRun(ctx)` runs before value validation, schemas, Context construction, and the Command Handler, in `.extend()` order. Return `ctx.finish()` to end the invocation successfully: later `preRun` hooks and the remaining invocation work do not run.
+`preRun(ctx)` runs before validation, Contexts, and the Command Handler, in `.extend()` order. Return `ctx.finish()` to end the invocation successfully and skip the remaining work:
 
-```ts
-const cached = defineExtension("cached", {
-  hooks: {
-    preRun(ctx) {
-      if (ctx.flags.cached !== true) return;
-      ctx.stdout("cached result");
-      return ctx.finish();
-    },
-  },
-});
-```
+<include lang="ts">../../../examples/extensions/hooks.ts#cached</include>
 
 ### `postRun`
 
-`postRun(ctx, outcome)` runs after every invocation that reached the hooks, including a failure or `ctx.finish()` short-circuit. Hooks run in reverse `.extend()` order (LIFO), making this the cleanup and post-run side-effect slot.
+`postRun(ctx, outcome)` runs after every invocation that reached the hooks — including failures and `ctx.finish()` short-circuits — in reverse `.extend()` order. It is the cleanup and post-run side-effect slot. `outcome` is frozen:
 
-`outcome` is one of:
+```ts
+type InvocationOutcome =
+  | { status: "completed" }
+  | { status: "finished"; by: string }
+  | { status: "failed"; error: unknown };
+```
 
-- `{ status: "completed" }` after the Command Handler completes
-- `{ status: "finished", by: string }` after an Extension returns `ctx.finish()`
-- `{ status: "failed", error: unknown }` after a `preRun` hook or the command pipeline throws
-
-A failing `postRun` cannot mask an existing invocation failure. After a completed or finished invocation, the first `postRun` failure is thrown after the remaining cleanup hooks run.
-
-Use a module-level `WeakMap<ExtensionContext, State>` for state shared by a hook pair. The same context identity reaches all hooks for one invocation, and entries can be removed in `postRun`; the diagnostics timer above follows this pattern.
+Use a module-level `WeakMap<ExtensionContext, State>` for state shared by a hook pair: the same context identity reaches all hooks for one invocation, and entries can be removed in `postRun`. The diagnostics timer above follows this pattern.
 
 ### `onError`
 
 `onError(error, ctx)` presents failures for `execute()` only, in `.extend()` order. Return `true` after rendering to stop presentation; return nothing (or `false`) to delegate to the next Extension and ultimately Core's default renderer.
 
-```ts
-const serviceErrors = defineExtension("service-errors", {
-  hooks: {
-    onError(error, ctx) {
-      if (!(error instanceof Error) || error.name !== "ServiceUnavailableError") return;
-      ctx.stderr(error.message);
-      return true;
-    },
-  },
-});
-```
+<include lang="ts">../../../examples/extensions/hooks.ts#service-errors</include>
 
-Core sets a nonzero exit status before `onError` hooks run, so rendering cannot turn a failure into success. Programmatic `run()` never invokes `onError`; it throws the original error. `AbortError` cancellation renders nothing and also skips `onError`.
+Rendering never turns a failure into success, and programmatic `run()` throws the original error instead of invoking `onError` — see [Error flow](/docs/guide/lifecycle#error-flow).
 
 ## Extension context
 
-Hooks receive an `ExtensionContext` containing:
+Hooks receive a readonly `ExtensionContext`. The values are invocation data, not mutable command definitions:
 
-- `argv`, syntax-parsed `args` and `flags`, and `rawArgs`
-- `rootCommand` and `command` as readonly serializable Command Snapshots
-- `commandPath` and `finish()`
-- injectable `stdout(text)` and `stderr(text)` writers
-
-The values are invocation data, not mutable command definitions.
+<auto-type-table path="../../../../../packages/core/src/api/extension.ts" name="ExtensionContext" />

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -21,7 +21,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 Two consequences of the root-only model:
 
 - Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to mounted and inline commands alike.
-- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's compile-time flag requirements; declare required inheritable flags on the root itself.
+- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's flag requirements; declare required inheritable flags on the root itself.
 
 ## Author an Extension
 
@@ -35,7 +35,7 @@ Two consequences of the root-only model:
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `inherit` controls ordinary command inheritance and remains available on the flag definition.
 
-Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare Context requirements; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
+Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context requirements; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide either. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -3,11 +3,11 @@ title: Flags
 description: Define typed named inputs, aliases, repeated values, and inherited flags.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
-
 `.flags(...defs)` takes named flag definitions — values from `defineFlag(name, def)` or inline literals carrying `name`:
 
 ```ts
+import { Crust } from "@crustjs/core";
+
 const command = new Crust("serve")
   .flags(
     { name: "port", type: "number", default: 3000, short: "p" },
@@ -94,7 +94,4 @@ new Crust("serve")
   });
 ```
 
-<Callout type="warn">
-  Do not combine `schema` with core value options such as `default`, `required`, `choices`, or
-  `parse`.
-</Callout>
+A schema cannot be combined with core value options — see [Schema-backed definitions](/docs/guide/types#schema-backed-definitions) for the full rule.

--- a/apps/docs/content/docs/guide/split-files.mdx
+++ b/apps/docs/content/docs/guide/split-files.mdx
@@ -9,17 +9,9 @@ For a small application, mount definitions inline at the root. When a command be
 
 Keep the flag definitions and Context factories that commands require in a dependency-free shared module:
 
-```ts title="src/shared.ts"
-import { defineContext, defineFlag } from "@crustjs/core";
-
-export const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-
-export const logger = defineContext("logger", () => ({
-  write(message: string) {
-    console.error(message);
-  },
-}));
-```
+<include lang="ts" meta='title="src/shared.ts"'>
+  ../../../examples/split-files/shared.ts
+</include>
 
 Requirements are arrays of these values, so the required shape and the root definition are the same object — they cannot drift.
 
@@ -27,20 +19,9 @@ Requirements are arrays of these values, so the required shape and the root defi
 
 A command file imports `defineCommand` and the shared values, never the application builder:
 
-```ts title="src/commands/greet.ts"
-import { defineCommand } from "@crustjs/core";
-import { logger, verbose } from "../shared.ts";
-
-export const greetCommand = defineCommand("greet", { flags: [verbose], ctx: [logger] }, (command) =>
-  command
-    .args({ name: "name", type: "string", default: "world" })
-    .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })
-    .handle(({ args, flags, ctx, stdout }) => {
-      if (flags.verbose) ctx.logger.write("Preparing greeting");
-      stdout(`${flags.greeting}, ${args.name}!`);
-    }),
-);
-```
+<include lang="ts" meta='title="src/commands/greet.ts"'>
+  ../../../examples/split-files/commands/greet.ts
+</include>
 
 The recipe builder is typed from the declared requirements. The exported definition is inert and carries its own name: importing it does not build or run a command.
 
@@ -48,40 +29,19 @@ The recipe builder is typed from the declared requirements. The exported definit
 
 Define the root and its application-wide Extensions independently:
 
-```ts title="src/app.ts"
-import { Crust } from "@crustjs/core";
-import { help, version } from "@crustjs/extensions";
-import { logger, verbose } from "./shared.ts";
-
-export const app = new Crust("my-cli")
-  .meta({ description: "A split-file CLI" })
-  .extend(version("0.2.0"), help())
-  .flags(verbose)
-  .provide(logger());
-```
+<include lang="ts" meta='title="src/app.ts"'>
+  ../../../examples/split-files/app.ts
+</include>
 
 ## Mount and execute
 
 The composition root imports both sides:
 
-```ts title="src/cli.ts"
-import { app } from "./app.ts";
-import { greetCommand } from "./commands/greet.ts";
+<include lang="ts" meta='title="src/cli.ts"'>
+  ../../../examples/split-files/cli.ts
+</include>
 
-await app.mount(greetCommand).execute();
-```
-
-`.mount()` checks that `app` provides a compatible inheritable `verbose` flag and `logger` Context. Missing or incompatible requirements are reported at this line — compile-time, and at runtime for Context names. Use `greetCommand.as("hello")` to mount the same definition under another name.
-
-## Finalize before mounting
-
-Fluent builders are immutable, and a mount captures the parent scope used at that call. Add required `inherit: true` flags and Contexts before `.mount()`:
-
-```ts
-const complete = new Crust("app").flags(verbose).provide(logger()).mount(greetCommand);
-```
-
-A later `.flags()` or `.provide()` call creates a new parent builder; it does not backfill a definition that was already mounted.
+`.mount()` checks that `app` provides a compatible inheritable `verbose` flag and `logger` Context, and reports missing or incompatible requirements at this line. [How mount checking and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-mounting rule — is covered in Subcommands.
 
 ## Inline or split?
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -44,7 +44,7 @@ const clone = defineCommand("clone", { flags: [verbose], ctx: [repository] }, (c
 const app = new Crust("git").flags(verbose).provide(repository()).mount(clone);
 ```
 
-`.mount()` checks the requirements at each call — compile-time and runtime — and creates a fresh command node. Use `.as(name)` to mount one definition under different names:
+`.mount()` checks the requirements at each call and creates a fresh command node. Use `.as(name)` to mount one definition under different names:
 
 ```ts
 const git = new Crust("git").flags(verbose).provide(repository()).mount(clone, clone.as("copy"));

--- a/apps/docs/content/docs/guide/types.mdx
+++ b/apps/docs/content/docs/guide/types.mdx
@@ -13,7 +13,7 @@ new Crust("inspect")
   .flags({ name: "config", type: "json" })
   .handle(({ args, flags }) => {
     args.file; // string
-    flags.config; // unknown | undefined
+    flags.config; // unknown
   });
 ```
 
@@ -62,6 +62,8 @@ Schemas exclusively own coercion, defaults, requiredness, choices, and validatio
 All schema failures in an invocation are aggregated into one `CrustError` with code `VALIDATION`:
 
 ```ts
+import { CrustError } from "@crustjs/core";
+
 try {
   await command.run(argv);
 } catch (error) {

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -16,11 +16,28 @@ Most CLI tools in the TypeScript ecosystem are either **minimal arg parsers** th
 
 Crust sits in the sweet spot: more structured than a bare parser, lighter than a full framework, and designed so you only pull in what you actually use.
 
-## Quick Examples
+## Quick example
 
-Here is a simple CLI: a `greet` command with a defaulted positional, a `--shout`/`-s` boolean flag, and help/version commands built with Crust and other popular libraries:
+A `greet` command with a defaulted positional, a `--shout`/`-s` boolean flag, and help/version wired by two Extensions:
+
+<include lang="ts" meta='title="src/cli.ts"'>
+  ../../examples/landing/greet.ts
+</include>
+
+```sh
+$ greet Ada --shout
+HELLO, ADA!
+$ greet --help
+```
 
 ## Philosophy
+
+- **One way to do it.** One starter pattern. `defineCommand()` for every command; `new Crust()` appears exactly once, at the root.
+- **Inference over annotation.** Types flow from definitions to handlers. No decorators, no codegen, no manual generics.
+- **Plain values, immutable builders.** Definitions and Extensions are frozen data; every fluent call returns a new builder.
+- **Fail loud at definition time.** Collisions and malformed definitions are `DEFINITION` errors at startup and in `crust build` — never warn-and-skip.
+- **Standards over lock-in.** Standard Schema for validation, `NO_COLOR`/`FORCE_COLOR` and OSC 8 conventions, native `Symbol.dispose` cleanup.
+- **Pay only for what you use.** Zero-dependency core, composable modules, Contexts constructed lazily for the resolved path only.
 
 ## Feature highlight
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -85,16 +85,15 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Extension types
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| `Extension`         | Named frozen Extension value                            |
-| `ExtensionConfig`   | Owned flags, commands, and named hooks                  |
-| `ExtensionCommand`  | Structural configured-command contribution              |
-| `ExtensionFlagDef`  | Extension-owned flag with optional `recursive` scope    |
-| `ExtensionContext`  | Readonly invocation view, including `finish()`          |
-| `ExtensionHooks`    | `preRun`, `postRun`, and `onError` hook slots           |
-| `Finished`          | Opaque token returned by `ExtensionContext.finish()`    |
-| `InvocationOutcome` | Completed, short-circuited, or failed invocation result |
+| Type                | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `Extension`         | Named frozen Extension value                               |
+| `ExtensionConfig`   | Owned flags, `CommandDefinition` commands, and named hooks |
+| `ExtensionFlagDef`  | Extension-owned flag with optional `recursive` scope       |
+| `ExtensionContext`  | Readonly invocation view, including `finish()`             |
+| `ExtensionHooks`    | `preRun`, `postRun`, and `onError` hook slots              |
+| `Finished`          | Opaque token returned by `ExtensionContext.finish()`       |
+| `InvocationOutcome` | Completed, short-circuited, or failed invocation result    |
 
 ## Error types
 

--- a/apps/docs/content/docs/modules/extensions/meta.json
+++ b/apps/docs/content/docs/modules/extensions/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extensions",
-  "pages": ["index", "help", "version", "completion", "did-you-mean", "no-color", "update-notifier"]
+  "pages": ["help", "version", "completion", "did-you-mean", "no-color", "update-notifier"]
 }

--- a/apps/docs/content/docs/modules/extensions/no-color.mdx
+++ b/apps/docs/content/docs/modules/extensions/no-color.mdx
@@ -29,6 +29,6 @@ When the flag is passed, the Extension scopes the standard color environment var
 - `--color` sets `FORCE_COLOR=3` and clears `NO_COLOR` — forces all ANSI on (truecolor), overriding non-TTY detection. Any `FORCE_COLOR`-aware library obeys it, and child processes inherit it.
 - `--no-color` sets `NO_COLOR=1` and clears `FORCE_COLOR` — suppresses colors per [no-color.org](https://no-color.org/), while non-color modifiers and hyperlinks keep following TTY detection.
 
-Previous values are restored after the command finishes.
+Previous values are restored after the command finishes. Overlapping programmatic runs are last-writer-wins while active; the ambient environment is restored once the last run finishes.
 
 The flag has no default. When it is omitted, the Extension changes nothing — environment-based color detection (`NO_COLOR`, `FORCE_COLOR`, TTY) remains the responsibility of `@crustjs/style`.

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -33,7 +33,7 @@ function updateNotifier(options: UpdateNotifierOptions): Extension;
   name="UpdateNotifierOptions"
 />
 
-The `postRun` hook checks for an update only after a Command Handler completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written to process stderr. Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
+The `postRun` hook checks for an update only after a Command Handler completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written through the invocation's stderr callback (process stderr under `execute()`). Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
 
 Without `cache`, the check occurs once per process execution. With `cache`, a fresh cached result is reused for `intervalMs` and duplicate notices for the same version are suppressed.
 

--- a/apps/docs/content/docs/modules/meta.json
+++ b/apps/docs/content/docs/modules/meta.json
@@ -5,13 +5,13 @@
     "core",
     "extensions",
     "crust",
+    "man",
+    "skills",
     "create",
     "progress",
     "prompts",
-    "testing",
-    "style",
     "store",
-    "skills",
-    "man"
+    "style",
+    "testing"
   ]
 }

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -88,7 +88,7 @@ test("accepts a name", async () => {
 });
 ```
 
-Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks.
+Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `stripAnsi`, `encodeKey`, and the types `PromptTestIO` and `RenderedPrompt`.
 
 ## Prompts
 
@@ -413,6 +413,7 @@ Only one prompt can be active per input or output stream. Prompts on fully disti
 | `runPrompt`           | Low-level prompt runner; accepts optional `PromptIO` |
 | `submit`              | Create a submit result to resolve a prompt           |
 | `assertTTY`           | Throw `NonInteractiveError` if stdin is not a TTY    |
+| `isTTY`               | Check whether an input stream is an interactive TTY  |
 | `withPromptIO`        | Scope prompt IO for nested async prompt calls        |
 | `PromptIO`            | Optional input/output streams for prompts            |
 | `NonInteractiveError` | Error thrown when a TTY is required but absent       |
@@ -443,6 +444,8 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 | `MultiselectOptions<T>`   | Options for `multiselect()`                                                         |
 | `FilterOptions<T>`        | Options for `filter()`                                                              |
 | `MultifilterOptions<T>`   | Options for `multifilter()`                                                         |
+| `PromptInput`             | Input stream contract composing `PromptIO`                                          |
+| `PromptOutput`            | Output stream contract composing `PromptIO`                                         |
 | `PromptTheme`             | Complete theme with all style slots                                                 |
 | `PartialPromptTheme`      | Partial theme for overrides                                                         |
 | `Choice<T>`               | Choice item: string or `{ label, value, hint? }`                                    |

--- a/apps/docs/content/docs/quick-start.mdx
+++ b/apps/docs/content/docs/quick-start.mdx
@@ -9,39 +9,13 @@ icon: Rocket
 ```sh
 bun create crust my-cli
 cd my-cli
-bun install
 ```
 
-The generated project uses the single supported starter pattern:
+The scaffolder offers to install dependencies and initialize git. The generated project uses the single supported starter pattern:
 
-```ts title="src/cli.ts"
-import { Crust } from "@crustjs/core";
-import { help, version } from "@crustjs/extensions";
-
-import pkg from "../package.json";
-
-const app = new Crust("my-cli")
-  .meta({ description: "A CLI built with Crust" })
-  .extend(version(pkg.version), help())
-  .args({
-    name: "name",
-    type: "string",
-    description: "Your name",
-    default: "world",
-  })
-  .flags({
-    name: "greet",
-    type: "string",
-    description: "Greeting to use",
-    default: "Hello",
-    short: "g",
-  })
-  .handle(({ args, flags, stdout }) => {
-    stdout(`${flags.greet}, ${args.name}!`);
-  });
-
-await app.execute();
-```
+<include lang="ts" meta='title="src/cli.ts"'>
+  ../../examples/quick-start/starter.ts
+</include>
 
 Run it directly:
 
@@ -52,32 +26,13 @@ bun run src/cli.ts Ada --greet Welcome
 
 ## Add a subcommand
 
-```ts
-import { Crust, defineCommand } from "@crustjs/core";
-
-const app = new Crust("my-cli")
-  .extend(help())
-  .mount(
-    defineCommand("build", (command) =>
-      command
-        .flags({ name: "minify", type: "boolean" })
-        .handle(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
-    ),
-  );
-```
+<include lang="ts">../../examples/quick-start/subcommand.ts</include>
 
 Use [the split-file pattern](/docs/guide/split-files) when the command tree grows.
 
 ## Invoke from code
 
-```ts
-const output: string[] = [];
-
-await app.run(["Ada", "--greet", "Hi"], {
-  stdout: (line) => output.push(line),
-  stderr: (line) => output.push(line),
-});
-```
+<include lang="ts">../../examples/quick-start/invoke.ts#run</include>
 
 `run()` throws the original error and does not set `process.exitCode`. Use `execute()` only at the terminal entrypoint.
 

--- a/apps/docs/examples/extensions/diagnostics.ts
+++ b/apps/docs/examples/extensions/diagnostics.ts
@@ -1,0 +1,31 @@
+import { type ExtensionContext, defineCommand, defineExtension } from "@crustjs/core";
+
+const timers = new WeakMap<ExtensionContext, number>();
+
+export const diagnostics = defineExtension("diagnostics", {
+  flags: {
+    trace: {
+      type: "boolean",
+      description: "Print diagnostic timing",
+      inherit: true,
+    },
+  },
+  commands: [
+    defineCommand("doctor", (command) =>
+      command
+        .meta({ description: "Check the installation" })
+        .handle(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
+    ),
+  ],
+  hooks: {
+    preRun(ctx) {
+      if (ctx.flags.trace === true) timers.set(ctx, performance.now());
+    },
+    postRun(ctx, outcome) {
+      const started = timers.get(ctx);
+      if (started === undefined) return;
+      timers.delete(ctx);
+      ctx.stderr(`${outcome.status} in ${performance.now() - started}ms`);
+    },
+  },
+});

--- a/apps/docs/examples/extensions/hooks.ts
+++ b/apps/docs/examples/extensions/hooks.ts
@@ -1,0 +1,25 @@
+import { defineExtension } from "@crustjs/core";
+
+//#region cached
+export const cached = defineExtension("cached", {
+  hooks: {
+    preRun(ctx) {
+      if (ctx.flags.cached !== true) return;
+      ctx.stdout("cached result");
+      return ctx.finish();
+    },
+  },
+});
+//#endregion
+
+//#region service-errors
+export const serviceErrors = defineExtension("service-errors", {
+  hooks: {
+    onError(error, ctx) {
+      if (!(error instanceof Error) || error.name !== "ServiceUnavailableError") return;
+      ctx.stderr(error.message);
+      return true;
+    },
+  },
+});
+//#endregion

--- a/apps/docs/examples/extensions/install.ts
+++ b/apps/docs/examples/extensions/install.ts
@@ -1,0 +1,18 @@
+import { Crust } from "@crustjs/core";
+import {
+  completion,
+  didYouMean,
+  help,
+  noColor,
+  updateNotifier,
+  version,
+} from "@crustjs/extensions";
+
+export const app = new Crust("my-cli").extend(
+  help(),
+  version("0.2.0"),
+  completion(),
+  didYouMean(),
+  noColor(),
+  updateNotifier({ packageName: "my-cli", currentVersion: "0.2.0" }),
+);

--- a/apps/docs/examples/landing/greet.ts
+++ b/apps/docs/examples/landing/greet.ts
@@ -1,0 +1,14 @@
+import { Crust } from "@crustjs/core";
+import { help, version } from "@crustjs/extensions";
+
+const app = new Crust("greet")
+  .extend(help(), version("1.0.0"))
+  .args({ name: "name", type: "string", default: "world" })
+  .flags({ name: "shout", type: "boolean", short: "s" })
+  .handle(({ args, flags, stdout }) => {
+    // args.name: string · flags.shout: boolean | undefined
+    const line = `Hello, ${args.name}!`;
+    stdout(flags.shout ? line.toUpperCase() : line);
+  });
+
+await app.execute();

--- a/apps/docs/examples/package.json
+++ b/apps/docs/examples/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Anchor for doc examples that mirror the create-crust template's `import pkg from \"../package.json\"` line."
+}

--- a/apps/docs/examples/quick-start/invoke.ts
+++ b/apps/docs/examples/quick-start/invoke.ts
@@ -1,0 +1,15 @@
+import { Crust } from "@crustjs/core";
+
+const app = new Crust("my-cli")
+  .args({ name: "name", type: "string", default: "world" })
+  .flags({ name: "greet", type: "string", default: "Hello", short: "g" })
+  .handle(({ args, flags, stdout }) => stdout(`${flags.greet}, ${args.name}!`));
+
+//#region run
+const output: string[] = [];
+
+await app.run(["Ada", "--greet", "Hi"], {
+  stdout: (line) => output.push(line),
+  stderr: (line) => output.push(line),
+});
+//#endregion

--- a/apps/docs/examples/quick-start/starter.ts
+++ b/apps/docs/examples/quick-start/starter.ts
@@ -1,0 +1,26 @@
+import { Crust } from "@crustjs/core";
+import { help, version } from "@crustjs/extensions";
+
+import pkg from "../package.json";
+
+const app = new Crust("my-cli")
+  .meta({ description: "A CLI built with Crust" })
+  .extend(version(pkg.version), help())
+  .args({
+    name: "name",
+    type: "string",
+    description: "Your name",
+    default: "world",
+  })
+  .flags({
+    name: "greet",
+    type: "string",
+    description: "Greeting to use",
+    default: "Hello",
+    short: "g",
+  })
+  .handle(({ args, flags, stdout }) => {
+    stdout(`${flags.greet}, ${args.name}!`);
+  });
+
+await app.execute();

--- a/apps/docs/examples/quick-start/subcommand.ts
+++ b/apps/docs/examples/quick-start/subcommand.ts
@@ -1,0 +1,12 @@
+import { Crust, defineCommand } from "@crustjs/core";
+import { help } from "@crustjs/extensions";
+
+export const app = new Crust("my-cli")
+  .extend(help())
+  .mount(
+    defineCommand("build", (command) =>
+      command
+        .flags({ name: "minify", type: "boolean" })
+        .handle(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
+    ),
+  );

--- a/apps/docs/examples/split-files/app.ts
+++ b/apps/docs/examples/split-files/app.ts
@@ -1,0 +1,10 @@
+import { Crust } from "@crustjs/core";
+import { help, version } from "@crustjs/extensions";
+
+import { logger, verbose } from "./shared.ts";
+
+export const app = new Crust("my-cli")
+  .meta({ description: "A split-file CLI" })
+  .extend(version("0.2.0"), help())
+  .flags(verbose)
+  .provide(logger());

--- a/apps/docs/examples/split-files/cli.ts
+++ b/apps/docs/examples/split-files/cli.ts
@@ -1,0 +1,4 @@
+import { app } from "./app.ts";
+import { greetCommand } from "./commands/greet.ts";
+
+await app.mount(greetCommand).execute();

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -1,0 +1,13 @@
+import { defineCommand } from "@crustjs/core";
+
+import { logger, verbose } from "../shared.ts";
+
+export const greetCommand = defineCommand("greet", { flags: [verbose], ctx: [logger] }, (command) =>
+  command
+    .args({ name: "name", type: "string", default: "world" })
+    .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })
+    .handle(({ args, flags, ctx, stdout }) => {
+      if (flags.verbose) ctx.logger.write("Preparing greeting");
+      stdout(`${flags.greeting}, ${args.name}!`);
+    }),
+);

--- a/apps/docs/examples/split-files/shared.ts
+++ b/apps/docs/examples/split-files/shared.ts
@@ -1,0 +1,9 @@
+import { defineContext, defineFlag } from "@crustjs/core";
+
+export const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+
+export const logger = defineContext("logger", () => ({
+  write(message: string) {
+    console.error(message);
+  },
+}));

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.47.0",
+    "@crustjs/core": "workspace:*",
+    "@crustjs/extensions": "workspace:*",
     "@tailwindcss/vite": "^4.3.3",
     "@types/mdx": "^2.0.14",
     "@types/node": "^24",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -18,6 +18,7 @@
       "@/*": ["./src/*"],
       "fumadocs-mdx:collections/*": ["./.source/*"]
     },
+    "allowImportingTsExtensions": true,
     "noEmit": true
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,8 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.47.0",
+        "@crustjs/core": "workspace:*",
+        "@crustjs/extensions": "workspace:*",
         "@tailwindcss/vite": "^4.3.3",
         "@types/mdx": "^2.0.14",
         "@types/node": "^24",

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -1,4 +1,4 @@
-import type { CommandNode } from "../command/node.ts";
+import type { CommandDefinition } from "../command/crust.ts";
 import type { CommandSnapshot } from "../command/snapshot.ts";
 import { CrustError } from "../errors.ts";
 import type { FlagDef } from "../types.ts";
@@ -78,20 +78,11 @@ export interface ExtensionHooks {
  */
 export type ExtensionFlagDef = FlagDef & { readonly recursive?: boolean };
 
-/**
- * A configured command builder contributed by an Extension. Structural on
- * purpose (any `Crust` builder satisfies it) so Extension values stay
- * assignable across separately-bundled type declarations.
- */
-export interface ExtensionCommand {
-	readonly _node: CommandNode;
-}
-
 export interface ExtensionConfig {
 	/** Flags this Extension owns and contributes to the application */
 	readonly flags?: Readonly<Record<string, ExtensionFlagDef>>;
-	/** Root commands this Extension owns and contributes to the application */
-	readonly commands?: readonly ExtensionCommand[];
+	/** Root command definitions this Extension owns and contributes to the application */
+	readonly commands?: readonly CommandDefinition<any>[];
 	readonly hooks?: ExtensionHooks;
 }
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
+import { defineContext } from "../api/context.ts";
 import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
@@ -994,35 +995,108 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
 
-	it("Extension commands are routable, validated, and receive the root snapshot", async () => {
+	it("Extension command definitions are routable, validated, and inherit recursive flags", async () => {
 		const lines: string[] = [];
 		const completion = defineExtension("completion", {
 			commands: [
-				new Crust("completion")
-					.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh"] })
-					.handle(({ args, rootCommand }) => {
-						lines.push(`completion:${args.shell}:${rootCommand.meta.name}`);
-					}),
+				defineCommand("completion", (command) =>
+					command
+						.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh"] })
+						.handle(({ args, flags, rootCommand }) => {
+							lines.push(
+								`completion:${args.shell}:${(flags as Record<string, unknown>).verbose}:${rootCommand.meta.name}`,
+							);
+						}),
+				),
 			],
 		});
+		const verbose = defineExtension("verbose", {
+			flags: { verbose: { type: "boolean" } },
+		});
 
-		const app = new Crust("cli").extend(completion).handle(() => {});
+		const app = new Crust("cli").extend(completion, verbose).handle(() => {});
 
-		await app.run(["completion", "bash"]);
-		expect(lines).toEqual(["completion:bash:cli"]);
+		await app.run(["completion", "bash", "--verbose"]);
+		expect(lines).toEqual(["completion:bash:true:cli"]);
 		await expect(app.run(["completion", "fish"])).rejects.toMatchObject({ code: "PARSE" });
 		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
 	});
 
+	it("Extension command requirements name the Extension and missing Context", async () => {
+		const db = defineContext("db", () => "database");
+		const databaseTools = defineExtension("database-tools", {
+			commands: [defineCommand("users", { ctx: [db] }, (command) => command.handle(() => {}))],
+		});
+
+		try {
+			await new Crust("cli").extend(databaseTools).run(["users"]);
+			expect.unreachable("should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(CrustError);
+			expect((error as CrustError).code).toBe("DEFINITION");
+			expect((error as CrustError).message).toContain('Extension "database-tools"');
+			expect((error as CrustError).message).toContain('Context "db"');
+		}
+	});
+
 	it("Extension command colliding with an application command is a DEFINITION error", async () => {
 		const clash = defineExtension("clash", {
-			commands: [new Crust("sub").handle(() => {})],
+			commands: [defineCommand("sub", (command) => command.handle(() => {}))],
 		});
 		const app = new Crust("cli")
 			.mount(defineCommand("sub", (cmd) => cmd.handle(() => {})))
 			.extend(clash);
 
 		await expect(app.run(["sub"])).rejects.toMatchObject({ code: "DEFINITION" });
+	});
+
+	it("rejects non-definition Extension commands", async () => {
+		const invalid = defineExtension("invalid", { commands: [{} as never] });
+
+		await expect(new Crust("cli").extend(invalid).run([])).rejects.toMatchObject({
+			code: "DEFINITION",
+			message: 'Extension "invalid" commands must be created by defineCommand()',
+		});
+	});
+
+	it("attributes foreign builders returned by Extension command definitions", async () => {
+		const invalid = defineExtension("invalid", {
+			commands: [defineCommand("foreign", () => new Crust("other") as never)],
+		});
+
+		await expect(new Crust("cli").extend(invalid).run([])).rejects.toMatchObject({
+			code: "DEFINITION",
+			message:
+				'Extension "invalid" command "foreign" definition must return the same command builder it received',
+			details: {
+				subject: "extension",
+				name: "invalid",
+				reason: "foreign-command-builder",
+			},
+		});
+	});
+
+	it("attributes nested Extensions inside Extension command definitions", async () => {
+		const invalid = defineExtension("invalid", {
+			commands: [
+				defineCommand(
+					"nested",
+					(command) =>
+						(command as unknown as Crust).extend(defineExtension("nested-extension")) as never,
+				),
+			],
+		});
+
+		await expect(new Crust("cli").extend(invalid).run([])).rejects.toMatchObject({
+			code: "DEFINITION",
+			message:
+				'Extension "invalid" command "nested" cannot register Extensions inside command definitions',
+			details: {
+				subject: "extension",
+				name: "invalid",
+				reason: "nested-command-extension",
+			},
+		});
 	});
 
 	it("does not mutate the source builder across executions", async () => {
@@ -1216,9 +1290,11 @@ describe("Extension named hooks", () => {
 		const roots: string[] = [];
 		const extension = defineExtension("extension", {
 			commands: [
-				new Crust("owned").handle(({ rootCommand }) => {
-					roots.push(rootCommand.meta.name);
-				}),
+				defineCommand("owned", (command) =>
+					command.handle(({ rootCommand }) => {
+						roots.push(rootCommand.meta.name);
+					}),
+				),
 			],
 		});
 		const app = new Crust("cli").extend(extension).handle(({ rootCommand }) => {
@@ -1637,11 +1713,13 @@ describe("Crust .execute()", () => {
 		});
 		const skillLike = defineExtension("inject-subcommand", {
 			commands: [
-				new Crust("skill").mount(
-					defineCommand("update", (cmd) =>
-						cmd.handle((runCtx) => {
-							receivedFlags = runCtx.flags as Record<string, unknown>;
-						}),
+				defineCommand("skill", (command) =>
+					command.mount(
+						defineCommand("update", (cmd) =>
+							cmd.handle((runCtx) => {
+								receivedFlags = runCtx.flags as Record<string, unknown>;
+							}),
+						),
 					),
 				),
 			],
@@ -2087,7 +2165,9 @@ describe("Crust .mount() aliases", () => {
 		// Without this guard, an Extension could attach an alias that silently
 		// changes routing for an existing user command.
 		const rogue = defineExtension("rogue", {
-			commands: [new Crust("info").meta({ aliases: ["i"] }).handle(() => {})],
+			commands: [
+				defineCommand("info", (command) => command.meta({ aliases: ["i"] }).handle(() => {})),
+			],
 		});
 
 		const app = new Crust("cli")

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1022,6 +1022,27 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
 	});
 
+	it("Extension command requirements reject missing inherited flags", async () => {
+		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		let recipeRan = false;
+		const tools = defineExtension("tools", {
+			commands: [
+				defineCommand("status", { flags: [verbose] }, (command) => {
+					recipeRan = true;
+					return command.handle(() => {});
+				}),
+			],
+		});
+
+		await expect(new Crust("cli").extend(tools).run(["status"])).rejects.toMatchObject({
+			code: "DEFINITION",
+			message:
+				'Extension "tools" command "status" requires flag "--verbose", which is not declared with inherit: true on application root "cli"',
+			details: { subject: "flag", name: "verbose", reason: "missing-required-flag" },
+		});
+		expect(recipeRan).toBe(false);
+	});
+
 	it("Extension command requirements name the Extension and missing Context", async () => {
 		const db = defineContext("db", () => "database");
 		const databaseTools = defineExtension("database-tools", {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -211,24 +211,10 @@ function injectExtensionFlag(
 
 /** Attach one Extension's owned root commands to a cloned tree. */
 function applyExtensionCommands(root: CommandNode, ext: Extension): void {
-	for (const builder of ext.commands ?? []) {
-		const name = builder._node.meta.name;
-		if (root.subCommands[name]) {
-			throw new CrustError(
-				"DEFINITION",
-				`Extension "${ext.name}" command "${name}" collides with an existing root command`,
-				{ subject: "command", name, reason: "extension-command-collision" },
-			);
-		}
-		// Alias collisions with existing root commands are definition errors too
-		validateIncomingAliases(
-			{ canonicalName: name, aliases: builder._node.meta.aliases },
-			root.subCommands,
-			name,
-		);
-		const node = deepCloneCommandNode(builder._node);
+	for (const definition of ext.commands ?? []) {
+		const node = materializeCommandDefinition(definition, root, root.effectiveFlags, ext.name);
 		applyInheritedFlagsToSubtree(node, root.effectiveFlags);
-		root.subCommands[name] = node;
+		root.subCommands[definition.name] = node;
 	}
 }
 
@@ -329,7 +315,7 @@ type CommandRecipe<R extends CommandRequirements> = (
 	>,
 ) => AnyCommandDefinitionBuilder;
 
-const commandDefinitionInternal: unique symbol = Symbol("crust.commandDefinition");
+const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
 
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
@@ -346,6 +332,111 @@ export interface CommandDefinition<R extends CommandRequirements = {}> {
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
 	/** @internal — phantom carrying the requirements for mount-site checks */
 	readonly _requirements?: R;
+}
+
+function materializeCommandDefinition(
+	definition: CommandDefinition,
+	parent: CommandNode,
+	parentEffective: FlagsDef,
+	extensionName?: string,
+): CommandNode {
+	const internal = (definition as Partial<CommandDefinition> | null)?.[commandDefinitionInternal];
+	if (internal === undefined) {
+		if (extensionName) {
+			throw new CrustError(
+				"DEFINITION",
+				`Extension "${extensionName}" commands must be created by defineCommand()`,
+				{
+					subject: "extension",
+					name: extensionName,
+					reason: "invalid-command-definition",
+				},
+			);
+		}
+		throw new CrustError(
+			"DEFINITION",
+			"mount() requires a command definition created by defineCommand()",
+		);
+	}
+
+	const name = definition.name;
+	if (parent.subCommands[name]) {
+		if (extensionName) {
+			throw new CrustError(
+				"DEFINITION",
+				`Extension "${extensionName}" command "${name}" collides with an existing root command`,
+				{ subject: "command", name, reason: "extension-command-collision" },
+			);
+		}
+		throw new CrustError("DEFINITION", `Subcommand "${name}" is already registered`);
+	}
+
+	const providedNames = new Set(parent.contexts.map((context) => context.name));
+	for (const ctxName of internal.requiredCtxNames) {
+		if (!providedNames.has(ctxName)) {
+			const message = extensionName
+				? `Extension "${extensionName}" command "${name}" requires Context "${ctxName}", which is not provided on application root "${parent.meta.name}"`
+				: `Command "${name}" requires Context "${ctxName}", which is not provided on "${parent.meta.name}" — call .provide() before .mount()`;
+			throw new CrustError("DEFINITION", message, {
+				subject: "context",
+				name: ctxName,
+				reason: "missing-context",
+			});
+		}
+	}
+
+	const child = new Crust(name);
+	(child as { _inheritedFlags: FlagsDef })._inheritedFlags = parentEffective;
+	child._node.effectiveFlags = computeEffectiveFlags(parentEffective, {});
+	(child._node as { contexts: ContextInstance[] }).contexts = [...parent.contexts];
+
+	const configured = internal.recipe(
+		child as unknown as AnyCommandDefinitionBuilder,
+	) as unknown as Crust;
+	if (configured?._inheritedFlags !== parentEffective) {
+		if (extensionName) {
+			throw new CrustError(
+				"DEFINITION",
+				`Extension "${extensionName}" command "${name}" definition must return the same command builder it received`,
+				{
+					subject: "extension",
+					name: extensionName,
+					reason: "foreign-command-builder",
+				},
+			);
+		}
+		throw new CrustError(
+			"DEFINITION",
+			"Command definition must return the same command builder it received",
+		);
+	}
+	if (configured._node.extensions.length > 0) {
+		if (extensionName) {
+			throw new CrustError(
+				"DEFINITION",
+				`Extension "${extensionName}" command "${name}" cannot register Extensions inside command definitions`,
+				{
+					subject: "extension",
+					name: extensionName,
+					reason: "nested-command-extension",
+				},
+			);
+		}
+		throw new CrustError(
+			"DEFINITION",
+			"Extensions cannot be registered inside command definitions",
+		);
+	}
+
+	validateIncomingAliases(
+		{ canonicalName: name, aliases: configured._node.meta.aliases },
+		parent.subCommands,
+		name,
+	);
+
+	const childNode = deepCloneCommandNode(configured._node);
+	childNode.meta.name = name;
+	return childNode;
 }
 
 type FlagValue<D extends FlagDef> = InferFlags<{ value: D }>["value"];
@@ -820,67 +911,11 @@ export class Crust<
 	}
 
 	private _mountDefinition(definition: CommandDefinition): Crust<Inherited, Local, A, Eff, Ctx> {
-		const internal = (definition as Partial<CommandDefinition> | null)?.[commandDefinitionInternal];
-		if (internal === undefined) {
-			throw new CrustError(
-				"DEFINITION",
-				"mount() requires a command definition created by defineCommand()",
-			);
-		}
-		const name = definition.name;
-		if (this._node.subCommands[name]) {
-			throw new CrustError("DEFINITION", `Subcommand "${name}" is already registered`);
-		}
-
-		// Runtime counterpart of the compile-time Mountable check: a mounted
-		// definition's Context requirements must already be provided on this
-		// path, so a missing dependency fails here instead of surfacing as a
-		// silently-undefined ctx value at dispatch.
-		const providedNames = new Set(this._node.contexts.map((context) => context.name));
-		for (const ctxName of internal.requiredCtxNames) {
-			if (!providedNames.has(ctxName)) {
-				throw new CrustError(
-					"DEFINITION",
-					`Command "${name}" requires Context "${ctxName}", which is not provided on "${this._node.meta.name}" — call .provide() before .mount()`,
-					{ subject: "context", name: ctxName, reason: "missing-context" },
-				);
-			}
-		}
-
-		const recipe = internal.recipe;
 		const parentEffective = computeEffectiveFlags(this._inheritedFlags, this._node.localFlags);
-		const child = new Crust(name);
-		(child as { _inheritedFlags: FlagsDef })._inheritedFlags = parentEffective;
-		child._node.effectiveFlags = computeEffectiveFlags(parentEffective, {});
-		(child._node as { contexts: ContextInstance[] }).contexts = [...this._node.contexts];
-
-		const configured = recipe(child as unknown as AnyCommandDefinitionBuilder) as unknown as
-			| Crust
-			| undefined;
-		if (configured?._inheritedFlags !== parentEffective) {
-			throw new CrustError(
-				"DEFINITION",
-				"Command definition must return the same command builder it received",
-			);
-		}
-		if (configured._node.extensions.length > 0) {
-			throw new CrustError(
-				"DEFINITION",
-				"Extensions cannot be registered inside command definitions",
-			);
-		}
-
-		validateIncomingAliases(
-			{ canonicalName: name, aliases: configured._node.meta.aliases },
-			this._node.subCommands,
-			name,
-		);
-
-		const childNode = deepCloneCommandNode(configured._node);
-		childNode.meta.name = name;
+		const childNode = materializeCommandDefinition(definition, this._node, parentEffective);
 
 		return this._clone({
-			subCommands: { ...this._node.subCommands, [name]: childNode },
+			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
 		}) as Crust<Inherited, Local, A, Eff, Ctx>;
 	}
 

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -295,7 +295,8 @@ function freezeTree(node: CommandNode): void {
  * verified at runtime when the definition is mounted.
  *
  * Structurally identical to {@link ContextRequirements} — the shared
- * shape is defined once in `api/context.ts`.
+ * shape is defined once in `api/context.ts`. Both requirement kinds are
+ * verified at runtime as a backstop for untyped mount sites.
  */
 export type CommandRequirements = ContextRequirements;
 
@@ -319,7 +320,8 @@ const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefini
 
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
-	/** Context requirement names, runtime-checked at each mount site */
+	/** Requirement names, runtime-checked at each mount site */
+	readonly requiredFlagNames: readonly string[];
 	readonly requiredCtxNames: readonly string[];
 }
 
@@ -369,6 +371,19 @@ function materializeCommandDefinition(
 			);
 		}
 		throw new CrustError("DEFINITION", `Subcommand "${name}" is already registered`);
+	}
+
+	for (const flagName of internal.requiredFlagNames) {
+		if (parentEffective[flagName]?.inherit !== true) {
+			const message = extensionName
+				? `Extension "${extensionName}" command "${name}" requires flag "--${flagName}", which is not declared with inherit: true on application root "${parent.meta.name}"`
+				: `Command "${name}" requires flag "--${flagName}", which is not declared with inherit: true on "${parent.meta.name}" — declare flags before .mount()`;
+			throw new CrustError("DEFINITION", message, {
+				subject: "flag",
+				name: flagName,
+				reason: "missing-required-flag",
+			});
+		}
 	}
 
 	const providedNames = new Set(parent.contexts.map((context) => context.name));
@@ -578,6 +593,7 @@ export function defineCommand(
 	}
 	const internal: CommandDefinitionInternal = {
 		recipe: recipe as CommandDefinitionInternal["recipe"],
+		requiredFlagNames: (requirements.flags ?? []).map((flag) => flag.name),
 		requiredCtxNames: (requirements.ctx ?? []).map((dep) => dep.contextName),
 	};
 	const named = (defName: string): CommandDefinition<CommandRequirements> => {

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -249,13 +249,17 @@ describe("command definitions", () => {
 			// @ts-expect-error -- an optional parent flag cannot satisfy a required requirement
 			.mount(strictDefinition);
 
-		// @ts-expect-error -- missing inherited flags: verbose
-		new Crust("cli").provide(auth()).mount(definition);
-		new Crust("cli")
-			.flags({ name: "verbose", type: "boolean" })
-			.provide(auth())
+		expect(() =>
 			// @ts-expect-error -- missing inherited flags: verbose
-			.mount(definition);
+			new Crust("cli").provide(auth()).mount(definition),
+		).toThrow(/requires flag "--verbose"/);
+		expect(() =>
+			new Crust("cli")
+				.flags({ name: "verbose", type: "boolean" })
+				.provide(auth())
+				// @ts-expect-error -- missing inherited flags: verbose
+				.mount(definition),
+		).toThrow(/requires flag "--verbose"/);
 		new Crust("cli")
 			.flags({ name: "verbose", type: "string", inherit: true })
 			.provide(auth())

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// v0.1 builder API
+// Contexts and Extensions
 export type {
 	AnyContextFactory,
 	ContextFactory,
@@ -10,7 +10,6 @@ export type {
 export { defineContext } from "./api/context.ts";
 export type {
 	Extension,
-	ExtensionCommand,
 	ExtensionConfig,
 	ExtensionContext,
 	ExtensionFlagDef,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -457,7 +457,7 @@ interface SchemaBooleanFlagDef extends SchemaFlagBase {
 	type: "boolean";
 	/** When `true`, the flag is repeatable and the schema receives `boolean[]` */
 	multiple?: true;
-	/** When `true`, disables the auto-generated `--no-<name>` negation */
+	/** When `true`, hide the generated `--no-{name}` help label */
 	noNegate?: true;
 }
 

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 
-import { Crust, type Extension, defineExtension } from "@crustjs/core";
+import { type Extension, defineCommand, defineExtension } from "@crustjs/core";
 
 import { assertSafeBinName, sanitizeFreeText } from "./escape.ts";
 import { renderBash } from "./templates/bash.ts";
@@ -102,71 +102,73 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 	const shells = options.shells ?? SUPPORTED_SHELLS;
 	const version = options.version ?? "0.0.0";
 
-	const completionCommand = new Crust(subcommandName)
-		.meta({
-			description: "Generate shell tab-completion scripts",
-		})
-		.args({
-			name: "shell",
-			type: "string",
-			required: true,
-			description: "Shell to generate completion for",
-			choices: SUPPORTED_SHELLS,
-		})
-		.flags({
-			name: "output-dir",
-			type: "string",
-			description:
-				"Write all configured shells' scripts into this directory instead of printing to stdout",
-		})
-		.handle(async (context) => {
-			const rootCommand = context.rootCommand;
-			// Validate `binName` before emitting anything so misconfigured
-			// CLIs fail loudly. The walker also re-validates command/flag
-			// identifiers when it builds the spec.
-			const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
-			// `version` flows into header comments only; sanitise to drop
-			// control characters (newlines especially) so they cannot break
-			// out of the comment line in the emitted script.
-			const safeVersion = sanitizeFreeText(version);
+	const completionCommand = defineCommand(subcommandName, (cmd) =>
+		cmd
+			.meta({
+				description: "Generate shell tab-completion scripts",
+			})
+			.args({
+				name: "shell",
+				type: "string",
+				required: true,
+				description: "Shell to generate completion for",
+				choices: SUPPORTED_SHELLS,
+			})
+			.flags({
+				name: "output-dir",
+				type: "string",
+				description:
+					"Write all configured shells' scripts into this directory instead of printing to stdout",
+			})
+			.handle(async (context) => {
+				const rootCommand = context.rootCommand;
+				// Validate `binName` before emitting anything so misconfigured
+				// CLIs fail loudly. The walker also re-validates command/flag
+				// identifiers when it builds the spec.
+				const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
+				// `version` flows into header comments only; sanitise to drop
+				// control characters (newlines especially) so they cannot break
+				// out of the comment line in the emitted script.
+				const safeVersion = sanitizeFreeText(version);
 
-			const { shell: requestedShell } = context.args;
-			const spec = walkCommandNode(rootCommand);
-			const outputDir = context.flags["output-dir"];
+				const { shell: requestedShell } = context.args;
+				const spec = walkCommandNode(rootCommand);
+				const outputDir = context.flags["output-dir"];
 
-			if (outputDir === undefined) {
-				const script = renderForShell(requestedShell, spec, binName, safeVersion);
-				context.stdout(script);
-				return;
-			}
-
-			// File path: write **all** configured shells. This matches
-			// the packaging-time use case — distributors generate every
-			// supported file in one invocation regardless of which
-			// shell they nominally requested.
-			const targetDir = resolvePath(outputDir);
-			await mkdir(targetDir, { recursive: true });
-			for (const shell of shells) {
-				const filename = filenameForShell(shell, binName);
-				const script = renderForShell(shell, spec, binName, safeVersion);
-				const targetPath = resolvePath(targetDir, filename);
-				// Defence-in-depth: even though `binName` is validated
-				// upstream (rejects path separators / `..`), verify the
-				// resolved path stays inside `targetDir`. This catches
-				// future regressions in the validator and platform-
-				// specific edge cases (e.g. Windows drive letters).
-				if (
-					targetPath !== targetDir &&
-					!targetPath.startsWith(`${targetDir}/`) &&
-					!targetPath.startsWith(`${targetDir}\\`)
-				) {
-					throw new Error(
-						`completion extension: refusing to write outside output dir (${targetPath})`,
-					);
+				if (outputDir === undefined) {
+					const script = renderForShell(requestedShell, spec, binName, safeVersion);
+					context.stdout(script);
+					return;
 				}
-				await writeFile(targetPath, script, "utf8");
-			}
-		});
+
+				// File path: write **all** configured shells. This matches
+				// the packaging-time use case — distributors generate every
+				// supported file in one invocation regardless of which
+				// shell they nominally requested.
+				const targetDir = resolvePath(outputDir);
+				await mkdir(targetDir, { recursive: true });
+				for (const shell of shells) {
+					const filename = filenameForShell(shell, binName);
+					const script = renderForShell(shell, spec, binName, safeVersion);
+					const targetPath = resolvePath(targetDir, filename);
+					// Defence-in-depth: even though `binName` is validated
+					// upstream (rejects path separators / `..`), verify the
+					// resolved path stays inside `targetDir`. This catches
+					// future regressions in the validator and platform-
+					// specific edge cases (e.g. Windows drive letters).
+					if (
+						targetPath !== targetDir &&
+						!targetPath.startsWith(`${targetDir}/`) &&
+						!targetPath.startsWith(`${targetDir}\\`)
+					) {
+						throw new Error(
+							`completion extension: refusing to write outside output dir (${targetPath})`,
+						);
+					}
+					await writeFile(targetPath, script, "utf8");
+				}
+			}),
+	);
 
 	return defineExtension("completion", { commands: [completionCommand] });
 }

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -68,14 +68,16 @@ const stripAnsi = stripVTControlCharacters;
 function lateSkillExtension() {
 	return defineExtension("late-skill", {
 		commands: [
-			new Crust("skill")
-				.meta({ description: "Manage agent skills" })
-				.mount(
-					defineCommand("update", (cmd) =>
-						cmd.meta({ description: "Update installed skills" }).handle(() => {}),
-					),
-				)
-				.handle(() => {}),
+			defineCommand("skill", (command) =>
+				command
+					.meta({ description: "Manage agent skills" })
+					.mount(
+						defineCommand("update", (cmd) =>
+							cmd.meta({ description: "Update installed skills" }).handle(() => {}),
+						),
+					)
+					.handle(() => {}),
+			),
 		],
 	});
 }

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -4,7 +4,6 @@
 
 import {
 	type CommandSnapshot,
-	Crust,
 	type Extension,
 	defineCommand,
 	defineExtension,
@@ -652,47 +651,49 @@ function buildSkillCommandGrammar(
 	options: SkillOptions,
 	getCustomSkills: (mainName: string) => readonly CustomSkillConfig[],
 ) {
-	return new Crust(commandName)
-		.meta({ description: "Manage agent skill installations" })
-		.flags(
-			{
-				name: "scope",
-				type: "string",
-				description: "Install scope (project or global)",
-			},
-			{
-				name: "all",
-				type: "boolean",
-				description: "Install for all detected agents non-interactively (universal + detected)",
-			},
-		)
-		.mount(
-			defineCommand("update", (cmd) =>
-				cmd
-					.meta({ description: "Update installed skills to latest version" })
-					.flags({
-						name: "scope",
-						type: "string",
-						description: "Update scope (project or global)",
-					})
-					.handle(async (context) => {
-						await runSkillUpdateFlow(
-							context.rootCommand,
-							options,
-							getCustomSkills(context.rootCommand.meta.name),
-							context.flags,
-						);
-					}),
-			),
-		)
-		.handle(async (context) => {
-			await runSkillInstallFlow(
-				context.rootCommand,
-				options,
-				getCustomSkills(context.rootCommand.meta.name),
-				context.flags,
-			);
-		});
+	return defineCommand(commandName, (command) =>
+		command
+			.meta({ description: "Manage agent skill installations" })
+			.flags(
+				{
+					name: "scope",
+					type: "string",
+					description: "Install scope (project or global)",
+				},
+				{
+					name: "all",
+					type: "boolean",
+					description: "Install for all detected agents non-interactively (universal + detected)",
+				},
+			)
+			.mount(
+				defineCommand("update", (cmd) =>
+					cmd
+						.meta({ description: "Update installed skills to latest version" })
+						.flags({
+							name: "scope",
+							type: "string",
+							description: "Update scope (project or global)",
+						})
+						.handle(async (context) => {
+							await runSkillUpdateFlow(
+								context.rootCommand,
+								options,
+								getCustomSkills(context.rootCommand.meta.name),
+								context.flags,
+							);
+						}),
+				),
+			)
+			.handle(async (context) => {
+				await runSkillInstallFlow(
+					context.rootCommand,
+					options,
+					getCustomSkills(context.rootCommand.meta.name),
+					context.flags,
+				);
+			}),
+	);
 }
 
 async function runSkillInstallFlow(


### PR DESCRIPTION
## What

Two related changes finishing the v0.2 refactor train:

### 1. `ExtensionConfig.commands` now takes `defineCommand()` definitions (breaking)

`new Crust()` is now exclusively the application root — extensions contribute commands the same way applications mount them.

- `ExtensionCommand` removed; `commands?: readonly CommandDefinition<any>[]`
- Materialization logic shared between `.mount()` and extension apply (no duplication)
- Definition brand uses `Symbol.for` so duplicate core copies interoperate
- Definition ctx requirements are runtime-checked at prepare with `DEFINITION` errors naming the contributing extension
- Closes a footgun: contributed `Crust` builders could carry `.extend()` calls that were silently dropped
- `completion` and `skills` migrated; changeset included (minor bumps for core/extensions/skills)

**Migration:** wrap contributed commands in `defineCommand(name, recipe)`.

### 2. Full v0.2 docs verification + compiled-examples infrastructure

Every docs page was verified claim-by-claim against the implementation (5 independent review passes over guide/modules/api/nav).

- **Compiled examples:** doc snippets now live as real `.ts` files under `apps/docs/examples/`, typechecked by the docs `check:types` gate and embedded via fumadocs `<include>` (with `#region` slices). Caught a real bug: a quick-start snippet used `help()` without importing it.
- **Auto-type-tables** replace hand-maintained field lists (`CrustCommandContext` — which had already drifted, missing `rootCommand` — and `ExtensionContext`).
- **Accuracy fixes:** `noNegate` documented as display-only (runtime-verified; parser still accepts `--no-name`), per-OS npm packaging tab no longer shows a manifest that would publish the staging tree, update-notifier stderr wording, stale post-#146 wording.
- **Dedup:** rules stated on 2–3 pages (schema exclusivity, finalize-before-mount, `.as()`) now have one canonical home + links.
- **Landing page:** quick example (compiled) + design philosophy section filled in (previously empty headings).

## Verification

- `bun run check`, `bun run check:types`, `bun run test` — green
- docs `vite build` — exit 0 (validates all `<include>` paths and auto-type-table targets)
- New core tests: ctx-requirement failure, collisions, non-definition rejection, nested-`.extend()` rejection, foreign-builder rejection