### PR TITLE
fix: routing, cancellation, type-export, version, progress, and testing gaps

### DIFF
--- a/.changeset/capture-execute.md
+++ b/.changeset/capture-execute.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/testing": minor
+"@crustjs/core": minor
+---
+
+New `captureExecute(app, argv)` in `@crustjs/testing` drives the terminal `execute()` path in-process: exit-code protocol (`0`/`1`/`130`), Extension `onError` rendering, and cancellation are assertable without subprocess probes; `process.exitCode` is restored afterwards. To support it, `Crust.execute()` now accepts an optional `io` override alongside `argv`.

--- a/.changeset/export-simplify.md
+++ b/.changeset/export-simplify.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Export the `Simplify` helper type from the package root. Consumers with `declaration: true` exporting inferred `defineFlag`/`defineArg`/builder values no longer hit TS2742/TS2883 ("cannot be named without a reference to a private chunk").

--- a/.changeset/oncancel-hooks.md
+++ b/.changeset/oncancel-hooks.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+`execute()` now offers `AbortError` cancellation to Extension `onError` hooks before finishing, so applications can render a cancellation message (e.g. "Operation cancelled") centrally. Exit code stays `130` and cancellation remains silent when no hook claims it — default behavior is unchanged.

--- a/.changeset/progress-imperative.md
+++ b/.changeset/progress-imperative.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/progress": minor
+---
+
+New primitives: `createSpinner()` — an imperative spinner handle whose `start`/`updateMessage`/`stop(outcome, message?)` can live in different call frames, with `stop("error")` rendering the `✗` final line without throwing — and `createProgress()` — a determinate `(current/total)` indicator with `advance()`. Both (and `spinner()`) accept `sigint: false` to skip the built-in `SIGINT → exit(130)` handler so applications can own cancellation cleanup. `spinner()` is now implemented on top of `createSpinner()`; its behavior is unchanged.

--- a/.changeset/router-flag-skipping.md
+++ b/.changeset/router-flag-skipping.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/core": minor
+---
+
+Routing now skips known flags (and their values) that appear before a subcommand name, so `app --quiet translate` runs `translate` instead of silently resolving the handler-less root and exiting 0. All parser-accepted spellings are recognized during routing: long names, `--flag=value`, `--no-<name>` negation (respecting `noNegate`), short flags, long aliases, and bundled short booleans. Unknown flags and the `--` terminator still stop routing as before.
+
+Behavior change: recursive flags placed before a subcommand now bind to the subcommand's invocation — e.g. `app --help sub` shows `sub`'s help (previously the root's), and a root-only flag before a subcommand name is now an "unknown flag" error in the subcommand (previously a silent no-op).

--- a/.changeset/router-flag-skipping.md
+++ b/.changeset/router-flag-skipping.md
@@ -2,6 +2,6 @@
 "@crustjs/core": minor
 ---
 
-Routing now skips known flags (and their values) that appear before a subcommand name, so `app --quiet translate` runs `translate` instead of silently resolving the handler-less root and exiting 0. All parser-accepted spellings are recognized during routing: long names, `--flag=value`, `--no-<name>` negation (respecting `noNegate`), short flags, long aliases, and bundled short booleans. Unknown flags and the `--` terminator still stop routing as before.
+Routing now skips known flags (and their values) that appear before a subcommand name, so `app --quiet translate` runs `translate` instead of silently resolving the handler-less root and exiting 0. All parser-accepted spellings are recognized during routing: long names, `--flag=value`, `--no-<name>` negation (respecting `noNegate`), short flags and inline values, long aliases, and bundled short booleans. Unknown flags and the `--` terminator still stop routing as before.
 
 Behavior change: recursive flags placed before a subcommand now bind to the subcommand's invocation — e.g. `app --help sub` shows `sub`'s help (previously the root's), and a root-only flag before a subcommand name is now an "unknown flag" error in the subcommand (previously a silent no-op).

--- a/.changeset/version-extension-options.md
+++ b/.changeset/version-extension-options.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/extensions": minor
+---
+
+`versionExtension(value, options?)` accepts new options: `short` remaps or disables the short alias (`{ short: "V" }`, `{ short: false }`), and `format` controls output (`"plain"` for the bare version, or a `(version, context) => string` function). Defaults are unchanged (`-v`, `<name> v<version>`).

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -328,7 +328,7 @@ Runs the terminal boundary. By default it parses `process.argv.slice(2)`; `optio
 await app.execute();
 ```
 
-`execute()` renders a failure once through Extension `onError` hooks ending in Core's renderer, sets `process.exitCode` to `1`, and resolves. A standard `AbortError` cancellation is silent and sets exit code `130`.
+`execute()` renders a failure once through Extension `onError` hooks ending in Core's renderer, sets `process.exitCode` to `1`, and resolves. A standard `AbortError` cancellation sets exit code `130` and is offered to `onError` hooks; it renders nothing when no hook claims it.
 
 <Callout type="warn">
   Use `.handle(handler)` to define behavior. `.run(argv, io)` is only programmatic invocation;

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -319,10 +319,16 @@ await app.run(["Ada"], {
 ## `.execute(options?)`
 
 ```ts
-execute(options?: { argv?: string[] }): Promise<void>
+execute(options?: {
+  argv?: string[];
+  io?: {
+    stdout?: (text: string) => void;
+    stderr?: (text: string) => void;
+  };
+}): Promise<void>
 ```
 
-Runs the terminal boundary. By default it parses `process.argv.slice(2)`; `options.argv` is useful in tests.
+Runs the terminal boundary. By default it parses `process.argv.slice(2)`; `options.argv` overrides it, while `options.io` captures rendered output in tests.
 
 ```ts
 await app.execute();

--- a/apps/docs/content/docs/guide/error-handling.mdx
+++ b/apps/docs/content/docs/guide/error-handling.mdx
@@ -74,4 +74,19 @@ try {
 }
 ```
 
-`execute()` treats this as silent cancellation and sets `process.exitCode` to `130`. `run()` throws the same exception.
+`execute()` sets `process.exitCode` to `130` and offers the `AbortError` to Extension `onError` hooks, so an application can render a cancellation message in one place:
+
+```ts
+const cancelMessage = defineExtension("cancel-message", {
+  hooks: {
+    onError(error, ctx) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        ctx.stderr("Operation cancelled");
+        return true;
+      }
+    },
+  },
+});
+```
+
+When no hook claims it, cancellation stays silent — there is no default rendering. `run()` throws the same exception.

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -103,3 +103,58 @@ new Crust("serve")
 ```
 
 A schema cannot be combined with core value options — see [Schema-backed definitions](/docs/guide/types#schema-backed-definitions) for the full rule.
+
+## Commander migration compatibility
+
+Crust's parser is built on `node:util.parseArgs`, and three Commander grammars are intentionally **not supported**. They conflict with `parseArgs` token rules or make flag/positional boundaries ambiguous; CLIs migrating from Commander should normalize argv app-side before `execute()`.
+
+### Greedy multi-value flags (won't fix)
+
+Commander's variadic options consume every following token until the next flag: `--locales en fr de`. Crust `multiple` flags require one option token per value — `--locales en --locales fr --locales de`. An unrepeated trailing value becomes an unmatched positional.
+
+### Optional-valued flags (won't fix)
+
+Commander supports `--tag` (boolean) and `--tag v1.2` (string) on the same option. A Crust flag is either `boolean` or value-taking — there is no optional-value variant, because whether the next token is the flag's value or a positional would depend on runtime lookahead.
+
+### Separated dash-leading values (won't fix)
+
+`--timeout -5` is rejected by `parseArgs` as ambiguous (`-5` looks like a flag). Use the `=` form: `--timeout=-5`.
+
+### Recommended normalization pattern
+
+Rewrite argv once at the entry point, before `execute()`:
+
+```ts
+const GREEDY_FLAGS = new Set(["--locales", "--new"]);
+
+function normalizeArgv(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (token === "--") return [...out, ...argv.slice(i)];
+
+    // Greedy multi-value: `--locales en fr` -> `--locales en --locales fr`
+    if (GREEDY_FLAGS.has(token)) {
+      while (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) {
+        out.push(token, argv[++i]!);
+      }
+      continue;
+    }
+
+    // Separated dash-leading value: `--timeout -5` -> `--timeout=-5`
+    if (token === "--timeout" && /^-\d/.test(argv[i + 1] ?? "")) {
+      out.push(`${token}=${argv[++i]}`);
+      continue;
+    }
+
+    out.push(token);
+  }
+  return out;
+}
+
+await app.execute({ argv: normalizeArgv(process.argv.slice(2)) });
+```
+
+For optional-valued flags, split them into a boolean flag plus a value-taking flag (e.g. `--tag` and `--tag-name v1.2`), or normalize `--tag <value>` to `--tag-name=<value>` in the same pass.
+
+What migrators no longer need to normalize: inherited flags before a subcommand (`app --quiet translate`) route correctly, and `-V` / bare version output are covered by [`versionExtension` options](/docs/modules/extensions/version#options).

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -135,6 +135,7 @@ function normalizeArgv(argv: string[]): string[] {
 
     // Greedy multi-value: `--locales en fr` -> `--locales en --locales fr`
     if (GREEDY_FLAGS.has(token)) {
+      if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) out.push(token);
       while (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) {
         out.push(token, argv[++i]!);
       }

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -45,7 +45,7 @@ With `run()`, the original value is thrown to the caller. Handler and Context fa
 
 With `execute()`, Crust first establishes a nonzero status, then invokes Extension `onError` hooks in `.extend()` order. A hook returns `true` when it rendered the failure; falsy results continue to the next hook and then Core's default renderer. `onError` is presentation only and never runs for `run()`.
 
-A `DOMException` whose name is `"AbortError"` is cancellation. `execute()` sets status `130` and renders nothing. `run()` still throws it.
+A `DOMException` whose name is `"AbortError"` is cancellation. `execute()` sets status `130`, offers the error to `onError` hooks (so an application can render "Operation cancelled" centrally), and renders nothing by default when no hook claims it. `run()` still throws it.
 
 ## Setup and cleanup
 

--- a/apps/docs/content/docs/modules/extensions/version.mdx
+++ b/apps/docs/content/docs/modules/extensions/version.mdx
@@ -25,7 +25,12 @@ my-cli v1.2.3
 ```ts
 type VersionValue = string | (() => string);
 
-function version(value?: VersionValue): Extension;
+interface VersionExtensionOptions {
+  short?: string | false; // default "v"
+  format?: "plain" | ((version: string, context: ExtensionContext) => string);
+}
+
+function version(value?: VersionValue, options?: VersionExtensionOptions): Extension;
 ```
 
 The default value is `"0.0.0"`. Pass a function to resolve the version only when the flag is handled:
@@ -35,3 +40,28 @@ const app = new Crust("my-cli").extend(version(() => process.env.APP_VERSION ?? 
 ```
 
 `version()` owns a root-only boolean `version` flag with short name `v`. It prints through `ctx.stdout` and short-circuits the Command Handler only for a root invocation with `--version` or `-v`; subcommands do not receive the flag.
+
+## Options
+
+### `short`
+
+Remap or disable the short alias. Commander-migrated CLIs conventionally use `-V`:
+
+```ts
+version(pkg.version, { short: "V" }); // -V and --version
+version(pkg.version, { short: false }); // --version only, -v is free
+```
+
+### `format`
+
+Control the printed line. `"plain"` prints the bare version, which scripts can capture via `$(my-cli --version)`:
+
+```ts
+version("1.2.3", { format: "plain" });
+// $ my-cli --version
+// 1.2.3
+
+version("1.2.3", { format: (v, ctx) => `${ctx.rootCommand.meta.name}/${v}` });
+// $ my-cli --version
+// my-cli/1.2.3
+```

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Progress"
-description: Non-interactive progress indicators for CLI applications — currently spinner support for async tasks.
+description: Progress indicators for CLI applications — task-scoped and imperative spinners, plus determinate progress.
 ---
 
-`@crustjs/progress` provides non-interactive progress indicators for building polished CLI experiences. It currently includes `spinner()`, a stderr-based async task wrapper with message updates, theming, and non-TTY fallbacks.
+`@crustjs/progress` provides stderr-based progress indicators for building polished CLI experiences: `spinner()` (task-scoped), `createSpinner()` (imperative start/stop), and `createProgress()` (determinate `current/total`), all with message updates, theming, SIGINT policy, and non-TTY fallbacks.
 
 ## Install
 
@@ -48,6 +48,65 @@ await spinner({
 ```
 
 <auto-type-table path="../../../../../packages/progress/src/spinner.ts" name="SpinnerOptions" />
+
+### `createSpinner(options)`
+
+An imperative spinner whose `start` and `stop` can live in different call frames — workflow engines, logger adapters, anywhere a task callback does not fit. `stop()` takes the final outcome, so a failure can render `✗` without throwing:
+
+```ts
+import { createSpinner } from "@crustjs/progress";
+
+const handle = createSpinner({ message: "Deploying..." });
+handle.start();
+
+// ...later, in another call frame:
+if (failed) {
+  handle.stop("error", "Deploy failed");
+} else {
+  handle.stop("success", "Deployed");
+}
+```
+
+`stop()` is idempotent; the default outcome is `"success"`.
+
+<auto-type-table
+  path="../../../../../packages/progress/src/spinner.ts"
+  name="CreateSpinnerOptions"
+/>
+
+### `createProgress(options)`
+
+Determinate progress rendered as `⠋ <message> (<current>/<total>)`:
+
+```ts
+import { createProgress } from "@crustjs/progress";
+
+const progress = createProgress({ total: files.length, message: "Translating" });
+progress.start();
+for (const file of files) {
+  await translate(file);
+  progress.advance(1, file.name);
+}
+progress.stop("success", "All files translated");
+```
+
+<auto-type-table
+  path="../../../../../packages/progress/src/progress.ts"
+  name="CreateProgressOptions"
+/>
+
+### SIGINT policy
+
+By default an interactive spinner installs a `SIGINT` handler that restores the cursor and exits with code 130. Applications that own SIGINT (cleanup, log flushing) can opt out with `sigint: false` — the spinner then installs no handler, and the application's cleanup should call `stop()` to restore the cursor:
+
+```ts
+const handle = createSpinner({ message: "Working...", sigint: false });
+process.once("SIGINT", () => {
+  handle.stop("error", "Cancelled");
+  flushLogs();
+  process.exit(130);
+});
+```
 
 ### `SpinnerController`
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -42,6 +42,19 @@ if (result.error) throw result.error;
 console.log(result.stdout);
 ```
 
+## `captureExecute(app, argv)`
+
+Drive the terminal `execute()` path in-process. Unlike `captureRun()`, this exercises `execute()`'s exit-code protocol — `0` on success, `1` for rendered failures, `130` for `AbortError` cancellation — and the Extension `onError` rendering chain, so exit codes and rendered failure output are assertable without spawning a subprocess. `process.exitCode` is restored afterwards.
+
+```ts
+import { captureExecute } from "@crustjs/testing";
+
+const result = await captureExecute(app, ["deploy", "--bad-flag"]);
+
+expect(result.exitCode).toBe(1);
+expect(result.stderr).toContain("Unknown flag");
+```
+
 ## `interactiveRun(app, argv)`
 
 Run an application against a fake TTY. Use `waitFor()` before sending input with `type()` or `keys()`, then await `done`.

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1672,6 +1672,52 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks).toEqual([]);
 	});
 
+	it("offers AbortError to onError hooks before the silent default", async () => {
+		const seen: unknown[] = [];
+		const cancelRenderer = defineExtension("cancel-renderer", {
+			hooks: {
+				onError(error, ctx) {
+					seen.push(error);
+					ctx.stderr("Operation cancelled");
+					return true;
+				},
+			},
+		});
+
+		const app = new Crust("test").extend(cancelRenderer).handle(() => {
+			throw new DOMException("Prompt was cancelled.", "AbortError");
+		});
+
+		await app.execute({ argv: [] });
+
+		expect(process.exitCode).toBe(130);
+		expect(seen).toHaveLength(1);
+		expect((seen[0] as Error).name).toBe("AbortError");
+		expect(stderrChunks.join("\n")).toContain("Operation cancelled");
+	});
+
+	it("keeps cancellation silent when onError hooks decline it", async () => {
+		let observed = false;
+		const observer = defineExtension("observer", {
+			hooks: {
+				onError() {
+					observed = true;
+					// Decline: Core's default for cancellation stays silent
+				},
+			},
+		});
+
+		const app = new Crust("test").extend(observer).handle(() => {
+			throw new DOMException("Prompt was cancelled.", "AbortError");
+		});
+
+		await app.execute({ argv: [] });
+
+		expect(process.exitCode).toBe(130);
+		expect(observed).toBe(true);
+		expect(stderrChunks).toEqual([]);
+	});
+
 	it("handles unknown flag error", async () => {
 		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).handle(() => {});
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1696,6 +1696,24 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks.join("\n")).toContain("Operation cancelled");
 	});
 
+	it("preserves the cancellation exit code after onError hooks", async () => {
+		const exitCodeOverride = defineExtension("exit-code-override", {
+			hooks: {
+				onError() {
+					process.exitCode = 1;
+				},
+			},
+		});
+
+		const app = new Crust("test").extend(exitCodeOverride).handle(() => {
+			throw new DOMException("Prompt was cancelled.", "AbortError");
+		});
+
+		await app.execute({ argv: [] });
+
+		expect(process.exitCode).toBe(130);
+	});
+
 	it("keeps cancellation silent when onError hooks decline it", async () => {
 		let observed = false;
 		const observer = defineExtension("observer", {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1027,7 +1027,7 @@ export class Crust<
 				// onError hooks may observe it to render a message (e.g.
 				// "Operation cancelled"). Core's default stays silent.
 				process.exitCode = EXIT_CODE_CANCELLED;
-				await renderFailure(error, argv, prepared, io, extensionContext, { silentDefault: true });
+				await renderFailure(error, argv, prepared, io, extensionContext, true);
 				return;
 			}
 			// Core always preserves a nonzero failure outcome, regardless of
@@ -1151,12 +1151,12 @@ async function renderFailure(
 	prepared: PreparedInvocation,
 	io: InvocationIO,
 	extensionContext: ExtensionContext | undefined,
-	options?: { silentDefault?: boolean },
+	silentDefault = false,
 ): Promise<void> {
 	const renderDefault = (): void => {
 		// Cancellation (AbortError) has no default rendering — a user abort
 		// is not an error to report unless an onError hook claims it.
-		if (options?.silentDefault) return;
+		if (silentDefault) return;
 		const message = error instanceof Error ? error.message : String(error);
 		io.stderr(`Error: ${message}`);
 	};

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -971,11 +971,16 @@ export class Crust<
 	 * Core's default renderer), sets `process.exitCode` (`1`, or
 	 * `130` for an `AbortError` cancellation), and resolves.
 	 *
-	 * @param options - Optional overrides (e.g. custom `argv` for testing)
+	 * @param options - Optional overrides (e.g. custom `argv` and captured
+	 *                   `io` for in-process testing of exit codes and
+	 *                   rendered failures)
 	 */
-	async execute(options?: { argv?: string[] }): Promise<void> {
+	async execute(options?: {
+		argv?: string[];
+		io?: { stdout?: (text: string) => void; stderr?: (text: string) => void };
+	}): Promise<void> {
 		const argv = options?.argv ?? process.argv.slice(2);
-		const io = DEFAULT_IO;
+		const io: InvocationIO = { ...DEFAULT_IO, ...options?.io };
 
 		let prepared: PreparedInvocation;
 		try {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1018,7 +1018,11 @@ export class Crust<
 			});
 		} catch (error) {
 			if (isAbortError(error)) {
+				// Cancellation keeps its dedicated exit code, but Extension
+				// onError hooks may observe it to render a message (e.g.
+				// "Operation cancelled"). Core's default stays silent.
 				process.exitCode = EXIT_CODE_CANCELLED;
+				await renderFailure(error, argv, prepared, io, extensionContext, { silentDefault: true });
 				return;
 			}
 			// Core always preserves a nonzero failure outcome, regardless of
@@ -1142,8 +1146,12 @@ async function renderFailure(
 	prepared: PreparedInvocation,
 	io: InvocationIO,
 	extensionContext: ExtensionContext | undefined,
+	options?: { silentDefault?: boolean },
 ): Promise<void> {
 	const renderDefault = (): void => {
+		// Cancellation (AbortError) has no default rendering — a user abort
+		// is not an error to report unless an onError hook claims it.
+		if (options?.silentDefault) return;
 		const message = error instanceof Error ? error.message : String(error);
 		io.stderr(`Error: ${message}`);
 	};

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1028,6 +1028,7 @@ export class Crust<
 				// "Operation cancelled"). Core's default stays silent.
 				process.exitCode = EXIT_CODE_CANCELLED;
 				await renderFailure(error, argv, prepared, io, extensionContext, true);
+				process.exitCode = EXIT_CODE_CANCELLED;
 				return;
 			}
 			// Core always preserves a nonzero failure outcome, regardless of

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -561,3 +561,121 @@ describe("resolveCommand — aliases", () => {
 		expect(result.argv).toEqual(["--help"]);
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Known-flag skipping — inherited/root flags before a subcommand
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("resolveCommand — known-flag skipping", () => {
+	function makeRoot(): CommandNode {
+		const translate = makeNode({
+			meta: "translate",
+			run() {
+				/* noop */
+			},
+		});
+		return makeNode({
+			meta: "app",
+			flags: {
+				quiet: { type: "boolean", short: "q", description: "quiet" },
+				verbose: { type: "boolean", noNegate: true, description: "verbose" },
+				config: { type: "string", aliases: ["conf"], description: "config file" },
+			},
+			subCommands: { translate },
+		});
+	}
+
+	it("routes past a known boolean flag into the subcommand", () => {
+		const result = resolveCommand(makeRoot(), ["--quiet", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["--quiet"]);
+	});
+
+	it("routes past a known short flag", () => {
+		const result = resolveCommand(makeRoot(), ["-q", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["-q"]);
+	});
+
+	it("routes past a negated boolean flag", () => {
+		const result = resolveCommand(makeRoot(), ["--no-quiet", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["--no-quiet"]);
+	});
+
+	it("does not treat --no-<flag> as known when the flag is noNegate", () => {
+		const result = resolveCommand(makeRoot(), ["--no-verbose", "translate"]);
+		expect(result.commandPath).toEqual(["app"]);
+		expect(result.argv).toEqual(["--no-verbose", "translate"]);
+	});
+
+	it("consumes the value token of a known value-taking flag", () => {
+		const result = resolveCommand(makeRoot(), ["--config", "a.json", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["--config", "a.json"]);
+	});
+
+	it("consumes a value that shadows a subcommand name", () => {
+		// "--config translate" means config=translate, not the subcommand
+		const result = resolveCommand(makeRoot(), ["--config", "translate"]);
+		expect(result.commandPath).toEqual(["app"]);
+		expect(result.argv).toEqual(["--config", "translate"]);
+	});
+
+	it("does not consume a value for --flag=value form", () => {
+		const result = resolveCommand(makeRoot(), ["--config=a.json", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["--config=a.json"]);
+	});
+
+	it("routes past a known long alias", () => {
+		const result = resolveCommand(makeRoot(), ["--conf=a.json", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+	});
+
+	it("routes past bundled known short booleans", () => {
+		const root = makeRoot();
+		// add a second short boolean for bundling
+		root.effectiveFlags = {
+			...root.effectiveFlags,
+			force: { type: "boolean", short: "f", description: "force" },
+		};
+		const result = resolveCommand(root, ["-qf", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["-qf"]);
+	});
+
+	it("still breaks on unknown flags", () => {
+		const result = resolveCommand(makeRoot(), ["--bogus", "translate"]);
+		expect(result.commandPath).toEqual(["app"]);
+		expect(result.argv).toEqual(["--bogus", "translate"]);
+	});
+
+	it("still breaks on the -- terminator", () => {
+		const result = resolveCommand(makeRoot(), ["--", "translate"]);
+		expect(result.commandPath).toEqual(["app"]);
+		expect(result.argv).toEqual(["--", "translate"]);
+	});
+
+	it("skips flags at multiple routing levels and preserves token order", () => {
+		const leaf = makeNode({
+			meta: "leaf",
+			run() {
+				/* noop */
+			},
+		});
+		const mid = makeNode({
+			meta: "mid",
+			flags: { deep: { type: "boolean", description: "deep" } },
+			subCommands: { leaf },
+		});
+		const root = makeNode({
+			meta: "app",
+			flags: { quiet: { type: "boolean", description: "quiet" } },
+			subCommands: { mid },
+		});
+		const result = resolveCommand(root, ["--quiet", "mid", "--deep", "leaf", "rest"]);
+		expect(result.commandPath).toEqual(["app", "mid", "leaf"]);
+		expect(result.argv).toEqual(["--quiet", "--deep", "rest"]);
+	});
+});

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -579,7 +579,7 @@ describe("resolveCommand — known-flag skipping", () => {
 			flags: {
 				quiet: { type: "boolean", short: "q", description: "quiet" },
 				verbose: { type: "boolean", noNegate: true, description: "verbose" },
-				config: { type: "string", aliases: ["conf"], description: "config file" },
+				config: { type: "string", short: "c", aliases: ["conf"], description: "config file" },
 			},
 			subCommands: { translate },
 		});
@@ -595,6 +595,12 @@ describe("resolveCommand — known-flag skipping", () => {
 		const result = resolveCommand(makeRoot(), ["-q", "translate"]);
 		expect(result.commandPath).toEqual(["app", "translate"]);
 		expect(result.argv).toEqual(["-q"]);
+	});
+
+	it("routes past a short flag with an inline value", () => {
+		const result = resolveCommand(makeRoot(), ["-ca.json", "translate"]);
+		expect(result.commandPath).toEqual(["app", "translate"]);
+		expect(result.argv).toEqual(["-ca.json"]);
 	});
 
 	it("routes past a negated boolean flag", () => {

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -67,9 +67,8 @@ function lookupFlag(flags: FlagsDef, spelling: string): FlagDef | undefined {
  * whether the flag consumes the following argv token as its value.
  *
  * Mirrors the parser's accepted spellings: `--name`, `--name=value`,
- * `--no-name` (boolean negation unless `noNegate`), `-s`, and bundled
- * short booleans (`-ab`). Tokens with `=` after a short prefix are left
- * to the parser.
+ * `--no-name` (boolean negation unless `noNegate`), `-s`, inline short
+ * values (`-svalue`), and bundled short flags (`-absvalue`).
  */
 function matchKnownFlagToken(flags: FlagsDef, token: string): { consumesValue: boolean } | null {
 	if (token === "--") return null;
@@ -88,18 +87,17 @@ function matchKnownFlagToken(flags: FlagsDef, token: string): { consumesValue: b
 		return null;
 	}
 
-	// Short form: `-q` or bundled `-qf`. Every char must be a known
-	// single-char spelling; only the last may take a value.
+	// Short form: `-q`, bundled `-qf`, or inline value `-ca.json`.
 	const chars = token.slice(1);
-	if (chars.length === 0 || chars.includes("=")) return null;
-	let last: FlagDef | undefined;
-	for (const char of chars) {
-		const def = lookupFlag(flags, char);
+	if (chars.length === 0) return null;
+	for (let index = 0; index < chars.length; index++) {
+		const def = lookupFlag(flags, chars[index]!);
 		if (!def) return null;
-		if (last && last.type !== "boolean") return null; // value-taking short mid-bundle
-		last = def;
+		if (def.type !== "boolean") {
+			return { consumesValue: index === chars.length - 1 };
+		}
 	}
-	return { consumesValue: last !== undefined && last.type !== "boolean" };
+	return { consumesValue: false };
 }
 
 /**

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -1,4 +1,5 @@
 import { CrustError } from "../errors.ts";
+import type { FlagDef, FlagsDef } from "../types.ts";
 import type { CommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
 
@@ -48,6 +49,62 @@ function findAliasMatch(
 	return null;
 }
 
+/** Find a flag def by any spelling: canonical name, short, or long alias. */
+function lookupFlag(flags: FlagsDef, spelling: string): FlagDef | undefined {
+	for (const [name, def] of Object.entries(flags)) {
+		if (name === spelling || def.short === spelling || def.aliases?.includes(spelling)) {
+			return def;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Match a dash token against a command's effective flags.
+ *
+ * Returns `null` when the token is not a known flag of this command (routing
+ * then stops, preserving the pre-existing fallback behavior), otherwise
+ * whether the flag consumes the following argv token as its value.
+ *
+ * Mirrors the parser's accepted spellings: `--name`, `--name=value`,
+ * `--no-name` (boolean negation unless `noNegate`), `-s`, and bundled
+ * short booleans (`-ab`). Tokens with `=` after a short prefix are left
+ * to the parser.
+ */
+function matchKnownFlagToken(
+	flags: FlagsDef,
+	token: string,
+): { consumesValue: boolean } | null {
+	if (token === "--") return null;
+
+	if (token.startsWith("--")) {
+		const eq = token.indexOf("=");
+		const spelling = eq === -1 ? token.slice(2) : token.slice(2, eq);
+		const def = lookupFlag(flags, spelling);
+		if (def) return { consumesValue: def.type !== "boolean" && eq === -1 };
+		if (spelling.startsWith("no-")) {
+			const base = lookupFlag(flags, spelling.slice(3));
+			if (base && base.type === "boolean" && !base.noNegate) {
+				return { consumesValue: false };
+			}
+		}
+		return null;
+	}
+
+	// Short form: `-q` or bundled `-qf`. Every char must be a known
+	// single-char spelling; only the last may take a value.
+	const chars = token.slice(1);
+	if (chars.length === 0 || chars.includes("=")) return null;
+	let last: FlagDef | undefined;
+	for (const char of chars) {
+		const def = lookupFlag(flags, char);
+		if (!def) return null;
+		if (last && last.type !== "boolean") return null; // value-taking short mid-bundle
+		last = def;
+	}
+	return { consumesValue: last !== undefined && last.type !== "boolean" };
+}
+
 /**
  * Resolve a command from an argv array by walking the subcommand tree.
  *
@@ -81,6 +138,10 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 
 	let current: CommandNode = command;
 	let routedArgv = argv;
+	// Known flags (and their values) encountered before a subcommand name are
+	// set aside during routing and re-prepended for the resolved command's
+	// parser, preserving token order.
+	const skippedFlagTokens: string[] = [];
 
 	while (routedArgv.length > 0) {
 		const subCommands = current.subCommands;
@@ -91,9 +152,23 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 
 		const candidate = routedArgv[0];
 
-		// Skip if the candidate looks like a flag (starts with -) or doesn't exist
-		if (!candidate || candidate.startsWith("-")) {
-			break;
+		if (!candidate) break;
+
+		// Flag-shaped token: skip it (and its value) when it is a known flag of
+		// the current command so routing can continue to a subcommand name —
+		// `app --quiet translate` must run `translate`, not silently resolve the
+		// root. Unknown flags and `--` stop routing (parser reports them).
+		if (candidate.startsWith("-")) {
+			const match = matchKnownFlagToken(current.effectiveFlags, candidate);
+			if (!match) break;
+			skippedFlagTokens.push(candidate);
+			routedArgv = routedArgv.slice(1);
+			const value = routedArgv[0];
+			if (match.consumesValue && value !== undefined) {
+				skippedFlagTokens.push(value);
+				routedArgv = routedArgv.slice(1);
+			}
+			continue;
 		}
 
 		// Check if it matches a known subcommand by canonical name
@@ -135,7 +210,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 
 	return {
 		command: current,
-		argv: routedArgv,
+		argv: skippedFlagTokens.length > 0 ? [...skippedFlagTokens, ...routedArgv] : routedArgv,
 		commandPath: path,
 	};
 }

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -71,10 +71,7 @@ function lookupFlag(flags: FlagsDef, spelling: string): FlagDef | undefined {
  * short booleans (`-ab`). Tokens with `=` after a short prefix are left
  * to the parser.
  */
-function matchKnownFlagToken(
-	flags: FlagsDef,
-	token: string,
-): { consumesValue: boolean } | null {
+function matchKnownFlagToken(flags: FlagsDef, token: string): { consumesValue: boolean } | null {
 	if (token === "--") return null;
 
 	if (token.startsWith("--")) {

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -207,7 +207,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 
 	return {
 		command: current,
-		argv: skippedFlagTokens.length > 0 ? [...skippedFlagTokens, ...routedArgv] : routedArgv,
+		argv: [...skippedFlagTokens, ...routedArgv],
 		commandPath: path,
 	};
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	ContextMap,
 	ContextRequirements,
 	ContextSetup,
+	Simplify,
 } from "./api/context.ts";
 export { defineContext } from "./api/context.ts";
 export type {

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Declaration emission — a consumer with `declaration: true` must be able to
+// export values with inferred builder types. If a type used in a public
+// inferred signature (e.g. `Simplify` in defineFlag's return type) is not
+// re-exported from the package root, tsc fails with TS2742 ("cannot be
+// named") because the private dist chunk is not an importable specifier.
+// ────────────────────────────────────────────────────────────────────────────
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const corePkg = resolve(import.meta.dir, "..");
+const tscBin = join(repoRoot, "node_modules/.bin/tsc");
+
+const CONSUMER_SOURCE = `import { Crust, defineCommand, defineFlag } from "@crustjs/core";
+
+// Inferred defineFlag element type references Simplify
+export const configFlag = defineFlag("config", {
+	type: "string",
+	description: "Path to config file",
+});
+
+export const flags = [
+	configFlag,
+	defineFlag("quiet", { type: "boolean", short: "q", description: "Quiet mode" }),
+];
+
+// Inferred builder type references EffectiveFlags / flag def shapes
+export const app = new Crust("consumer-cli")
+	.flags(...flags)
+	.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+`;
+
+let fixtureDir: string;
+
+beforeAll(() => {
+	// Build the real publishable artifact — declaration emission must be
+	// checked against dist, where types live in a private chunk.
+	const build = Bun.spawnSync(["bun", "run", "build"], { cwd: corePkg });
+	if (build.exitCode !== 0) {
+		throw new Error(`core build failed:\n${build.stderr.toString()}`);
+	}
+
+	fixtureDir = mkdtempSync(join(tmpdir(), "crust-dts-consumer-"));
+	// Consume like a real dependency (package.json exports map in effect),
+	// mirroring link:/node_modules resolution.
+	mkdirSync(join(fixtureDir, "node_modules/@crustjs"), { recursive: true });
+	symlinkSync(corePkg, join(fixtureDir, "node_modules/@crustjs/core"));
+
+	writeFileSync(join(fixtureDir, "consumer.ts"), CONSUMER_SOURCE);
+	writeFileSync(
+		join(fixtureDir, "tsconfig.json"),
+		JSON.stringify({
+			compilerOptions: {
+				module: "esnext",
+				moduleResolution: "bundler",
+				target: "esnext",
+				strict: true,
+				declaration: true,
+				emitDeclarationOnly: true,
+				outDir: "out",
+			},
+			include: ["consumer.ts"],
+		}),
+	);
+});
+
+describe("declaration emission for consumers", () => {
+	it("emits declarations for exported inferred builder types without TS2742/TS4058", () => {
+		const result = Bun.spawnSync([tscBin, "-p", "."], { cwd: fixtureDir });
+		const output = result.stdout.toString() + result.stderr.toString();
+		expect(output).toBe("");
+		expect(result.exitCode).toBe(0);
+	});
+});

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -37,11 +37,17 @@ export const app = new Crust("consumer-cli")
 let fixtureDir: string;
 
 beforeAll(() => {
-	// Build the real publishable artifact — declaration emission must be
-	// checked against dist, where types live in a private chunk.
-	const build = Bun.spawnSync(["bun", "run", "build"], { cwd: corePkg });
-	if (build.exitCode !== 0) {
-		throw new Error(`core build failed:\n${build.stdout.toString()}\n${build.stderr.toString()}`);
+	// Declaration emission must be checked against dist, where types live in
+	// a private chunk. Never rebuild an existing dist here: sibling packages'
+	// tests import @crustjs/core from dist in parallel, and a rebuild races
+	// them. In turbo runs core:build precedes core:test (packages/core/
+	// turbo.json); this fallback only serves a direct `bun test` on a fresh
+	// checkout.
+	if (!existsSync(join(corePkg, "dist/index.d.ts"))) {
+		const build = Bun.spawnSync(["bun", "run", "build"], { cwd: corePkg });
+		if (build.exitCode !== 0) {
+			throw new Error(`core build failed:\n${build.stdout.toString()}\n${build.stderr.toString()}`);
+		}
 	}
 
 	fixtureDir = mkdtempSync(join(tmpdir(), "crust-dts-consumer-"));

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -41,7 +41,7 @@ beforeAll(() => {
 	// checked against dist, where types live in a private chunk.
 	const build = Bun.spawnSync(["bun", "run", "build"], { cwd: corePkg });
 	if (build.exitCode !== 0) {
-		throw new Error(`core build failed:\n${build.stderr.toString()}`);
+		throw new Error(`core build failed:\n${build.stdout.toString()}\n${build.stderr.toString()}`);
 	}
 
 	fixtureDir = mkdtempSync(join(tmpdir(), "crust-dts-consumer-"));

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://turborepo.dev/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"test": {
+			// declaration-emission.test.ts rebuilds dist via bunup; without this
+			// own-build dependency it races turbo's core:build writing the same dist.
+			"dependsOn": ["^build", "build"]
+		}
+	}
+}

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -13,4 +13,4 @@ export type {
 	UpdateNotifierOptions,
 } from "./update-notifier.ts";
 export { versionExtension as version } from "./version.ts";
-export type { VersionValue } from "./version.ts";
+export type { VersionExtensionOptions, VersionValue } from "./version.ts";

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -530,9 +530,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin supports a custom short alias", async () => {
-		const app = new Crust("app")
-			.extend(versionExtension("1.2.3", { short: "V" }))
-			.handle(() => {});
+		const app = new Crust("app").extend(versionExtension("1.2.3", { short: "V" })).handle(() => {});
 
 		await app.execute({ argv: ["-V"] });
 
@@ -540,9 +538,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin rejects -v when short is remapped", async () => {
-		const app = new Crust("app")
-			.extend(versionExtension("1.2.3", { short: "V" }))
-			.handle(() => {});
+		const app = new Crust("app").extend(versionExtension("1.2.3", { short: "V" })).handle(() => {});
 
 		await app.execute({ argv: ["-v"] });
 

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -529,6 +529,60 @@ describe("built-in plugins", () => {
 		expect(getStdout()).toContain("app v3.5.0");
 	});
 
+	it("version plugin supports a custom short alias", async () => {
+		const app = new Crust("app")
+			.extend(versionExtension("1.2.3", { short: "V" }))
+			.handle(() => {});
+
+		await app.execute({ argv: ["-V"] });
+
+		expect(getStdout()).toContain("app v1.2.3");
+	});
+
+	it("version plugin rejects -v when short is remapped", async () => {
+		const app = new Crust("app")
+			.extend(versionExtension("1.2.3", { short: "V" }))
+			.handle(() => {});
+
+		await app.execute({ argv: ["-v"] });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("version plugin supports disabling the short alias", async () => {
+		const app = new Crust("app")
+			.extend(versionExtension("1.2.3", { short: false }))
+			.handle(() => {});
+
+		await app.execute({ argv: ["-v"] });
+
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("version plugin supports plain format", async () => {
+		const app = new Crust("app")
+			.extend(versionExtension("1.2.3", { format: "plain" }))
+			.handle(() => {});
+
+		await app.execute({ argv: ["--version"] });
+
+		expect(getStdout()).toBe("1.2.3");
+	});
+
+	it("version plugin supports a custom format function", async () => {
+		const app = new Crust("app")
+			.extend(
+				versionExtension("1.2.3", {
+					format: (version, context) => `${context.rootCommand.meta.name}/${version}`,
+				}),
+			)
+			.handle(() => {});
+
+		await app.execute({ argv: ["--version"] });
+
+		expect(getStdout()).toBe("app/1.2.3");
+	});
+
 	// ──────────────────────────────────────────────────────────────────────────────
 	// helpExtension alias rendering
 	// ──────────────────────────────────────────────────────────────────────────────

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -1,13 +1,37 @@
-import { type Extension, defineExtension } from "@crustjs/core";
+import { type Extension, type ExtensionContext, defineExtension } from "@crustjs/core";
 
 export type VersionValue = string | (() => string);
 
-export function versionExtension(versionValue: VersionValue = "0.0.0"): Extension {
+export interface VersionExtensionOptions {
+	/**
+	 * Short alias for `--version`. Pass `false` to disable the short alias
+	 * (e.g. to free `-v` for a verbose flag), or another character such as
+	 * `"V"` for Commander-style CLIs.
+	 *
+	 * @default "v"
+	 */
+	readonly short?: string | false;
+	/**
+	 * Output format. `"plain"` prints the bare version (script-friendly:
+	 * `$(cli --version)`); a function receives the resolved version and the
+	 * extension context and returns the line to print.
+	 *
+	 * @default `${rootName} v${version}`
+	 */
+	readonly format?: "plain" | ((version: string, context: ExtensionContext) => string);
+}
+
+export function versionExtension(
+	versionValue: VersionValue = "0.0.0",
+	options: VersionExtensionOptions = {},
+): Extension {
+	const { short = "v", format } = options;
+
 	return defineExtension("version", {
 		flags: {
 			version: {
 				type: "boolean",
-				short: "v",
+				...(short === false ? {} : { short }),
 				noNegate: true,
 				description: "Show version number",
 				recursive: false,
@@ -19,7 +43,13 @@ export function versionExtension(versionValue: VersionValue = "0.0.0"): Extensio
 				if (context.commandPath.length !== 1 || context.flags.version !== true) return;
 
 				const version = typeof versionValue === "function" ? versionValue() : versionValue;
-				context.stdout(`${context.rootCommand.meta.name} v${version}`);
+				const line =
+					format === "plain"
+						? version
+						: format
+							? format(version, context)
+							: `${context.rootCommand.meta.name} v${version}`;
+				context.stdout(line);
 				return context.finish();
 			},
 		},

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -2,7 +2,17 @@
 // @crustjs/progress — Progress indicators for Crust
 // ────────────────────────────────────────────────────────────────────────────
 
-export type { SpinnerController, SpinnerOptions, SpinnerType } from "./spinner.ts";
-export { spinner } from "./spinner.ts";
+export type { CreateProgressOptions, ProgressHandle } from "./progress.ts";
+export { createProgress } from "./progress.ts";
+export type {
+	CreateSpinnerOptions,
+	SpinnerController,
+	SpinnerHandle,
+	SpinnerOptions,
+	SpinnerOutcome,
+	SpinnerSigintPolicy,
+	SpinnerType,
+} from "./spinner.ts";
+export { createSpinner, spinner } from "./spinner.ts";
 export { createTheme, defaultTheme, setTheme } from "./theme.ts";
 export type { PartialProgressTheme, ProgressTheme } from "./types.ts";

--- a/packages/progress/src/progress.test.ts
+++ b/packages/progress/src/progress.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createProgress } from "./progress.ts";
+
+const originalStderrWrite = process.stderr.write;
+const originalStderrIsTTY = process.stderr.isTTY;
+
+let stderrOutput: string;
+
+beforeEach(() => {
+	stderrOutput = "";
+	process.stderr.write = (chunk: string | Uint8Array) => {
+		if (typeof chunk === "string") stderrOutput += chunk;
+		return true;
+	};
+	Object.defineProperty(process.stderr, "isTTY", {
+		value: true,
+		writable: true,
+		configurable: true,
+	});
+});
+
+afterEach(() => {
+	process.stderr.write = originalStderrWrite;
+	Object.defineProperty(process.stderr, "isTTY", {
+		value: originalStderrIsTTY,
+		writable: true,
+		configurable: true,
+	});
+});
+
+describe("createProgress — determinate", () => {
+	it("renders current/total alongside the message", () => {
+		const progress = createProgress({ total: 10, message: "Translating" });
+
+		progress.start();
+		progress.advance(3);
+		progress.stop();
+
+		expect(stderrOutput).toContain("(3/10)");
+		expect(stderrOutput).toContain("Translating");
+		expect(stderrOutput).toContain("✓");
+	});
+
+	it("advance accepts a message and defaults to +1", () => {
+		const progress = createProgress({ total: 2, message: "Files" });
+
+		progress.start();
+		progress.advance(1, "a.json");
+		progress.advance(1, "b.json");
+		progress.stop("success", "All files done");
+
+		expect(stderrOutput).toContain("a.json (1/2)");
+		expect(stderrOutput).toContain("b.json (2/2)");
+		expect(stderrOutput).toContain("All files done (2/2)");
+	});
+
+	it("stop('error') renders the failure symbol", () => {
+		const progress = createProgress({ total: 5, message: "Uploading" });
+
+		progress.start();
+		progress.advance(2);
+		progress.stop("error", "Upload failed");
+
+		expect(stderrOutput).toContain("✗");
+		expect(stderrOutput).toContain("Upload failed (2/5)");
+	});
+});

--- a/packages/progress/src/progress.ts
+++ b/packages/progress/src/progress.ts
@@ -1,0 +1,58 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Progress — Determinate (current/total) progress for @crustjs/progress
+// ────────────────────────────────────────────────────────────────────────────
+
+import {
+	type CreateSpinnerOptions,
+	type SpinnerHandle,
+	type SpinnerOutcome,
+	createSpinner,
+} from "./spinner.ts";
+
+export interface CreateProgressOptions extends CreateSpinnerOptions {
+	/** Total number of units of work. */
+	readonly total: number;
+}
+
+export interface ProgressHandle {
+	/** Begin rendering at `(0/total)`. */
+	start: () => void;
+	/** Advance by `amount` units and repaint, optionally with a new message. */
+	advance: (amount?: number, message?: string) => void;
+	/**
+	 * Finish: render the final `✓`/`✗` line with the last `(current/total)`.
+	 *
+	 * @param outcome - Final symbol to render. @default "success"
+	 * @param message - Final message. Defaults to the last message shown.
+	 */
+	stop: (outcome?: SpinnerOutcome, message?: string) => void;
+}
+
+/**
+ * Create a determinate progress indicator rendered as
+ * `⠋ <message> (<current>/<total>)` on the spinner line.
+ */
+export function createProgress(options: CreateProgressOptions): ProgressHandle {
+	const { total } = options;
+	let current = 0;
+	let message = options.message;
+
+	const format = (msg: string): string => `${msg} (${current}/${total})`;
+
+	const handle: SpinnerHandle = createSpinner({
+		...options,
+		message: format(message),
+	});
+
+	return {
+		start: handle.start,
+		advance(amount = 1, nextMessage?: string) {
+			current += amount;
+			if (nextMessage !== undefined) message = nextMessage;
+			handle.updateMessage(format(message));
+		},
+		stop(outcome: SpinnerOutcome = "success", finalMessage?: string) {
+			handle.stop(outcome, format(finalMessage ?? message));
+		},
+	};
+}

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { type SpinnerController, spinner } from "./spinner.ts";
+import { type SpinnerController, createSpinner, spinner } from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -634,7 +634,6 @@ describe("createSpinner — imperative", () => {
 	afterEach(restoreMocks);
 
 	it("start and stop live in different call frames", async () => {
-		const { createSpinner } = await import("./spinner.ts");
 		const handle = createSpinner({ message: "Working..." });
 
 		handle.start();
@@ -647,7 +646,6 @@ describe("createSpinner — imperative", () => {
 	});
 
 	it("stop('error') renders the failure symbol without throwing", async () => {
-		const { createSpinner } = await import("./spinner.ts");
 		const handle = createSpinner({ message: "Deploying..." });
 
 		handle.start();
@@ -659,7 +657,6 @@ describe("createSpinner — imperative", () => {
 	});
 
 	it("updateMessage repaints while running", async () => {
-		const { createSpinner } = await import("./spinner.ts");
 		const handle = createSpinner({ message: "Step 1" });
 
 		handle.start();
@@ -670,7 +667,6 @@ describe("createSpinner — imperative", () => {
 	});
 
 	it("stop is idempotent", async () => {
-		const { createSpinner } = await import("./spinner.ts");
 		const handle = createSpinner({ message: "Once" });
 
 		handle.start();
@@ -687,7 +683,6 @@ describe("createSpinner — imperative", () => {
 			return process;
 		}) as typeof process.once;
 
-		const { createSpinner } = await import("./spinner.ts");
 		const handle = createSpinner({ message: "No sigint", sigint: false });
 		handle.start();
 		handle.stop();

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -624,3 +624,95 @@ describe("spinner — non-interactive", () => {
 		expect(stderrOutput).not.toContain("Late update...");
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// createSpinner — imperative controller
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("createSpinner — imperative", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("start and stop live in different call frames", async () => {
+		const { createSpinner } = await import("./spinner.ts");
+		const handle = createSpinner({ message: "Working..." });
+
+		handle.start();
+		await tick(20);
+		handle.stop();
+
+		expect(stderrOutput).toContain("Working...");
+		expect(stderrOutput).toContain("✓");
+		expect(stderrOutput).toContain("\x1B[?25h");
+	});
+
+	it("stop('error') renders the failure symbol without throwing", async () => {
+		const { createSpinner } = await import("./spinner.ts");
+		const handle = createSpinner({ message: "Deploying..." });
+
+		handle.start();
+		handle.stop("error", "Deploy failed");
+
+		expect(stderrOutput).toContain("✗");
+		expect(stderrOutput).toContain("Deploy failed");
+		expect(stderrOutput).not.toContain("✓");
+	});
+
+	it("updateMessage repaints while running", async () => {
+		const { createSpinner } = await import("./spinner.ts");
+		const handle = createSpinner({ message: "Step 1" });
+
+		handle.start();
+		handle.updateMessage("Step 2");
+		handle.stop();
+
+		expect(stderrOutput).toContain("Step 2");
+	});
+
+	it("stop is idempotent", async () => {
+		const { createSpinner } = await import("./spinner.ts");
+		const handle = createSpinner({ message: "Once" });
+
+		handle.start();
+		handle.stop("success", "done");
+		handle.stop("error", "again");
+
+		expect(stderrOutput).not.toContain("✗");
+	});
+
+	it("sigint: false installs no SIGINT handler", async () => {
+		let registered = false;
+		process.once = ((event: string | symbol, _listener: unknown) => {
+			if (event === "SIGINT") registered = true;
+			return process;
+		}) as typeof process.once;
+
+		const { createSpinner } = await import("./spinner.ts");
+		const handle = createSpinner({ message: "No sigint", sigint: false });
+		handle.start();
+		handle.stop();
+
+		expect(registered).toBe(false);
+	});
+});
+
+describe("spinner — sigint option", () => {
+	beforeEach(setupMocks);
+	afterEach(restoreMocks);
+
+	it("sigint: false leaves SIGINT to the application", async () => {
+		let registered = false;
+		process.once = ((event: string | symbol, _listener: unknown) => {
+			if (event === "SIGINT") registered = true;
+			return process;
+		}) as typeof process.once;
+
+		await spinner({
+			message: "App-owned SIGINT",
+			sigint: false,
+			task: async () => "ok",
+		});
+
+		expect(registered).toBe(false);
+	});
+});

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -1,5 +1,5 @@
 // ────────────────────────────────────────────────────────────────────────────
-// Spinner — Display a spinner while running an async task for @crustjs/progress
+// Spinner — Animated progress spinner for @crustjs/progress
 // ────────────────────────────────────────────────────────────────────────────
 
 import { resolveTheme } from "./theme.ts";
@@ -45,16 +45,27 @@ export type SpinnerType =
 	| "bounce"
 	| { readonly frames: readonly string[]; readonly interval: number };
 
+/** Final outcome of a spinner or progress indicator. */
+export type SpinnerOutcome = "success" | "error";
+
+/**
+ * SIGINT policy for interactive spinners.
+ *
+ * - `"exit"` (default): install a `SIGINT` handler that restores the cursor
+ *   and exits with code 130.
+ * - `false`: install no handler — the application owns SIGINT and should
+ *   `stop()` the spinner (restoring the cursor) in its own cleanup.
+ */
+export type SpinnerSigintPolicy = "exit" | false;
+
 export interface SpinnerController {
 	/** Update the message displayed alongside the spinner. */
 	updateMessage: (message: string) => void;
 }
 
-export interface SpinnerOptions<T> {
+export interface CreateSpinnerOptions {
 	/** The message displayed alongside the spinner. */
 	readonly message: string;
-	/** The async task to run while the spinner is displayed. */
-	readonly task: (controller: SpinnerController) => Promise<T>;
 	/**
 	 * Spinner animation style.
 	 *
@@ -63,6 +74,32 @@ export interface SpinnerOptions<T> {
 	readonly spinner?: SpinnerType;
 	/** Per-spinner theme overrides. */
 	readonly theme?: PartialProgressTheme;
+	/**
+	 * SIGINT policy.
+	 *
+	 * @default "exit"
+	 */
+	readonly sigint?: SpinnerSigintPolicy;
+}
+
+export interface SpinnerHandle {
+	/** Begin rendering. No-op if already started. */
+	start: () => void;
+	/** Update the message displayed alongside the spinner. */
+	updateMessage: (message: string) => void;
+	/**
+	 * Finish the spinner: render the final `✓`/`✗` line and restore the
+	 * cursor. Idempotent — later calls are no-ops.
+	 *
+	 * @param outcome - Final symbol to render. @default "success"
+	 * @param message - Final message. Defaults to the last message shown.
+	 */
+	stop: (outcome?: SpinnerOutcome, message?: string) => void;
+}
+
+export interface SpinnerOptions<T> extends CreateSpinnerOptions {
+	/** The async task to run while the spinner is displayed. */
+	readonly task: (controller: SpinnerController) => Promise<T>;
 }
 
 function resolveSpinner(spinnerType: SpinnerType | undefined): SpinnerFrameSet {
@@ -82,46 +119,36 @@ function renderFrame(frame: string, message: string, theme: ProgressTheme): stri
 function renderFinal(
 	message: string,
 	theme: ProgressTheme,
-	symbol: string,
-	styleSymbol: ProgressTheme["success"],
+	outcome: SpinnerOutcome,
 	erase: boolean,
 ): string {
+	const symbol = outcome === "success" ? SUCCESS_SYMBOL : ERROR_SYMBOL;
+	const styleSymbol = outcome === "success" ? theme.success : theme.error;
 	const line = `${styleSymbol(symbol)} ${theme.message(message)}\n`;
 	return erase ? ERASE_LINE + CURSOR_TO_START + line : line;
 }
 
-export async function spinner<T>(options: SpinnerOptions<T>): Promise<T> {
+/**
+ * Create an imperative spinner whose `start` and `stop` can live in
+ * different call frames (workflow engines, logger adapters).
+ *
+ * Non-interactive stderr renders no animation frames — only the final
+ * `✓`/`✗` line on `stop()`.
+ */
+export function createSpinner(options: CreateSpinnerOptions): SpinnerHandle {
 	const theme = resolveTheme(options.theme);
 	const isInteractive = process.stderr.isTTY;
-
-	if (!isInteractive) {
-		let currentMessage = options.message;
-		const controller: SpinnerController = {
-			updateMessage(message: string) {
-				currentMessage = message;
-			},
-		};
-
-		try {
-			const result = await options.task(controller);
-			process.stderr.write(
-				renderFinal(currentMessage, theme, SUCCESS_SYMBOL, theme.success, false),
-			);
-			return result;
-		} catch (error) {
-			process.stderr.write(renderFinal(currentMessage, theme, ERROR_SYMBOL, theme.error, false));
-			throw error;
-		}
-	}
-
 	const { frames, interval } = resolveSpinner(options.spinner);
-	let frameIndex = 0;
+	const sigint = options.sigint ?? "exit";
+
 	let currentMessage = options.message;
+	let frameIndex = 0;
+	let started = false;
 	let finished = false;
 	let timerId: ReturnType<typeof setInterval> | undefined;
 	let sigintHandler: (() => void) | undefined;
 
-	function cleanupInteractive(): void {
+	function cleanup(): void {
 		if (timerId !== undefined) {
 			clearInterval(timerId);
 			timerId = undefined;
@@ -132,41 +159,69 @@ export async function spinner<T>(options: SpinnerOptions<T>): Promise<T> {
 		}
 	}
 
-	const controller: SpinnerController = {
+	return {
+		start() {
+			if (started || finished) return;
+			started = true;
+			if (!isInteractive) return;
+
+			process.stderr.write(HIDE_CURSOR);
+			process.stderr.write(renderFrame(frames[0] as string, currentMessage, theme));
+
+			timerId = setInterval(() => {
+				frameIndex = (frameIndex + 1) % frames.length;
+				process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
+			}, interval);
+
+			if (sigint === "exit") {
+				sigintHandler = () => {
+					cleanup();
+					process.stderr.write(SHOW_CURSOR);
+					process.exit(130);
+				};
+				process.once("SIGINT", sigintHandler);
+			}
+		},
+
 		updateMessage(message: string) {
 			if (finished) return;
 			currentMessage = message;
-			process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
+			if (started && isInteractive) {
+				process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
+			}
+		},
+
+		stop(outcome: SpinnerOutcome = "success", message?: string) {
+			if (!started || finished) return;
+			finished = true;
+			if (message !== undefined) currentMessage = message;
+			cleanup();
+			process.stderr.write(renderFinal(currentMessage, theme, outcome, isInteractive));
+			if (isInteractive) {
+				process.stderr.write(SHOW_CURSOR);
+			}
 		},
 	};
+}
 
-	process.stderr.write(HIDE_CURSOR);
-	process.stderr.write(renderFrame(frames[0] as string, currentMessage, theme));
+/**
+ * Display a spinner while running an async task. The final line renders `✓`
+ * when the task resolves and `✗` when it throws (the error is re-thrown).
+ */
+export async function spinner<T>(options: SpinnerOptions<T>): Promise<T> {
+	const handle = createSpinner(options);
+	handle.start();
 
-	timerId = setInterval(() => {
-		frameIndex = (frameIndex + 1) % frames.length;
-		process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
-	}, interval);
-
-	sigintHandler = () => {
-		cleanupInteractive();
-		process.stderr.write(SHOW_CURSOR);
-		process.exit(130);
+	const controller: SpinnerController = {
+		updateMessage: handle.updateMessage,
 	};
-	process.once("SIGINT", sigintHandler);
 
 	try {
 		const result = await options.task(controller);
-		finished = true;
-		cleanupInteractive();
-		process.stderr.write(renderFinal(currentMessage, theme, SUCCESS_SYMBOL, theme.success, true));
-		process.stderr.write(SHOW_CURSOR);
+		handle.stop("success");
 		return result;
 	} catch (error) {
-		finished = true;
-		cleanupInteractive();
-		process.stderr.write(renderFinal(currentMessage, theme, ERROR_SYMBOL, theme.error, true));
-		process.stderr.write(SHOW_CURSOR);
+		handle.stop("error");
 		throw error;
 	}
 }

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -212,12 +212,8 @@ export async function spinner<T>(options: SpinnerOptions<T>): Promise<T> {
 	const handle = createSpinner(options);
 	handle.start();
 
-	const controller: SpinnerController = {
-		updateMessage: handle.updateMessage,
-	};
-
 	try {
-		const result = await options.task(controller);
+		const result = await options.task(handle);
 		handle.stop("success");
 		return result;
 	} catch (error) {

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -81,3 +81,72 @@ describe("interactiveRun", () => {
 		await run.done;
 	});
 });
+
+describe("captureExecute", () => {
+	it("captures exit code 0 and stdout on success", async () => {
+		const { Crust } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const app = new Crust("test-cli").handle(({ stdout }) => {
+			stdout("hello");
+		});
+
+		const result = await captureExecute(app, []);
+		expect(result).toEqual({ stdout: "hello", stderr: "", exitCode: 0 });
+	});
+
+	it("captures exit code 1 and the rendered failure", async () => {
+		const { Crust } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const app = new Crust("test-cli").handle(() => {
+			throw new Error("boom");
+		});
+
+		const result = await captureExecute(app, []);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("boom");
+	});
+
+	it("captures exit code 130 for AbortError cancellation", async () => {
+		const { Crust } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const app = new Crust("test-cli").handle(() => {
+			throw new DOMException("Prompt was cancelled.", "AbortError");
+		});
+
+		const result = await captureExecute(app, []);
+		expect(result.exitCode).toBe(130);
+		expect(result.stderr).toBe("");
+	});
+
+	it("captures onError extension rendering", async () => {
+		const { Crust, defineExtension } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const renderer = defineExtension("renderer", {
+			hooks: {
+				onError(error, ctx) {
+					ctx.stderr(`custom: ${(error as Error).message}`);
+					return true;
+				},
+			},
+		});
+		const app = new Crust("test-cli").extend(renderer).handle(() => {
+			throw new Error("boom");
+		});
+
+		const result = await captureExecute(app, []);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe("custom: boom");
+	});
+
+	it("restores process.exitCode", async () => {
+		const { Crust } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const before = process.exitCode;
+		const app = new Crust("test-cli").handle(() => {
+			throw new Error("boom");
+		});
+
+		await captureExecute(app, []);
+		expect(process.exitCode).toBe(before);
+	});
+});

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -138,6 +138,46 @@ describe("captureExecute", () => {
 		expect(result.stderr).toBe("custom: boom");
 	});
 
+	it("isolates exit codes across overlapping captures", async () => {
+		const { Crust } = await import("@crustjs/core");
+		const { captureExecute } = await import("./index.ts");
+		const originalExitCode = process.exitCode;
+		try {
+			// Non-zero ambient value: if capture B reads state restored by capture
+			// A's finally block, B reports 7 instead of its own 0.
+			process.exitCode = 7;
+
+			let releaseA!: () => void;
+			const gateA = new Promise<void>((resolve) => {
+				releaseA = resolve;
+			});
+			let releaseB!: () => void;
+			const gateB = new Promise<void>((resolve) => {
+				releaseB = resolve;
+			});
+
+			const appA = new Crust("test-cli").handle(async () => {
+				await gateA;
+			});
+			const appB = new Crust("test-cli").handle(async () => {
+				await gateB;
+			});
+
+			const pendingA = captureExecute(appA, []);
+			await Bun.sleep(0);
+			const pendingB = captureExecute(appB, []);
+			await Bun.sleep(0);
+
+			releaseA();
+			expect((await pendingA).exitCode).toBe(0);
+			releaseB();
+			expect((await pendingB).exitCode).toBe(0);
+			expect(process.exitCode).toBe(7);
+		} finally {
+			process.exitCode = originalExitCode;
+		}
+	});
+
 	it("restores process.exitCode", async () => {
 		const { Crust } = await import("@crustjs/core");
 		const { captureExecute } = await import("./index.ts");

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
+import { Crust, defineExtension } from "@crustjs/core";
 import { input } from "@crustjs/prompts";
 
-import { captureRun, interactiveRun, type RunnableApp } from "./index.ts";
+import { captureExecute, captureRun, interactiveRun, type RunnableApp } from "./index.ts";
 
 describe("captureRun", () => {
 	it("captures output from a structural runnable as lines", async () => {
@@ -84,8 +85,6 @@ describe("interactiveRun", () => {
 
 describe("captureExecute", () => {
 	it("captures exit code 0 and stdout on success", async () => {
-		const { Crust } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const app = new Crust("test-cli").handle(({ stdout }) => {
 			stdout("hello");
 		});
@@ -95,8 +94,6 @@ describe("captureExecute", () => {
 	});
 
 	it("captures exit code 1 and the rendered failure", async () => {
-		const { Crust } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const app = new Crust("test-cli").handle(() => {
 			throw new Error("boom");
 		});
@@ -107,8 +104,6 @@ describe("captureExecute", () => {
 	});
 
 	it("captures exit code 130 for AbortError cancellation", async () => {
-		const { Crust } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const app = new Crust("test-cli").handle(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
@@ -119,8 +114,6 @@ describe("captureExecute", () => {
 	});
 
 	it("captures onError extension rendering", async () => {
-		const { Crust, defineExtension } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const renderer = defineExtension("renderer", {
 			hooks: {
 				onError(error, ctx) {
@@ -139,8 +132,6 @@ describe("captureExecute", () => {
 	});
 
 	it("isolates exit codes across overlapping captures", async () => {
-		const { Crust } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const originalExitCode = process.exitCode;
 		try {
 			// Non-zero ambient value: if capture B reads state restored by capture
@@ -179,8 +170,6 @@ describe("captureExecute", () => {
 	});
 
 	it("restores process.exitCode", async () => {
-		const { Crust } = await import("@crustjs/core");
-		const { captureExecute } = await import("./index.ts");
 		const before = process.exitCode;
 		const app = new Crust("test-cli").handle(() => {
 			throw new Error("boom");

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -64,12 +64,30 @@ export interface CapturedExecute {
 	readonly exitCode: number;
 }
 
+// `execute()` reports status only through the process-global
+// `process.exitCode`, so overlapping captures would read or restore each
+// other's state. Chain every capture behind the previous one so the whole
+// save/reset/execute/read/restore sequence runs exclusively.
+let captureExecuteChain: Promise<unknown> = Promise.resolve();
+
 /**
  * Drive the terminal `execute()` path in-process: exit-code protocol,
  * Extension `onError` rendering, and cancellation (130) are all observable
  * without spawning a subprocess. `process.exitCode` is restored afterwards.
+ * Concurrent calls are serialized because the exit-code protocol is
+ * process-global.
  */
-export async function captureExecute(
+export function captureExecute(
+	app: ExecutableApp,
+	argv: readonly string[],
+): Promise<CapturedExecute> {
+	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
+	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
+	captureExecuteChain = run.catch(() => {});
+	return run;
+}
+
+async function captureExecuteExclusive(
 	app: ExecutableApp,
 	argv: readonly string[],
 ): Promise<CapturedExecute> {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,15 +1,15 @@
 import { withPromptIO } from "@crustjs/prompts";
 import { createPromptIO } from "@crustjs/prompts/testing";
 
+/** Structural io shape shared by `run()` and `execute()` captures. */
+export interface CaptureIO {
+	readonly stdout?: (text: string) => void;
+	readonly stderr?: (text: string) => void;
+}
+
 /** Minimal structural surface invoked by the testing helpers. */
 export interface RunnableApp {
-	run(
-		argv: readonly string[],
-		io?: {
-			stdout?: (text: string) => void;
-			stderr?: (text: string) => void;
-		},
-	): Promise<void>;
+	run(argv: readonly string[], io?: CaptureIO): Promise<void>;
 }
 
 export interface CapturedRun {
@@ -48,13 +48,7 @@ export async function captureRun(app: RunnableApp, argv: readonly string[]): Pro
 
 /** Minimal structural surface of `execute()` invoked by {@link captureExecute}. */
 export interface ExecutableApp {
-	execute(options?: {
-		argv?: string[];
-		io?: {
-			stdout?: (text: string) => void;
-			stderr?: (text: string) => void;
-		};
-	}): Promise<void>;
+	execute(options?: { argv?: string[]; io?: CaptureIO }): Promise<void>;
 }
 
 export interface CapturedExecute {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -46,6 +46,60 @@ export async function captureRun(app: RunnableApp, argv: readonly string[]): Pro
 	return failed ? { stdout, stderr, error } : { stdout, stderr };
 }
 
+/** Minimal structural surface of `execute()` invoked by {@link captureExecute}. */
+export interface ExecutableApp {
+	execute(options?: {
+		argv?: string[];
+		io?: {
+			stdout?: (text: string) => void;
+			stderr?: (text: string) => void;
+		};
+	}): Promise<void>;
+}
+
+export interface CapturedExecute {
+	readonly stdout: string;
+	readonly stderr: string;
+	/** The exit code `execute()` established (`0`, `1`, or `130` for cancellation). */
+	readonly exitCode: number;
+}
+
+/**
+ * Drive the terminal `execute()` path in-process: exit-code protocol,
+ * Extension `onError` rendering, and cancellation (130) are all observable
+ * without spawning a subprocess. `process.exitCode` is restored afterwards.
+ */
+export async function captureExecute(
+	app: ExecutableApp,
+	argv: readonly string[],
+): Promise<CapturedExecute> {
+	const stdoutLines: string[] = [];
+	const stderrLines: string[] = [];
+	const savedExitCode = process.exitCode;
+	process.exitCode = 0;
+
+	try {
+		await app.execute({
+			argv: [...argv],
+			io: {
+				stdout: (text) => {
+					stdoutLines.push(text);
+				},
+				stderr: (text) => {
+					stderrLines.push(text);
+				},
+			},
+		});
+		return {
+			stdout: stdoutLines.join("\n"),
+			stderr: stderrLines.join("\n"),
+			exitCode: Number(process.exitCode ?? 0),
+		};
+	} finally {
+		process.exitCode = savedExitCode;
+	}
+}
+
 export interface InteractiveRun {
 	waitFor(pattern: RegExp, timeoutMs?: number): Promise<void>;
 	type(text: string): void;


### PR DESCRIPTION
Fixes a set of framework gaps surfaced by a real-world downstream CLI: a silent routing failure, hardcoded version extension policy, a type-export hole breaking consumer declaration emission, invisible cancellation, missing progress primitives, and untestable `execute()` semantics. Each issue was reproduced first and fixed test-first.

## Changes

| Issue | Commit | Resolution |
|---|---|---|
| Router: a known flag before a subcommand → silent no-op (exit 0, nothing runs) | `fix(core): route past known flags before a subcommand name` | `resolveCommand` skips known flags (+values) during routing, matching all parser spellings (long, `=`, `--no-` respecting `noNegate`, short, long aliases, bundled shorts). Unknown flags and `--` still stop routing. |
| `versionExtension` hardcodes `-v` and `${name} v${version}` | `feat(extensions): versionExtension short/format options` | `versionExtension(value, { short?: string \| false, format?: "plain" \| fn })`; defaults unchanged. |
| TS2742/TS2883: `Simplify` unexported from package root | `fix(core): export Simplify ...` | Exported `Simplify`; added a declaration-emission integration test (builds dist, symlinks a consumer, runs `tsc` with `declaration: true`). |
| `AbortError` bypasses `onError` hooks | `feat(core): offer AbortError cancellation to onError hooks` | Cancellation now flows through the `onError` chain with a silent default; exit 130 and no-hook behavior unchanged. |
| Progress: no imperative controller, no failure final, no determinate primitive, forced SIGINT exit | `feat(progress): imperative spinner, determinate progress, SIGINT policy` | `createSpinner()` (start/stop across call frames, `stop("error")` renders ✗ without throwing), `createProgress()` (`(current/total)` + `advance()`), `sigint: false` opt-out. `spinner()` is now a thin wrapper; behavior unchanged. |
| `captureRun` can't test `execute()` semantics | `feat(testing): captureExecute for in-process execute() semantics` | `captureExecute(app, argv)` → `{ stdout, stderr, exitCode }`; `execute()` gained an optional `io` override. |
| Parser grammar gaps (greedy multi-value, optional-valued flags, `--timeout -5`) | `docs: ... flags guide` | Won't-fix by design (parseArgs foundation); documented with the recommended app-side `normalizeArgv` pattern. |

## Breaking change (flagged in changeset)

The router fix changes where pre-subcommand flags bind:
- `app --help sub` now shows `sub`'s help (previously the root's).
- A root-only flag before a subcommand name is now an "unknown flag" error in the subcommand (previously a silent no-op — the motivating bug).

## Verification

- `bun test`: 2243 pass / 0 fail across the workspace
- `bun run check` and `bun run check:types`: green
- Live repro of the router bug (`app --quiet translate`) confirmed fixed
- Changesets included for all five affected packages
