### PR TITLE
feat: alias-symmetric boolean negation and flag aliases in help

### DIFF
--- a/.changeset/alias-symmetric-negation.md
+++ b/.changeset/alias-symmetric-negation.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Boolean negation is now alias-symmetric: `--no-<alias>` works for every long alias, matching what man pages and completion scripts already advertised. `noNegate: true` is now enforced by the parser — negating a `noNegate` boolean via any spelling is a `PARSE` error instead of being silently accepted.

--- a/.changeset/help-shows-flag-aliases.md
+++ b/.changeset/help-shows-flag-aliases.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/extensions": minor
+---
+
+`help()` now renders long flag aliases (e.g. `-o, --output, --out`). Negation is shown for the canonical name only; man pages remain the exhaustive reference.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# Crust — Glossary
+
+## Flag alias
+
+An alternate long or short spelling of a flag. An alias is a **perfect
+synonym**: every operation valid on the canonical name is valid on any
+alias, including boolean negation (`--no-<alias>`). Parsed values are
+always reported under the canonical name.
+
+## Negation
+
+The automatic `--no-<spelling>` form of a boolean flag. Applies to the
+canonical name and every long alias. A flag opts out with `noNegate`.
+The `no-` prefix is reserved: no flag name, short, or alias may start
+with it.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -167,9 +167,9 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls replace the local flags. A duplicate name within one call throws `DEFINITION`.
+Repeated `.flags()` calls **replace** the local flags — they do not merge; pass all definitions in one call. A duplicate name within one call throws `DEFINITION`.
 
-`inherit: true` exposes a flag to descendant commands and allows it to satisfy mounted definition and Context requirements. Boolean flags support generated `--no-name` negation; `noNegate: true` hides the generated label from help, completion, and man output (the parser still accepts `--no-name`). Names and aliases beginning with `no-` are reserved.
+`inherit: true` exposes a flag to descendant commands and allows it to satisfy mounted definition and Context requirements. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
 Schema-backed flags require `type: "string" | "boolean"` only to declare whether the flag consumes a token. Their schema owns the value rules and receives the raw parsed value.
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -3,6 +3,8 @@ title: Flags
 description: Define typed named inputs, aliases, repeated values, and inherited flags.
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
 `.flags(...defs)` takes named flag definitions — values from `defineFlag(name, def)` or inline literals carrying `name`:
 
 ```ts
@@ -16,7 +18,13 @@ const command = new Crust("serve")
   .handle(({ flags, stdout }) => stdout(`${flags.port} ${flags.verbose ?? false}`));
 ```
 
-See [`FlagDef`](/docs/api/types#flagdef) for the complete definition. Repeated `.flags()` calls replace the local flags; a duplicate name within one call is a `DEFINITION` error.
+See [`FlagDef`](/docs/api/types#flagdef) for the complete definition. A duplicate name within one call is a `DEFINITION` error.
+
+<Callout type="warn">
+  Repeated `.flags()` calls **replace** the local flags — they do not merge. `.flags(a).flags(b)`
+  leaves only `b`. Pass all definitions in a single `.flags()` call. This differs from
+  Commander/yargs `.option()`, which is additive.
+</Callout>
 
 ## Aliases and negation
 
@@ -26,7 +34,7 @@ See [`FlagDef`](/docs/api/types#flagdef) for the complete definition. Repeated `
 .flags({ name: "output", type: "path", short: "o", aliases: ["out"] })
 ```
 
-Boolean flags support canonical `--no-name` negation. They do not accept `--name=true`. Flag names, short forms, and aliases must be unique, and the `no-` prefix is reserved; violations are `DEFINITION` errors.
+Boolean flags support `--no-<spelling>` negation for the canonical name and every long alias — an alias is a full synonym, so `--no-out` behaves like `--no-output`. Set `noNegate: true` to reject negation entirely (a `PARSE` error for any spelling). Boolean flags do not accept `--name=true`. Flag names, short forms, and aliases must be unique, and the `no-` prefix is reserved; violations are `DEFINITION` errors.
 
 ## Required and defaulted values
 

--- a/docs/adr/0001-alias-symmetric-boolean-negation.md
+++ b/docs/adr/0001-alias-symmetric-boolean-negation.md
@@ -1,0 +1,19 @@
+# Alias-symmetric boolean negation, parser-enforced noNegate
+
+A flag alias is a perfect synonym, so `--no-<alias>` negates a boolean
+exactly like `--no-<name>`. This is also the native behavior of
+`util.parseArgs` with `allowNegative` — the parser originally carried
+extra code (`validateCanonicalNegationUsage`) to _forbid_ alias
+negation, which drifted out of sync with the man/completion generators
+that all advertised `--no-<alias>`. We removed the restriction rather
+than patching three generators; no ambiguity is possible because the
+`no-` prefix is rejected at definition time for names, shorts, and
+aliases. In the same change, `noNegate` was promoted from a
+display-only hint to a parser-enforced contract: `--no-<any spelling>`
+of a `noNegate` boolean is a PARSE error.
+
+## Considered Options
+
+- Canonical-only negation (previous behavior): kept ~40 lines of
+  restriction code and required fixing man + bash/zsh/fish generators
+  to hide alias negation; rejected as a paper cut with no payoff.

--- a/docs/adr/0002-flags-replace-semantics.md
+++ b/docs/adr/0002-flags-replace-semantics.md
@@ -1,0 +1,10 @@
+# .flags() replaces local flags instead of merging
+
+Repeated `.flags()` calls on a builder replace the command's local flag
+definitions; they do not merge. Additive merge (the Commander/yargs
+convention) would require record-intersection types on every call —
+the same TypeScript type-check cost the builder already avoids by
+omitting compile-time inherited/local collision checks. The intended
+idiom is a single `.flags()` call carrying all definitions, which is
+also the best-inferring form. The docs carry a prominent callout so
+migrating users don't lose flags to `.flags(a).flags(b)`.

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -934,6 +934,22 @@ describe("parseArgs — boolean negation", () => {
 	it("last-token-wins across mixed spellings", () => {
 		const result = parseArgs(cmd, ["--verbose", "--no-loud"]);
 		expect(result.flags.verbose).toBe(false);
+
+		// Regression: parseArgs values group by key, so a repeated earlier
+		// spelling must not shadow the final token.
+		const result2 = parseArgs(cmd, ["--verbose", "--no-loud", "--verbose"]);
+		expect(result2.flags.verbose).toBe(true);
+	});
+
+	it("multiple flags preserve argv order across mixed aliases", () => {
+		const multiCmd = makeNode({
+			meta: { name: "test" },
+			flags: {
+				tag: { type: "string", multiple: true, short: "t", aliases: ["label"] },
+			},
+		});
+		const result = parseArgs(multiCmd, ["-t", "a", "--label", "b", "--tag", "c"]);
+		expect(result.flags.tag).toEqual(["a", "b", "c"]);
 	});
 
 	it("rejects negation of a noNegate boolean via any spelling", () => {

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -895,10 +895,10 @@ describe("parseArgs — negated boolean flag with value assignment", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Canonical-only negation (reject --no-<alias>)
+// Alias-symmetric negation (--no-<alias> works; noNegate enforced)
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("parseArgs — canonical-only negation", () => {
+describe("parseArgs — boolean negation", () => {
 	const cmd = makeNode({
 		meta: { name: "test" },
 		flags: {
@@ -926,16 +926,35 @@ describe("parseArgs — canonical-only negation", () => {
 		expect(result.flags.verbose).toBe(true);
 	});
 
-	it("throws CrustError with PARSE code on --no-<long-alias>", () => {
-		try {
-			parseArgs(cmd, ["--no-loud"]);
-			expect.unreachable("should have thrown");
-		} catch (err) {
-			expect(err).toBeInstanceOf(CrustError);
-			expect((err as CrustError).code).toBe("PARSE");
-			expect((err as CrustError).message).toBe(
-				'Cannot negate alias "--no-loud"; use "--no-verbose" instead',
-			);
+	it("allows --no-<long-alias> (--no-loud sets canonical false)", () => {
+		const result = parseArgs(cmd, ["--no-loud"]);
+		expect(result.flags.verbose).toBe(false);
+	});
+
+	it("last-token-wins across mixed spellings", () => {
+		const result = parseArgs(cmd, ["--verbose", "--no-loud"]);
+		expect(result.flags.verbose).toBe(false);
+	});
+
+	it("rejects negation of a noNegate boolean via any spelling", () => {
+		const noNegateCmd = makeNode({
+			meta: { name: "test" },
+			flags: {
+				version: { type: "boolean", noNegate: true, aliases: ["ver"] },
+			},
+		});
+
+		for (const spelling of ["--no-version", "--no-ver"]) {
+			try {
+				parseArgs(noNegateCmd, [spelling]);
+				expect.unreachable("should have thrown");
+			} catch (err) {
+				expect(err).toBeInstanceOf(CrustError);
+				expect((err as CrustError).code).toBe("PARSE");
+				expect((err as CrustError).message).toBe(
+					`Flag "--version" does not support negation ("${spelling}")`,
+				);
+			}
 		}
 	});
 

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -440,13 +440,14 @@ function resolveArgs(argsDef: ArgsDef | undefined, positionals: string[]): Recor
 }
 
 /**
- * Enforce canonical-only boolean negation.
+ * Enforce `noNegate` at parse time.
  *
- * `--no-<name>` is accepted only for the canonical boolean flag name.
- * Negating long aliases (for example `--no-loud` where `loud` aliases
- * `verbose`) is rejected with a targeted CrustError.
+ * `--no-<spelling>` works for the canonical name and every long alias
+ * (an alias is a perfect synonym — see ADR 0001), but a boolean that
+ * opted out via `noNegate` rejects every negated spelling. Without this
+ * pre-scan, `util.parseArgs` (`allowNegative`) would silently accept it.
  */
-function validateCanonicalNegationUsage(
+function validateNoNegateUsage(
 	argv: string[],
 	flagsDef: FlagsDef | undefined,
 	aliasToName: Record<string, string>,
@@ -465,16 +466,15 @@ function validateCanonicalNegationUsage(
 
 		if (!rawName) continue;
 
-		const canonical = aliasToName[rawName];
+		const canonical = aliasToName[rawName] ?? (rawName in flagsDef ? rawName : undefined);
 		if (!canonical) continue;
-		if (canonical === rawName) continue;
 
 		const def = flagsDef[canonical];
-		if (def?.type !== "boolean") continue;
+		if (def?.type !== "boolean" || def.noNegate !== true) continue;
 
 		throw new CrustError(
 			"PARSE",
-			`Cannot negate alias "--no-${rawName}"; use "--no-${canonical}" instead`,
+			`Flag "--${canonical}" does not support negation ("--no-${rawName}")`,
 		);
 	}
 }
@@ -512,7 +512,7 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 
 	const { options: parseOptions, aliasToName } = buildParseArgsOptionDescriptor(flagsDef);
 
-	validateCanonicalNegationUsage(argv, flagsDef, aliasToName);
+	validateNoNegateUsage(argv, flagsDef, aliasToName);
 
 	let parsed: ReturnType<typeof nodeParseArgs>;
 

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -18,6 +18,9 @@ import { coerceJson, coercePath, coerceUrl } from "./coercers.ts";
  */
 type ParsedFlagValue = string | boolean | (string | boolean)[] | undefined;
 
+/** Element type of `parseArgs(...).tokens` — not exported by `@types/node`. */
+type ParseArgsToken = NonNullable<ReturnType<typeof nodeParseArgs>["tokens"]>[number];
+
 // ────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ────────────────────────────────────────────────────────────────────────────
@@ -327,26 +330,42 @@ function coerceFlagValue(
 }
 
 /**
- * Resolve aliases in raw parsed values to their canonical flag names,
- * merging arrays for `multiple` flags that are provided via mixed aliases.
+ * Resolve parsed option tokens to canonical flag names, in argv order.
+ *
+ * Works from `parsed.tokens` rather than `parsed.values` because
+ * `util.parseArgs` groups values by option key: with aliases, the last *key*
+ * would win instead of the last *token* (`--verbose --no-loud --verbose`
+ * must be `true`), and `multiple` flags spread across aliases would lose
+ * their interleaved argv order.
  */
 function resolveAliases(
-	parsedValues: Record<string, unknown>,
+	tokens: ParseArgsToken[],
 	aliasToName: Record<string, string>,
 	flagsDef: FlagsDef,
 ): Record<string, ParsedFlagValue> {
 	const canonical: Record<string, ParsedFlagValue> = {};
 
-	for (const key in parsedValues) {
-		const canonicalName = aliasToName[key] ?? key;
-		if (!(canonicalName in flagsDef)) continue;
+	for (const token of tokens) {
+		if (token.kind !== "option") continue;
 
-		const value = parsedValues[key];
-		const existing = canonical[canonicalName];
-		if (existing !== undefined && Array.isArray(existing) && Array.isArray(value)) {
-			existing.push(...value);
+		const canonicalName = aliasToName[token.name] ?? token.name;
+		const def = flagsDef[canonicalName];
+		if (!def) continue;
+
+		// Booleans carry no token value; a `--no-` spelling means false
+		// (allowNegative). Non-booleans always have a string value in strict mode.
+		const value: string | boolean =
+			def.type === "boolean" ? !token.rawName.startsWith("--no-") : (token.value as string);
+
+		if (def.multiple) {
+			const existing = canonical[canonicalName];
+			if (Array.isArray(existing)) {
+				existing.push(value);
+			} else {
+				canonical[canonicalName] = [value];
+			}
 		} else {
-			canonical[canonicalName] = value as ParsedFlagValue;
+			canonical[canonicalName] = value;
 		}
 	}
 
@@ -359,12 +378,12 @@ function resolveAliases(
  */
 function resolveFlags(
 	flagsDef: FlagsDef | undefined,
-	parsedValues: Record<string, unknown>,
+	tokens: ParseArgsToken[],
 	aliasToName: Record<string, string>,
 ) {
 	if (!flagsDef) return {};
 
-	const canonical = resolveAliases(parsedValues, aliasToName, flagsDef);
+	const canonical = resolveAliases(tokens, aliasToName, flagsDef);
 	const resolved: Record<string, unknown> = {};
 
 	for (const [name, def] of Object.entries(flagsDef)) {
@@ -553,7 +572,7 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 		preSeparatorPositionals.push(...parsed.positionals);
 	}
 
-	const resolvedFlags = resolveFlags(flagsDef, parsed.values, aliasToName);
+	const resolvedFlags = resolveFlags(flagsDef, parsed.tokens ?? [], aliasToName);
 	const resolvedArgs = resolveArgs(argsDef, preSeparatorPositionals);
 
 	// The runtime logic correctly builds args/flags matching InferArgs<A> and

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -303,7 +303,7 @@ interface BooleanFlagDef extends SingleFlagBase {
 	type: "boolean";
 	/** Default boolean value */
 	default?: boolean;
-	/** When `true`, hide the generated `--no-{name}` help label */
+	/** When `true`, reject `--no-{name}` (and negated aliases) at parse time and hide the generated help label */
 	noNegate?: true;
 	/** Not supported on boolean flags — use `type: "string"` with `parse`. */
 	parse?: never;
@@ -385,7 +385,7 @@ interface BooleanMultiFlagDef extends MultiFlagBase {
 	type: "boolean";
 	/** Default boolean array value */
 	default?: boolean[];
-	/** When `true`, hide the generated `--no-{name}` help label */
+	/** When `true`, reject `--no-{name}` (and negated aliases) at parse time and hide the generated help label */
 	noNegate?: true;
 	/** Not supported — use `type: "string"`, `multiple: true`, with `parse`. */
 	parse?: never;
@@ -457,7 +457,7 @@ interface SchemaBooleanFlagDef extends SchemaFlagBase {
 	type: "boolean";
 	/** When `true`, the flag is repeatable and the schema receives `boolean[]` */
 	multiple?: true;
-	/** When `true`, hide the generated `--no-{name}` help label */
+	/** When `true`, reject `--no-{name}` (and negated aliases) at parse time and hide the generated help label */
 	noNegate?: true;
 }
 

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -73,6 +73,13 @@ function formatFlagName(name: string, def: FlagSnapshot): string {
 
 	labels.push(`--${name}`);
 
+	// Long aliases are callable, so help discloses them. Negation is shown
+	// for the canonical name only — "any long spelling negates" is the rule,
+	// and the man page documents the exhaustive --no-<alias> surface.
+	if (def.aliases) {
+		for (const alias of def.aliases) labels.push(`--${alias}`);
+	}
+
 	if (def.type === "boolean" && !def.noNegate) {
 		labels.push(`--no-${name}`);
 	}

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -127,7 +127,7 @@ describe("built-in plugins", () => {
 		expect(plain).toContain('[default: "."]');
 	});
 
-	it("renderHelp shows canonical boolean negation instead of negated aliases", () => {
+	it("renderHelp shows long aliases with canonical-only negation", () => {
 		const command = new Crust("app").flags({
 			name: "verbose",
 			type: "boolean",
@@ -135,7 +135,7 @@ describe("built-in plugins", () => {
 		})._node;
 
 		const output = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(output).toContain("--verbose, --no-verbose");
+		expect(output).toContain("--verbose, --loud, --no-verbose");
 		expect(output).not.toContain("--no-loud");
 	});
 


### PR DESCRIPTION
> Stacked on #149 — merge that first, then retarget/merge this.

Resolves upstream issues found during downstream migration reconnaissance.

## Changes

**`@crustjs/core`** (minor)
- `--no-<alias>` now negates a boolean for every long alias. An alias is a perfect synonym (ADR 0001). Deletes `validateCanonicalNegationUsage` — man pages and bash/zsh/fish completions already advertised these spellings, so parser and generators now agree with zero generator changes.
- `noNegate: true` is now parser-enforced: negating via any spelling is a `PARSE` error. Previously it only hid the label from help/man/completions while the parser silently accepted `--no-x`.

**`@crustjs/extensions`** (minor)
- `help()` renders long flag aliases (`-o, --output, --out, --no-output`). Negation label stays canonical-only; man pages remain the exhaustive reference.

**Docs**
- `guide/flags.mdx`: negation rule rewritten; prominent warning callout that repeated `.flags()` calls **replace** local flags (ADR 0002).
- `api/crust.mdx`: removed the now-false "parser still accepts `--no-name`" note.
- New `docs/adr/0001`, `docs/adr/0002`, `CONTEXT.md` glossary.

## Not changed (by design)

- Node compatibility of `@crustjs/extensions`: Crust is Bun-native; enforced via `engines.bun` in every published package.
- Man/completion generators: untouched — their output was already correct under the new semantics.

## Verification

- `bun run check` ✓, `bun run check:types` ✓, `bun run test` ✓ (all packages)
- New tests: `--no-<alias>` sets canonical false; mixed-spelling last-token-wins; `noNegate` rejected per spelling; help alias rendering