### PR TITLE
feat(core)!: context-owned flags, capabilities-only requirements

### DIFF
--- a/.changeset/beta-api-revamp.md
+++ b/.changeset/beta-api-revamp.md
@@ -10,7 +10,7 @@
 Ship the 0.2 API revamp for the framework spine (see `docs/adr/0001`–`0009`):
 
 - Extensions replace plugins: `@crustjs/extensions` package, `defineExtension(name, config)` plain frozen configs with `intercept(ctx, next)` and `handleError` presentation chain; `.use()` removed.
-- Contexts are command dependencies: `defineContext(name, requirements?, setup)` always returns a factory, attached with the variadic `.provide(...)`, constructed topologically by declared `ctx` dependencies, and disposed via native `Symbol.dispose`/`Symbol.asyncDispose` in reverse construction order.
+- Contexts are command dependencies: `defineContext(name, config?, setup)` always returns a factory, attached with the variadic `.provide(...)`, constructed topologically by declared `requires` dependencies (values arrive via `ctx`), and disposed via native `Symbol.dispose`/`Symbol.asyncDispose` in reverse construction order.
 - `.handle(handler)` defines the Command Handler; `.run(argv, { stdout, stderr })` throws for programmatic embedding; `.execute()` renders and sets `process.exitCode`. `preRun`/`postRun` removed.
 - `CrustError` keeps four stable codes (`DEFINITION`, `PARSE`, `VALIDATION`, `COMMAND_NOT_FOUND`); `_tag`, `CONFIG`, and `EXECUTION` removed; handler and Context errors pass through unwrapped.
 - Standard Schema supported directly on arg/flag definitions; `@crustjs/validate` removed.

--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -17,15 +17,16 @@ const deploy = parent.sub("deploy").handle(({ flags, ctx }) => {});
 const app = parent.command(deploy);
 
 // After
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean" });
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 const auth = defineContext("auth", () => createAuthClient());
 
-const deploy = defineCommand("deploy", { flags: [verbose], ctx: [auth] }, (command) =>
+const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [auth] } }, (command) =>
 	command.handle(({ flags, ctx }) => {}),
 );
 
-const app = parent.mount(deploy);
+const app = parent.provide(logging(), auth()).mount(deploy);
 const shipToo = parent.mount(deploy.as("ship"));
 ```
 
-Declare inheritable flags with `.flags()` and provide Contexts with `.provide()` on the parent builder before `.mount()`. Extension-contributed commands are unchanged.
+Provide Contexts (including any whose owned flags a definition requires) with `.provide()` on the parent builder before `.mount()`. Extension-contributed commands are unchanged.

--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -5,7 +5,7 @@
 
 Add inert reusable command definitions with `defineCommand(name, requirements?, recipe)` and checked mounting with the variadic `.mount(...definitions)`.
 
-A definition carries its own name and declares what it needs from its mount site as value arrays: `requirements.flags` (named flag definitions it expects to inherit) and `requirements.ctx` (Context factories whose instances must be provided on the parent path). Every requirement is checked at the `.mount()` call — compile-time for missing/incompatible inherited flags and Contexts, and at runtime for Context requirement names missing from the parent path. Every mount materializes a fresh command under the definition's carried name; use `.as(newName)` to mount one definition under multiple names or parents, and definitions can `.mount()` other definitions.
+A definition carries its own name and declares what it needs from its mount site as value arrays: `requires.flags` (named flag definitions it expects to inherit) and `requires.ctx` (Context factories whose instances must be provided on the parent path). Every requirement is checked at the `.mount()` call — compile-time for missing/incompatible inherited flags and Contexts, and at runtime for Context requirement names missing from the parent path. Every mount materializes a fresh command under the definition's carried name; use `.as(newName)` to mount one definition under multiple names or parents, and definitions can `.mount()` other definitions.
 
 Remove `.sub()`, `.command(name, callback)`, `.command(builder)`, and the exported `ChildCrust` type. One-off inline commands are `.mount(defineCommand("up", (command) => ...))`.
 

--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -5,7 +5,7 @@
 
 Add inert reusable command definitions with `defineCommand(name, requirements?, recipe)` and checked mounting with the variadic `.mount(...definitions)`.
 
-A definition carries its own name and declares what it needs from its mount site as value arrays: `requires.flags` (named flag definitions it expects to inherit) and `requires.ctx` (Context factories whose instances must be provided on the parent path). Every requirement is checked at the `.mount()` call — compile-time for missing/incompatible inherited flags and Contexts, and at runtime for Context requirement names missing from the parent path. Every mount materializes a fresh command under the definition's carried name; use `.as(newName)` to mount one definition under multiple names or parents, and definitions can `.mount()` other definitions.
+A definition carries its own name and lists the Context capabilities it needs from its mount site in a plain `requires` array. Every requirement is checked at the `.mount()` call — compile-time for missing or incompatible Context values, and at runtime for required Context names missing from the parent path. Every mount materializes a fresh command under the definition's carried name; use `.as(newName)` to mount one definition under multiple names or parents, and definitions can `.mount()` other definitions.
 
 Remove `.sub()`, `.command(name, callback)`, `.command(builder)`, and the exported `ChildCrust` type. One-off inline commands are `.mount(defineCommand("up", (command) => ...))`.
 
@@ -21,12 +21,12 @@ const verbose = defineFlag("verbose", { type: "boolean" });
 const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 const auth = defineContext("auth", () => createAuthClient());
 
-const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [auth] } }, (command) =>
-	command.handle(({ flags, ctx }) => {}),
+const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
+	command.handle(({ ctx }) => {}),
 );
 
 const app = parent.provide(logging(), auth()).mount(deploy);
 const shipToo = parent.mount(deploy.as("ship"));
 ```
 
-Provide Contexts (including any whose owned flags a definition requires) with `.provide()` on the parent builder before `.mount()`. Extension-contributed commands are unchanged.
+Provide required Context capabilities with `.provide()` on the parent builder before `.mount()`. Extension-contributed commands are unchanged.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -13,7 +13,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) =>
 const app = new Crust("cli").provide(api()).mount(deploy);
 ```
 
-Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. The previous flat fields and the intermediate `requires: { flags, ctx }` shape are removed. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
+Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
 
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -15,6 +15,14 @@ const app = new Crust("cli").provide(api()).mount(deploy);
 
 Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
 
+Context setup now receives the invocation's injected `stdout` and `stderr` callbacks, shared with the Command Handler. Contexts can encapsulate output behavior instead of exposing flag state for every handler to interpret:
+
+```ts
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
+  debug: (message: string) => flags.verbose && stderr(message),
+}));
+```
+
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 
 `.of(value)` test doubles retain owned flags so test and production command grammars match. `.provide()` does not backfill descendants mounted on an earlier builder.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -2,19 +2,21 @@
 "@crustjs/core": minor
 ---
 
-Add Context-owned flags with `defineContext(name, { ownFlags }, setup)`. Calling `.provide()` installs each owned flag as an inheritable effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
+Add Context-owned flags with `defineContext(name, { flags }, setup)`. Calling `.provide()` installs each owned flag as an inheritable effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
 
 ```ts
 const apiKey = defineFlag("api-key", { type: "string" });
-const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) =>
+const api = defineContext("api", { flags: [apiKey] }, ({ flags }) =>
   createClient({ apiKey: flags["api-key"] }),
 );
 
 const app = new Crust("cli").provide(api()).mount(deploy);
 ```
 
+Reshape dependencies on both definition APIs under a shared `requires` field. `defineCommand(name, { requires: { flags, ctx } }, recipe)` and `defineContext(name, { flags, requires: { flags, ctx } }, setup)` group declarations by relationship direction: top-level `flags` means flags the definition owns or parses, while `requires` means typed dependencies supplied by the command path. The previous flat `defineCommand` `{ flags, ctx }` fields and `defineContext` `{ ownFlags, flags, ctx }` fields are removed.
+
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 
-`.of(value)` test doubles retain owned flags so test and production command grammars match. Existing `inherit: true` flags and `{ flags: [...] }` requirements are unchanged, and `.provide()` does not backfill descendants mounted on an earlier builder.
+`.of(value)` test doubles retain owned flags so test and production command grammars match. Existing `inherit: true` flag behavior is unchanged, and `.provide()` does not backfill descendants mounted on an earlier builder.
 
 `ContextInstance` and `ContextFactory` gain an owned-flags generic, while `Crust` and `CommandDefinitionBuilder` gain an `Owned` generic. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -13,10 +13,10 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) =>
 const app = new Crust("cli").provide(api()).mount(deploy);
 ```
 
-Reshape dependencies on both definition APIs under a shared `requires` field. `defineCommand(name, { requires: { flags, ctx } }, recipe)` and `defineContext(name, { flags, requires: { flags, ctx } }, setup)` group declarations by relationship direction: top-level `flags` means flags the definition owns or parses, while `requires` means typed dependencies supplied by the command path. The previous flat `defineCommand` `{ flags, ctx }` fields and `defineContext` `{ ownFlags, flags, ctx }` fields are removed.
+Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. The previous flat fields and the intermediate `requires: { flags, ctx }` shape are removed. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
 
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 
 `.of(value)` test doubles retain owned flags so test and production command grammars match. `.provide()` does not backfill descendants mounted on an earlier builder.
 
-`ContextInstance` and `ContextFactory` gain an owned-flags generic, while `Crust` and `CommandDefinitionBuilder` gain an `Owned` generic. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.
+The generic slots on `ContextInstance`, `ContextFactory`, `ContextSetup`, `Crust`, and `CommandDefinitionBuilder` now carry Context-owned flags instead of required or inherited flags. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -1,0 +1,20 @@
+---
+"@crustjs/core": minor
+---
+
+Add Context-owned flags with `defineContext(name, { ownFlags }, setup)`. Calling `.provide()` installs each owned flag as an inheritable effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
+
+```ts
+const apiKey = defineFlag("api-key", { type: "string" });
+const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) =>
+  createClient({ apiKey: flags["api-key"] }),
+);
+
+const app = new Crust("cli").provide(api()).mount(deploy);
+```
+
+Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
+
+`.of(value)` test doubles retain owned flags so test and production command grammars match. Existing `inherit: true` flags and `{ flags: [...] }` requirements are unchanged, and `.provide()` does not backfill descendants mounted on an earlier builder.
+
+`ContextInstance` and `ContextFactory` gain an owned-flags generic, while `Crust` and `CommandDefinitionBuilder` gain an `Owned` generic. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -2,7 +2,7 @@
 "@crustjs/core": minor
 ---
 
-Add Context-owned flags with `defineContext(name, { flags }, setup)`. Calling `.provide()` installs each owned flag as an inheritable effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
+Add Context-owned flags with `defineContext(name, { flags }, setup)`. Calling `.provide()` installs each owned flag as a propagating effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
 
 ```ts
 const apiKey = defineFlag("api-key", { type: "string" });
@@ -17,6 +17,6 @@ Reshape dependencies on both definition APIs under a shared `requires` field. `d
 
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 
-`.of(value)` test doubles retain owned flags so test and production command grammars match. Existing `inherit: true` flag behavior is unchanged, and `.provide()` does not backfill descendants mounted on an earlier builder.
+`.of(value)` test doubles retain owned flags so test and production command grammars match. `.provide()` does not backfill descendants mounted on an earlier builder.
 
 `ContextInstance` and `ContextFactory` gain an owned-flags generic, while `Crust` and `CommandDefinitionBuilder` gain an `Owned` generic. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.

--- a/.changeset/context-requirements.md
+++ b/.changeset/context-requirements.md
@@ -2,9 +2,9 @@
 "@crustjs/core": minor
 ---
 
-Contexts declare requirements: `defineContext(name, config, setup)` accepts `{ requires: { flags?: [...named flag defs], ctx?: [...Context factories] } }`, and setup receives `{ options, flags, ctx }` — the validated parsed flags of the resolved invocation narrowed to the declared flag defs, plus the values of the declared Context dependencies.
+Contexts declare capability requirements: `defineContext(name, config, setup)` accepts `{ flags?: [...owned flag defs], requires?: [...Context factories] }`, and setup receives `{ options, flags, ctx }` — validated values for that Context's owned flags only, plus the values of its declared Context dependencies.
 
-`.provide(...instances)` is variadic and provide order is free: Contexts on the resolved command path are constructed topologically by their declared `ctx` dependencies. A missing dependency or a dependency cycle throws `CrustError("DEFINITION", ...)`, also caught by command-tree validation. Flag requirements are checked at the `.provide()` call site — compile-time against the builder's inheritable flags and at runtime (declare `.flags()` before `.provide()`).
+`.provide(...instances)` is variadic and provide order is free: Contexts on the resolved command path are constructed topologically by their declared `requires` dependencies. A missing dependency or a dependency cycle throws `CrustError("DEFINITION", ...)`, also caught by command-tree validation.
 
 Every factory also exposes `.of(value)`, returning an instance whose setup yields the precomputed value with its requirements considered satisfied — for test doubles:
 
@@ -12,7 +12,7 @@ Every factory also exposes `.of(value)`, returning an instance whose setup yield
 const env = defineFlag("env", { type: "string" });
 
 const config = defineContext("config", { flags: [env] }, ({ flags }) => loadConfig(flags.env));
-const db = defineContext("db", { requires: { ctx: [config] } }, ({ ctx }) => connect(ctx.config));
+const db = defineContext("db", { requires: [config] }, ({ ctx }) => connect(ctx.config));
 
 app.provide(db(), config()); // constructed as config → db
 

--- a/.changeset/context-requirements.md
+++ b/.changeset/context-requirements.md
@@ -2,19 +2,19 @@
 "@crustjs/core": minor
 ---
 
-Contexts declare requirements: `defineContext(name, requirements, setup)` accepts `{ flags?: [...named flag defs], ctx?: [...Context factories] }`, and setup receives `{ options, flags, ctx }` — the validated parsed flags of the resolved invocation narrowed to the declared flag defs, plus the values of the declared Context dependencies.
+Contexts declare requirements: `defineContext(name, config, setup)` accepts `{ requires: { flags?: [...named flag defs], ctx?: [...Context factories] } }`, and setup receives `{ options, flags, ctx }` — the validated parsed flags of the resolved invocation narrowed to the declared flag defs, plus the values of the declared Context dependencies.
 
 `.provide(...instances)` is variadic and provide order is free: Contexts on the resolved command path are constructed topologically by their declared `ctx` dependencies. A missing dependency or a dependency cycle throws `CrustError("DEFINITION", ...)`, also caught by command-tree validation. Flag requirements are checked at the `.provide()` call site — compile-time against the builder's inheritable flags and at runtime (declare `.flags()` before `.provide()`).
 
 Every factory also exposes `.of(value)`, returning an instance whose setup yields the precomputed value with its requirements considered satisfied — for test doubles:
 
 ```ts
-const env = defineFlag("env", { type: "string", inherit: true });
+const env = defineFlag("env", { type: "string" });
 
 const config = defineContext("config", { flags: [env] }, ({ flags }) => loadConfig(flags.env));
-const db = defineContext("db", { ctx: [config] }, ({ ctx }) => connect(ctx.config));
+const db = defineContext("db", { requires: { ctx: [config] } }, ({ ctx }) => connect(ctx.config));
 
-app.flags(env).provide(db(), config()); // constructed as config → db
+app.provide(db(), config()); // constructed as config → db
 
 // In tests:
 app.provide(db.of(fakeDb), config.of(fakeConfig));

--- a/.changeset/define-api-names.md
+++ b/.changeset/define-api-names.md
@@ -4,7 +4,7 @@
 
 Name every definition helper with a `define*` prefix: `defineContext(name, ...)`, `defineExtension(name, config)`, `defineCommand(name, ...)`, and the new `defineFlag(name, def)` and `defineArg(name, def)`.
 
-`defineFlag` and `defineArg` are const-generic helpers that return the definition with its `name` attached, preserving literal types without `as const`. Named definitions attach through the now-variadic builder methods — `.flags(...defs)` replaces `.flags(record)` and `.args(...defs)` replaces `.args(tuple)` — and are referenced in `requires.flags` arrays. Inline object literals carrying a `name` work everywhere a named definition does:
+`defineFlag` and `defineArg` are const-generic helpers that return the definition with its `name` attached, preserving literal types without `as const`. Named definitions attach through the now-variadic builder methods — `.flags(...defs)` replaces `.flags(record)` and `.args(...defs)` replaces `.args(tuple)` — and Contexts may own flag definitions through their top-level `flags` array. Inline object literals carrying a `name` work everywhere a named definition does:
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean", short: "v" });

--- a/.changeset/define-api-names.md
+++ b/.changeset/define-api-names.md
@@ -4,7 +4,7 @@
 
 Name every definition helper with a `define*` prefix: `defineContext(name, ...)`, `defineExtension(name, config)`, `defineCommand(name, ...)`, and the new `defineFlag(name, def)` and `defineArg(name, def)`.
 
-`defineFlag` and `defineArg` are const-generic helpers that return the definition with its `name` attached, preserving literal types without `as const`. Named definitions attach through the now-variadic builder methods — `.flags(...defs)` replaces `.flags(record)` and `.args(...defs)` replaces `.args(tuple)` — and are referenced in `requirements.flags` arrays. Inline object literals carrying a `name` work everywhere a named definition does:
+`defineFlag` and `defineArg` are const-generic helpers that return the definition with its `name` attached, preserving literal types without `as const`. Named definitions attach through the now-variadic builder methods — `.flags(...defs)` replaces `.flags(record)` and `.args(...defs)` replaces `.args(tuple)` — and are referenced in `requires.flags` arrays. Inline object literals carrying a `name` work everywhere a named definition does:
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });

--- a/.changeset/define-api-names.md
+++ b/.changeset/define-api-names.md
@@ -7,7 +7,7 @@ Name every definition helper with a `define*` prefix: `defineContext(name, ...)`
 `defineFlag` and `defineArg` are const-generic helpers that return the definition with its `name` attached, preserving literal types without `as const`. Named definitions attach through the now-variadic builder methods — `.flags(...defs)` replaces `.flags(record)` and `.args(...defs)` replaces `.args(tuple)` — and are referenced in `requires.flags` arrays. Inline object literals carrying a `name` work everywhere a named definition does:
 
 ```ts
-const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 const target = defineArg("target", { type: "string", required: true });
 
 const app = new Crust("my-cli")

--- a/.changeset/remove-flag-inherit.md
+++ b/.changeset/remove-flag-inherit.md
@@ -1,0 +1,15 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": minor
+---
+
+**BREAKING:** Remove `FlagDef.inherit`. Command flags declared with `.flags()` are now always local; Context-owned flags are the only application-level flag propagation mechanism. Recursive Extension flags continue to use `ExtensionFlagDef.recursive`.
+
+The public `FlagSnapshot.inherit` field and the `InheritableFlags` and `ForceInherit` utility types are also removed. A local child flag can no longer override a same-named inherited flag because ordinary flags no longer inherit; Context-owned name collisions remain `DEFINITION` errors.
+
+| Previous usage | Migration |
+| --- | --- |
+| `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before mounting descendants. Handlers should require the derived Context capability. |
+| Each command reads the raw flag directly | Define the descriptor once with `defineFlag()` and attach it with `.flags()` to each command that parses it. |
+
+`requires.flags` now accepts only flags propagated by a provided Context. A same-named mount-site local flag does not satisfy the requirement at either the TypeScript or runtime boundary.

--- a/.changeset/remove-flag-inherit.md
+++ b/.changeset/remove-flag-inherit.md
@@ -12,4 +12,4 @@ The public `FlagSnapshot.inherit` field and the `InheritableFlags` and `ForceInh
 | `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before mounting descendants. Handlers should require the derived Context capability. |
 | Each command reads the raw flag directly | Define the descriptor once with `defineFlag()` and attach it with `.flags()` to each command that parses it. |
 
-`requires.flags` now accepts only flags propagated by a provided Context. A same-named mount-site local flag does not satisfy the requirement at either the TypeScript or runtime boundary.
+Cross-command dependencies are capability-only: list Context factories in `requires` and consume their derived values through `ctx`. Raw flag requirements are removed.

--- a/.changeset/remove-flag-inherit.md
+++ b/.changeset/remove-flag-inherit.md
@@ -5,7 +5,7 @@
 
 **BREAKING:** Remove `FlagDef.inherit`. Command flags declared with `.flags()` are now always local; Context-owned flags are the only application-level flag propagation mechanism. Recursive Extension flags continue to use `ExtensionFlagDef.recursive`.
 
-The public `FlagSnapshot.inherit` field and the `InheritableFlags` and `ForceInherit` utility types are also removed. A local child flag can no longer override a same-named inherited flag because ordinary flags no longer inherit; Context-owned name collisions remain `DEFINITION` errors.
+The public `FlagSnapshot.inherit` field and the internal `InheritableFlags` and `ForceInherit` utility types are also removed. A local child flag can no longer override a same-named inherited flag because ordinary flags no longer inherit; Context-owned name collisions remain `DEFINITION` errors.
 
 | Previous usage | Migration |
 | --- | --- |

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -26,28 +26,20 @@ import {
 
 ```ts
 interface CommandRequirements {
-  readonly requires?: ContextRequirements;
+  readonly requires?: readonly AnyContextFactory[];
 }
 
-interface ContextRequirements {
-  readonly flags?: readonly NamedFlagDef[];
-  readonly ctx?: readonly AnyContextFactory[];
-}
+type ContextRequirements = readonly AnyContextFactory[];
 ```
 
-The nested `requires` fields are arrays of defined values describing what a mount site must supply:
+`requires` lists Context factories whose capabilities the mount path must provide. It types the recipe builder's `ctx` and is checked at every `.mount()`: compile-time for missing or incompatible values, plus a runtime check for missing Context names.
 
-- `requires.flags` lists named flag definitions (from `defineFlag()`) the parent must provide as propagating Context-owned flags.
-- `requires.ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
-
-Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required propagating flags and Context names are provided on the parent path.
-
-`defineContext()` accepts `ContextConfig`, where top-level `flags` are owned and activated by `.provide()`, while nested `requires` uses the same dependency shape. Thus `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. Command requirements never hoist flags into a parent.
+`defineContext()` accepts `ContextConfig`, where top-level `flags` are owned and activated by `.provide()`, while `requires` is the same plain capability array. The grammar is: `flags` means definitions this unit owns or parses; `requires` means capabilities supplied by the command path.
 
 ### `CommandDefinitionBuilder`
 
 ```ts
-interface CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx> {
+interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx> {
   meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder;
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
@@ -59,7 +51,7 @@ interface CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx> {
 }
 ```
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, flag, and Context types, seeded from the declared requirements. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -91,14 +83,16 @@ Creates an inert reusable definition under a required name. The recipe builder i
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean" });
-const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+  verbose: flags.verbose === true,
+}));
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
-const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [auth] } }, (command) =>
+const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
   command
     .args({ name: "target", type: "string", required: true })
-    .handle(({ args, flags, ctx, stdout }) => {
-      stdout(`${ctx.auth.user}:${args.target}:${flags.verbose}`);
+    .handle(({ args, ctx, stdout }) => {
+      stdout(`${ctx.auth.user}:${args.target}:${ctx.logging.verbose}`);
     }),
 );
 ```
@@ -177,7 +171,7 @@ const app = new Crust("serve").flags(
 
 Repeated `.flags()` calls **replace** the local flags — they do not merge; pass all definitions in one call. A duplicate name within one call throws `DEFINITION`.
 
-Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant commands and mounted definition or Context requirements. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
+Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
 Schema-backed flags require `type: "string" | "boolean"` only to declare whether the flag consumes a token. Their schema owns the value rules and receives the raw parsed value.
 
@@ -193,13 +187,12 @@ const app = new Crust("serve").flags({
 
 ```ts
 provide<const Cs extends readonly ContextInstance[]>(
-  ...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>,
+  ...instances: Cs,
 ): Crust<
-  Inherited,
   Local,
   MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
   A,
-  EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+  EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
   MergeContext<Ctx, ContextsOutput<Cs>>
 >
 ```
@@ -221,11 +214,11 @@ const app = new Crust("my-cli")
   });
 ```
 
-Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared ctx requirements, with registration order preserved among independent Contexts. A missing ctx dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
+Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared capability requirements, with registration order preserved among independent Contexts. A missing capability dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
 
-A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be owned by a Context on this builder. Its top-level `flags` are installed as propagating flags on this builder and later-mounted descendants, without mutating the original definitions.
+A Context's top-level `flags` are installed as propagating flags on this builder and later-mounted descendants, without mutating the original definitions. Its `requires` capabilities are resolved topologically at invocation.
 
-Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, a missing required flag, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
+Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
 
 ## `.extend(...extensions)`
 
@@ -271,17 +264,14 @@ The context contains typed `args`, typed effective `flags`, typed Context values
 
 ```ts
 mount<const Ds extends readonly CommandDefinition<any>[]>(
-  ...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>,
+  ...definitions: MountChecks<Ctx, Ds>,
 ): Crust
 ```
 
 Materializes inert definitions as fresh child commands, each under its carried name. `.as(name)` renames a definition, so the same definition can route under different names:
 
 ```ts
-const app = new Crust("git")
-  .provide(loggingFlags())
-  .provide(auth())
-  .mount(deploy, deploy.as("ship"));
+const app = new Crust("git").provide(logging()).provide(auth()).mount(deploy, deploy.as("ship"));
 ```
 
 Inline one-off commands are mounted the same way:
@@ -294,20 +284,18 @@ const app = new Crust("my-cli").mount(
 
 `MountChecks` is internal declaration machinery that checks each definition's requirements against the parent builder. On failure, TypeScript reports one or more readable structural properties at the `.mount()` call:
 
-- `"missing propagating flags"`
-- `"incompatible propagating flags"`
 - `"missing Contexts"`
 - `"incompatible Contexts"`
 
-Only Context-owned flags on the parent path are considered; local `.flags()` definitions do not satisfy requirements. Compatibility compares inferred handler value types, including schema and custom-parser outputs: a provided value must be assignable to the required value. A stricter required parent flag can satisfy an optional requirement, but an optional parent flag cannot satisfy a required requirement. Context values use the same provided-to-required assignability direction.
+Compatibility compares provided and required Context value types in the provided-to-required assignability direction.
 
-At runtime, empty names, duplicate sibling names, alias collisions, duplicate provided Context names, ctx requirement names not provided on the parent path, unrelated recipe returns, values that are not `defineCommand()` definitions, and Extensions registered inside definitions throw `CrustError` code `DEFINITION`.
+At runtime, empty names, duplicate sibling names, alias collisions, duplicate provided Context names, required Context names not provided on the parent path, unrelated recipe returns, values that are not `defineCommand()` definitions, and Extensions registered inside definitions throw `CrustError` code `DEFINITION`.
 
 A definition can mount other definitions. Nested requirements are checked against the enclosing definition builder at that exact point.
 
 <Callout type="info">
-  Finalize Context-owned flags and Contexts on the builder used for `.mount()`. Later fluent calls
-  create a new builder and do not backfill an existing mount.
+  Finalize Contexts on the builder used for `.mount()`. Later fluent calls create a new builder and
+  do not backfill an existing mount.
 </Callout>
 
 ## `.run(argv, io?)`

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -83,17 +83,17 @@ Creates an inert reusable definition under a required name. The recipe builder i
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean" });
-const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
-  verbose: flags.verbose === true,
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
+  debug(message: string) {
+    if (flags.verbose) stderr(message);
+  },
 }));
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
 const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
-  command
-    .args({ name: "target", type: "string", required: true })
-    .handle(({ args, ctx, stdout }) => {
-      stdout(`${ctx.auth.user}:${args.target}:${ctx.logging.verbose}`);
-    }),
+  command.args({ name: "target", type: "string", required: true }).handle(({ args, ctx }) => {
+    ctx.logging.debug(`${ctx.auth.user}:${args.target}`);
+  }),
 );
 ```
 
@@ -258,7 +258,7 @@ const app = new Crust("greet")
   });
 ```
 
-The context contains typed `args`, typed effective `flags`, typed Context values in `ctx`, `rawArgs` after `--`, the resolved `command` and application `rootCommand` snapshots, and injectable `stdout(text)` and `stderr(text)` callbacks.
+The context contains typed `args`, typed effective `flags`, typed Context values in `ctx`, `rawArgs` after `--`, the resolved `command` and application `rootCommand` snapshots, and injectable `stdout(text)` and `stderr(text)` callbacks from `InvocationIO`. `CrustCommandContext` extends `InvocationIO`; Context setups receive those same callbacks for the invocation.
 
 ## `.mount(...definitions)`
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -14,6 +14,7 @@ import {
   type CommandDefinition,
   type CommandDefinitionBuilder,
   type CommandRequirements,
+  type ContextConfig,
 } from "@crustjs/core";
 ```
 
@@ -35,12 +36,14 @@ Requirements are arrays of defined values describing what a mount site must supp
 - `flags` lists named flag definitions (from `defineFlag()`) the parent must provide as inheritable flags. Every required flag must have `inherit: true`.
 - `ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
 
-The same shape types `defineContext()` requirements. Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required inheritable flags and Context names are provided on the parent path.
+Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required inheritable flags and Context names are provided on the parent path.
+
+`defineContext()` instead accepts `ContextConfig`, which extends this requirement shape with `ownFlags`. Ownership belongs to Context definitions and is activated by `.provide()`; command requirements remain dependency declarations and never hoist flags into a parent.
 
 ### `CommandDefinitionBuilder`
 
 ```ts
-interface CommandDefinitionBuilder<Inherited, Local, A, Eff, Ctx> {
+interface CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx> {
   meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder;
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
@@ -186,10 +189,17 @@ const app = new Crust("serve").flags({
 ```ts
 provide<const Cs extends readonly ContextInstance[]>(
   ...instances: ProvideChecks<Eff, Cs>,
-): Crust
+): Crust<
+  Inherited,
+  Local,
+  MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+  A,
+  EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+  MergeContext<Ctx, ContextsOutput<Cs>>
+>
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Handler.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Handler. The return type merges every instance's `ownFlags` into the builder's owned and effective flag types.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";
@@ -208,9 +218,9 @@ const app = new Crust("my-cli")
 
 Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared ctx requirements, with registration order preserved among independent Contexts. A missing ctx dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
 
-A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be declared with `inherit: true` on this builder — declare flags before `.provide()`.
+A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be declared with `inherit: true` on this builder — declare flags before `.provide()`. Its `ownFlags` are installed as inheritable flags on this builder and later-mounted descendants, without mutating the original definitions.
 
-Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name on one command path, a missing required flag, or passing a factory instead of an instance throws `DEFINITION`.
+Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, a missing required flag, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
 
 ## `.extend(...extensions)`
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -37,10 +37,10 @@ interface ContextRequirements {
 
 The nested `requires` fields are arrays of defined values describing what a mount site must supply:
 
-- `requires.flags` lists named flag definitions (from `defineFlag()`) the parent must provide as inheritable flags. Every required flag must have `inherit: true`.
+- `requires.flags` lists named flag definitions (from `defineFlag()`) the parent must provide as propagating Context-owned flags.
 - `requires.ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
 
-Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required inheritable flags and Context names are provided on the parent path.
+Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required propagating flags and Context names are provided on the parent path.
 
 `defineContext()` accepts `ContextConfig`, where top-level `flags` are owned and activated by `.provide()`, while nested `requires` uses the same dependency shape. Thus `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. Command requirements never hoist flags into a parent.
 
@@ -90,7 +90,8 @@ defineCommand<const R extends CommandRequirements>(
 Creates an inert reusable definition under a required name. The recipe builder is typed from the requirement values:
 
 ```ts
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean" });
+const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
 const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [auth] } }, (command) =>
@@ -168,7 +169,7 @@ Defines local flags from named flag definitions — values from `defineFlag(name
 
 ```ts
 const app = new Crust("serve").flags(
-  { name: "verbose", type: "boolean", short: "v", inherit: true },
+  { name: "verbose", type: "boolean", short: "v" },
   { name: "port", type: "number", default: 3000 },
   { name: "include", type: "string", multiple: true },
 );
@@ -176,7 +177,7 @@ const app = new Crust("serve").flags(
 
 Repeated `.flags()` calls **replace** the local flags — they do not merge; pass all definitions in one call. A duplicate name within one call throws `DEFINITION`.
 
-`inherit: true` exposes a flag to descendant commands and allows it to satisfy mounted definition and Context requirements. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
+Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant commands and mounted definition or Context requirements. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
 Schema-backed flags require `type: "string" | "boolean"` only to declare whether the flag consumes a token. Their schema owns the value rules and receives the raw parsed value.
 
@@ -192,7 +193,7 @@ const app = new Crust("serve").flags({
 
 ```ts
 provide<const Cs extends readonly ContextInstance[]>(
-  ...instances: ProvideChecks<Eff, Cs>,
+  ...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>,
 ): Crust<
   Inherited,
   Local,
@@ -222,7 +223,7 @@ const app = new Crust("my-cli")
 
 Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared ctx requirements, with registration order preserved among independent Contexts. A missing ctx dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
 
-A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be declared with `inherit: true` on this builder — declare flags before `.provide()`. Its top-level `flags` are installed as inheritable flags on this builder and later-mounted descendants, without mutating the original definitions.
+A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be owned by a Context on this builder. Its top-level `flags` are installed as propagating flags on this builder and later-mounted descendants, without mutating the original definitions.
 
 Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, a missing required flag, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
 
@@ -270,14 +271,17 @@ The context contains typed `args`, typed effective `flags`, typed Context values
 
 ```ts
 mount<const Ds extends readonly CommandDefinition<any>[]>(
-  ...definitions: MountChecks<Eff, Ctx, Ds>,
+  ...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>,
 ): Crust
 ```
 
 Materializes inert definitions as fresh child commands, each under its carried name. `.as(name)` renames a definition, so the same definition can route under different names:
 
 ```ts
-const app = new Crust("git").flags(verbose).provide(auth()).mount(deploy, deploy.as("ship"));
+const app = new Crust("git")
+  .provide(loggingFlags())
+  .provide(auth())
+  .mount(deploy, deploy.as("ship"));
 ```
 
 Inline one-off commands are mounted the same way:
@@ -290,19 +294,19 @@ const app = new Crust("my-cli").mount(
 
 `MountChecks` is internal declaration machinery that checks each definition's requirements against the parent builder. On failure, TypeScript reports one or more readable structural properties at the `.mount()` call:
 
-- `"missing inherited flags"`
-- `"incompatible inherited flags"`
+- `"missing propagating flags"`
+- `"incompatible propagating flags"`
 - `"missing Contexts"`
 - `"incompatible Contexts"`
 
-Only `inherit: true` parent flags are considered. Compatibility compares inferred handler value types, including schema and custom-parser outputs: a provided value must be assignable to the required value. A stricter required parent flag can satisfy an optional requirement, but an optional parent flag cannot satisfy a required requirement. Context values use the same provided-to-required assignability direction.
+Only Context-owned flags on the parent path are considered; local `.flags()` definitions do not satisfy requirements. Compatibility compares inferred handler value types, including schema and custom-parser outputs: a provided value must be assignable to the required value. A stricter required parent flag can satisfy an optional requirement, but an optional parent flag cannot satisfy a required requirement. Context values use the same provided-to-required assignability direction.
 
 At runtime, empty names, duplicate sibling names, alias collisions, duplicate provided Context names, ctx requirement names not provided on the parent path, unrelated recipe returns, values that are not `defineCommand()` definitions, and Extensions registered inside definitions throw `CrustError` code `DEFINITION`.
 
 A definition can mount other definitions. Nested requirements are checked against the enclosing definition builder at that exact point.
 
 <Callout type="info">
-  Finalize inheritable flags and Contexts on the builder used for `.mount()`. Later fluent calls
+  Finalize Context-owned flags and Contexts on the builder used for `.mount()`. Later fluent calls
   create a new builder and do not backfill an existing mount.
 </Callout>
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -26,19 +26,23 @@ import {
 
 ```ts
 interface CommandRequirements {
+  readonly requires?: ContextRequirements;
+}
+
+interface ContextRequirements {
   readonly flags?: readonly NamedFlagDef[];
   readonly ctx?: readonly AnyContextFactory[];
 }
 ```
 
-Requirements are arrays of defined values describing what a mount site must supply:
+The nested `requires` fields are arrays of defined values describing what a mount site must supply:
 
-- `flags` lists named flag definitions (from `defineFlag()`) the parent must provide as inheritable flags. Every required flag must have `inherit: true`.
-- `ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
+- `requires.flags` lists named flag definitions (from `defineFlag()`) the parent must provide as inheritable flags. Every required flag must have `inherit: true`.
+- `requires.ctx` lists Context factories (from `defineContext()`) whose instances must be provided on the mount path.
 
 Requirements do not create flags or Contexts — they type the recipe builder and are checked at every `.mount()`: compile-time for flags and Contexts, plus runtime checks that required inheritable flags and Context names are provided on the parent path.
 
-`defineContext()` instead accepts `ContextConfig`, which extends this requirement shape with `ownFlags`. Ownership belongs to Context definitions and is activated by `.provide()`; command requirements remain dependency declarations and never hoist flags into a parent.
+`defineContext()` accepts `ContextConfig`, where top-level `flags` are owned and activated by `.provide()`, while nested `requires` uses the same dependency shape. Thus `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. Command requirements never hoist flags into a parent.
 
 ### `CommandDefinitionBuilder`
 
@@ -89,7 +93,7 @@ Creates an inert reusable definition under a required name. The recipe builder i
 const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
-const deploy = defineCommand("deploy", { flags: [verbose], ctx: [auth] }, (command) =>
+const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [auth] } }, (command) =>
   command
     .args({ name: "target", type: "string", required: true })
     .handle(({ args, flags, ctx, stdout }) => {
@@ -199,7 +203,7 @@ provide<const Cs extends readonly ContextInstance[]>(
 >
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Handler. The return type merges every instance's `ownFlags` into the builder's owned and effective flag types.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Handler. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";
@@ -218,7 +222,7 @@ const app = new Crust("my-cli")
 
 Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared ctx requirements, with registration order preserved among independent Contexts. A missing ctx dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
 
-A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be declared with `inherit: true` on this builder — declare flags before `.provide()`. Its `ownFlags` are installed as inheritable flags on this builder and later-mounted descendants, without mutating the original definitions.
+A Context's declared flag requirements are checked at this call, compile-time and at runtime: each required flag must already be declared with `inherit: true` on this builder — declare flags before `.provide()`. Its top-level `flags` are installed as inheritable flags on this builder and later-mounted descendants, without mutating the original definitions.
 
 Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, a missing required flag, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
 

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -9,15 +9,15 @@ All exports on these pages come from `@crustjs/core`.
 
 ## Runtime API
 
-| Export                                                  | Description                                                      |
-| ------------------------------------------------------- | ---------------------------------------------------------------- |
-| [`Crust`](/docs/api/crust)                              | Immutable, chainable command builder and invocation boundary     |
-| [`defineCommand(name, reqs?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.mount()` |
-| `defineContext(name, reqs?, setup)`                     | Define a named command dependency factory                        |
-| `defineExtension(name, config)`                         | Define an application-wide Extension                             |
-| `defineFlag(name, definition)`                          | Define one named flag, preserving its literal definition         |
-| `defineArg(name, definition)`                           | Define one named positional argument                             |
-| [`CrustError`](/docs/api/errors)                        | Structured framework error with one of four stable codes         |
+| Export                                                    | Description                                                      |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary     |
+| [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.mount()` |
+| `defineContext(name, config?, setup)`                     | Define a named command dependency factory                        |
+| `defineExtension(name, config)`                           | Define an application-wide Extension                             |
+| `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition         |
+| `defineArg(name, definition)`                             | Define one named positional argument                             |
+| [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes         |
 
 ## Types
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -86,7 +86,7 @@ The schema receives the raw `string | undefined` or `boolean | undefined`; with 
 type NamedFlagDef = FlagDef & { readonly name: string };
 ```
 
-The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, `requirements.flags`, Context `ownFlags`, and `defineFlag()` all use it.
+The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, `requires.flags`, Context-owned `flags`, and `defineFlag()` all use it.
 
 ### `defineFlag` and `defineArg`
 
@@ -163,8 +163,9 @@ interface ContextRequirements {
   readonly ctx?: readonly AnyContextFactory[];
 }
 
-interface ContextConfig extends ContextRequirements {
-  readonly ownFlags?: readonly NamedFlagDef[];
+interface ContextConfig {
+  readonly flags?: readonly NamedFlagDef[];
+  readonly requires?: ContextRequirements;
 }
 
 interface ContextSetup<Options, RF, RC, OF> {
@@ -174,7 +175,7 @@ interface ContextSetup<Options, RF, RC, OF> {
 }
 ```
 
-`ContextRequirements.flags` declares inheritable flags a Context reads from its command path, while `ContextConfig.ownFlags` declares flags installed when an instance is provided. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
+`ContextConfig.flags` declares flags installed when an instance is provided, while `ContextConfig.requires.flags` declares inheritable flags a Context reads from its command path and `requires.ctx` declares Context dependencies. This is the same `requires: { flags, ctx }` dependency shape accepted by `defineCommand()`: `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
 
 ### `ContextInstance`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -86,7 +86,7 @@ The schema receives the raw `string | undefined` or `boolean | undefined`; with 
 type NamedFlagDef = FlagDef & { readonly name: string };
 ```
 
-The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, `requirements.flags` arrays, and `defineFlag()` all use it.
+The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, `requirements.flags`, Context `ownFlags`, and `defineFlag()` all use it.
 
 ### `defineFlag` and `defineArg`
 
@@ -118,7 +118,7 @@ Command Snapshots are readonly, serializable descriptions. They contain no Comma
   name="CommandSnapshot"
 />
 
-`flags` contains effective inherited and local flags. Command Handlers, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
+`flags` contains effective inherited, local, and Context-owned flags. Command Handlers, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
 
 ### `ArgSnapshot`
 
@@ -146,16 +146,16 @@ Snapshots omit schemas and parse functions. `URL` defaults become strings, and a
 ### `ContextFactory`
 
 ```ts
-interface ContextFactory<Name extends string, Options, Value, RF, RC> {
-  (options: Options): ContextInstance<Name, Value, RF, RC>;
+interface ContextFactory<Name extends string, Options, Value, RF, RC, OF> {
+  (options: Options): ContextInstance<Name, Value, RF, RC, OF>;
   readonly contextName: Name;
-  of(value: Value): ContextInstance<Name, Value>;
+  of(value: Value): ContextInstance<Name, Value, {}, {}, OF>;
 }
 ```
 
-`defineContext(name, setup)` and `defineContext(name, requirements, setup)` always return a factory. Invoke it even when `Options` is `void`. `contextName` lets requirement arrays reference the factory directly; `.of(value)` produces an instance returning the precomputed value with requirements considered satisfied — for test doubles. `AnyContextFactory` is the requirement-array element type.
+`defineContext(name, setup)` and `defineContext(name, config, setup)` always return a factory. Invoke it even when `Options` is `void`. `contextName` lets requirement arrays reference the factory directly; `.of(value)` produces an instance returning the precomputed value with requirements considered satisfied while retaining its owned flags. `AnyContextFactory` is the requirement-array element type.
 
-### `ContextRequirements` and `ContextSetup`
+### `ContextRequirements`, `ContextConfig`, and `ContextSetup`
 
 ```ts
 interface ContextRequirements {
@@ -163,14 +163,18 @@ interface ContextRequirements {
   readonly ctx?: readonly AnyContextFactory[];
 }
 
-interface ContextSetup<Options, RF, RC> {
+interface ContextConfig extends ContextRequirements {
+  readonly ownFlags?: readonly NamedFlagDef[];
+}
+
+interface ContextSetup<Options, RF, RC, OF> {
   readonly options: Options;
-  readonly flags: InferFlags<RF>;
+  readonly flags: InferFlags<MergeFlags<RF, OF>>;
   readonly ctx: Readonly<RC>;
 }
 ```
 
-`ContextRequirements` declares the flags a Context reads and the Contexts it depends on. `ContextSetup` is the typed input every setup receives: the factory argument, the validated parsed flags narrowed to the declared requirements, and the values of the declared ctx dependencies.
+`ContextRequirements.flags` declares inheritable flags a Context reads from its command path, while `ContextConfig.ownFlags` declares flags installed when an instance is provided. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
 
 ### `ContextInstance`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -63,13 +63,13 @@ Core-value flag definitions support:
 
 ```ts
 const flags = {
-  verbose: { type: "boolean", short: "v", inherit: true },
+  verbose: { type: "boolean", short: "v" },
   include: { type: "string", multiple: true },
   port: { type: "number", default: 3000 },
 } satisfies FlagsDef;
 ```
 
-Schema-backed flags support `type: "string" | "boolean"`, `schema`, and the syntax fields `description`, `short`, `aliases`, `inherit`, and `multiple`. Boolean schema flags also support `noNegate`. `type` only declares token consumption: a string flag consumes a token; a boolean flag is a toggle.
+Schema-backed flags support `type: "string" | "boolean"`, `schema`, and the syntax fields `description`, `short`, `aliases`, and `multiple`. Boolean schema flags also support `noNegate`. `type` only declares token consumption: a string flag consumes a token; a boolean flag is a toggle.
 
 ```ts
 const flags = {
@@ -95,7 +95,7 @@ Use these const-generic helpers when a definition is declared separately from `.
 ```ts
 import { defineArg, defineFlag } from "@crustjs/core";
 
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true, short: "v" });
+const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 const target = defineArg("target", { type: "string", required: true });
 ```
 
@@ -118,7 +118,7 @@ Command Snapshots are readonly, serializable descriptions. They contain no Comma
   name="CommandSnapshot"
 />
 
-`flags` contains effective inherited, local, and Context-owned flags. Command Handlers, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
+`flags` contains effective local and Context-owned flags. Command Handlers, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
 
 ### `ArgSnapshot`
 
@@ -175,7 +175,7 @@ interface ContextSetup<Options, RF, RC, OF> {
 }
 ```
 
-`ContextConfig.flags` declares flags installed when an instance is provided, while `ContextConfig.requires.flags` declares inheritable flags a Context reads from its command path and `requires.ctx` declares Context dependencies. This is the same `requires: { flags, ctx }` dependency shape accepted by `defineCommand()`: `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
+`ContextConfig.flags` declares propagating flags installed when an instance is provided, while `ContextConfig.requires.flags` declares Context-owned flags a Context reads from its command path and `requires.ctx` declares Context dependencies. This is the same `requires: { flags, ctx }` dependency shape accepted by `defineCommand()`: `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
 
 ### `ContextInstance`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -86,7 +86,7 @@ The schema receives the raw `string | undefined` or `boolean | undefined`; with 
 type NamedFlagDef = FlagDef & { readonly name: string };
 ```
 
-The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, `requires.flags`, Context-owned `flags`, and `defineFlag()` all use it.
+The public authoring shape: a flag definition carrying its name. `.flags(...defs)`, Context-owned `flags`, and `defineFlag()` all use it.
 
 ### `defineFlag` and `defineArg`
 
@@ -146,10 +146,10 @@ Snapshots omit schemas and parse functions. `URL` defaults become strings, and a
 ### `ContextFactory`
 
 ```ts
-interface ContextFactory<Name extends string, Options, Value, RF, RC, OF> {
-  (options: Options): ContextInstance<Name, Value, RF, RC, OF>;
+interface ContextFactory<Name extends string, Options, Value, RC, OF> {
+  (options: Options): ContextInstance<Name, Value, RC, OF>;
   readonly contextName: Name;
-  of(value: Value): ContextInstance<Name, Value, {}, {}, OF>;
+  of(value: Value): ContextInstance<Name, Value, {}, OF>;
 }
 ```
 
@@ -158,24 +158,21 @@ interface ContextFactory<Name extends string, Options, Value, RF, RC, OF> {
 ### `ContextRequirements`, `ContextConfig`, and `ContextSetup`
 
 ```ts
-interface ContextRequirements {
-  readonly flags?: readonly NamedFlagDef[];
-  readonly ctx?: readonly AnyContextFactory[];
-}
+type ContextRequirements = readonly AnyContextFactory[];
 
 interface ContextConfig {
   readonly flags?: readonly NamedFlagDef[];
   readonly requires?: ContextRequirements;
 }
 
-interface ContextSetup<Options, RF, RC, OF> {
+interface ContextSetup<Options, RC, OF> {
   readonly options: Options;
-  readonly flags: InferFlags<MergeFlags<RF, OF>>;
+  readonly flags: InferFlags<OF>;
   readonly ctx: Readonly<RC>;
 }
 ```
 
-`ContextConfig.flags` declares propagating flags installed when an instance is provided, while `ContextConfig.requires.flags` declares Context-owned flags a Context reads from its command path and `requires.ctx` declares Context dependencies. This is the same `requires: { flags, ctx }` dependency shape accepted by `defineCommand()`: `flags` always means flags the thing owns or parses, and `requires` always means typed dependencies from the environment. `ContextSetup` receives the factory argument, validated values for required and owned flags, and the declared Context dependencies. See [Contexts](/docs/guide/contexts) for attachment ordering and collision rules.
+`ContextConfig.flags` declares propagating flags installed when an instance is provided; `requires` lists Context capabilities needed from the command path. This is the same plain capability array accepted by `defineCommand()`: `flags` always means definitions the unit owns or parses, and `requires` always means capabilities supplied by the environment. `ContextSetup` receives the factory argument, validated values for its owned flags only, and the declared Context values. See [Contexts](/docs/guide/contexts) for construction order and collision rules.
 
 ### `ContextInstance`
 
@@ -184,7 +181,7 @@ interface ContextSetup<Options, RF, RC, OF> {
   name="ContextInstance"
 />
 
-Attach an instance with `.provide()`. Core constructs it lazily on the resolved path, topologically ordered by declared ctx requirements.
+Attach an instance with `.provide()`. Core constructs it lazily on the resolved path, topologically ordered by declared capability requirements.
 
 ### `ContextMap`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -130,6 +130,14 @@ Command Snapshots are readonly, serializable descriptions. They contain no Comma
 
 Snapshots omit schemas and parse functions. `URL` defaults become strings, and array defaults are copied and frozen.
 
+## Invocation I/O
+
+### `InvocationIO`
+
+<auto-type-table path="../../../../../packages/core/src/types.ts" name="InvocationIO" />
+
+The same injectable callbacks are passed to the Command Handler and every Context setup constructed for that invocation.
+
 ## Command Handler context
 
 ### `CrustCommandContext<A, F, Ctx>`
@@ -165,14 +173,14 @@ interface ContextConfig {
   readonly requires?: ContextRequirements;
 }
 
-interface ContextSetup<Options, RC, OF> {
+interface ContextSetup<Options, RC, OF> extends InvocationIO {
   readonly options: Options;
   readonly flags: InferFlags<OF>;
   readonly ctx: Readonly<RC>;
 }
 ```
 
-`ContextConfig.flags` declares propagating flags installed when an instance is provided; `requires` lists Context capabilities needed from the command path. This is the same plain capability array accepted by `defineCommand()`: `flags` always means definitions the unit owns or parses, and `requires` always means capabilities supplied by the environment. `ContextSetup` receives the factory argument, validated values for its owned flags only, and the declared Context values. See [Contexts](/docs/guide/contexts) for construction order and collision rules.
+`ContextConfig.flags` declares propagating flags installed when an instance is provided; `requires` lists Context capabilities needed from the command path. This is the same plain capability array accepted by `defineCommand()`: `flags` always means definitions the unit owns or parses, and `requires` always means capabilities supplied by the environment. `ContextSetup` receives the factory argument, validated values for its owned flags only, the declared Context values, and the invocation's `stdout` and `stderr` callbacks. See [Contexts](/docs/guide/contexts) for construction order and collision rules.
 
 ### `ContextInstance`
 

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -179,14 +179,14 @@ If you pass `--env-file`, the validation subprocess receives the same explicit e
 
 | Issue                          | Error Code   | Example                                                    |
 | ------------------------------ | ------------ | ---------------------------------------------------------- |
-| Flag alias collision           | `DEFINITION` | Two flags share `-v` as alias                              |
+| Flag alias collision           | `DEFINITION` | App, Context, or Extension flags share `-v` as an alias    |
 | `no-` prefixed flag name       | `DEFINITION` | Flag named `no-cache` instead of `cache`                   |
 | `no-` prefixed alias           | `DEFINITION` | Alias `no-store` on a flag                                 |
 | Long alias shadowing flag name | `DEFINITION` | Alias `out` when another flag is named `out`               |
 | Missing Context dependency     | `DEFINITION` | A provided Context requires a Context absent from its path |
 | Context dependency cycle       | `DEFINITION` | Two provided Contexts require each other                   |
 
-Extension-owned command names, aliases, flag names, short forms, and long aliases are checked against application definitions and other Extensions. Collisions are `DEFINITION` errors; Crust never warns and skips a contribution.
+Extension-owned command names, aliases, flag names, short forms, and long aliases are checked against application and Context-owned definitions and other Extensions. Collisions are `DEFINITION` errors; Crust never warns and skips a contribution.
 
 ### Skipping validation
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -164,7 +164,7 @@ const status = defineCommand("status", { requires: [database] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
-const app = new Crust("app").provide(loggingFlags()).provide(config(), database()).mount(status);
+const app = new Crust("app").provide(logging(), config(), database()).mount(status);
 ```
 
 Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. Contexts and their owned flags do not backfill children mounted on an earlier builder. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -30,21 +30,21 @@ const app = new Crust("app").provide(clock());
 
 ## Owned flags
 
-A Context can own the flags used to construct its value. Declare each flag once in `ownFlags`; attaching the Context installs those flags on the provider command and its later-mounted descendants:
+A Context can own the flags used to construct its value. Declare each flag once in its top-level `flags`; attaching the Context installs those flags on the provider command and its later-mounted descendants:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 const apiKey = defineFlag("api-key", { type: "string" });
 
-const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
   apiKey: flags["api-key"],
   get(path: string) {
     return `${flags["api-key"] ?? "anonymous"}:${path}`;
   },
 }));
 
-const deploy = defineCommand("deploy", { ctx: [api] }, (command) =>
+const deploy = defineCommand("deploy", { requires: { ctx: [api] } }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
 );
 
@@ -53,18 +53,18 @@ const app = new Crust("app").provide(api()).mount(deploy);
 
 Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores an inheritable clone of the definition; the original `apiKey` value is not mutated.
 
-The child requires only `ctx.api` when the derived client is its dependency. If a handler also needs the raw value, add `apiKey` to that command definition's `requirements.flags`; ownership and raw flag access remain separate contracts.
+The child requires only `ctx.api` when the derived client is its dependency. If a handler also needs the raw value, add `apiKey` to that command definition's `requires.flags`; ownership and raw flag access remain separate contracts.
 
 ## Lazy construction and inheritance
 
 Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
 
-Contexts are inherited by descendant commands. A mounted command declares the factories it depends on in `requirements.ctx`, which types `ctx` in its handler:
+Contexts are inherited by descendant commands. A mounted command declares the factories it depends on in `requires.ctx`, which types `ctx` in its handler:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
 
-const status = defineCommand("status", { ctx: [database] }, (command) =>
+const status = defineCommand("status", { requires: { ctx: [database] } }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
@@ -75,13 +75,13 @@ Setups may be synchronous or asynchronous.
 
 ## Requirements
 
-`defineContext(name, config, setup)` accepts two different flag relationships:
+`defineContext(name, config, setup)` groups declarations by relationship direction:
 
-- `flags` declares inheritable flags that must already exist on the command path.
-- `ownFlags` defines flags installed when this Context is provided.
-- `ctx` declares other Context values needed by setup.
+- Top-level `flags` are owned by the Context and installed when it is provided. This matches builder `.flags()`: `flags` always means flags the thing owns or parses.
+- `requires.flags` declares inheritable flags that must already exist on the command path.
+- `requires.ctx` declares other Context values needed by setup. The same `requires: { flags, ctx }` dependency shape is used by `defineCommand()`.
 
-All three are arrays of defined values:
+All three arrays contain defined values:
 
 ```ts
 import { defineContext, defineFlag } from "@crustjs/core";
@@ -89,17 +89,21 @@ import { defineContext, defineFlag } from "@crustjs/core";
 const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 const config = defineContext("config", () => ({ url: "postgres://localhost/app" }));
 
-const database = defineContext("db", { flags: [verbose], ctx: [config] }, ({ flags, ctx }) => {
-  if (flags.verbose) console.error(`connecting to ${ctx.config.url}`);
-  return { query: (sql: string) => `${sql} on ${ctx.config.url}` };
-});
+const database = defineContext(
+  "db",
+  { requires: { flags: [verbose], ctx: [config] } },
+  ({ flags, ctx }) => {
+    if (flags.verbose) console.error(`connecting to ${ctx.config.url}`);
+    return { query: (sql: string) => `${sql} on ${ctx.config.url}` };
+  },
+);
 ```
 
 The setup input carries three fields:
 
 - `options` — the factory argument
-- `flags` — validated values for both `flags` requirements and `ownFlags`. These are the same schema-processed values the Command Handler receives.
-- `ctx` — the constructed values of the declared ctx dependencies
+- `flags` — validated values for both owned `flags` and `requires.flags`. These are the same schema-processed values the Command Handler receives.
+- `ctx` — the constructed values from `requires.ctx`
 
 ### Flag requirements
 
@@ -117,7 +121,7 @@ A missing or non-inheritable required flag is a `DEFINITION` error at `.provide(
 A Context may require a flag owned by another Context, but the owner must be attached in an earlier call so the next builder carries the flag type:
 
 ```ts
-const audit = defineContext("audit", { flags: [apiKey] }, ({ flags }) => ({
+const audit = defineContext("audit", { requires: { flags: [apiKey] } }, ({ flags }) => ({
   credentialPresent: flags["api-key"] !== undefined,
 }));
 
@@ -128,7 +132,7 @@ const app = new Crust("app").provide(api()).provide(audit());
 
 ### Ctx requirements and construction order
 
-Provide order is free: dependencies may be provided after their dependents. At invocation time, the Contexts on the resolved command path are constructed **topologically** by their declared `ctx` requirements; independent Contexts keep registration order.
+Provide order is free: dependencies may be provided after their dependents. At invocation time, the Contexts on the resolved command path are constructed **topologically** by their declared `requires.ctx` dependencies; independent Contexts keep registration order.
 
 ```ts
 // Equivalent — construction order is config, then database, either way:
@@ -150,7 +154,7 @@ const app = new Crust("app").provide(fake).handle(({ ctx, stdout }) => {
 });
 ```
 
-The fake needs none of the real setup's required flags or dependency Contexts. If the factory has `ownFlags`, callers may still pass them and the command's help and completion remain unchanged.
+The fake needs none of the real setup's required flags or dependency Contexts. If the factory has owned `flags`, callers may still pass them and the command's help and completion remain unchanged.
 
 ## Scope a guard to a subtree
 
@@ -161,16 +165,16 @@ const session = defineContext("session", () => ({
   user: undefined as { id: string } | undefined,
 }));
 
-const user = defineContext("user", { ctx: [session] }, ({ ctx }) => {
+const user = defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => {
   if (!ctx.session.user) throw new Error("Unauthenticated");
   return ctx.session.user;
 });
 
-const invoices = defineCommand("invoices", { ctx: [user] }, (child) =>
+const invoices = defineCommand("invoices", { requires: { ctx: [user] } }, (child) =>
   child.handle(({ ctx, stdout }) => stdout(`Invoices for ${ctx.user.id}`)),
 );
 
-const billing = defineCommand("billing", { ctx: [session] }, (command) =>
+const billing = defineCommand("billing", { requires: { ctx: [session] } }, (command) =>
   command.provide(user()).mount(invoices),
 );
 
@@ -184,7 +188,7 @@ A throwing setup aborts the invocation before the Command Handler and disposes t
 A reusable command declares the Context factories it needs, and every `.mount()` checks them — compile-time against the parent's provided value types, and at runtime by name:
 
 ```ts
-const status = defineCommand("status", { ctx: [database] }, (command) =>
+const status = defineCommand("status", { requires: { ctx: [database] } }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -51,7 +51,7 @@ const deploy = defineCommand("deploy", { requires: { ctx: [api] } }, (command) =
 const app = new Crust("app").provide(api()).mount(deploy);
 ```
 
-Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores an inheritable clone of the definition; the original `apiKey` value is not mutated.
+Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores a cloned definition in the Context-owned propagation channel; the original `apiKey` value is not mutated.
 
 The child requires only `ctx.api` when the derived client is its dependency. If a handler also needs the raw value, add `apiKey` to that command definition's `requires.flags`; ownership and raw flag access remain separate contracts.
 
@@ -78,7 +78,7 @@ Setups may be synchronous or asynchronous.
 `defineContext(name, config, setup)` groups declarations by relationship direction:
 
 - Top-level `flags` are owned by the Context and installed when it is provided. This matches builder `.flags()`: `flags` always means flags the thing owns or parses.
-- `requires.flags` declares inheritable flags that must already exist on the command path.
+- `requires.flags` declares propagating Context-owned flags that must already exist on the command path.
 - `requires.ctx` declares other Context values needed by setup. The same `requires: { flags, ctx }` dependency shape is used by `defineCommand()`.
 
 All three arrays contain defined values:
@@ -86,7 +86,8 @@ All three arrays contain defined values:
 ```ts
 import { defineContext, defineFlag } from "@crustjs/core";
 
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean" });
+const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
 const config = defineContext("config", () => ({ url: "postgres://localhost/app" }));
 
 const database = defineContext(
@@ -107,16 +108,16 @@ The setup input carries three fields:
 
 ### Flag requirements
 
-Flag requirements are checked at the `.provide()` call site — compile-time and runtime. Each required flag must already be declared with `inherit: true` on the builder, so declare flags before `.provide()`:
+Flag requirements are checked at the `.provide()` call site — compile-time and runtime. Each required flag must already be owned by a Context on the builder, so provide the owner first:
 
 ```ts
 const app = new Crust("app")
-  .flags(verbose)
+  .provide(loggingFlags())
   .provide(config(), database())
   .handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
 ```
 
-A missing or non-inheritable required flag is a `DEFINITION` error at `.provide()`.
+A missing required flag, or a same-named local `.flags()` definition, is a `DEFINITION` error at `.provide()`.
 
 A Context may require a flag owned by another Context, but the owner must be attached in an earlier call so the next builder carries the flag type:
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -44,7 +44,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
   },
 }));
 
-const deploy = defineCommand("deploy", { requires: { ctx: [api] } }, (command) =>
+const deploy = defineCommand("deploy", { requires: [api] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
 );
 
@@ -53,18 +53,18 @@ const app = new Crust("app").provide(api()).mount(deploy);
 
 Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores a cloned definition in the Context-owned propagation channel; the original `apiKey` value is not mutated.
 
-The child requires only `ctx.api` when the derived client is its dependency. If a handler also needs the raw value, add `apiKey` to that command definition's `requires.flags`; ownership and raw flag access remain separate contracts.
+The child requires `ctx.api`, not the raw flag. If a handler also needs the raw value, expose it from `api`; the owning Context remains the single boundary between CLI input and downstream capabilities.
 
 ## Lazy construction and inheritance
 
 Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
 
-Contexts are inherited by descendant commands. A mounted command declares the factories it depends on in `requires.ctx`, which types `ctx` in its handler:
+Contexts are inherited by descendant commands. A mounted command lists the factories it depends on in `requires`, which types `ctx` in its handler:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
 
-const status = defineCommand("status", { requires: { ctx: [database] } }, (command) =>
+const status = defineCommand("status", { requires: [database] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
@@ -75,70 +75,41 @@ Setups may be synchronous or asynchronous.
 
 ## Requirements
 
-`defineContext(name, config, setup)` groups declarations by relationship direction:
+`defineContext(name, config, setup)` has two relationships:
 
-- Top-level `flags` are owned by the Context and installed when it is provided. This matches builder `.flags()`: `flags` always means flags the thing owns or parses.
-- `requires.flags` declares propagating Context-owned flags that must already exist on the command path.
-- `requires.ctx` declares other Context values needed by setup. The same `requires: { flags, ctx }` dependency shape is used by `defineCommand()`.
+- Top-level `flags` are owned by the Context and installed when it is provided. `flags` always means flags the thing owns or parses.
+- `requires` lists other Context capabilities needed by setup. `defineCommand()` uses the same plain capability array.
 
-All three arrays contain defined values:
+Both arrays contain defined values:
 
 ```ts
 import { defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean" });
-const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+  verbose: flags.verbose === true,
+}));
 const config = defineContext("config", () => ({ url: "postgres://localhost/app" }));
 
-const database = defineContext(
-  "db",
-  { requires: { flags: [verbose], ctx: [config] } },
-  ({ flags, ctx }) => {
-    if (flags.verbose) console.error(`connecting to ${ctx.config.url}`);
-    return { query: (sql: string) => `${sql} on ${ctx.config.url}` };
-  },
-);
+const database = defineContext("db", { requires: [config] }, ({ ctx }) => ({
+  query: (sql: string) => `${sql} on ${ctx.config.url}`,
+}));
 ```
 
 The setup input carries three fields:
 
 - `options` — the factory argument
-- `flags` — validated values for both owned `flags` and `requires.flags`. These are the same schema-processed values the Command Handler receives.
-- `ctx` — the constructed values from `requires.ctx`
+- `flags` — validated values for this Context's owned `flags` only
+- `ctx` — the constructed values from `requires`
 
-### Flag requirements
+### Requirements and construction order
 
-Flag requirements are checked at the `.provide()` call site — compile-time and runtime. Each required flag must already be owned by a Context on the builder, so provide the owner first:
-
-```ts
-const app = new Crust("app")
-  .provide(loggingFlags())
-  .provide(config(), database())
-  .handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
-```
-
-A missing required flag, or a same-named local `.flags()` definition, is a `DEFINITION` error at `.provide()`.
-
-A Context may require a flag owned by another Context, but the owner must be attached in an earlier call so the next builder carries the flag type:
-
-```ts
-const audit = defineContext("audit", { requires: { flags: [apiKey] } }, ({ flags }) => ({
-  credentialPresent: flags["api-key"] !== undefined,
-}));
-
-const app = new Crust("app").provide(api()).provide(audit());
-```
-
-`.provide(api(), audit())` intentionally fails: every requirement in one variadic call is checked against the builder as it existed before that call. Context `ctx` dependencies do not have this restriction because they are ordered topologically at invocation time.
-
-### Ctx requirements and construction order
-
-Provide order is free: dependencies may be provided after their dependents. At invocation time, the Contexts on the resolved command path are constructed **topologically** by their declared `requires.ctx` dependencies; independent Contexts keep registration order.
+Provide order is free: dependencies may be provided after their dependents. At invocation time, the Contexts on the resolved command path are constructed **topologically** by their declared `requires` dependencies; independent Contexts keep registration order.
 
 ```ts
 // Equivalent — construction order is config, then database, either way:
-new Crust("app").provide(loggingFlags()).provide(config(), database());
-new Crust("app").provide(loggingFlags()).provide(database(), config());
+new Crust("app").provide(config(), database());
+new Crust("app").provide(database(), config());
 ```
 
 A ctx dependency that is not provided on the path, or a dependency cycle, is a `CrustError` with code `DEFINITION`, raised at dispatch and also caught by [`crust build`](/docs/guide/build)'s command-tree validation.
@@ -155,7 +126,7 @@ const app = new Crust("app").provide(fake).handle(({ ctx, stdout }) => {
 });
 ```
 
-The fake needs none of the real setup's required flags or dependency Contexts. If the factory has owned `flags`, callers may still pass them and the command's help and completion remain unchanged.
+The fake needs none of the real setup's dependency Contexts. If the factory has owned `flags`, callers may still pass them and the command's help and completion remain unchanged.
 
 ## Scope a guard to a subtree
 
@@ -166,16 +137,16 @@ const session = defineContext("session", () => ({
   user: undefined as { id: string } | undefined,
 }));
 
-const user = defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => {
+const user = defineContext("user", { requires: [session] }, ({ ctx }) => {
   if (!ctx.session.user) throw new Error("Unauthenticated");
   return ctx.session.user;
 });
 
-const invoices = defineCommand("invoices", { requires: { ctx: [user] } }, (child) =>
+const invoices = defineCommand("invoices", { requires: [user] }, (child) =>
   child.handle(({ ctx, stdout }) => stdout(`Invoices for ${ctx.user.id}`)),
 );
 
-const billing = defineCommand("billing", { requires: { ctx: [session] } }, (command) =>
+const billing = defineCommand("billing", { requires: [session] }, (command) =>
   command.provide(user()).mount(invoices),
 );
 
@@ -189,7 +160,7 @@ A throwing setup aborts the invocation before the Command Handler and disposes t
 A reusable command declares the Context factories it needs, and every `.mount()` checks them — compile-time against the parent's provided value types, and at runtime by name:
 
 ```ts
-const status = defineCommand("status", { requires: { ctx: [database] } }, (command) =>
+const status = defineCommand("status", { requires: [database] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
@@ -204,7 +175,7 @@ Providing two Context values with the same name on one command path is a `DEFINI
 
 Mounted definitions use the same rule. Because materialization starts with the parent's Context path, a definition or nested descendant that provides the same name is rejected during `.mount()`.
 
-A Context cannot both require and own the same flag. Owned flag names, short forms, and aliases must also be unique across application flags, other Contexts, and Extensions. Application and Context collisions fail while building; Extension collisions fail when `run()`, `execute()`, or `crust build` prepares the complete graph. Every case uses `CrustError` code `DEFINITION` rather than shadowing a definition.
+Owned flag names, short forms, and aliases must be unique across application flags, other Contexts, and Extensions. Application and Context collisions fail while building; Extension collisions fail when `run()`, `execute()`, or `crust build` prepares the complete graph. Every case uses `CrustError` code `DEFINITION` rather than shadowing a definition.
 
 ## Native disposal
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -21,7 +21,7 @@ const app = new Crust("app")
   .handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
 ```
 
-The setup receives one input object: `options` is the factory argument. A zero-option factory is still a factory — invoke it with no argument:
+The setup receives one input object. `options` is the factory argument; `stdout` and `stderr` are the same injectable callbacks passed to the Command Handler. A zero-option factory is still a factory — invoke it with no argument:
 
 ```ts
 const clock = defineContext("clock", () => ({ now: () => Date.now() }));
@@ -83,12 +83,17 @@ Setups may be synchronous or asynchronous.
 Both arrays contain defined values:
 
 ```ts
-import { defineContext, defineFlag } from "@crustjs/core";
+import { defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean" });
-const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
-  verbose: flags.verbose === true,
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
+  debug(message: string) {
+    if (flags.verbose) stderr(message);
+  },
 }));
+const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
+  command.handle(({ ctx }) => ctx.logging.debug("deploying")),
+);
 const config = defineContext("config", () => ({ url: "postgres://localhost/app" }));
 
 const database = defineContext("db", { requires: [config] }, ({ ctx }) => ({
@@ -96,11 +101,14 @@ const database = defineContext("db", { requires: [config] }, ({ ctx }) => ({
 }));
 ```
 
-The setup input carries three fields:
+The setup input carries five fields:
 
 - `options` — the factory argument
 - `flags` — validated values for this Context's owned `flags` only
 - `ctx` — the constructed values from `requires`
+- `stdout` and `stderr` — the invocation's injectable output callbacks
+
+Contexts receive the exact callbacks passed to the Command Handler, so capabilities can encapsulate output behavior such as verbose logging. Tests that inject capturing callbacks through `run()` or `execute()` observe Context output through those same callbacks.
 
 ### Requirements and construction order
 
@@ -126,7 +134,7 @@ const app = new Crust("app").provide(fake).handle(({ ctx, stdout }) => {
 });
 ```
 
-The fake needs none of the real setup's dependency Contexts. If the factory has owned `flags`, callers may still pass them and the command's help and completion remain unchanged.
+The fake needs none of the real setup's dependency Contexts and skips setup entirely, including its I/O use. If the factory has owned `flags`, callers may still pass them and the command's help and completion remain unchanged.
 
 ## Scope a guard to a subtree
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -137,8 +137,8 @@ Provide order is free: dependencies may be provided after their dependents. At i
 
 ```ts
 // Equivalent — construction order is config, then database, either way:
-new Crust("app").flags(verbose).provide(config(), database());
-new Crust("app").flags(verbose).provide(database(), config());
+new Crust("app").provide(loggingFlags()).provide(config(), database());
+new Crust("app").provide(loggingFlags()).provide(database(), config());
 ```
 
 A ctx dependency that is not provided on the path, or a dependency cycle, is a `CrustError` with code `DEFINITION`, raised at dispatch and also caught by [`crust build`](/docs/guide/build)'s command-tree validation.
@@ -193,7 +193,7 @@ const status = defineCommand("status", { requires: { ctx: [database] } }, (comma
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
-const app = new Crust("app").flags(verbose).provide(config(), database()).mount(status);
+const app = new Crust("app").provide(loggingFlags()).provide(config(), database()).mount(status);
 ```
 
 Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. Contexts and their owned flags do not backfill children mounted on an earlier builder. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -28,6 +28,33 @@ const clock = defineContext("clock", () => ({ now: () => Date.now() }));
 const app = new Crust("app").provide(clock());
 ```
 
+## Owned flags
+
+A Context can own the flags used to construct its value. Declare each flag once in `ownFlags`; attaching the Context installs those flags on the provider command and its later-mounted descendants:
+
+```ts
+import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
+
+const apiKey = defineFlag("api-key", { type: "string" });
+
+const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+  apiKey: flags["api-key"],
+  get(path: string) {
+    return `${flags["api-key"] ?? "anonymous"}:${path}`;
+  },
+}));
+
+const deploy = defineCommand("deploy", { ctx: [api] }, (command) =>
+  command.handle(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
+);
+
+const app = new Crust("app").provide(api()).mount(deploy);
+```
+
+Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores an inheritable clone of the definition; the original `apiKey` value is not mutated.
+
+The child requires only `ctx.api` when the derived client is its dependency. If a handler also needs the raw value, add `apiKey` to that command definition's `requirements.flags`; ownership and raw flag access remain separate contracts.
+
 ## Lazy construction and inheritance
 
 Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
@@ -48,7 +75,13 @@ Setups may be synchronous or asynchronous.
 
 ## Requirements
 
-`defineContext(name, requirements, setup)` declares what a Context needs: flags it reads and other Contexts it depends on. Requirements are arrays of defined values:
+`defineContext(name, config, setup)` accepts two different flag relationships:
+
+- `flags` declares inheritable flags that must already exist on the command path.
+- `ownFlags` defines flags installed when this Context is provided.
+- `ctx` declares other Context values needed by setup.
+
+All three are arrays of defined values:
 
 ```ts
 import { defineContext, defineFlag } from "@crustjs/core";
@@ -65,7 +98,7 @@ const database = defineContext("db", { flags: [verbose], ctx: [config] }, ({ fla
 The setup input carries three fields:
 
 - `options` — the factory argument
-- `flags` — the validated parsed flags of the resolved invocation, narrowed to the declared flag definitions. These are the same values the Command Handler receives, after schema application.
+- `flags` — validated values for both `flags` requirements and `ownFlags`. These are the same schema-processed values the Command Handler receives.
 - `ctx` — the constructed values of the declared ctx dependencies
 
 ### Flag requirements
@@ -81,6 +114,18 @@ const app = new Crust("app")
 
 A missing or non-inheritable required flag is a `DEFINITION` error at `.provide()`.
 
+A Context may require a flag owned by another Context, but the owner must be attached in an earlier call so the next builder carries the flag type:
+
+```ts
+const audit = defineContext("audit", { flags: [apiKey] }, ({ flags }) => ({
+  credentialPresent: flags["api-key"] !== undefined,
+}));
+
+const app = new Crust("app").provide(api()).provide(audit());
+```
+
+`.provide(api(), audit())` intentionally fails: every requirement in one variadic call is checked against the builder as it existed before that call. Context `ctx` dependencies do not have this restriction because they are ordered topologically at invocation time.
+
 ### Ctx requirements and construction order
 
 Provide order is free: dependencies may be provided after their dependents. At invocation time, the Contexts on the resolved command path are constructed **topologically** by their declared `ctx` requirements; independent Contexts keep registration order.
@@ -95,7 +140,7 @@ A ctx dependency that is not provided on the path, or a dependency cycle, is a `
 
 ## Test doubles with `.of()`
 
-Every factory carries `.of(value)`: it produces an instance whose setup returns the precomputed value under the same name and value type, with requirements considered satisfied. Use it to swap a real Context for a fake in tests:
+Every factory carries `.of(value)`: it produces an instance whose setup returns the precomputed value under the same name and value type, with requirements considered satisfied. Owned flags remain installed so production and test command grammars match. Use it to swap a real Context for a fake in tests:
 
 ```ts
 const fake = database.of({ query: (sql) => `fake: ${sql}` });
@@ -105,7 +150,7 @@ const app = new Crust("app").provide(fake).handle(({ ctx, stdout }) => {
 });
 ```
 
-Because the fake declares no requirements, no flags or dependency Contexts are needed.
+The fake needs none of the real setup's required flags or dependency Contexts. If the factory has `ownFlags`, callers may still pass them and the command's help and completion remain unchanged.
 
 ## Scope a guard to a subtree
 
@@ -146,13 +191,15 @@ const status = defineCommand("status", { ctx: [database] }, (command) =>
 const app = new Crust("app").flags(verbose).provide(config(), database()).mount(status);
 ```
 
-Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).
+Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. Contexts and their owned flags do not backfill children mounted on an earlier builder. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).
 
-## One name per command path
+## Name and flag collisions
 
 Providing two Context values with the same name on one command path is a `DEFINITION` error at the `.provide()` call. This includes a descendant re-providing a name it inherited.
 
 Mounted definitions use the same rule. Because materialization starts with the parent's Context path, a definition or nested descendant that provides the same name is rejected during `.mount()`.
+
+A Context cannot both require and own the same flag. Owned flag names, short forms, and aliases must also be unique across application flags, other Contexts, and Extensions. Application and Context collisions fail while building; Extension collisions fail when `run()`, `execute()`, or `crust build` prepares the complete graph. Every case uses `CrustError` code `DEFINITION` rather than shadowing a definition.
 
 ## Native disposal
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -35,7 +35,7 @@ Two consequences of the root-only model:
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `inherit` controls ordinary command inheritance and remains available on the flag definition.
 
-Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context requirements; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
+Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context dependencies under `requires`; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide with application flags, [Context-owned flags](/docs/guide/contexts#owned-flags), or other Extensions. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -37,7 +37,9 @@ Extension flags default to `recursive: true`, which contributes them to every co
 
 Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context requirements; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 
-A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide either. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
+A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide with application flags, [Context-owned flags](/docs/guide/contexts#owned-flags), or other Extensions. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
+
+Application and Context-owned collisions are rejected by `.flags()` or `.provide()` while building. Extensions join the graph during preparation, so collisions involving an Extension surface consistently from `run()`, `execute()`, or `crust build`, regardless of fluent registration order.
 
 ## Hooks
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -21,7 +21,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 Two consequences of the root-only model:
 
 - Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to mounted and inline commands alike.
-- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's flag requirements; use a Context-owned flag when a definition declares `requires.flags`.
+- Extension-owned flags are runtime parser inputs, not typed command capabilities. Use a Context-owned flag when downstream handlers need a typed value.
 
 ## Author an Extension
 
@@ -35,7 +35,7 @@ Two consequences of the root-only model:
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. Ordinary command flags are always local; Context-owned flags are the application-level propagation mechanism.
 
-Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context dependencies under `requires`; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
+Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare Context capabilities under `requires`; a missing capability is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide with application flags, [Context-owned flags](/docs/guide/contexts#owned-flags), or other Extensions. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -21,7 +21,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 Two consequences of the root-only model:
 
 - Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to mounted and inline commands alike.
-- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's flag requirements; declare required inheritable flags on the root itself.
+- Extension-owned flags are not represented in the root builder's TypeScript generics, so they cannot satisfy a reusable definition's flag requirements; use a Context-owned flag when a definition declares `requires.flags`.
 
 ## Author an Extension
 
@@ -33,7 +33,7 @@ Two consequences of the root-only model:
 
 ## Owned flags and commands
 
-Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `inherit` controls ordinary command inheritance and remains available on the flag definition.
+Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. Ordinary command flags are always local; Context-owned flags are the application-level propagation mechanism.
 
 Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare flag and Context dependencies under `requires`; a missing requirement is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -88,6 +88,25 @@ The flag is parsed and shown in help at each descendant. `defineFlag(name, def)`
 
 A command mounted without a flag requirement still inherits `inherit: true` flags at runtime, but its handler's `flags` type does not include them — declare requirements to see them.
 
+Inherited flags can appear before or after the subcommand: both `app --verbose deploy` and `app deploy --verbose` route to `deploy`.
+
+## Context-owned flags
+
+When a flag exists to construct a dependency—such as `--api-key` configuring an HTTP client—let the Context own it instead of separately registering it on the root:
+
+```ts
+import { Crust, defineContext, defineFlag } from "@crustjs/core";
+
+const apiKey = defineFlag("api-key", { type: "string" });
+const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+  apiKey: flags["api-key"],
+}));
+
+const app = new Crust("app").provide(api());
+```
+
+`.provide(api())` installs an inheritable copy of `apiKey`, while handlers can depend on the derived `ctx.api`. Raw shared controls such as `--verbose` should continue to use `inherit: true` and explicit command `requirements.flags`. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
+
 ## Standard Schemas
 
 For a schema-backed flag, `type` controls token grammar only: `"string"` consumes a token and `"boolean"` does not. The schema owns the resulting value.

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -91,7 +91,7 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
   verbose: flags.verbose === true,
 }));
 
-const deploy = defineCommand("deploy", { requires: { ctx: [logging] } }, (command) =>
+const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
   command.handle(({ ctx, stderr }) => {
     if (ctx.logging.verbose) stderr("deploying");
   }),
@@ -104,7 +104,7 @@ The Context declares, parses, and consumes `--verbose`; the handler writes diagn
 
 Context-owned flags are parsed and shown in help at the provider and later-mounted descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
-If a handler genuinely needs a Context-owned raw value, declare it under the command's `requires.flags`. `.mount()` accepts only propagating Context-owned flags for this requirement; a same-named local `.flags()` definition does not satisfy it.
+If a handler needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into a mounted handler's types.
 
 ## Standard Schemas
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -1,6 +1,6 @@
 ---
 title: Flags
-description: Define typed named inputs, aliases, repeated values, and inherited flags.
+description: Define typed named inputs, aliases, repeated values, and shared flag capabilities.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -63,49 +63,48 @@ Both values are non-optional in the Command Handler. Other flags include `undefi
 
 Choices are supported on string flags and invalid values produce `PARSE` errors.
 
-## Inherited flags
+## Reusing flag definitions
 
-Set `inherit: true` to expose a parent flag to descendant Command Handlers:
+Flags declared with `.flags()` belong only to that command. Define a descriptor once and attach it to each command that parses the value directly:
 
 ```ts
 import { Crust, defineCommand, defineFlag } from "@crustjs/core";
 
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const format = defineFlag("format", { type: "string", default: "json" });
+const print = defineCommand("print", (command) => command.flags(format));
+const inspect = defineCommand("inspect", (command) => command.flags(format));
 
-const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-  command.flags({ name: "env", type: "string", required: true }).handle(({ flags }) => {
-    flags.verbose; // boolean | undefined
-    flags.env; // string
+const app = new Crust("app").mount(print, inspect);
+```
+
+This keeps one source of truth without adding the flag to commands that do not use it.
+
+## Propagating flags with Contexts
+
+When one flag configures shared behavior for a command subtree, let a Context own and consume it. Handlers depend on the derived capability rather than the raw flag:
+
+```ts
+import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
+
+const verbose = defineFlag("verbose", { type: "boolean" });
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+  verbose: flags.verbose === true,
+}));
+
+const deploy = defineCommand("deploy", { requires: { ctx: [logging] } }, (command) =>
+  command.handle(({ ctx, stderr }) => {
+    if (ctx.logging.verbose) stderr("deploying");
   }),
 );
 
-const app = new Crust("app").flags(verbose).mount(deploy);
+const app = new Crust("app").provide(logging()).mount(deploy);
 ```
 
-The flag is parsed and shown in help at each descendant. `defineFlag(name, def)` preserves the literal definition, so the requirement array and the parent's `.flags()` call reference the same value.
+The Context declares, parses, and consumes `--verbose`; the handler writes diagnostics through its injected `stderr`. Renaming the flag or deriving log levels later changes the Context rather than every handler.
 
-`.mount()` checks the parent's current builder. Define required flags with `inherit: true` before mounting. A same-named non-inheritable flag is treated as missing, and incompatible inferred value types are rejected. Flags added on a later builder do not backfill an earlier mount.
+Context-owned flags are parsed and shown in help at the provider and later-mounted descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
-A command mounted without a flag requirement still inherits `inherit: true` flags at runtime, but its handler's `flags` type does not include them — declare requirements to see them.
-
-Inherited flags can appear before or after the subcommand: both `app --verbose deploy` and `app deploy --verbose` route to `deploy`.
-
-## Context-owned flags
-
-When a flag exists to construct a dependency—such as `--api-key` configuring an HTTP client—let the Context own it instead of separately registering it on the root:
-
-```ts
-import { Crust, defineContext, defineFlag } from "@crustjs/core";
-
-const apiKey = defineFlag("api-key", { type: "string" });
-const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
-  apiKey: flags["api-key"],
-}));
-
-const app = new Crust("app").provide(api());
-```
-
-`.provide(api())` installs an inheritable copy of `apiKey`, while handlers can depend on the derived `ctx.api`. Raw shared controls such as `--verbose` should continue to use `inherit: true` and explicit command `requires.flags`. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
+If a handler genuinely needs a Context-owned raw value, declare it under the command's `requires.flags`. `.mount()` accepts only propagating Context-owned flags for this requirement; a same-named local `.flags()` definition does not satisfy it.
 
 ## Standard Schemas
 
@@ -177,4 +176,4 @@ await app.execute({ argv: normalizeArgv(process.argv.slice(2)) });
 
 For optional-valued flags, split them into a boolean flag plus a value-taking flag (e.g. `--tag` and `--tag-name v1.2`), or normalize `--tag <value>` to `--tag-name=<value>` in the same pass.
 
-What migrators no longer need to normalize: inherited flags before a subcommand (`app --quiet translate`) route correctly, and bare version output is covered by [`versionExtension`'s `format` option](/docs/modules/extensions/version#options).
+What migrators no longer need to normalize: propagating flags before a subcommand (`app --quiet translate`) route correctly, and bare version output is covered by [`versionExtension`'s `format` option](/docs/modules/extensions/version#options).

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -87,20 +87,20 @@ When one flag configures shared behavior for a command subtree, let a Context ow
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean" });
-const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
-  verbose: flags.verbose === true,
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
+  debug(message: string) {
+    if (flags.verbose) stderr(message);
+  },
 }));
 
 const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-  command.handle(({ ctx, stderr }) => {
-    if (ctx.logging.verbose) stderr("deploying");
-  }),
+  command.handle(({ ctx }) => ctx.logging.debug("deploying")),
 );
 
 const app = new Crust("app").provide(logging()).mount(deploy);
 ```
 
-The Context declares, parses, and consumes `--verbose`; the handler writes diagnostics through its injected `stderr`. Renaming the flag or deriving log levels later changes the Context rather than every handler.
+The Context declares, parses, and consumes `--verbose`, then wraps the invocation's injected `stderr` as behavior. Handlers call the logging capability without re-checking the flag. Renaming the flag or deriving log levels later changes the Context rather than every handler.
 
 Context-owned flags are parsed and shown in help at the provider and later-mounted descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -72,7 +72,7 @@ import { Crust, defineCommand, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 
-const deploy = defineCommand("deploy", { flags: [verbose] }, (command) =>
+const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
   command.flags({ name: "env", type: "string", required: true }).handle(({ flags }) => {
     flags.verbose; // boolean | undefined
     flags.env; // string
@@ -98,14 +98,14 @@ When a flag exists to construct a dependency—such as `--api-key` configuring a
 import { Crust, defineContext, defineFlag } from "@crustjs/core";
 
 const apiKey = defineFlag("api-key", { type: "string" });
-const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
   apiKey: flags["api-key"],
 }));
 
 const app = new Crust("app").provide(api());
 ```
 
-`.provide(api())` installs an inheritable copy of `apiKey`, while handlers can depend on the derived `ctx.api`. Raw shared controls such as `--verbose` should continue to use `inherit: true` and explicit command `requirements.flags`. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
+`.provide(api())` installs an inheritable copy of `apiKey`, while handlers can depend on the derived `ctx.api`. Raw shared controls such as `--verbose` should continue to use `inherit: true` and explicit command `requires.flags`. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
 ## Standard Schemas
 

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -32,7 +32,7 @@ It requires explicit argv, honors injected writers, throws the original error, d
 4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Handler.
 5. **Validate structure** — enforce required values, choices, and other core rules.
 6. **Apply schemas** — validate and transform every schema-backed input, aggregating issues.
-7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared ctx requirements (registration order among independent Contexts), passing each setup the validated flags it requires or owns.
+7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared capability requirements (registration order among independent Contexts), passing each setup only its validated owned flags.
 8. **Run the Command Handler**.
 9. **Dispose Contexts** — run `Symbol.dispose` or `Symbol.asyncDispose` in reverse construction order, including after failure.
 10. **Run `postRun` hooks** — invoke every Extension hook in reverse `.extend()` order with the completed, finished, or failed outcome. This is the invocation-level `finally` slot.

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -26,13 +26,13 @@ It requires explicit argv, honors injected writers, throws the original error, d
 
 ## Successful invocation order
 
-1. **Prepare definitions** — apply Extensions and reject command, flag, and alias collisions (duplicate Context names are rejected earlier, at the `.provide()` call).
+1. **Prepare definitions** — apply Extensions and reject command, flag, and alias collisions, including collisions with Context-owned flags (application and Context-only collisions are rejected earlier by `.flags()` or `.provide()`).
 2. **Route** — resolve the command path.
 3. **Parse syntax** — consume positional and flag tokens.
 4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Handler.
 5. **Validate structure** — enforce required values, choices, and other core rules.
 6. **Apply schemas** — validate and transform every schema-backed input, aggregating issues.
-7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared ctx requirements (registration order among independent Contexts), passing each setup the validated flags it declared.
+7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared ctx requirements (registration order among independent Contexts), passing each setup the validated flags it requires or owns.
 8. **Run the Command Handler**.
 9. **Dispose Contexts** — run `Symbol.dispose` or `Symbol.asyncDispose` in reverse construction order, including after failure.
 10. **Run `postRun` hooks** — invoke every Extension hook in reverse `.extend()` order with the completed, finished, or failed outcome. This is the invocation-level `finally` slot.

--- a/apps/docs/content/docs/guide/split-files.mdx
+++ b/apps/docs/content/docs/guide/split-files.mdx
@@ -45,4 +45,4 @@ The composition root imports both sides:
 
 ## Inline or split?
 
-Mount `defineCommand(name, recipe)` inline when the implementation is short and local. Move the definition to its own file, with a requirements array, when a separate file improves readability or when the same command should be mounted more than once.
+Mount `defineCommand(name, recipe)` inline when the implementation is short and local. Move the definition to its own file, with a `requires` config when needed, when a separate file improves readability or when the same command should be mounted more than once.

--- a/apps/docs/content/docs/guide/split-files.mdx
+++ b/apps/docs/content/docs/guide/split-files.mdx
@@ -7,13 +7,13 @@ For a small application, mount definitions inline at the root. When a command be
 
 ## Shared definitions
 
-Keep the flag definitions and Context factories that commands require in a dependency-free shared module:
+Keep shared Context factories and their owned flag definitions in a dependency-free module:
 
 <include lang="ts" meta='title="src/shared.ts"'>
   ../../../examples/split-files/shared.ts
 </include>
 
-Requirements are arrays of these values, so the required shape and the root definition are the same object — they cannot drift.
+Here `logger` owns `--verbose`, so its setup consumes the raw flag and commands depend only on the derived logger value. The flag definition and its consumer stay together.
 
 ## Standalone command definition
 
@@ -41,7 +41,7 @@ The composition root imports both sides:
   ../../../examples/split-files/cli.ts
 </include>
 
-`.mount()` checks that `app` provides a compatible inheritable `verbose` flag and `logger` Context, and reports missing or incompatible requirements at this line. [How mount checking and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-mounting rule — is covered in Subcommands.
+`.mount()` checks that `app` provides a compatible `logger` Context and reports a missing or incompatible requirement at this line. Because `.provide(logger())` precedes the mount, its owned `--verbose` flag is also available to the command. [How mount checking and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-mounting rule — is covered in Subcommands.
 
 ## Inline or split?
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -23,7 +23,7 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition declares the inheritable flags and Contexts it expects from any parent as arrays of defined values. The recipe builder — and the handler's `flags` and `ctx` — are typed from them:
+A definition declares the inheritable flags and Contexts it expects from any parent as arrays of defined values. `requirements.flags` describes raw flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -74,7 +74,9 @@ const app = new Crust("app").flags(verbose).mount(deploy);
 
 ## Context inheritance
 
-Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requirements.ctx` to see them in the handler's types. Finalize required Contexts and inheritable flags on the parent builder before the `.mount()` call; later fluent calls do not backfill an earlier mount.
+Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requirements.ctx` to see them in the handler's types.
+
+Finalize inheritable flags and `.provide()` calls on the parent builder before `.mount()`. This includes [flags owned by a provided Context](/docs/guide/contexts#owned-flags). Later fluent calls return a new builder and do not backfill an earlier mount.
 
 ## Unknown commands
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -23,41 +23,38 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition groups the propagating Context-owned flags and Contexts it expects from any parent under `requires`. Its `flags` and `ctx` fields are arrays of defined values. `requires.flags` describes raw Context-owned flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
+A definition lists the Context capabilities it expects from its parent in the `requires` array. The recipe builder and handler's `ctx` are typed from those factories:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean" });
-const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+  verbose: flags.verbose === true,
+}));
 const repository = defineContext("repository", () => ({
   defaultBranch: "main",
 }));
 
-const clone = defineCommand(
-  "clone",
-  { requires: { flags: [verbose], ctx: [repository] } },
-  (command) =>
-    command
-      .args({ name: "url", type: "url", required: true })
-      .handle(({ args, flags, ctx, stdout }) => {
-        stdout(`${args.url} ${ctx.repository.defaultBranch} ${flags.verbose}`);
-      }),
+const clone = defineCommand("clone", { requires: [logging, repository] }, (command) =>
+  command.args({ name: "url", type: "url", required: true }).handle(({ args, ctx, stdout }) => {
+    stdout(`${args.url} ${ctx.repository.defaultBranch} ${ctx.logging.verbose}`);
+  }),
 );
 
-const app = new Crust("git").provide(loggingFlags()).provide(repository()).mount(clone);
+const app = new Crust("git").provide(logging(), repository()).mount(clone);
 ```
 
 `.mount()` checks the requirements at each call and creates a fresh command node. Use `.as(name)` to mount one definition under different names:
 
 ```ts
 const git = new Crust("git")
-  .provide(loggingFlags())
+  .provide(logging())
   .provide(repository())
   .mount(clone, clone.as("copy"));
 ```
 
-Missing or incompatible propagating flags and Contexts are TypeScript errors on `.mount()`; missing requirements are also runtime `DEFINITION` errors. A same-named local `.flags()` definition does not count because local flags do not propagate.
+Missing or incompatible Context capabilities are TypeScript errors on `.mount()`; missing capabilities are also runtime `DEFINITION` errors.
 
 ## Nested definitions
 
@@ -65,24 +62,24 @@ Definitions can mount other definitions. Nested requirements must be available a
 
 ```ts
 const environment = defineFlag("environment", { type: "string" });
-const deployFlags = defineContext("deploy-flags", { flags: [environment] }, () => ({}));
+const deployment = defineContext("deployment", { flags: [environment] }, ({ flags }) => flags);
 
-const status = defineCommand("status", { requires: { flags: [verbose, environment] } }, (command) =>
-  command.handle(({ flags, stdout }) => {
-    stdout(`${flags.environment} ${flags.verbose}`);
+const status = defineCommand("status", { requires: [logging, deployment] }, (command) =>
+  command.handle(({ ctx, stdout }) => {
+    stdout(`${ctx.deployment.environment} ${ctx.logging.verbose}`);
   }),
 );
 
-const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-  command.provide(deployFlags()).mount(status),
+const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
+  command.provide(deployment()).mount(status),
 );
 
-const app = new Crust("app").provide(loggingFlags()).mount(deploy);
+const app = new Crust("app").provide(logging()).mount(deploy);
 ```
 
 ## Context inheritance
 
-Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requires.ctx` to see them in the handler's types.
+Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; list factories in `requires` to see them in the handler's types.
 
 Finalize `.provide()` calls on the parent builder before `.mount()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into later-mounted descendants. Later fluent calls return a new builder and do not backfill an earlier mount.
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -23,12 +23,13 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition groups the inheritable flags and Contexts it expects from any parent under `requires`. Its `flags` and `ctx` fields are arrays of defined values. `requires.flags` describes raw flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
+A definition groups the propagating Context-owned flags and Contexts it expects from any parent under `requires`. Its `flags` and `ctx` fields are arrays of defined values. `requires.flags` describes raw Context-owned flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
-const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean" });
+const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
 const repository = defineContext("repository", () => ({
   defaultBranch: "main",
 }));
@@ -44,23 +45,27 @@ const clone = defineCommand(
       }),
 );
 
-const app = new Crust("git").flags(verbose).provide(repository()).mount(clone);
+const app = new Crust("git").provide(loggingFlags()).provide(repository()).mount(clone);
 ```
 
 `.mount()` checks the requirements at each call and creates a fresh command node. Use `.as(name)` to mount one definition under different names:
 
 ```ts
-const git = new Crust("git").flags(verbose).provide(repository()).mount(clone, clone.as("copy"));
+const git = new Crust("git")
+  .provide(loggingFlags())
+  .provide(repository())
+  .mount(clone, clone.as("copy"));
 ```
 
-Missing or incompatible inherited flags and Contexts are TypeScript errors on `.mount()`; a ctx requirement name not provided on the parent path is a runtime `DEFINITION` error. A same-named parent flag only counts when it has `inherit: true`.
+Missing or incompatible propagating flags and Contexts are TypeScript errors on `.mount()`; missing requirements are also runtime `DEFINITION` errors. A same-named local `.flags()` definition does not count because local flags do not propagate.
 
 ## Nested definitions
 
 Definitions can mount other definitions. Nested requirements must be available at the exact nested `.mount()` call:
 
 ```ts
-const environment = defineFlag("environment", { type: "string", inherit: true });
+const environment = defineFlag("environment", { type: "string" });
+const deployFlags = defineContext("deploy-flags", { flags: [environment] }, () => ({}));
 
 const status = defineCommand("status", { requires: { flags: [verbose, environment] } }, (command) =>
   command.handle(({ flags, stdout }) => {
@@ -69,17 +74,17 @@ const status = defineCommand("status", { requires: { flags: [verbose, environmen
 );
 
 const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-  command.flags(environment).mount(status),
+  command.provide(deployFlags()).mount(status),
 );
 
-const app = new Crust("app").flags(verbose).mount(deploy);
+const app = new Crust("app").provide(loggingFlags()).mount(deploy);
 ```
 
 ## Context inheritance
 
 Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requires.ctx` to see them in the handler's types.
 
-Finalize inheritable flags and `.provide()` calls on the parent builder before `.mount()`. This includes [flags owned by a provided Context](/docs/guide/contexts#owned-flags). Later fluent calls return a new builder and do not backfill an earlier mount.
+Finalize `.provide()` calls on the parent builder before `.mount()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into later-mounted descendants. Later fluent calls return a new builder and do not backfill an earlier mount.
 
 ## Unknown commands
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -23,7 +23,7 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition declares the inheritable flags and Contexts it expects from any parent as arrays of defined values. `requirements.flags` describes raw flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
+A definition groups the inheritable flags and Contexts it expects from any parent under `requires`. Its `flags` and `ctx` fields are arrays of defined values. `requires.flags` describes raw flags already available on the path; it does not create or hoist them. The recipe builder — and the handler's `flags` and `ctx` — are typed from these requirements:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -33,12 +33,15 @@ const repository = defineContext("repository", () => ({
   defaultBranch: "main",
 }));
 
-const clone = defineCommand("clone", { flags: [verbose], ctx: [repository] }, (command) =>
-  command
-    .args({ name: "url", type: "url", required: true })
-    .handle(({ args, flags, ctx, stdout }) => {
-      stdout(`${args.url} ${ctx.repository.defaultBranch} ${flags.verbose}`);
-    }),
+const clone = defineCommand(
+  "clone",
+  { requires: { flags: [verbose], ctx: [repository] } },
+  (command) =>
+    command
+      .args({ name: "url", type: "url", required: true })
+      .handle(({ args, flags, ctx, stdout }) => {
+        stdout(`${args.url} ${ctx.repository.defaultBranch} ${flags.verbose}`);
+      }),
 );
 
 const app = new Crust("git").flags(verbose).provide(repository()).mount(clone);
@@ -59,13 +62,13 @@ Definitions can mount other definitions. Nested requirements must be available a
 ```ts
 const environment = defineFlag("environment", { type: "string", inherit: true });
 
-const status = defineCommand("status", { flags: [verbose, environment] }, (command) =>
+const status = defineCommand("status", { requires: { flags: [verbose, environment] } }, (command) =>
   command.handle(({ flags, stdout }) => {
     stdout(`${flags.environment} ${flags.verbose}`);
   }),
 );
 
-const deploy = defineCommand("deploy", { flags: [verbose] }, (command) =>
+const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
   command.flags(environment).mount(status),
 );
 
@@ -74,7 +77,7 @@ const app = new Crust("app").flags(verbose).mount(deploy);
 
 ## Context inheritance
 
-Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requirements.ctx` to see them in the handler's types.
+Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; declare `requires.ctx` to see them in the handler's types.
 
 Finalize inheritable flags and `.provide()` calls on the parent builder before `.mount()`. This includes [flags owned by a provided Context](/docs/guide/contexts#owned-flags). Later fluent calls return a new builder and do not backfill an earlier mount.
 

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -29,8 +29,10 @@ A definition lists the Context capabilities it expects from its parent in the `r
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean" });
-const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
-  verbose: flags.verbose === true,
+const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
+  debug(message: string) {
+    if (flags.verbose) stderr(message);
+  },
 }));
 const repository = defineContext("repository", () => ({
   defaultBranch: "main",
@@ -38,7 +40,8 @@ const repository = defineContext("repository", () => ({
 
 const clone = defineCommand("clone", { requires: [logging, repository] }, (command) =>
   command.args({ name: "url", type: "url", required: true }).handle(({ args, ctx, stdout }) => {
-    stdout(`${args.url} ${ctx.repository.defaultBranch} ${ctx.logging.verbose}`);
+    ctx.logging.debug(`cloning ${args.url}`);
+    stdout(ctx.repository.defaultBranch);
   }),
 );
 
@@ -65,8 +68,8 @@ const environment = defineFlag("environment", { type: "string" });
 const deployment = defineContext("deployment", { flags: [environment] }, ({ flags }) => flags);
 
 const status = defineCommand("status", { requires: [logging, deployment] }, (command) =>
-  command.handle(({ ctx, stdout }) => {
-    stdout(`${ctx.deployment.environment} ${ctx.logging.verbose}`);
+  command.handle(({ ctx }) => {
+    ctx.logging.debug(`environment: ${ctx.deployment.environment}`);
   }),
 );
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -47,7 +47,7 @@ $ greet --help
 - **Composable, not monolithic** — Every capability ships as its own module with zero runtime dependencies in core. Install only what you need — `@crustjs/core` for the framework, `@crustjs/extensions` for official extensions, `@crustjs/crust` for build tooling.
 - **Extensions** — App-wide capabilities like help, version, completion, and update notices, attached once at the root
 - **Contexts** — Named command dependencies created lazily for the resolved command path
-- **Subcommands** — Nested command trees with automatic resolution and flag inheritance via `inherit: true`
+- **Subcommands** — Nested command trees with automatic resolution and Context-owned flag propagation
 - **Built for Bun** — Targets the Bun runtime from the ground up. No Node compatibility layers, no legacy baggage.
 
 ## Roadmap

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -33,17 +33,34 @@ const app = new Crust("deploy")
 await app.execute();
 ```
 
+## Context-owned flags
+
+Use `ContextConfig.ownFlags` when a flag exists to construct a dependency. The Context defines and consumes the flag once; `.provide()` installs it on the current command and later-mounted descendants:
+
+```ts
+import { Crust, defineContext, defineFlag } from "@crustjs/core";
+
+const apiKey = defineFlag("api-key", { type: "string" });
+const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+  apiKey: flags["api-key"],
+}));
+
+const app = new Crust("my-cli").provide(api());
+```
+
+Use `ContextRequirements.flags` instead when the Context reads an inheritable flag already supplied by its command path. See [Contexts](/docs/guide/contexts).
+
 ## Runtime exports
 
-| Export                              | Description                                                                                                                    |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [`Crust`](/docs/api/crust)          | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, programmatic `.run()`, and terminal `.execute()` |
-| [`defineCommand`](/docs/api/crust)  | Create a named, inert reusable command definition                                                                              |
-| `defineContext(name, reqs?, setup)` | Define a named Context factory; invoke it and attach the instance with `.provide()`                                            |
-| `defineExtension(name, config)`     | Define a frozen, application-wide Extension value                                                                              |
-| `defineFlag(name, definition)`      | Define one named flag, preserving its literal definition                                                                       |
-| `defineArg(name, definition)`       | Define one named positional argument, preserving its literal definition                                                        |
-| [`CrustError`](/docs/api/errors)    | Framework error for definition, routing, parsing, and validation failures                                                      |
+| Export                                | Description                                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, programmatic `.run()`, and terminal `.execute()` |
+| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                              |
+| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; attach an instance with `.provide()`                |
+| `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                              |
+| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                       |
+| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                        |
+| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                      |
 
 ## Definition types
 
@@ -80,7 +97,8 @@ See [Types](/docs/api/types) for field-level definitions.
 | `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()` |
 | `AnyContextFactory`   | Requirement-array element type for `requirements.ctx`                 |
 | `ContextInstance`     | Named lazy dependency attached with `.provide()`                      |
-| `ContextRequirements` | Declared flag and ctx requirements of a Context                       |
+| `ContextRequirements` | Inherited flag and Context dependencies required from a command path  |
+| `ContextConfig`       | Context requirements plus flags owned and installed by the Context    |
 | `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`     |
 | `ContextMap`          | Record shape used for inferred Command Handler `ctx` values           |
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -48,7 +48,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
 const app = new Crust("my-cli").provide(api());
 ```
 
-Use `ContextConfig.requires.flags` instead when the Context reads a propagating flag already owned by another Context on its command path. See [Contexts](/docs/guide/contexts).
+Downstream commands and Contexts list `api` in their `requires` array and consume the derived capability through `ctx`. See [Contexts](/docs/guide/contexts).
 
 ## Runtime exports
 
@@ -71,7 +71,7 @@ Use `ContextConfig.requires.flags` instead when the Context reads a propagating 
 | [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                                      |
 | [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                               |
 | `CommandMeta`                                 | Name, description, usage, aliases, and visibility                                |
-| [`CommandRequirements`](/docs/api/crust)      | Propagating Context-owned flag and Context requirements checked at mount time    |
+| [`CommandRequirements`](/docs/api/crust)      | Context capability requirements checked at mount time                            |
 | `FlagDef`                                     | Core-value or Standard Schema flag definition                                    |
 | `FlagsDef`                                    | Flag-name-to-definition record                                                   |
 | `NamedFlagDef`                                | Flag definition carrying its `name` (the `.flags()` input shape)                 |
@@ -92,15 +92,15 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Context types
 
-| Type                  | Description                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------ |
-| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()`                |
-| `AnyContextFactory`   | Requirement-array element type for `requires.ctx`                                    |
-| `ContextInstance`     | Named lazy dependency attached with `.provide()`                                     |
-| `ContextRequirements` | Propagating Context-owned flag and Context dependencies required from a command path |
-| `ContextConfig`       | Owned flags plus dependencies grouped under `requires`                               |
-| `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`                    |
-| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values                          |
+| Type                  | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()` |
+| `AnyContextFactory`   | Requirement-array element type for `requires`                         |
+| `ContextInstance`     | Named lazy dependency attached with `.provide()`                      |
+| `ContextRequirements` | Context capabilities required from a command path                     |
+| `ContextConfig`       | Owned flags plus capability dependencies under `requires`             |
+| `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`     |
+| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values           |
 
 ## Extension types
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -35,20 +35,20 @@ await app.execute();
 
 ## Context-owned flags
 
-Use `ContextConfig.ownFlags` when a flag exists to construct a dependency. The Context defines and consumes the flag once; `.provide()` installs it on the current command and later-mounted descendants:
+Use top-level `ContextConfig.flags` when a flag exists to construct a dependency. The Context defines and consumes the flag once; `.provide()` installs it on the current command and later-mounted descendants:
 
 ```ts
 import { Crust, defineContext, defineFlag } from "@crustjs/core";
 
 const apiKey = defineFlag("api-key", { type: "string" });
-const api = defineContext("api", { ownFlags: [apiKey] }, ({ flags }) => ({
+const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
   apiKey: flags["api-key"],
 }));
 
 const app = new Crust("my-cli").provide(api());
 ```
 
-Use `ContextRequirements.flags` instead when the Context reads an inheritable flag already supplied by its command path. See [Contexts](/docs/guide/contexts).
+Use `ContextConfig.requires.flags` instead when the Context reads an inheritable flag already supplied by its command path. See [Contexts](/docs/guide/contexts).
 
 ## Runtime exports
 
@@ -95,10 +95,10 @@ See [Types](/docs/api/types) for field-level definitions.
 | Type                  | Description                                                           |
 | --------------------- | --------------------------------------------------------------------- |
 | `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()` |
-| `AnyContextFactory`   | Requirement-array element type for `requirements.ctx`                 |
+| `AnyContextFactory`   | Requirement-array element type for `requires.ctx`                     |
 | `ContextInstance`     | Named lazy dependency attached with `.provide()`                      |
 | `ContextRequirements` | Inherited flag and Context dependencies required from a command path  |
-| `ContextConfig`       | Context requirements plus flags owned and installed by the Context    |
+| `ContextConfig`       | Owned flags plus dependencies grouped under `requires`                |
 | `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`     |
 | `ContextMap`          | Record shape used for inferred Command Handler `ctx` values           |
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -48,7 +48,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
 const app = new Crust("my-cli").provide(api());
 ```
 
-Use `ContextConfig.requires.flags` instead when the Context reads an inheritable flag already supplied by its command path. See [Contexts](/docs/guide/contexts).
+Use `ContextConfig.requires.flags` instead when the Context reads a propagating flag already owned by another Context on its command path. See [Contexts](/docs/guide/contexts).
 
 ## Runtime exports
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -56,7 +56,7 @@ Downstream commands and Contexts list `api` in their `requires` array and consum
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, programmatic `.run()`, and terminal `.execute()` |
 | [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                              |
-| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; attach an instance with `.provide()`                |
+| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                       |
 | `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                              |
 | `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                       |
 | `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                        |
@@ -83,24 +83,25 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Command boundary types
 
-| Type                  | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `CrustCommandContext` | Typed context passed to a Command Handler, including `rootCommand` |
-| `CommandSnapshot`     | Readonly, serializable command description                         |
-| `ArgSnapshot`         | Serializable argument projection                                   |
-| `FlagSnapshot`        | Serializable flag projection                                       |
+| Type                  | Description                                                          |
+| --------------------- | -------------------------------------------------------------------- |
+| `CrustCommandContext` | Typed context passed to a Command Handler, including `rootCommand`   |
+| `InvocationIO`        | Injectable `stdout` and `stderr` callbacks shared with Context setup |
+| `CommandSnapshot`     | Readonly, serializable command description                           |
+| `ArgSnapshot`         | Serializable argument projection                                     |
+| `FlagSnapshot`        | Serializable flag projection                                         |
 
 ## Context types
 
-| Type                  | Description                                                           |
-| --------------------- | --------------------------------------------------------------------- |
-| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()` |
-| `AnyContextFactory`   | Requirement-array element type for `requires`                         |
-| `ContextInstance`     | Named lazy dependency attached with `.provide()`                      |
-| `ContextRequirements` | Context capabilities required from a command path                     |
-| `ContextConfig`       | Owned flags plus capability dependencies under `requires`             |
-| `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`     |
-| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values           |
+| Type                  | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()`       |
+| `AnyContextFactory`   | Requirement-array element type for `requires`                               |
+| `ContextInstance`     | Named lazy dependency attached with `.provide()`                            |
+| `ContextRequirements` | Context capabilities required from a command path                           |
+| `ContextConfig`       | Owned flags plus capability dependencies under `requires`                   |
+| `ContextSetup`        | Typed setup input: `options`, `flags`, dependency `ctx`, and invocation I/O |
+| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values                 |
 
 ## Extension types
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -71,7 +71,7 @@ Use `ContextConfig.requires.flags` instead when the Context reads a propagating 
 | [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                                      |
 | [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                               |
 | `CommandMeta`                                 | Name, description, usage, aliases, and visibility                                |
-| [`CommandRequirements`](/docs/api/crust)      | Inherited flag and Context requirements checked at mount time                    |
+| [`CommandRequirements`](/docs/api/crust)      | Propagating Context-owned flag and Context requirements checked at mount time    |
 | `FlagDef`                                     | Core-value or Standard Schema flag definition                                    |
 | `FlagsDef`                                    | Flag-name-to-definition record                                                   |
 | `NamedFlagDef`                                | Flag definition carrying its `name` (the `.flags()` input shape)                 |
@@ -92,15 +92,15 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Context types
 
-| Type                  | Description                                                           |
-| --------------------- | --------------------------------------------------------------------- |
-| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()` |
-| `AnyContextFactory`   | Requirement-array element type for `requires.ctx`                     |
-| `ContextInstance`     | Named lazy dependency attached with `.provide()`                      |
-| `ContextRequirements` | Inherited flag and Context dependencies required from a command path  |
-| `ContextConfig`       | Owned flags plus dependencies grouped under `requires`                |
-| `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`     |
-| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values           |
+| Type                  | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `ContextFactory`      | Factory returned by `defineContext()`, with `contextName` and `.of()`                |
+| `AnyContextFactory`   | Requirement-array element type for `requires.ctx`                                    |
+| `ContextInstance`     | Named lazy dependency attached with `.provide()`                                     |
+| `ContextRequirements` | Propagating Context-owned flag and Context dependencies required from a command path |
+| `ContextConfig`       | Owned flags plus dependencies grouped under `requires`                               |
+| `ContextSetup`        | Typed setup input: `options`, validated `flags`, dependency `ctx`                    |
+| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values                          |
 
 ## Extension types
 

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -1,6 +1,6 @@
 ---
 title: Help
-description: Add inherited help output to every command.
+description: Add help output to every command.
 ---
 
 ## Usage
@@ -27,7 +27,7 @@ my-cli deploy --help
 function help(): Extension;
 ```
 
-`help()` owns an inherited boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Handler also displays help.
+`help()` owns a recursive boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Handler also displays help.
 
 The renderer includes usage, visible subcommands, positional arguments, effective flags, aliases, defaults, and choices. Commands with `meta.hidden: true` stay routable but are omitted from listings.
 

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -43,11 +43,11 @@ await app.execute();
 
 | Factory                                                               | Contribution                                      |
 | --------------------------------------------------------------------- | ------------------------------------------------- |
-| [`help()`](/docs/modules/extensions/help)                             | Inherited `--help` / `-h` flag and help rendering |
+| [`help()`](/docs/modules/extensions/help)                             | Recursive `--help` / `-h` flag and help rendering |
 | [`version(value?)`](/docs/modules/extensions/version)                 | Root-only `--version` / `-v` flag                 |
 | [`completion(options?)`](/docs/modules/extensions/completion)         | Static bash, zsh, and fish completion command     |
 | [`didYouMean(options?)`](/docs/modules/extensions/did-you-mean)       | `COMMAND_NOT_FOUND` presentation                  |
-| [`noColor()`](/docs/modules/extensions/no-color)                      | Inherited `--color` / `--no-color` flag           |
+| [`noColor()`](/docs/modules/extensions/no-color)                      | Recursive `--color` / `--no-color` flag           |
 | [`updateNotifier(options)`](/docs/modules/extensions/update-notifier) | Post-handler npm update notice                    |
 
 These factories return plain `Extension` values. Contributions are application-wide. Extension-owned command, flag, short-name, or alias collisions with the application or another Extension are `DEFINITION` errors.

--- a/apps/docs/content/docs/modules/extensions/no-color.mdx
+++ b/apps/docs/content/docs/modules/extensions/no-color.mdx
@@ -1,6 +1,6 @@
 ---
 title: No Color
-description: Control terminal color with an inherited flag.
+description: Control terminal color with a recursive Extension flag.
 ---
 
 ```ts
@@ -16,7 +16,7 @@ await app.execute();
 function noColor(): Extension;
 ```
 
-`noColor()` owns an inherited boolean `color` flag. Crust's normal boolean negation provides both forms:
+`noColor()` owns a recursive boolean `color` flag. Crust's normal boolean negation provides both forms:
 
 ```sh
 my-cli --color

--- a/apps/docs/examples/extensions/diagnostics.ts
+++ b/apps/docs/examples/extensions/diagnostics.ts
@@ -7,7 +7,6 @@ export const diagnostics = defineExtension("diagnostics", {
     trace: {
       type: "boolean",
       description: "Print diagnostic timing",
-      inherit: true,
     },
   },
   commands: [

--- a/apps/docs/examples/split-files/app.ts
+++ b/apps/docs/examples/split-files/app.ts
@@ -1,10 +1,9 @@
 import { Crust } from "@crustjs/core";
 import { help, version } from "@crustjs/extensions";
 
-import { logger, verbose } from "./shared.ts";
+import { logger } from "./shared.ts";
 
 export const app = new Crust("my-cli")
   .meta({ description: "A split-file CLI" })
   .extend(version("0.2.0"), help())
-  .flags(verbose)
   .provide(logger());

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "@crustjs/core";
 
 import { logger } from "../shared.ts";
 
-export const greetCommand = defineCommand("greet", { ctx: [logger] }, (command) =>
+export const greetCommand = defineCommand("greet", { requires: { ctx: [logger] } }, (command) =>
   command
     .args({ name: "name", type: "string", default: "world" })
     .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -1,13 +1,13 @@
 import { defineCommand } from "@crustjs/core";
 
-import { logger, verbose } from "../shared.ts";
+import { logger } from "../shared.ts";
 
-export const greetCommand = defineCommand("greet", { flags: [verbose], ctx: [logger] }, (command) =>
+export const greetCommand = defineCommand("greet", { ctx: [logger] }, (command) =>
   command
     .args({ name: "name", type: "string", default: "world" })
     .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })
     .handle(({ args, flags, ctx, stdout }) => {
-      if (flags.verbose) ctx.logger.write("Preparing greeting");
+      ctx.logger.write("Preparing greeting");
       stdout(`${flags.greeting}, ${args.name}!`);
     }),
 );

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "@crustjs/core";
 
 import { logger } from "../shared.ts";
 
-export const greetCommand = defineCommand("greet", { requires: { ctx: [logger] } }, (command) =>
+export const greetCommand = defineCommand("greet", { requires: [logger] }, (command) =>
   command
     .args({ name: "name", type: "string", default: "world" })
     .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })

--- a/apps/docs/examples/split-files/shared.ts
+++ b/apps/docs/examples/split-files/shared.ts
@@ -2,7 +2,7 @@ import { defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-export const logger = defineContext("logger", { ownFlags: [verbose] }, ({ flags }) => ({
+export const logger = defineContext("logger", { flags: [verbose] }, ({ flags }) => ({
   write(message: string) {
     if (flags.verbose) console.error(message);
   },

--- a/apps/docs/examples/split-files/shared.ts
+++ b/apps/docs/examples/split-files/shared.ts
@@ -1,9 +1,9 @@
 import { defineContext, defineFlag } from "@crustjs/core";
 
-export const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-export const logger = defineContext("logger", () => ({
+export const logger = defineContext("logger", { ownFlags: [verbose] }, ({ flags }) => ({
   write(message: string) {
-    console.error(message);
+    if (flags.verbose) console.error(message);
   },
 }));

--- a/apps/docs/examples/split-files/shared.ts
+++ b/apps/docs/examples/split-files/shared.ts
@@ -2,8 +2,8 @@ import { defineContext, defineFlag } from "@crustjs/core";
 
 const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-export const logger = defineContext("logger", { flags: [verbose] }, ({ flags }) => ({
+export const logger = defineContext("logger", { flags: [verbose] }, ({ flags, stderr }) => ({
   write(message: string) {
-    if (flags.verbose) console.error(message);
+    if (flags.verbose) stderr(message);
   },
 }));

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -17,23 +17,25 @@ describe("public beta API", () => {
 			},
 		}));
 
-		const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [db] } }, (cmd) =>
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
+		const deploy = defineCommand("deploy", { requires: [logging, db] }, (cmd) =>
 			cmd
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "env", type: "string", default: "prod" })
 				.handle(({ args, flags, ctx }) => {
 					type _target = Expect<Equal<typeof args.target, string>>;
 					type _env = Expect<Equal<typeof flags.env, string>>;
-					type _verbose = Expect<Equal<typeof flags.verbose, boolean | undefined>>;
+					type _verbose = Expect<Equal<typeof ctx.logging.verbose, boolean>>;
 					type _dbUrl = Expect<Equal<typeof ctx.db.url, string>>;
 
-					ctx.db.query(`${args.target}:${flags.env}:${flags.verbose}`);
+					ctx.db.query(`${args.target}:${flags.env}:${ctx.logging.verbose}`);
 				}),
 		);
 
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
 		const app = new Crust("my-cli")
-			.provide(globalFlags())
+			.provide(logging())
 			.provide(db({ url: "memory://test" }))
 			.mount(deploy);
 
@@ -45,7 +47,7 @@ describe("public beta API", () => {
 	it("mounts one definition twice via .as()", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", () => ({ user: "chenxin" }));
-		const deploy = defineCommand("deploy", { requires: { ctx: [auth] } }, (command) =>
+		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
 			command.args({ name: "target", type: "string", required: true }).handle(({ args, ctx }) => {
 				type _target = Expect<Equal<typeof args.target, string>>;
 				type _user = Expect<Equal<typeof ctx.auth.user, string>>;

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -17,7 +17,7 @@ describe("public beta API", () => {
 			},
 		}));
 
-		const deploy = defineCommand("deploy", { flags: [verbose], ctx: [db] }, (cmd) =>
+		const deploy = defineCommand("deploy", { requires: { flags: [verbose], ctx: [db] } }, (cmd) =>
 			cmd
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "env", type: "string", default: "prod" })
@@ -44,7 +44,7 @@ describe("public beta API", () => {
 	it("mounts one definition twice via .as()", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", () => ({ user: "chenxin" }));
-		const deploy = defineCommand("deploy", { ctx: [auth] }, (command) =>
+		const deploy = defineCommand("deploy", { requires: { ctx: [auth] } }, (command) =>
 			command.args({ name: "target", type: "string", required: true }).handle(({ args, ctx }) => {
 				type _target = Expect<Equal<typeof args.target, string>>;
 				type _user = Expect<Equal<typeof ctx.auth.user, string>>;

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -9,7 +9,7 @@ type Equal<A, B> =
 describe("public beta API", () => {
 	it("passes typed command context into mounted definitions with requirements", async () => {
 		const calls: string[] = [];
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const db = defineContext("db", ({ options }: { options: { url: string } }) => ({
 			url: options.url,
 			query(sql: string) {
@@ -31,8 +31,9 @@ describe("public beta API", () => {
 				}),
 		);
 
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
 		const app = new Crust("my-cli")
-			.flags(verbose)
+			.provide(globalFlags())
 			.provide(db({ url: "memory://test" }))
 			.mount(deploy);
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -204,7 +204,6 @@ describe("Context-owned flags", () => {
 			short: "k",
 			aliases: ["token"],
 		});
-		expect("inherit" in apiKey).toBe(false);
 
 		const app = new Crust("cli").provide(instance).handle(({ flags, ctx }) => {
 			type _HandlerApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -221,7 +221,10 @@ describe("Context-owned flags", () => {
 			return {};
 		});
 
-		await new Crust("cli").provide(server()).handle(() => {}).run(["--port", "8080"]);
+		await new Crust("cli")
+			.provide(server())
+			.handle(() => {})
+			.run(["--port", "8080"]);
 
 		expect(seen).toEqual([8080]);
 	});

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -39,7 +39,7 @@ describe("defineContext()", () => {
 	});
 
 	it(".of() produces an instance returning the precomputed value with requirements absent", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const db = defineContext("db", { requires: { flags: [verbose] } }, ({ flags }) => ({
 			url: `real:${String(flags.verbose)}`,
 		}));
@@ -191,7 +191,7 @@ describe("Context-owned flags", () => {
 		aliases: ["token"],
 	});
 
-	it("installs an inheritable cloned flag and exposes its validated value to setup", async () => {
+	it("installs a propagating cloned flag and exposes its validated value to setup", async () => {
 		const seen: unknown[] = [];
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => {
 			type _ApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
@@ -203,7 +203,6 @@ describe("Context-owned flags", () => {
 			type: "string",
 			short: "k",
 			aliases: ["token"],
-			inherit: true,
 		});
 		expect("inherit" in apiKey).toBe(false);
 
@@ -214,6 +213,20 @@ describe("Context-owned flags", () => {
 		await app.run(["--api-key", "secret"]);
 
 		expect(seen).toEqual(["secret", "secret"]);
+	});
+
+	it("derives a logging capability while handlers keep injected stderr", async () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
+		const messages: string[] = [];
+		const app = new Crust("cli").provide(logging()).handle(({ ctx, stderr }) => {
+			if (ctx.logging.verbose) stderr("debug");
+		});
+
+		await app.run(["--verbose"], { stderr: (message) => messages.push(message) });
+		expect(messages).toEqual(["debug"]);
 	});
 
 	it("satisfies later mounted flag and Context requirements", async () => {
@@ -243,10 +256,10 @@ describe("Context-owned flags", () => {
 
 		type _OwnedKeys = Assert<IsEqual<keyof (typeof app)["_types"]["owned"], "api-key" | "format">>;
 		type _EffectiveApiKey = Assert<
-			IsEqual<(typeof app)["_types"]["effective"]["api-key"]["inherit"], true>
+			IsEqual<(typeof app)["_types"]["effective"]["api-key"]["type"], "string">
 		>;
 		type _EffectiveFormat = Assert<
-			IsEqual<(typeof app)["_types"]["effective"]["format"]["inherit"], true>
+			IsEqual<(typeof app)["_types"]["effective"]["format"]["type"], "string">
 		>;
 	});
 
@@ -287,7 +300,7 @@ describe("Context-owned flags", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({ real: true }));
 		const fake = auth.of({ real: false });
 		expect(fake.requiredFlags).toEqual({});
-		expect(fake.ownedFlags["api-key"]?.inherit).toBe(true);
+		expect(fake.ownedFlags["api-key"]).toBeDefined();
 
 		await new Crust("cli")
 			.provide(fake)
@@ -356,7 +369,7 @@ describe("Context-owned flags", () => {
 });
 
 describe("Context flag requirements", () => {
-	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+	const verbose = defineFlag("verbose", { type: "boolean" });
 
 	it("passes the validated parsed flags of the resolved invocation to setup", async () => {
 		const seen: unknown[] = [];
@@ -366,8 +379,9 @@ describe("Context flag requirements", () => {
 			return { level: flags.verbose ? "debug" : "info" };
 		});
 
+		const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
 		const app = new Crust("cli")
-			.flags(verbose)
+			.provide(loggingFlags())
 			.provide(logger())
 			.handle(({ ctx }) => {
 				seen.push(ctx.logger.level);
@@ -384,7 +398,7 @@ describe("Context flag requirements", () => {
 		const seen: unknown[] = [];
 		const port = defineFlag("port", {
 			type: "string",
-			inherit: true,
+
 			parse: (raw: string) => Number(raw),
 		});
 		const server = defineContext("server", { requires: { flags: [port] } }, ({ flags }) => {
@@ -392,8 +406,9 @@ describe("Context flag requirements", () => {
 			return {};
 		});
 
+		const serverFlags = defineContext("server-flags", { flags: [port] }, () => ({}));
 		await new Crust("cli")
-			.flags(port)
+			.provide(serverFlags())
 			.provide(server())
 			.handle(() => {})
 			.run(["--port", "8080"]);
@@ -407,26 +422,27 @@ describe("Context flag requirements", () => {
 		expect(() => new Crust("cli").provide(logger() as never)).toThrow(/requires flag "--verbose"/);
 	});
 
-	it("throws DEFINITION at .provide() when the flag is declared without inherit: true", () => {
+	it("does not let a local flag satisfy a Context flag requirement at runtime", () => {
 		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
 
 		expect(() =>
 			new Crust("cli").flags({ name: "verbose", type: "boolean" }).provide(logger() as never),
-		).toThrow(/inherit: true/);
+		).toThrow(/propagating Context-owned flag/);
 	});
 
 	it("checks flag requirements at compile time at the .provide() call site", () => {
 		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
 
-		new Crust("cli").flags(verbose).provide(logger());
-		// @ts-expect-error -- missing inherited flags: verbose
+		const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
+		new Crust("cli").provide(loggingFlags()).provide(logger());
+		// @ts-expect-error -- missing propagating flags: verbose
 		expect(() => new Crust("cli").provide(logger())).toThrow(CrustError);
 		expect(() =>
 			new Crust("cli")
-				.flags({ name: "verbose", type: "string", inherit: true })
-				// @ts-expect-error -- incompatible inherited flags: verbose
+				.flags(verbose)
+				// @ts-expect-error -- local flags do not satisfy propagating requirements
 				.provide(logger()),
-		).not.toThrow();
+		).toThrow(/propagating Context-owned flag/);
 	});
 });
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -40,7 +40,7 @@ describe("defineContext()", () => {
 
 	it(".of() produces an instance returning the precomputed value with requirements absent", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const db = defineContext("db", { flags: [verbose] }, ({ flags }) => ({
+		const db = defineContext("db", { requires: { flags: [verbose] } }, ({ flags }) => ({
 			url: `real:${String(flags.verbose)}`,
 		}));
 
@@ -125,7 +125,7 @@ describe("Crust .provide()", () => {
 	it("throws DEFINITION when a mounted subtree re-provides a path name", () => {
 		const parentDb = defineContext("db", () => "parent");
 		const nestedDb = defineContext("db", () => "nested");
-		const sub = defineCommand("sub", { ctx: [parentDb] }, (command) =>
+		const sub = defineCommand("sub", { requires: { ctx: [parentDb] } }, (command) =>
 			command.mount(defineCommand("g", (child) => child.provide(nestedDb()).handle(() => {}))),
 		);
 
@@ -135,9 +135,9 @@ describe("Crust .provide()", () => {
 	it("seeds mounted descendants with the parent Context path", async () => {
 		const seen: string[] = [];
 		const db = defineContext("db", () => "root-db");
-		const sub = defineCommand("sub", { ctx: [db] }, (command) =>
+		const sub = defineCommand("sub", { requires: { ctx: [db] } }, (command) =>
 			command.mount(
-				defineCommand("g", { ctx: [db] }, (child) =>
+				defineCommand("g", { requires: { ctx: [db] } }, (child) =>
 					child.handle(({ ctx }) => {
 						seen.push(ctx.db);
 					}),
@@ -193,7 +193,7 @@ describe("Context-owned flags", () => {
 
 	it("installs an inheritable cloned flag and exposes its validated value to setup", async () => {
 		const seen: unknown[] = [];
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => {
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => {
 			type _ApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
 			seen.push(flags["api-key"]);
 			return { apiKey: flags["api-key"] };
@@ -218,14 +218,17 @@ describe("Context-owned flags", () => {
 
 	it("satisfies later mounted flag and Context requirements", async () => {
 		const seen: string[] = [];
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
-		const deploy = defineCommand("deploy", { flags: [apiKey], ctx: [auth] }, (command) =>
-			command.handle(({ flags, ctx }) => {
-				type _Raw = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
-				seen.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
-			}),
+		const deploy = defineCommand(
+			"deploy",
+			{ requires: { flags: [apiKey], ctx: [auth] } },
+			(command) =>
+				command.handle(({ flags, ctx }) => {
+					type _Raw = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
+					seen.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
+				}),
 		);
 
 		await new Crust("cli").provide(auth()).mount(deploy).run(["--api-key", "secret", "deploy"]);
@@ -233,9 +236,9 @@ describe("Context-owned flags", () => {
 	});
 
 	it("merges owned flag types from multiple Contexts in one provide call", () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const format = defineFlag("format", { type: "string", choices: ["json", "text"] });
-		const output = defineContext("output", { ownFlags: [format] }, () => ({}));
+		const output = defineContext("output", { flags: [format] }, () => ({}));
 		const app = new Crust("cli").provide(auth(), output());
 
 		type _OwnedKeys = Assert<IsEqual<keyof (typeof app)["_types"]["owned"], "api-key" | "format">>;
@@ -248,7 +251,7 @@ describe("Context-owned flags", () => {
 	});
 
 	it("keeps owned flags when later .flags() calls replace local flags", async () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
 			.flags({ name: "verbose", type: "boolean" })
@@ -263,7 +266,7 @@ describe("Context-owned flags", () => {
 
 	it("allows one owning factory on sibling command branches", async () => {
 		const seen: string[] = [];
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
 		const branch = (name: string) =>
@@ -281,7 +284,7 @@ describe("Context-owned flags", () => {
 	});
 
 	it("retains owned flags on .of() test doubles", async () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({ real: true }));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({ real: true }));
 		const fake = auth.of({ real: false });
 		expect(fake.requiredFlags).toEqual({});
 		expect(fake.ownedFlags["api-key"]?.inherit).toBe(true);
@@ -297,14 +300,14 @@ describe("Context-owned flags", () => {
 
 	it("rejects owning and requiring the same flag", () => {
 		expect(() =>
-			defineContext("auth", { flags: [apiKey], ownFlags: [apiKey] }, () => ({})),
+			defineContext("auth", { flags: [apiKey], requires: { flags: [apiKey] } }, () => ({})),
 		).toThrow(/cannot both require and own flag "--api-key"/);
 	});
 
 	it("rejects duplicate owned flag names at definition time", () => {
 		const duplicates: readonly NamedFlagDef[] = [apiKey, apiKey];
 
-		expect(() => defineContext("auth", { ownFlags: duplicates }, () => ({}))).toThrow(
+		expect(() => defineContext("auth", { flags: duplicates }, () => ({}))).toThrow(
 			/owns flag "--api-key" more than once/,
 		);
 	});
@@ -315,22 +318,22 @@ describe("Context-owned flags", () => {
 			{ name: "key-file", type: "string", aliases: ["k"] },
 		];
 
-		expect(() => defineContext("auth", { ownFlags: colliding }, () => ({}))).toThrow(
+		expect(() => defineContext("auth", { flags: colliding }, () => ({}))).toThrow(
 			/Context "auth" flag "--key-file" spelling "k" collides with flag "--api-key"/,
 		);
 	});
 
 	it("rejects application and Context-owned collisions in both fluent orders", () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		expect(() => new Crust("cli").flags(apiKey).provide(auth())).toThrow(/collides/);
 		expect(() => new Crust("cli").provide(auth()).flags(apiKey)).toThrow(/collides/);
 	});
 
 	it("rejects collisions between different Contexts in one or separate provide calls", () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const session = defineContext(
 			"session",
-			{ ownFlags: [{ name: "session-key", type: "string", short: "k" }] },
+			{ flags: [{ name: "session-key", type: "string", short: "k" }] },
 			() => ({}),
 		);
 		expect(() => new Crust("cli").provide(auth(), session())).toThrow(/collides/);
@@ -338,7 +341,7 @@ describe("Context-owned flags", () => {
 	});
 
 	it("rejects Extension collisions regardless of fluent registration order", async () => {
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const extension = defineExtension("auth-extension", {
 			flags: { other: { type: "string", aliases: ["api-key"] } },
 		});
@@ -357,7 +360,7 @@ describe("Context flag requirements", () => {
 
 	it("passes the validated parsed flags of the resolved invocation to setup", async () => {
 		const seen: unknown[] = [];
-		const logger = defineContext("logger", { flags: [verbose] }, ({ flags }) => {
+		const logger = defineContext("logger", { requires: { flags: [verbose] } }, ({ flags }) => {
 			type _Verbose = Assert<IsEqual<typeof flags.verbose, boolean | undefined>>;
 			seen.push(flags.verbose);
 			return { level: flags.verbose ? "debug" : "info" };
@@ -384,7 +387,7 @@ describe("Context flag requirements", () => {
 			inherit: true,
 			parse: (raw: string) => Number(raw),
 		});
-		const server = defineContext("server", { flags: [port] }, ({ flags }) => {
+		const server = defineContext("server", { requires: { flags: [port] } }, ({ flags }) => {
 			seen.push(flags.port);
 			return {};
 		});
@@ -399,13 +402,13 @@ describe("Context flag requirements", () => {
 	});
 
 	it("throws DEFINITION at .provide() when a required flag is missing", () => {
-		const logger = defineContext("logger", { flags: [verbose] }, () => ({}));
+		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
 
 		expect(() => new Crust("cli").provide(logger() as never)).toThrow(/requires flag "--verbose"/);
 	});
 
 	it("throws DEFINITION at .provide() when the flag is declared without inherit: true", () => {
-		const logger = defineContext("logger", { flags: [verbose] }, () => ({}));
+		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
 
 		expect(() =>
 			new Crust("cli").flags({ name: "verbose", type: "boolean" }).provide(logger() as never),
@@ -413,7 +416,7 @@ describe("Context flag requirements", () => {
 	});
 
 	it("checks flag requirements at compile time at the .provide() call site", () => {
-		const logger = defineContext("logger", { flags: [verbose] }, () => ({}));
+		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
 
 		new Crust("cli").flags(verbose).provide(logger());
 		// @ts-expect-error -- missing inherited flags: verbose
@@ -434,11 +437,11 @@ describe("Context ctx requirements (topological construction)", () => {
 			order.push("config");
 			return { endpoint: "https://api.example.com" };
 		});
-		const client = defineContext("client", { ctx: [config] }, ({ ctx }) => {
+		const client = defineContext("client", { requires: { ctx: [config] } }, ({ ctx }) => {
 			order.push(`client:${ctx.config.endpoint}`);
 			return { endpoint: ctx.config.endpoint };
 		});
-		const workspace = defineContext("workspace", { ctx: [client] }, ({ ctx }) => {
+		const workspace = defineContext("workspace", { requires: { ctx: [client] } }, ({ ctx }) => {
 			order.push(`workspace:${ctx.client.endpoint}`);
 			return "crust";
 		});
@@ -464,7 +467,7 @@ describe("Context ctx requirements (topological construction)", () => {
 			order.push("config");
 			return { url: "u" };
 		});
-		const client = defineContext("client", { ctx: [config] }, ({ ctx }) => {
+		const client = defineContext("client", { requires: { ctx: [config] } }, ({ ctx }) => {
 			order.push("client");
 			return { url: ctx.config.url };
 		});
@@ -482,7 +485,7 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("types ctx in setup from the declared dependency factories", () => {
 		const session = defineContext("session", () => ({ userId: "yan" }));
-		defineContext("user", { ctx: [session] }, ({ ctx }) => {
+		defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => {
 			type _Session = Assert<IsEqual<typeof ctx.session, { userId: string }>>;
 			// @ts-expect-error -- only declared dependencies are visible
 			void ctx.other;
@@ -492,7 +495,7 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("throws DEFINITION at dispatch when a dependency is missing from the path", async () => {
 		const config = defineContext("config", () => ({}));
-		const client = defineContext("client", { ctx: [config] }, () => ({}));
+		const client = defineContext("client", { requires: { ctx: [config] } }, () => ({}));
 
 		const app = new Crust("cli").provide(client()).handle(() => {});
 
@@ -521,10 +524,10 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("satisfies a mounted definition's Context requirement before its dependents construct", async () => {
 		const session = defineContext("session", () => ({ userId: "yan" }));
-		const user = defineContext("user", { ctx: [session] }, ({ ctx }) => ({
+		const user = defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => ({
 			id: ctx.session.userId,
 		}));
-		const account = defineCommand("account", { ctx: [session] }, (command) =>
+		const account = defineCommand("account", { requires: { ctx: [session] } }, (command) =>
 			command.provide(user()).handle(({ ctx }) => {
 				type _User = Assert<IsEqual<typeof ctx.user, { id: string }>>;
 				expect(ctx.user).toEqual({ id: "yan" });
@@ -569,7 +572,7 @@ describe("Context disposal", () => {
 				log.push("dispose:base");
 			},
 		}));
-		const derived = defineContext("derived", { ctx: [base] }, () => ({
+		const derived = defineContext("derived", { requires: { ctx: [base] } }, () => ({
 			[Symbol.dispose]() {
 				log.push("dispose:derived");
 			},
@@ -640,7 +643,7 @@ describe("Context disposal", () => {
 				events.push("disposed");
 			},
 		}));
-		const guard = defineContext("guard", { ctx: [resource] }, () => {
+		const guard = defineContext("guard", { requires: { ctx: [resource] } }, () => {
 			throw new Error("Unauthenticated");
 		});
 		const app = new Crust("cli").provide(resource(), guard()).handle(() => {

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -22,9 +22,9 @@ describe("defineContext()", () => {
 		const instance = auth();
 		expect(instance.kind).toBe("context");
 		expect(instance.name).toBe("auth");
-		await expect(Promise.resolve(instance.setup({ flags: {}, ctx: {} }))).resolves.toEqual({
-			user: "chenxin",
-		});
+		await expect(
+			Promise.resolve(instance.setup({ flags: {}, ctx: {}, stdout: () => {}, stderr: () => {} })),
+		).resolves.toEqual({ user: "chenxin" });
 	});
 
 	it("passes the factory argument as options", async () => {
@@ -33,9 +33,9 @@ describe("defineContext()", () => {
 		}));
 
 		const instance = db({ url: "memory://test" });
-		await expect(Promise.resolve(instance.setup({ flags: {}, ctx: {} }))).resolves.toEqual({
-			url: "memory://test",
-		});
+		await expect(
+			Promise.resolve(instance.setup({ flags: {}, ctx: {}, stdout: () => {}, stderr: () => {} })),
+		).resolves.toEqual({ url: "memory://test" });
 	});
 
 	it(".of() produces an instance returning the precomputed value with requirements absent", async () => {
@@ -249,17 +249,31 @@ describe("Context-owned flags", () => {
 		expect(seen).toEqual([["api-key"], ["region"]]);
 	});
 
-	it("derives a logging capability while handlers keep injected stderr", async () => {
+	it("builds behavior capabilities with the handler's injected io", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
-			verbose: flags.verbose === true,
-		}));
+		let setupStdout: ((text: string) => void) | undefined;
+		let setupStderr: ((text: string) => void) | undefined;
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stdout, stderr }) => {
+			type _Stdout = Assert<IsEqual<typeof stdout, (text: string) => void>>;
+			type _Stderr = Assert<IsEqual<typeof stderr, (text: string) => void>>;
+			setupStdout = stdout;
+			setupStderr = stderr;
+			return {
+				debug(message: string) {
+					if (flags.verbose) stderr(message);
+				},
+			};
+		});
 		const messages: string[] = [];
-		const app = new Crust("cli").provide(logging()).handle(({ ctx, stderr }) => {
-			if (ctx.logging.verbose) stderr("debug");
+		const stdout = (_message: string) => {};
+		const stderr = (message: string) => messages.push(message);
+		const app = new Crust("cli").provide(logging()).handle(({ ctx, stdout, stderr }) => {
+			expect(setupStdout).toBe(stdout);
+			expect(setupStderr).toBe(stderr);
+			ctx.logging.debug("debug");
 		});
 
-		await app.run(["--verbose"], { stderr: (message) => messages.push(message) });
+		await app.run(["--verbose"], { stdout, stderr });
 		expect(messages).toEqual(["debug"]);
 	});
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -212,6 +212,20 @@ describe("Context-owned flags", () => {
 		expect(seen).toEqual(["secret", "secret"]);
 	});
 
+	it("passes parsed owned flag values to setup", async () => {
+		const port = defineFlag("port", { type: "string", parse: Number });
+		const seen: number[] = [];
+		const server = defineContext("server", { flags: [port] }, ({ flags }) => {
+			type _Port = Assert<IsEqual<typeof flags.port, number | undefined>>;
+			if (flags.port !== undefined) seen.push(flags.port);
+			return {};
+		});
+
+		await new Crust("cli").provide(server()).handle(() => {}).run(["--port", "8080"]);
+
+		expect(seen).toEqual([8080]);
+	});
+
 	it("passes only each Context's owned flags to its setup", async () => {
 		const region = defineFlag("region", { type: "string" });
 		const seen: string[][] = [];

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -398,7 +398,6 @@ describe("Context flag requirements", () => {
 		const seen: unknown[] = [];
 		const port = defineFlag("port", {
 			type: "string",
-
 			parse: (raw: string) => Number(raw),
 		});
 		const server = defineContext("server", { requires: { flags: [port] } }, ({ flags }) => {

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -321,7 +321,7 @@ describe("Context-owned flags", () => {
 		const duplicates: readonly NamedFlagDef[] = [apiKey, apiKey];
 
 		expect(() => defineContext("auth", { flags: duplicates }, () => ({}))).toThrow(
-			/owns flag "--api-key" more than once/,
+			/flag "--api-key" spelling "api-key" collides with flag "--api-key"/,
 		);
 	});
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -40,20 +40,18 @@ describe("defineContext()", () => {
 
 	it(".of() produces an instance returning the precomputed value with requirements absent", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const db = defineContext("db", { requires: { flags: [verbose] } }, ({ flags }) => ({
+		const db = defineContext("db", { flags: [verbose] }, ({ flags }) => ({
 			url: `real:${String(flags.verbose)}`,
 		}));
 
 		const fake = db.of({ url: "fake://db" });
 		expect(fake.name).toBe("db");
-		expect(fake.requiredFlags).toEqual({});
 		expect(fake.requiredCtx).toEqual([]);
 		type _Name = Assert<IsEqual<(typeof fake)["name"], "db">>;
 		// @ts-expect-error -- .of() takes the Context's value type
 		db.of({ wrong: true });
 
 		const seen: string[] = [];
-		// No verbose flag declared — .of() bypasses the flag requirement
 		const app = new Crust("cli").provide(fake).handle(({ ctx }) => {
 			seen.push(ctx.db.url);
 		});
@@ -125,7 +123,7 @@ describe("Crust .provide()", () => {
 	it("throws DEFINITION when a mounted subtree re-provides a path name", () => {
 		const parentDb = defineContext("db", () => "parent");
 		const nestedDb = defineContext("db", () => "nested");
-		const sub = defineCommand("sub", { requires: { ctx: [parentDb] } }, (command) =>
+		const sub = defineCommand("sub", { requires: [parentDb] }, (command) =>
 			command.mount(defineCommand("g", (child) => child.provide(nestedDb()).handle(() => {}))),
 		);
 
@@ -135,9 +133,9 @@ describe("Crust .provide()", () => {
 	it("seeds mounted descendants with the parent Context path", async () => {
 		const seen: string[] = [];
 		const db = defineContext("db", () => "root-db");
-		const sub = defineCommand("sub", { requires: { ctx: [db] } }, (command) =>
+		const sub = defineCommand("sub", { requires: [db] }, (command) =>
 			command.mount(
-				defineCommand("g", { requires: { ctx: [db] } }, (child) =>
+				defineCommand("g", { requires: [db] }, (child) =>
 					child.handle(({ ctx }) => {
 						seen.push(ctx.db);
 					}),
@@ -214,6 +212,26 @@ describe("Context-owned flags", () => {
 		expect(seen).toEqual(["secret", "secret"]);
 	});
 
+	it("passes only each Context's owned flags to its setup", async () => {
+		const region = defineFlag("region", { type: "string" });
+		const seen: string[][] = [];
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => {
+			seen.push(Object.keys(flags));
+			return {};
+		});
+		const location = defineContext("location", { flags: [region] }, ({ flags }) => {
+			seen.push(Object.keys(flags));
+			return {};
+		});
+
+		await new Crust("cli")
+			.provide(auth(), location())
+			.handle(() => {})
+			.run(["--api-key", "secret", "--region", "us"]);
+
+		expect(seen).toEqual([["api-key"], ["region"]]);
+	});
+
 	it("derives a logging capability while handlers keep injected stderr", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
@@ -228,23 +246,19 @@ describe("Context-owned flags", () => {
 		expect(messages).toEqual(["debug"]);
 	});
 
-	it("satisfies later mounted flag and Context requirements", async () => {
+	it("exposes a provided capability to later mounted commands", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
-		const deploy = defineCommand(
-			"deploy",
-			{ requires: { flags: [apiKey], ctx: [auth] } },
-			(command) =>
-				command.handle(({ flags, ctx }) => {
-					type _Raw = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
-					seen.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
-				}),
+		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
+			command.handle(({ ctx }) => {
+				seen.push(String(ctx.auth.apiKey));
+			}),
 		);
 
 		await new Crust("cli").provide(auth()).mount(deploy).run(["--api-key", "secret", "deploy"]);
-		expect(seen).toEqual(["secret:secret"]);
+		expect(seen).toEqual(["secret"]);
 	});
 
 	it("merges owned flag types from multiple Contexts in one provide call", () => {
@@ -298,7 +312,6 @@ describe("Context-owned flags", () => {
 	it("retains owned flags on .of() test doubles", async () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({ real: true }));
 		const fake = auth.of({ real: false });
-		expect(fake.requiredFlags).toEqual({});
 		expect(fake.ownedFlags["api-key"]).toBeDefined();
 
 		await new Crust("cli")
@@ -308,12 +321,6 @@ describe("Context-owned flags", () => {
 				expect(ctx.auth.real).toBe(false);
 			})
 			.run(["--api-key", "fake-key"]);
-	});
-
-	it("rejects owning and requiring the same flag", () => {
-		expect(() =>
-			defineContext("auth", { flags: [apiKey], requires: { flags: [apiKey] } }, () => ({})),
-		).toThrow(/cannot both require and own flag "--api-key"/);
 	});
 
 	it("rejects duplicate owned flag names at definition time", () => {
@@ -367,95 +374,18 @@ describe("Context-owned flags", () => {
 	});
 });
 
-describe("Context flag requirements", () => {
-	const verbose = defineFlag("verbose", { type: "boolean" });
-
-	it("passes the validated parsed flags of the resolved invocation to setup", async () => {
-		const seen: unknown[] = [];
-		const logger = defineContext("logger", { requires: { flags: [verbose] } }, ({ flags }) => {
-			type _Verbose = Assert<IsEqual<typeof flags.verbose, boolean | undefined>>;
-			seen.push(flags.verbose);
-			return { level: flags.verbose ? "debug" : "info" };
-		});
-
-		const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli")
-			.provide(loggingFlags())
-			.provide(logger())
-			.handle(({ ctx }) => {
-				seen.push(ctx.logger.level);
-			});
-
-		await app.run(["--verbose"]);
-		expect(seen).toEqual([true, "debug"]);
-
-		await app.run([]);
-		expect(seen).toEqual([true, "debug", undefined, "info"]);
-	});
-
-	it("setups see schema-validated flag values, not raw tokens", async () => {
-		const seen: unknown[] = [];
-		const port = defineFlag("port", {
-			type: "string",
-			parse: (raw: string) => Number(raw),
-		});
-		const server = defineContext("server", { requires: { flags: [port] } }, ({ flags }) => {
-			seen.push(flags.port);
-			return {};
-		});
-
-		const serverFlags = defineContext("server-flags", { flags: [port] }, () => ({}));
-		await new Crust("cli")
-			.provide(serverFlags())
-			.provide(server())
-			.handle(() => {})
-			.run(["--port", "8080"]);
-
-		expect(seen).toEqual([8080]);
-	});
-
-	it("throws DEFINITION at .provide() when a required flag is missing", () => {
-		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
-
-		expect(() => new Crust("cli").provide(logger() as never)).toThrow(/requires flag "--verbose"/);
-	});
-
-	it("does not let a local flag satisfy a Context flag requirement at runtime", () => {
-		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
-
-		expect(() =>
-			new Crust("cli").flags({ name: "verbose", type: "boolean" }).provide(logger() as never),
-		).toThrow(/propagating Context-owned flag/);
-	});
-
-	it("checks flag requirements at compile time at the .provide() call site", () => {
-		const logger = defineContext("logger", { requires: { flags: [verbose] } }, () => ({}));
-
-		const loggingFlags = defineContext("logging-flags", { flags: [verbose] }, () => ({}));
-		new Crust("cli").provide(loggingFlags()).provide(logger());
-		// @ts-expect-error -- missing propagating flags: verbose
-		expect(() => new Crust("cli").provide(logger())).toThrow(CrustError);
-		expect(() =>
-			new Crust("cli")
-				.flags(verbose)
-				// @ts-expect-error -- local flags do not satisfy propagating requirements
-				.provide(logger()),
-		).toThrow(/propagating Context-owned flag/);
-	});
-});
-
-describe("Context ctx requirements (topological construction)", () => {
+describe("Context capability requirements (topological construction)", () => {
 	it("constructs dependencies before dependents in registration order among independents", async () => {
 		const order: string[] = [];
 		const config = defineContext("config", () => {
 			order.push("config");
 			return { endpoint: "https://api.example.com" };
 		});
-		const client = defineContext("client", { requires: { ctx: [config] } }, ({ ctx }) => {
+		const client = defineContext("client", { requires: [config] }, ({ ctx }) => {
 			order.push(`client:${ctx.config.endpoint}`);
 			return { endpoint: ctx.config.endpoint };
 		});
-		const workspace = defineContext("workspace", { requires: { ctx: [client] } }, ({ ctx }) => {
+		const workspace = defineContext("workspace", { requires: [client] }, ({ ctx }) => {
 			order.push(`workspace:${ctx.client.endpoint}`);
 			return "crust";
 		});
@@ -481,7 +411,7 @@ describe("Context ctx requirements (topological construction)", () => {
 			order.push("config");
 			return { url: "u" };
 		});
-		const client = defineContext("client", { requires: { ctx: [config] } }, ({ ctx }) => {
+		const client = defineContext("client", { requires: [config] }, ({ ctx }) => {
 			order.push("client");
 			return { url: ctx.config.url };
 		});
@@ -499,7 +429,7 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("types ctx in setup from the declared dependency factories", () => {
 		const session = defineContext("session", () => ({ userId: "yan" }));
-		defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => {
+		defineContext("user", { requires: [session] }, ({ ctx }) => {
 			type _Session = Assert<IsEqual<typeof ctx.session, { userId: string }>>;
 			// @ts-expect-error -- only declared dependencies are visible
 			void ctx.other;
@@ -509,7 +439,7 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("throws DEFINITION at dispatch when a dependency is missing from the path", async () => {
 		const config = defineContext("config", () => ({}));
-		const client = defineContext("client", { requires: { ctx: [config] } }, () => ({}));
+		const client = defineContext("client", { requires: [config] }, () => ({}));
 
 		const app = new Crust("cli").provide(client()).handle(() => {});
 
@@ -538,10 +468,10 @@ describe("Context ctx requirements (topological construction)", () => {
 
 	it("satisfies a mounted definition's Context requirement before its dependents construct", async () => {
 		const session = defineContext("session", () => ({ userId: "yan" }));
-		const user = defineContext("user", { requires: { ctx: [session] } }, ({ ctx }) => ({
+		const user = defineContext("user", { requires: [session] }, ({ ctx }) => ({
 			id: ctx.session.userId,
 		}));
-		const account = defineCommand("account", { requires: { ctx: [session] } }, (command) =>
+		const account = defineCommand("account", { requires: [session] }, (command) =>
 			command.provide(user()).handle(({ ctx }) => {
 				type _User = Assert<IsEqual<typeof ctx.user, { id: string }>>;
 				expect(ctx.user).toEqual({ id: "yan" });
@@ -586,7 +516,7 @@ describe("Context disposal", () => {
 				log.push("dispose:base");
 			},
 		}));
-		const derived = defineContext("derived", { requires: { ctx: [base] } }, () => ({
+		const derived = defineContext("derived", { requires: [base] }, () => ({
 			[Symbol.dispose]() {
 				log.push("dispose:derived");
 			},
@@ -657,7 +587,7 @@ describe("Context disposal", () => {
 				events.push("disposed");
 			},
 		}));
-		const guard = defineContext("guard", { requires: { ctx: [resource] } }, () => {
+		const guard = defineContext("guard", { requires: [resource] }, () => {
 			throw new Error("Unauthenticated");
 		});
 		const app = new Crust("cli").provide(resource(), guard()).handle(() => {

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 
 import { Crust, defineCommand } from "../command/crust.ts";
 import { CrustError } from "../errors.ts";
+import type { NamedFlagDef } from "../types.ts";
 import { defineContext } from "./context.ts";
+import { defineExtension } from "./extension.ts";
 import { defineFlag } from "./flags.ts";
 
 type Assert<T extends true> = T;
@@ -179,6 +181,174 @@ describe("Crust .provide()", () => {
 		await app.run(["status"]);
 
 		expect(lateProvided).toBe(false);
+	});
+});
+
+describe("Context-owned flags", () => {
+	const apiKey = defineFlag("api-key", {
+		type: "string",
+		short: "k",
+		aliases: ["token"],
+	});
+
+	it("installs an inheritable cloned flag and exposes its validated value to setup", async () => {
+		const seen: unknown[] = [];
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => {
+			type _ApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
+			seen.push(flags["api-key"]);
+			return { apiKey: flags["api-key"] };
+		});
+		const instance = auth();
+		expect(instance.ownedFlags["api-key"]).toEqual({
+			type: "string",
+			short: "k",
+			aliases: ["token"],
+			inherit: true,
+		});
+		expect("inherit" in apiKey).toBe(false);
+
+		const app = new Crust("cli").provide(instance).handle(({ flags, ctx }) => {
+			type _HandlerApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
+			seen.push(ctx.auth.apiKey);
+		});
+		await app.run(["--api-key", "secret"]);
+
+		expect(seen).toEqual(["secret", "secret"]);
+	});
+
+	it("satisfies later mounted flag and Context requirements", async () => {
+		const seen: string[] = [];
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+			apiKey: flags["api-key"],
+		}));
+		const deploy = defineCommand("deploy", { flags: [apiKey], ctx: [auth] }, (command) =>
+			command.handle(({ flags, ctx }) => {
+				type _Raw = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
+				seen.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
+			}),
+		);
+
+		await new Crust("cli").provide(auth()).mount(deploy).run(["--api-key", "secret", "deploy"]);
+		expect(seen).toEqual(["secret:secret"]);
+	});
+
+	it("merges owned flag types from multiple Contexts in one provide call", () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const format = defineFlag("format", { type: "string", choices: ["json", "text"] });
+		const output = defineContext("output", { ownFlags: [format] }, () => ({}));
+		const app = new Crust("cli").provide(auth(), output());
+
+		type _OwnedKeys = Assert<IsEqual<keyof (typeof app)["_types"]["owned"], "api-key" | "format">>;
+		type _EffectiveApiKey = Assert<
+			IsEqual<(typeof app)["_types"]["effective"]["api-key"]["inherit"], true>
+		>;
+		type _EffectiveFormat = Assert<
+			IsEqual<(typeof app)["_types"]["effective"]["format"]["inherit"], true>
+		>;
+	});
+
+	it("keeps owned flags when later .flags() calls replace local flags", async () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const app = new Crust("cli")
+			.provide(auth())
+			.flags({ name: "verbose", type: "boolean" })
+			.handle(({ flags }) => {
+				expect(flags["api-key"]).toBe("secret");
+				expect(flags.verbose).toBe(true);
+			});
+
+		await app.run(["--api-key", "secret", "--verbose"]);
+		expect(app._node.ownedFlags["api-key"]).toBeDefined();
+	});
+
+	it("allows one owning factory on sibling command branches", async () => {
+		const seen: string[] = [];
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+			apiKey: flags["api-key"],
+		}));
+		const branch = (name: string) =>
+			defineCommand(name, (command) =>
+				command.provide(auth()).handle(({ ctx }) => {
+					seen.push(`${name}:${ctx.auth.apiKey}`);
+				}),
+			);
+		const app = new Crust("cli").mount(branch("first"), branch("second"));
+
+		await app.run(["first", "--api-key", "one"]);
+		await app.run(["second", "--api-key", "two"]);
+
+		expect(seen).toEqual(["first:one", "second:two"]);
+	});
+
+	it("retains owned flags on .of() test doubles", async () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({ real: true }));
+		const fake = auth.of({ real: false });
+		expect(fake.requiredFlags).toEqual({});
+		expect(fake.ownedFlags["api-key"]?.inherit).toBe(true);
+
+		await new Crust("cli")
+			.provide(fake)
+			.handle(({ flags, ctx }) => {
+				expect(flags["api-key"]).toBe("fake-key");
+				expect(ctx.auth.real).toBe(false);
+			})
+			.run(["--api-key", "fake-key"]);
+	});
+
+	it("rejects owning and requiring the same flag", () => {
+		expect(() =>
+			defineContext("auth", { flags: [apiKey], ownFlags: [apiKey] }, () => ({})),
+		).toThrow(/cannot both require and own flag "--api-key"/);
+	});
+
+	it("rejects duplicate owned flag names at definition time", () => {
+		const duplicates: readonly NamedFlagDef[] = [apiKey, apiKey];
+
+		expect(() => defineContext("auth", { ownFlags: duplicates }, () => ({}))).toThrow(
+			/owns flag "--api-key" more than once/,
+		);
+	});
+
+	it("rejects collisions between owned flag spellings at definition time", () => {
+		const colliding: readonly NamedFlagDef[] = [
+			{ name: "api-key", type: "string", short: "k" },
+			{ name: "key-file", type: "string", aliases: ["k"] },
+		];
+
+		expect(() => defineContext("auth", { ownFlags: colliding }, () => ({}))).toThrow(
+			/Context "auth" flag "--key-file" spelling "k" collides with flag "--api-key"/,
+		);
+	});
+
+	it("rejects application and Context-owned collisions in both fluent orders", () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		expect(() => new Crust("cli").flags(apiKey).provide(auth())).toThrow(/collides/);
+		expect(() => new Crust("cli").provide(auth()).flags(apiKey)).toThrow(/collides/);
+	});
+
+	it("rejects collisions between different Contexts in one or separate provide calls", () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const session = defineContext(
+			"session",
+			{ ownFlags: [{ name: "session-key", type: "string", short: "k" }] },
+			() => ({}),
+		);
+		expect(() => new Crust("cli").provide(auth(), session())).toThrow(/collides/);
+		expect(() => new Crust("cli").provide(auth()).provide(session())).toThrow(/collides/);
+	});
+
+	it("rejects Extension collisions regardless of fluent registration order", async () => {
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const extension = defineExtension("auth-extension", {
+			flags: { other: { type: "string", aliases: ["api-key"] } },
+		});
+
+		await expect(new Crust("cli").extend(extension).provide(auth()).run([])).rejects.toThrow(
+			/collides/,
+		);
+		await expect(new Crust("cli").provide(auth()).extend(extension).run([])).rejects.toThrow(
+			/collides/,
+		);
 	});
 });
 

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -1,5 +1,14 @@
 import { CrustError } from "../errors.ts";
-import type { FlagsDef, InferFlags, NamedFlagDef, NamedFlagsRecord } from "../types.ts";
+import { validateIncomingFlag } from "../parsing/flag-validation.ts";
+import type {
+	FlagDef,
+	FlagsDef,
+	InferFlags,
+	MergeFlags,
+	NamedFlagDef,
+	NamedFlagsRecord,
+	ValidateNamedFlagDefs,
+} from "../types.ts";
 
 export type ContextMap = Record<string, unknown>;
 export type Awaitable<T> = T | Promise<T>;
@@ -17,6 +26,17 @@ export interface ContextRequirements {
 	readonly flags?: readonly NamedFlagDef[];
 	readonly ctx?: readonly AnyContextFactory[];
 }
+
+/** Context definition config: path requirements plus flags owned by this Context. */
+export interface ContextConfig extends ContextRequirements {
+	readonly ownFlags?: readonly NamedFlagDef[];
+}
+
+type ValidateContextConfig<R extends ContextConfig> = {
+	readonly ownFlags?: R["ownFlags"] extends readonly NamedFlagDef[]
+		? ValidateNamedFlagDefs<R["ownFlags"]>
+		: never;
+};
 
 /** The runtime input every Context setup receives (typed per-factory by `defineContext`). */
 interface ContextSetupInput {
@@ -37,6 +57,7 @@ export interface ContextInstance<
 	Value = unknown,
 	RF extends FlagsDef = {},
 	RC extends ContextMap = {},
+	OF extends FlagsDef = {},
 > {
 	readonly kind: "context";
 	readonly name: Name;
@@ -44,18 +65,25 @@ export interface ContextInstance<
 	readonly requiredFlags: FlagsDef;
 	/** @internal — declared ctx dependency names (topological ordering) */
 	readonly requiredCtx: readonly string[];
+	/** @internal — flags installed by this Context at its provide site */
+	readonly ownedFlags: FlagsDef;
 	/** @internal */
 	setup(input: ContextSetupInput): Awaitable<Value>;
-	/** @internal — phantom carrying requirement types for attach-site checks */
-	readonly _requires?: { flags: RF; ctx: RC };
+	/** @internal — phantom carrying requirement and ownership types */
+	readonly _requires?: { flags: RF; ctx: RC; ownFlags: OF };
 }
 
 /** The typed setup input for one Context factory. */
-export interface ContextSetup<Options, RF extends FlagsDef, RC extends ContextMap> {
+export interface ContextSetup<
+	Options,
+	RF extends FlagsDef,
+	RC extends ContextMap,
+	OF extends FlagsDef = {},
+> {
 	/** The factory argument */
 	readonly options: Options;
-	/** Validated parsed flags of the resolved invocation, narrowed to the declared requirements */
-	readonly flags: InferFlags<RF>;
+	/** Validated parsed flags required or owned by this Context. */
+	readonly flags: InferFlags<MergeFlags<RF, OF>>;
 	/** Values of the declared ctx dependencies */
 	readonly ctx: Readonly<RC>;
 }
@@ -66,21 +94,22 @@ export interface ContextFactory<
 	Value,
 	RF extends FlagsDef = {},
 	RC extends ContextMap = {},
+	OF extends FlagsDef = {},
 > {
-	(options: Options): ContextInstance<Name, Value, RF, RC>;
+	(options: Options): ContextInstance<Name, Value, RF, RC, OF>;
 	/** The Context name this factory produces (used in `requirements.ctx` arrays). */
 	readonly contextName: Name;
 	/**
 	 * Produce an instance whose setup returns the precomputed `value`
 	 * (requirements considered satisfied/absent) — for test doubles.
 	 */
-	of(value: Value): ContextInstance<Name, Value>;
+	of(value: Value): ContextInstance<Name, Value, {}, {}, OF>;
 }
 
-export type AnyContextFactory = ContextFactory<string, any, any, any, any>;
+export type AnyContextFactory = ContextFactory<string, any, any, any, any, any>;
 
 export type ContextOutput<C> =
-	C extends ContextInstance<infer Name, infer Value, any, any>
+	C extends ContextInstance<infer Name, infer Value, any, any, any>
 		? { [K in Name]: Awaited<Value> }
 		: never;
 
@@ -93,7 +122,7 @@ export type ContextsOutput<Cs extends readonly ContextInstance[]> = Cs extends r
 	: {};
 
 type FactoryOutput<F> =
-	F extends ContextFactory<infer Name, any, infer Value, any, any>
+	F extends ContextFactory<infer Name, any, infer Value, any, any, any>
 		? { [K in Name]: Awaited<Value> }
 		: never;
 
@@ -105,9 +134,26 @@ export type FactoriesOutput<Fs extends readonly AnyContextFactory[]> = Fs extend
 	? FactoryOutput<H> & FactoriesOutput<T>
 	: {};
 
+/** Merged flags owned by a tuple of Context instances. */
+export type ContextsOwnedFlags<Cs extends readonly ContextInstance[]> = Cs extends readonly [
+	infer H,
+	...infer T extends readonly ContextInstance[],
+]
+	? MergeFlags<ContextOwnedFlags<H>, ContextsOwnedFlags<T>>
+	: {};
+
+type ContextOwnedFlags<C> = C extends ContextInstance<any, any, any, any, infer OF> ? OF : {};
+
 /** @internal — flag requirements of a `{ flags, ctx }` requirements object, as a record. */
 export type RequirementFlagsOf<R extends ContextRequirements> = R extends {
 	flags: infer F extends readonly NamedFlagDef[];
+}
+	? NamedFlagsRecord<F>
+	: {};
+
+/** @internal — flags owned by a Context config, as a record. */
+export type OwnedFlagsOf<R extends ContextConfig> = R extends {
+	ownFlags: infer F extends readonly NamedFlagDef[];
 }
 	? NamedFlagsRecord<F>
 	: {};
@@ -126,9 +172,10 @@ export type RequirementCtxOf<R extends ContextRequirements> = R extends {
  * setups, so the API reads uniformly as
  * `defineContext("db", factory)` → `.provide(db(options))` → `ctx.db`.
  *
- * With a `requirements` argument the setup additionally receives the
- * validated parsed `flags` it declared and the values of the Contexts it
- * depends on (`ctx`). Dependencies drive construction order: Contexts on
+ * With a config argument, `flags` declares path requirements while
+ * `ownFlags` installs inheritable flags at `.provide()`. Setup receives the
+ * validated values of both sets plus declared Context dependencies (`ctx`).
+ * Dependencies drive construction order: Contexts on
  * the resolved command path are constructed topologically, regardless of
  * `.provide()` order.
  *
@@ -142,19 +189,26 @@ export function defineContext<Name extends string, Value, Options = void>(
 ): ContextFactory<Name, Options, Value>;
 export function defineContext<
 	Name extends string,
-	const R extends ContextRequirements,
+	const R extends ContextConfig,
 	Value,
 	Options = void,
 >(
 	name: Name,
-	requirements: R,
+	config: R & ValidateContextConfig<R>,
 	setup: (
-		input: ContextSetup<Options, RequirementFlagsOf<R>, RequirementCtxOf<R>>,
+		input: ContextSetup<Options, RequirementFlagsOf<R>, RequirementCtxOf<R>, OwnedFlagsOf<R>>,
 	) => Awaitable<Value>,
-): ContextFactory<Name, Options, Value, RequirementFlagsOf<R>, RequirementCtxOf<R>>;
+): ContextFactory<
+	Name,
+	Options,
+	Value,
+	RequirementFlagsOf<R>,
+	RequirementCtxOf<R>,
+	OwnedFlagsOf<R>
+>;
 export function defineContext(
 	name: string,
-	requirementsOrSetup: ContextRequirements | ((input: never) => unknown),
+	requirementsOrSetup: ContextConfig | ((input: never) => unknown),
 	maybeSetup?: (input: never) => unknown,
 ): AnyContextFactory {
 	const hasRequirements = typeof requirementsOrSetup !== "function";
@@ -173,6 +227,31 @@ export function defineContext(
 		const { name: flagName, ...rest } = def;
 		requiredFlags[flagName] = rest;
 	}
+	const ownedFlags: FlagsDef = {};
+	for (const def of requirements.ownFlags ?? []) {
+		const { name: flagName, ...rest } = def;
+		if (flagName in requiredFlags) {
+			throw new CrustError(
+				"DEFINITION",
+				`Context "${name}" cannot both require and own flag "--${flagName}"`,
+				{ subject: "context", name, reason: "required-owned-flag-collision" },
+			);
+		}
+		if (flagName in ownedFlags) {
+			throw new CrustError(
+				"DEFINITION",
+				`Context "${name}" owns flag "--${flagName}" more than once`,
+				{ subject: "flag", name: flagName, reason: "duplicate-flag" },
+			);
+		}
+		const owned = {
+			...rest,
+			aliases: rest.aliases ? [...rest.aliases] : undefined,
+			inherit: true,
+		} as FlagDef;
+		validateIncomingFlag({ name: flagName, def: owned }, ownedFlags, `Context "${name}"`);
+		ownedFlags[flagName] = owned;
+	}
 	const requiredCtx = (requirements.ctx ?? []).map((dep) => dep.contextName);
 
 	const factory = (options: unknown): ContextInstance => ({
@@ -180,6 +259,7 @@ export function defineContext(
 		name,
 		requiredFlags,
 		requiredCtx,
+		ownedFlags,
 		setup: (input) => setup({ options, flags: input.flags, ctx: input.ctx } as never),
 	});
 	factory.contextName = name;
@@ -188,6 +268,7 @@ export function defineContext(
 		name,
 		requiredFlags: {},
 		requiredCtx: [],
+		ownedFlags,
 		setup: () => value,
 	});
 	return factory as AnyContextFactory;

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -27,14 +27,15 @@ export interface ContextRequirements {
 	readonly ctx?: readonly AnyContextFactory[];
 }
 
-/** Context definition config: path requirements plus flags owned by this Context. */
-export interface ContextConfig extends ContextRequirements {
-	readonly ownFlags?: readonly NamedFlagDef[];
+/** Context definition config: owned flags plus dependencies required from the command path. */
+export interface ContextConfig {
+	readonly flags?: readonly NamedFlagDef[];
+	readonly requires?: ContextRequirements;
 }
 
 type ValidateContextConfig<R extends ContextConfig> = {
-	readonly ownFlags?: R["ownFlags"] extends readonly NamedFlagDef[]
-		? ValidateNamedFlagDefs<R["ownFlags"]>
+	readonly flags?: R["flags"] extends readonly NamedFlagDef[]
+		? ValidateNamedFlagDefs<R["flags"]>
 		: never;
 };
 
@@ -70,7 +71,7 @@ export interface ContextInstance<
 	/** @internal */
 	setup(input: ContextSetupInput): Awaitable<Value>;
 	/** @internal — phantom carrying requirement and ownership types */
-	readonly _requires?: { flags: RF; ctx: RC; ownFlags: OF };
+	readonly _requires?: { flags: RF; ctx: RC; ownedFlags: OF };
 }
 
 /** The typed setup input for one Context factory. */
@@ -97,7 +98,7 @@ export interface ContextFactory<
 	OF extends FlagsDef = {},
 > {
 	(options: Options): ContextInstance<Name, Value, RF, RC, OF>;
-	/** The Context name this factory produces (used in `requirements.ctx` arrays). */
+	/** The Context name this factory produces (used in `requires.ctx` arrays). */
 	readonly contextName: Name;
 	/**
 	 * Produce an instance whose setup returns the precomputed `value`
@@ -126,7 +127,7 @@ type FactoryOutput<F> =
 		? { [K in Name]: Awaited<Value> }
 		: never;
 
-/** Merged outputs of a tuple of Context factories (as declared in `requirements.ctx`). */
+/** Merged outputs of a tuple of Context factories (as declared in `requires.ctx`). */
 export type FactoriesOutput<Fs extends readonly AnyContextFactory[]> = Fs extends readonly [
 	infer H,
 	...infer T extends readonly AnyContextFactory[],
@@ -144,23 +145,23 @@ export type ContextsOwnedFlags<Cs extends readonly ContextInstance[]> = Cs exten
 
 type ContextOwnedFlags<C> = C extends ContextInstance<any, any, any, any, infer OF> ? OF : {};
 
-/** @internal — flag requirements of a `{ flags, ctx }` requirements object, as a record. */
-export type RequirementFlagsOf<R extends ContextRequirements> = R extends {
-	flags: infer F extends readonly NamedFlagDef[];
+/** @internal — flag dependencies from a config's `requires` object, as a record. */
+export type RequirementFlagsOf<R extends { readonly requires?: ContextRequirements }> = R extends {
+	requires: { flags: infer F extends readonly NamedFlagDef[] };
 }
 	? NamedFlagsRecord<F>
 	: {};
 
 /** @internal — flags owned by a Context config, as a record. */
 export type OwnedFlagsOf<R extends ContextConfig> = R extends {
-	ownFlags: infer F extends readonly NamedFlagDef[];
+	flags: infer F extends readonly NamedFlagDef[];
 }
 	? NamedFlagsRecord<F>
 	: {};
 
-/** @internal — merged ctx outputs of a `{ flags, ctx }` requirements object. */
-export type RequirementCtxOf<R extends ContextRequirements> = R extends {
-	ctx: infer C extends readonly AnyContextFactory[];
+/** @internal — merged ctx outputs from a config's `requires` object. */
+export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements }> = R extends {
+	requires: { ctx: infer C extends readonly AnyContextFactory[] };
 }
 	? FactoriesOutput<C>
 	: {};
@@ -172,9 +173,10 @@ export type RequirementCtxOf<R extends ContextRequirements> = R extends {
  * setups, so the API reads uniformly as
  * `defineContext("db", factory)` → `.provide(db(options))` → `ctx.db`.
  *
- * With a config argument, `flags` declares path requirements while
- * `ownFlags` installs inheritable flags at `.provide()`. Setup receives the
- * validated values of both sets plus declared Context dependencies (`ctx`).
+ * With a config argument, `flags` installs flags owned by the Context at
+ * `.provide()`, while `requires` declares typed dependencies from the command
+ * path. Setup receives the validated flags from both relationships plus declared
+ * Context dependencies (`ctx`).
  * Dependencies drive construction order: Contexts on
  * the resolved command path are constructed topologically, regardless of
  * `.provide()` order.
@@ -208,12 +210,12 @@ export function defineContext<
 >;
 export function defineContext(
 	name: string,
-	requirementsOrSetup: ContextConfig | ((input: never) => unknown),
+	configOrSetup: ContextConfig | ((input: never) => unknown),
 	maybeSetup?: (input: never) => unknown,
 ): AnyContextFactory {
-	const hasRequirements = typeof requirementsOrSetup !== "function";
-	const requirements = hasRequirements ? requirementsOrSetup : {};
-	const setup = hasRequirements ? maybeSetup : requirementsOrSetup;
+	const hasConfig = typeof configOrSetup !== "function";
+	const config = hasConfig ? configOrSetup : {};
+	const setup = hasConfig ? maybeSetup : configOrSetup;
 	if (typeof setup !== "function") {
 		throw new CrustError("DEFINITION", `Context "${name}" requires a setup function`, {
 			subject: "context",
@@ -223,12 +225,12 @@ export function defineContext(
 	}
 
 	const requiredFlags: FlagsDef = {};
-	for (const def of requirements.flags ?? []) {
+	for (const def of config.requires?.flags ?? []) {
 		const { name: flagName, ...rest } = def;
 		requiredFlags[flagName] = rest;
 	}
 	const ownedFlags: FlagsDef = {};
-	for (const def of requirements.ownFlags ?? []) {
+	for (const def of config.flags ?? []) {
 		const { name: flagName, ...rest } = def;
 		if (flagName in requiredFlags) {
 			throw new CrustError(
@@ -252,7 +254,7 @@ export function defineContext(
 		validateIncomingFlag({ name: flagName, def: owned }, ownedFlags, `Context "${name}"`);
 		ownedFlags[flagName] = owned;
 	}
-	const requiredCtx = (requirements.ctx ?? []).map((dep) => dep.contextName);
+	const requiredCtx = (config.requires?.ctx ?? []).map((dep) => dep.contextName);
 
 	const factory = (options: unknown): ContextInstance => ({
 		kind: "context",

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -249,7 +249,6 @@ export function defineContext(
 		const owned = {
 			...rest,
 			aliases: rest.aliases ? [...rest.aliases] : undefined,
-			inherit: true,
 		} as FlagDef;
 		validateIncomingFlag({ name: flagName, def: owned }, ownedFlags, `Context "${name}"`);
 		ownedFlags[flagName] = owned;

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -41,8 +41,8 @@ interface ContextSetupInput {
  * Attach with `.provide()`; the value is constructed only when the
  * resolved command path executes.
  *
- * Generic parameter `RC` carries the declared Context requirements for
- * compile-time checking at attach sites.
+ * Generic parameter `RC` carries the declared Context requirements.
+ * Reserved for future attach-site checking; no call site consumes it yet.
  */
 export interface ContextInstance<
 	Name extends string = string,

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -239,19 +239,8 @@ export function defineContext(
 				{ subject: "context", name, reason: "required-owned-flag-collision" },
 			);
 		}
-		if (flagName in ownedFlags) {
-			throw new CrustError(
-				"DEFINITION",
-				`Context "${name}" owns flag "--${flagName}" more than once`,
-				{ subject: "flag", name: flagName, reason: "duplicate-flag" },
-			);
-		}
-		const owned = {
-			...rest,
-			aliases: rest.aliases ? [...rest.aliases] : undefined,
-		} as FlagDef;
-		validateIncomingFlag({ name: flagName, def: owned }, ownedFlags, `Context "${name}"`);
-		ownedFlags[flagName] = owned;
+		validateIncomingFlag({ name: flagName, def: rest as FlagDef }, ownedFlags, `Context "${name}"`);
+		ownedFlags[flagName] = rest as FlagDef;
 	}
 	const requiredCtx = (config.requires?.ctx ?? []).map((dep) => dep.contextName);
 

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -4,6 +4,7 @@ import type {
 	FlagDef,
 	FlagsDef,
 	InferFlags,
+	InvocationIO,
 	MergeFlags,
 	NamedFlagDef,
 	NamedFlagsRecord,
@@ -31,7 +32,7 @@ type ValidateContextConfig<R extends ContextConfig> = {
 };
 
 /** The runtime input every Context setup receives (typed per-factory by `defineContext`). */
-interface ContextSetupInput {
+interface ContextSetupInput extends InvocationIO {
 	readonly flags: Record<string, unknown>;
 	readonly ctx: Readonly<ContextMap>;
 }
@@ -63,7 +64,11 @@ export interface ContextInstance<
 }
 
 /** The typed setup input for one Context factory. */
-export interface ContextSetup<Options, RC extends ContextMap, OF extends FlagsDef = {}> {
+export interface ContextSetup<
+	Options,
+	RC extends ContextMap,
+	OF extends FlagsDef = {},
+> extends InvocationIO {
 	/** The factory argument */
 	readonly options: Options;
 	/** Validated parsed flags owned by this Context. */
@@ -150,9 +155,9 @@ export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements
  *
  * With a config argument, `flags` installs flags owned by the Context at
  * `.provide()`, while `requires` declares Context capabilities from the command
- * path. Setup receives the validated owned flags plus declared Context values (`ctx`).
- * Dependencies drive construction order: Contexts on
- * the resolved command path are constructed topologically, regardless of
+ * path. Setup receives the validated owned flags, declared Context values (`ctx`),
+ * and the invocation's injectable output callbacks. Dependencies drive construction
+ * order: Contexts on the resolved command path are constructed topologically, regardless of
  * `.provide()` order.
  *
  * Cleanup belongs to the value itself: implement `Symbol.dispose` or
@@ -202,7 +207,7 @@ export function defineContext(
 		name,
 		requiredCtx,
 		ownedFlags,
-		setup: (input) => setup({ options, flags: input.flags, ctx: input.ctx } as never),
+		setup: (input) => setup({ options, ...input } as never),
 	});
 	factory.contextName = name;
 	factory.of = (value: unknown): ContextInstance => ({
@@ -287,10 +292,12 @@ export function sortContexts(
  * values on `disposal` so they are torn down in reverse construction order.
  *
  * @param flags - The validated parsed flags of the resolved invocation
+ * @param io - The invocation output callbacks also passed to the handler
  */
 export async function buildContexts(
 	contexts: readonly ContextInstance[],
 	flags: Record<string, unknown>,
+	io: InvocationIO,
 	disposal: AsyncDisposableStack,
 	where: string,
 ): Promise<ContextMap> {
@@ -299,7 +306,7 @@ export async function buildContexts(
 		const ownedFlags = Object.fromEntries(
 			Object.keys(item.ownedFlags).map((name) => [name, flags[name]]),
 		);
-		const value = await item.setup({ flags: ownedFlags, ctx: values });
+		const value = await item.setup({ flags: ownedFlags, ctx: values, ...io });
 		values[item.name] = value;
 		registerDisposable(value, disposal);
 	}

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -15,19 +15,10 @@ export type Awaitable<T> = T | Promise<T>;
 export type Simplify<T> = { [K in keyof T]: T[K] };
 export type MergeContext<A, B> = Simplify<A & B>;
 
-/**
- * Requirements a Context declares about its command path: flags it reads
- * (as named flag definitions) and other Contexts it depends on (as their
- * factories). Flag requirements are checked at the `.provide()` call site;
- * ctx requirements drive topological construction order and are checked
- * when the resolved command path is constructed.
- */
-export interface ContextRequirements {
-	readonly flags?: readonly NamedFlagDef[];
-	readonly ctx?: readonly AnyContextFactory[];
-}
+/** Context capabilities required from the command path. */
+export type ContextRequirements = readonly AnyContextFactory[];
 
-/** Context definition config: owned flags plus dependencies required from the command path. */
+/** Context definition config: owned flags plus required capabilities. */
 export interface ContextConfig {
 	readonly flags?: readonly NamedFlagDef[];
 	readonly requires?: ContextRequirements;
@@ -50,42 +41,34 @@ interface ContextSetupInput {
  * Attach with `.provide()`; the value is constructed only when the
  * resolved command path executes.
  *
- * Generic parameters `RF`/`RC` carry the declared flag and ctx
- * requirements for compile-time checking at attach sites.
+ * Generic parameter `RC` carries the declared Context requirements for
+ * compile-time checking at attach sites.
  */
 export interface ContextInstance<
 	Name extends string = string,
 	Value = unknown,
-	RF extends FlagsDef = {},
 	RC extends ContextMap = {},
 	OF extends FlagsDef = {},
 > {
 	readonly kind: "context";
 	readonly name: Name;
-	/** @internal — declared flag requirements, keyed by flag name */
-	readonly requiredFlags: FlagsDef;
-	/** @internal — declared ctx dependency names (topological ordering) */
+	/** @internal — declared capability names (topological ordering) */
 	readonly requiredCtx: readonly string[];
 	/** @internal — flags installed by this Context at its provide site */
 	readonly ownedFlags: FlagsDef;
 	/** @internal */
 	setup(input: ContextSetupInput): Awaitable<Value>;
 	/** @internal — phantom carrying requirement and ownership types */
-	readonly _requires?: { flags: RF; ctx: RC; ownedFlags: OF };
+	readonly _requires?: { ctx: RC; ownedFlags: OF };
 }
 
 /** The typed setup input for one Context factory. */
-export interface ContextSetup<
-	Options,
-	RF extends FlagsDef,
-	RC extends ContextMap,
-	OF extends FlagsDef = {},
-> {
+export interface ContextSetup<Options, RC extends ContextMap, OF extends FlagsDef = {}> {
 	/** The factory argument */
 	readonly options: Options;
-	/** Validated parsed flags required or owned by this Context. */
-	readonly flags: InferFlags<MergeFlags<RF, OF>>;
-	/** Values of the declared ctx dependencies */
+	/** Validated parsed flags owned by this Context. */
+	readonly flags: InferFlags<OF>;
+	/** Values of the declared capability dependencies */
 	readonly ctx: Readonly<RC>;
 }
 
@@ -93,24 +76,23 @@ export interface ContextFactory<
 	Name extends string,
 	Options,
 	Value,
-	RF extends FlagsDef = {},
 	RC extends ContextMap = {},
 	OF extends FlagsDef = {},
 > {
-	(options: Options): ContextInstance<Name, Value, RF, RC, OF>;
-	/** The Context name this factory produces (used in `requires.ctx` arrays). */
+	(options: Options): ContextInstance<Name, Value, RC, OF>;
+	/** The Context name this factory produces (used in `requires` arrays). */
 	readonly contextName: Name;
 	/**
 	 * Produce an instance whose setup returns the precomputed `value`
 	 * (requirements considered satisfied/absent) — for test doubles.
 	 */
-	of(value: Value): ContextInstance<Name, Value, {}, {}, OF>;
+	of(value: Value): ContextInstance<Name, Value, {}, OF>;
 }
 
-export type AnyContextFactory = ContextFactory<string, any, any, any, any, any>;
+export type AnyContextFactory = ContextFactory<string, any, any, any, any>;
 
 export type ContextOutput<C> =
-	C extends ContextInstance<infer Name, infer Value, any, any, any>
+	C extends ContextInstance<infer Name, infer Value, any, any>
 		? { [K in Name]: Awaited<Value> }
 		: never;
 
@@ -123,11 +105,11 @@ export type ContextsOutput<Cs extends readonly ContextInstance[]> = Cs extends r
 	: {};
 
 type FactoryOutput<F> =
-	F extends ContextFactory<infer Name, any, infer Value, any, any, any>
+	F extends ContextFactory<infer Name, any, infer Value, any, any>
 		? { [K in Name]: Awaited<Value> }
 		: never;
 
-/** Merged outputs of a tuple of Context factories (as declared in `requires.ctx`). */
+/** Merged outputs of a tuple of Context factories (as declared in `requires`). */
 export type FactoriesOutput<Fs extends readonly AnyContextFactory[]> = Fs extends readonly [
 	infer H,
 	...infer T extends readonly AnyContextFactory[],
@@ -143,14 +125,7 @@ export type ContextsOwnedFlags<Cs extends readonly ContextInstance[]> = Cs exten
 	? MergeFlags<ContextOwnedFlags<H>, ContextsOwnedFlags<T>>
 	: {};
 
-type ContextOwnedFlags<C> = C extends ContextInstance<any, any, any, any, infer OF> ? OF : {};
-
-/** @internal — flag dependencies from a config's `requires` object, as a record. */
-export type RequirementFlagsOf<R extends { readonly requires?: ContextRequirements }> = R extends {
-	requires: { flags: infer F extends readonly NamedFlagDef[] };
-}
-	? NamedFlagsRecord<F>
-	: {};
+type ContextOwnedFlags<C> = C extends ContextInstance<any, any, any, infer OF> ? OF : {};
 
 /** @internal — flags owned by a Context config, as a record. */
 export type OwnedFlagsOf<R extends ContextConfig> = R extends {
@@ -159,9 +134,9 @@ export type OwnedFlagsOf<R extends ContextConfig> = R extends {
 	? NamedFlagsRecord<F>
 	: {};
 
-/** @internal — merged ctx outputs from a config's `requires` object. */
+/** @internal — merged capability outputs from a config's `requires` array. */
 export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements }> = R extends {
-	requires: { ctx: infer C extends readonly AnyContextFactory[] };
+	requires: infer C extends readonly AnyContextFactory[];
 }
 	? FactoriesOutput<C>
 	: {};
@@ -174,9 +149,8 @@ export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements
  * `defineContext("db", factory)` → `.provide(db(options))` → `ctx.db`.
  *
  * With a config argument, `flags` installs flags owned by the Context at
- * `.provide()`, while `requires` declares typed dependencies from the command
- * path. Setup receives the validated flags from both relationships plus declared
- * Context dependencies (`ctx`).
+ * `.provide()`, while `requires` declares Context capabilities from the command
+ * path. Setup receives the validated owned flags plus declared Context values (`ctx`).
  * Dependencies drive construction order: Contexts on
  * the resolved command path are constructed topologically, regardless of
  * `.provide()` order.
@@ -187,7 +161,7 @@ export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements
  */
 export function defineContext<Name extends string, Value, Options = void>(
 	name: Name,
-	setup: (input: ContextSetup<Options, {}, {}>) => Awaitable<Value>,
+	setup: (input: ContextSetup<Options, {}>) => Awaitable<Value>,
 ): ContextFactory<Name, Options, Value>;
 export function defineContext<
 	Name extends string,
@@ -197,17 +171,8 @@ export function defineContext<
 >(
 	name: Name,
 	config: R & ValidateContextConfig<R>,
-	setup: (
-		input: ContextSetup<Options, RequirementFlagsOf<R>, RequirementCtxOf<R>, OwnedFlagsOf<R>>,
-	) => Awaitable<Value>,
-): ContextFactory<
-	Name,
-	Options,
-	Value,
-	RequirementFlagsOf<R>,
-	RequirementCtxOf<R>,
-	OwnedFlagsOf<R>
->;
+	setup: (input: ContextSetup<Options, RequirementCtxOf<R>, OwnedFlagsOf<R>>) => Awaitable<Value>,
+): ContextFactory<Name, Options, Value, RequirementCtxOf<R>, OwnedFlagsOf<R>>;
 export function defineContext(
 	name: string,
 	configOrSetup: ContextConfig | ((input: never) => unknown),
@@ -224,30 +189,17 @@ export function defineContext(
 		});
 	}
 
-	const requiredFlags: FlagsDef = {};
-	for (const def of config.requires?.flags ?? []) {
-		const { name: flagName, ...rest } = def;
-		requiredFlags[flagName] = rest;
-	}
 	const ownedFlags: FlagsDef = {};
 	for (const def of config.flags ?? []) {
 		const { name: flagName, ...rest } = def;
-		if (flagName in requiredFlags) {
-			throw new CrustError(
-				"DEFINITION",
-				`Context "${name}" cannot both require and own flag "--${flagName}"`,
-				{ subject: "context", name, reason: "required-owned-flag-collision" },
-			);
-		}
 		validateIncomingFlag({ name: flagName, def: rest as FlagDef }, ownedFlags, `Context "${name}"`);
 		ownedFlags[flagName] = rest as FlagDef;
 	}
-	const requiredCtx = (config.requires?.ctx ?? []).map((dep) => dep.contextName);
+	const requiredCtx = (config.requires ?? []).map((dep) => dep.contextName);
 
 	const factory = (options: unknown): ContextInstance => ({
 		kind: "context",
 		name,
-		requiredFlags,
 		requiredCtx,
 		ownedFlags,
 		setup: (input) => setup({ options, flags: input.flags, ctx: input.ctx } as never),
@@ -256,7 +208,6 @@ export function defineContext(
 	factory.of = (value: unknown): ContextInstance => ({
 		kind: "context",
 		name,
-		requiredFlags: {},
 		requiredCtx: [],
 		ownedFlags,
 		setup: () => value,
@@ -281,7 +232,7 @@ function registerDisposable(value: unknown, disposal: AsyncDisposableStack): voi
 }
 
 /**
- * Order Context instances topologically by their declared ctx
+ * Order Context instances topologically by their declared capability
  * requirements, preserving registration order among independent Contexts.
  *
  * @param where - Attach-site label used in error messages (e.g. the command path)
@@ -298,7 +249,11 @@ export function sortContexts(
 				throw new CrustError(
 					"DEFINITION",
 					`Context "${context.name}" requires Context "${dep}", which is not provided on ${where}`,
-					{ subject: "context", name: context.name, reason: "missing-context-dependency" },
+					{
+						subject: "context",
+						name: context.name,
+						reason: "missing-context-dependency",
+					},
 				);
 			}
 		}
@@ -341,7 +296,10 @@ export async function buildContexts(
 ): Promise<ContextMap> {
 	const values: ContextMap = {};
 	for (const item of sortContexts(contexts, where)) {
-		const value = await item.setup({ flags, ctx: values });
+		const ownedFlags = Object.fromEntries(
+			Object.keys(item.ownedFlags).map((name) => [name, flags[name]]),
+		);
+		const value = await item.setup({ flags: ownedFlags, ctx: values });
 		values[item.name] = value;
 		registerDisposable(value, disposal);
 	}

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -1,7 +1,7 @@
 import type { CommandDefinition } from "../command/crust.ts";
 import type { CommandSnapshot } from "../command/snapshot.ts";
 import { CrustError } from "../errors.ts";
-import type { FlagDef } from "../types.ts";
+import type { FlagDef, InvocationIO } from "../types.ts";
 import type { Awaitable } from "./context.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ export type InvocationOutcome =
  * Commands cross this boundary as readonly, serializable
  * {@link CommandSnapshot}s — never as internal command nodes.
  */
-export interface ExtensionContext {
+export interface ExtensionContext extends Readonly<InvocationIO> {
 	readonly argv: readonly string[];
 	/** Snapshot of the application root, including Extension-contributed flags/commands */
 	readonly rootCommand: CommandSnapshot;
@@ -47,10 +47,6 @@ export interface ExtensionContext {
 	readonly rawArgs: readonly string[];
 	/** End the invocation successfully before validation, Context construction, and the handler. */
 	readonly finish: () => Finished;
-	/** Write a line of standard output (honors io injected via `run()`) */
-	readonly stdout: (text: string) => void;
-	/** Write a line of diagnostic output (honors io injected via `run()`) */
-	readonly stderr: (text: string) => void;
 }
 
 export interface ExtensionHooks {

--- a/packages/core/src/api/flags.test.ts
+++ b/packages/core/src/api/flags.test.ts
@@ -45,11 +45,13 @@ describe("defineFlag", () => {
 	});
 
 	it("brands invalid definitions on the offending variadic argument", () => {
-		new Crust("cli").flags(
-			// @ts-expect-error -- alias collision: short "f" is claimed twice (brands both defs)
-			{ name: "force", type: "boolean", short: "f" },
-			{ name: "format", type: "string", short: "f" },
-		);
+		expect(() =>
+			new Crust("cli").flags(
+				// @ts-expect-error -- alias collision: short "f" is claimed twice (brands both defs)
+				{ name: "force", type: "boolean", short: "f" },
+				{ name: "format", type: "string", short: "f" },
+			),
+		).toThrow(/spelling "f" collides/);
 		// @ts-expect-error -- "no-" prefixed names are reserved for boolean negation
 		new Crust("cli").flags({ name: "no-color", type: "boolean" });
 	});

--- a/packages/core/src/api/flags.test.ts
+++ b/packages/core/src/api/flags.test.ts
@@ -9,16 +9,15 @@ type IsEqual<A, B> =
 
 describe("defineFlag", () => {
 	it("returns the named definition with literal types preserved", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true, short: "v" });
+		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-		expect(verbose).toEqual({ name: "verbose", type: "boolean", inherit: true, short: "v" });
+		expect(verbose).toEqual({ name: "verbose", type: "boolean", short: "v" });
 		type _Flag = Assert<
 			IsEqual<
 				typeof verbose,
 				{
 					readonly name: "verbose";
 					readonly type: "boolean";
-					readonly inherit: true;
 					readonly short: "v";
 				}
 			>
@@ -31,18 +30,16 @@ describe("defineFlag", () => {
 	});
 
 	it("feeds .flags() with the same record typing as an inline literal", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const app = new Crust("cli").flags(verbose, { name: "output", type: "string", short: "o" });
 
 		type Local = (typeof app)["_types"]["local"];
-		type _Verbose = Assert<
-			IsEqual<Local["verbose"], { readonly type: "boolean"; readonly inherit: true }>
-		>;
+		type _Verbose = Assert<IsEqual<Local["verbose"], { readonly type: "boolean" }>>;
 		type _Output = Assert<
 			IsEqual<Local["output"], { readonly type: "string"; readonly short: "o" }>
 		>;
 		expect(app._node.localFlags).toEqual({
-			verbose: { type: "boolean", inherit: true },
+			verbose: { type: "boolean" },
 			output: { type: "string", short: "o" },
 		});
 	});

--- a/packages/core/src/api/flags.ts
+++ b/packages/core/src/api/flags.ts
@@ -11,7 +11,7 @@ export type UnnamedArgDef = OmitName<ArgDef>;
  * Define one named flag while preserving its literal definition type.
  *
  * The returned value carries its `name` and is attached with the variadic
- * `.flags(...defs)` or referenced in `requirements.flags` arrays.
+ * `.flags(...defs)` or referenced in `requires.flags` arrays.
  */
 export function defineFlag<const N extends string, const D extends FlagDef>(
 	name: N,

--- a/packages/core/src/api/flags.ts
+++ b/packages/core/src/api/flags.ts
@@ -11,7 +11,7 @@ export type UnnamedArgDef = OmitName<ArgDef>;
  * Define one named flag while preserving its literal definition type.
  *
  * The returned value carries its `name` and is attached with the variadic
- * `.flags(...defs)` or referenced in `requires.flags` arrays.
+ * `.flags(...defs)` or owned by a Context.
  */
 export function defineFlag<const N extends string, const D extends FlagDef>(
 	name: N,

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -752,18 +752,6 @@ describe("Crust .handle() type-level tests", () => {
 		);
 	});
 
-	it("override flag shows overridden type in handler", () => {
-		new Crust("cli").flags({ name: "output", type: "string" }).mount(
-			defineCommand("sub", (cmd) =>
-				cmd.flags({ name: "output", type: "number", default: 42 }).handle((_ctx) => {
-					type CtxFlags = typeof _ctx.flags;
-					// output was overridden from string to number
-					type _checkOutput = Expect<Equal<CtxFlags["output"], number>>;
-				}),
-			),
-		);
-	});
-
 	it("handler with no flags/args gets empty types", () => {
 		new Crust("test").handle((_ctx) => {
 			// With broad FlagsDef default, flags resolve to Record<string, ...>
@@ -950,7 +938,7 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
 
-	it("Extension command definitions are routable, validated, and inherit recursive flags", async () => {
+	it("Extension command definitions are routable, validated, and receive recursive flags", async () => {
 		const lines: string[] = [];
 		const completion = defineExtension("completion", {
 			commands: [
@@ -1853,7 +1841,7 @@ describe("Crust .execute()", () => {
 		expect(handlerRan).toBe(false);
 	});
 
-	it("inherited flags work across file-boundary pattern", async () => {
+	it("Context-owned flags work across file-boundary pattern", async () => {
 		let receivedVerbose: boolean | undefined;
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const sub = defineCommand("sub", { requires: { flags: [verbose] } }, (command) =>
@@ -1887,7 +1875,7 @@ describe("Crust .execute()", () => {
 		expect(receivedPort).toBe(3000);
 	});
 
-	it("inherited flag short alias works on subcommand", async () => {
+	it("Context-owned flag short alias works on subcommand", async () => {
 		let receivedVerbose: boolean | undefined;
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -96,7 +96,7 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 			".provide()",
 			(a) =>
 				a.provide(
-					defineContext("auth", { ownFlags: [{ name: "api-key", type: "string" }] }, () => ({}))(),
+					defineContext("auth", { flags: [{ name: "api-key", type: "string" }] }, () => ({}))(),
 				) as Crust,
 			(a) => {
 				expect(a._node.contexts).toEqual([]);
@@ -684,9 +684,9 @@ describe("Crust .mount() type-level tests", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const output = defineFlag("output", { type: "string", inherit: true });
 		new Crust("cli").flags(verbose, { name: "rootOnly", type: "string" }).mount(
-			defineCommand("level1", { flags: [verbose] }, (command) =>
+			defineCommand("level1", { requires: { flags: [verbose] } }, (command) =>
 				command.flags(output).mount(
-					defineCommand("level2", { flags: [verbose, output] }, (child) =>
+					defineCommand("level2", { requires: { flags: [verbose, output] } }, (child) =>
 						child
 							.args({ name: "target", type: "string", required: true })
 							.handle(({ args, flags }) => {
@@ -783,7 +783,7 @@ describe("Crust .handle() type-level tests", () => {
 	it("run handler receives EffectiveFlags (inherited + local merged) for flags", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		new Crust("cli").flags(verbose, { name: "port", type: "number", default: 3000 }).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
 					type CtxFlags = typeof _ctx.flags;
 					// inherited verbose (inherit: true) should be present
@@ -798,7 +798,7 @@ describe("Crust .handle() type-level tests", () => {
 	it("declared flag requirements are visible in mounted handlers", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true, default: false });
 		new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((_ctx) => {
 					// The handler sees the required flag even though the
 					// subcommand has no local flags
@@ -1039,7 +1039,7 @@ describe("Extension application at prepare time", () => {
 		let recipeRan = false;
 		const tools = defineExtension("tools", {
 			commands: [
-				defineCommand("status", { flags: [verbose] }, (command) => {
+				defineCommand("status", { requires: { flags: [verbose] } }, (command) => {
 					recipeRan = true;
 					return command.handle(() => {});
 				}),
@@ -1058,7 +1058,9 @@ describe("Extension application at prepare time", () => {
 	it("Extension command requirements name the Extension and missing Context", async () => {
 		const db = defineContext("db", () => "database");
 		const databaseTools = defineExtension("database-tools", {
-			commands: [defineCommand("users", { ctx: [db] }, (command) => command.handle(() => {}))],
+			commands: [
+				defineCommand("users", { requires: { ctx: [db] } }, (command) => command.handle(() => {})),
+			],
 		});
 
 		try {
@@ -1911,7 +1913,7 @@ describe("Crust .execute()", () => {
 	it("inherited flags work across file-boundary pattern", async () => {
 		let receivedVerbose: boolean | undefined;
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const sub = defineCommand("sub", { flags: [verbose] }, (command) =>
+		const sub = defineCommand("sub", { requires: { flags: [verbose] } }, (command) =>
 			command.handle(({ flags }) => {
 				receivedVerbose = flags.verbose;
 			}),
@@ -1928,7 +1930,7 @@ describe("Crust .execute()", () => {
 		const port = defineFlag("port", { type: "number", default: 3000, inherit: true });
 
 		const app = new Crust("cli").flags(port).mount(
-			defineCommand("sub", { flags: [port] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [port] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					receivedPort = ctx.flags.port;
 				}),
@@ -1945,7 +1947,7 @@ describe("Crust .execute()", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
 
 		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					receivedVerbose = ctx.flags.verbose;
 				}),

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -93,6 +93,18 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 			},
 		],
 		[
+			".provide()",
+			(a) =>
+				a.provide(
+					defineContext("auth", { ownFlags: [{ name: "api-key", type: "string" }] }, () => ({}))(),
+				) as Crust,
+			(a) => {
+				expect(a._node.contexts).toEqual([]);
+				expect(a._node.ownedFlags).toEqual({});
+				expect(a._node.effectiveFlags).toEqual({});
+			},
+		],
+		[
 			".meta()",
 			(a) => a.meta({ description: "desc" }) as Crust,
 			(a) => {

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -238,6 +238,27 @@ describe("Crust .flags()", () => {
 			),
 		).toThrow(/defined more than once/);
 	});
+
+	it("throws CrustError DEFINITION on short/alias collisions within one .flags() call", () => {
+		// Typed callers are caught by ValidateFlagAliases at compile time; the
+		// expect-error markers simulate dynamic/untyped construction, which must
+		// fail at registration rather than at first run() via validateCommandTree.
+		expect(() =>
+			new Crust("test").flags(
+				// @ts-expect-error -- short "v" claimed twice in one call
+				{ name: "verbose", type: "boolean", short: "v" },
+				{ name: "version", type: "boolean", short: "v" },
+			),
+		).toThrow(/spelling "v" collides with flag "--verbose"/);
+
+		expect(() =>
+			new Crust("test").flags(
+				{ name: "output", type: "string" },
+				// @ts-expect-error -- alias duplicates a sibling's canonical name
+				{ name: "outfile", type: "string", aliases: ["output"] },
+			),
+		).toThrow(/spelling "output" collides with flag "--output"/);
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -238,16 +238,6 @@ describe("Crust .flags()", () => {
 			),
 		).toThrow(/defined more than once/);
 	});
-
-	it("accepts flags with inherit: true", () => {
-		const app = new Crust("test").flags(
-			{ name: "verbose", type: "boolean", inherit: true },
-			{ name: "port", type: "number" },
-		);
-
-		expect(app._node.localFlags.verbose?.inherit).toBe(true);
-		expect(app._node.localFlags.port?.inherit).toBeUndefined();
-	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -478,13 +468,10 @@ describe("Crust type-level tests", () => {
 		>;
 	});
 
-	it("Inherited generic starts as {} for root builder", () => {
+	it("ancestor-owned generic starts as {} for a root builder", () => {
 		const app = new Crust("test");
-
-		// Root builder has no inherited flags — but defaults to broad FlagsDef
-		// After .flags(), Inherited should still be the default FlagsDef
-		type AppInherited = (typeof app)["_types"]["inherited"];
-		type _check = Expect<Equal<AppInherited, FlagsDef>>;
+		type AppAncestorOwned = (typeof app)["_types"]["ancestorOwned"];
+		type _check = Expect<Equal<AppAncestorOwned, {}>>;
 	});
 });
 
@@ -513,19 +500,16 @@ describe("Crust .mount() with inline definitions", () => {
 		});
 	});
 
-	it("subcommand node computes effectiveFlags from inherited + local", () => {
+	it("subcommand effectiveFlags include Context-owned and local flags only", () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
 		const app = new Crust("cli")
-			.flags({ name: "verbose", type: "boolean", inherit: true }, { name: "port", type: "number" })
+			.flags({ name: "port", type: "number" })
+			.provide(logging())
 			.mount(defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })));
 
 		const subNode = app._node.subCommands.sub;
-		expect(subNode).toBeDefined();
-		// Should include inherited verbose (inherit: true) and local output
-		// Should NOT include port (no inherit)
-		expect(subNode?.effectiveFlags.verbose).toEqual({
-			type: "boolean",
-			inherit: true,
-		});
+		expect(subNode?.effectiveFlags.verbose).toEqual({ type: "boolean" });
 		expect(subNode?.effectiveFlags.output).toEqual({ type: "string" });
 		expect(subNode?.effectiveFlags.port).toBeUndefined();
 	});
@@ -568,7 +552,7 @@ describe("Crust .mount() with inline definitions", () => {
 	it("callback receives a fresh builder (not the parent)", () => {
 		let receivedBuilder: CommandDefinitionBuilder | undefined;
 
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", inherit: true }).mount(
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).mount(
 			defineCommand("sub", (cmd) => {
 				receivedBuilder = cmd;
 				return cmd;
@@ -582,58 +566,23 @@ describe("Crust .mount() with inline definitions", () => {
 		expect(runtimeBuilder._node.localFlags).toEqual({});
 	});
 
-	it("callback child builder carries parent effective flags at runtime", () => {
-		let childInherited: FlagsDef = {};
+	it("callback child builder carries only ancestor-owned flags at runtime", () => {
+		let childOwned: FlagsDef = {};
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
 
 		new Crust("cli")
-			.flags({ name: "verbose", type: "boolean", inherit: true }, { name: "port", type: "number" })
+			.flags({ name: "port", type: "number" })
+			.provide(logging())
 			.mount(
 				defineCommand("sub", (cmd) => {
-					childInherited = (cmd as unknown as Crust)._inheritedFlags;
+					childOwned = (cmd as unknown as Crust)._ancestorOwnedFlags;
 					return cmd;
 				}),
 			);
 
-		// _inheritedFlags carries ALL parent effective flags (not just inheritable)
-		// The filtering for inherit:true happens when computeEffectiveFlags is called
-		// during the child's own .mount() or effectiveFlags computation
-		expect(childInherited.verbose).toEqual({
-			type: "boolean",
-			inherit: true,
-		});
-		expect(childInherited.port).toEqual({
-			type: "number",
-		});
-	});
-
-	it("nested mounted definitions work", () => {
-		const app = new Crust("cli")
-			.flags({ name: "verbose", type: "boolean", inherit: true })
-			.mount(
-				defineCommand("level1", (cmd) =>
-					cmd
-						.flags({ name: "output", type: "string", inherit: true })
-						.mount(
-							defineCommand("level2", (cmd2) => cmd2.flags({ name: "format", type: "string" })),
-						),
-				),
-			);
-
-		const level1 = app._node.subCommands.level1;
-		expect(level1).toBeDefined();
-		expect(level1?.subCommands.level2).toBeDefined();
-
-		const level2 = level1?.subCommands.level2;
-		// level2 should have effective flags: verbose (from root), output (from level1), format (local)
-		expect(level2?.effectiveFlags.verbose).toEqual({
-			type: "boolean",
-			inherit: true,
-		});
-		expect(level2?.effectiveFlags.output).toEqual({
-			type: "string",
-			inherit: true,
-		});
-		expect(level2?.effectiveFlags.format).toEqual({ type: "string" });
+		expect(childOwned.verbose).toEqual({ type: "boolean" });
+		expect(childOwned.port).toBeUndefined();
 	});
 
 	it("multiple subcommands can be registered", () => {
@@ -657,22 +606,6 @@ describe("Crust .mount() with inline definitions", () => {
 		expect(app._node.args?.length).toBe(1);
 		expect(app._node.args?.[0]?.name).toBe("file");
 	});
-
-	it("child flag override replaces inherited flag at runtime", () => {
-		const app = new Crust("cli").flags({ name: "output", type: "string", inherit: true }).mount(
-			defineCommand("sub", (cmd) =>
-				// Override output with a number type
-				cmd.flags({ name: "output", type: "number", default: 42 }),
-			),
-		);
-
-		const subNode = app._node.subCommands.sub;
-		expect(subNode).toBeDefined();
-		expect(subNode?.effectiveFlags.output).toEqual({
-			type: "number",
-			default: 42,
-		});
-	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -680,26 +613,31 @@ describe("Crust .mount() with inline definitions", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("Crust .mount() type-level tests", () => {
-	it("types inherited and refined values in handlers", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const output = defineFlag("output", { type: "string", inherit: true });
-		new Crust("cli").flags(verbose, { name: "rootOnly", type: "string" }).mount(
-			defineCommand("level1", { requires: { flags: [verbose] } }, (command) =>
-				command.flags(output).mount(
-					defineCommand("level2", { requires: { flags: [verbose, output] } }, (child) =>
-						child
-							.args({ name: "target", type: "string", required: true })
-							.handle(({ args, flags }) => {
-								type _target = Expect<Equal<typeof args.target, string>>;
-								type _verbose = Expect<Equal<typeof flags.verbose, boolean | undefined>>;
-								type _output = Expect<Equal<typeof flags.output, string | undefined>>;
-								// @ts-expect-error -- non-inheritable root flags are not available
-								void flags.rootOnly;
-							}),
+	it("types ancestor-owned and local values in handlers", () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const output = defineFlag("output", { type: "string" });
+		const rootFlags = defineContext("root-flags", { flags: [verbose] }, () => ({}));
+		const levelFlags = defineContext("level-flags", { flags: [output] }, () => ({}));
+		new Crust("cli")
+			.flags({ name: "rootOnly", type: "string" })
+			.provide(rootFlags())
+			.mount(
+				defineCommand("level1", { requires: { flags: [verbose] } }, (command) =>
+					command.provide(levelFlags()).mount(
+						defineCommand("level2", { requires: { flags: [verbose, output] } }, (child) =>
+							child
+								.args({ name: "target", type: "string", required: true })
+								.handle(({ args, flags }) => {
+									type _target = Expect<Equal<typeof args.target, string>>;
+									type _verbose = Expect<Equal<typeof flags.verbose, boolean | undefined>>;
+									type _output = Expect<Equal<typeof flags.output, string | undefined>>;
+									// @ts-expect-error -- root-local flags do not propagate
+									void flags.rootOnly;
+								}),
+						),
 					),
 				),
-			),
-		);
+			);
 	});
 });
 
@@ -780,24 +718,29 @@ describe("Crust .handle() type-level tests", () => {
 			});
 	});
 
-	it("run handler receives EffectiveFlags (inherited + local merged) for flags", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		new Crust("cli").flags(verbose, { name: "port", type: "number", default: 3000 }).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
-					type CtxFlags = typeof _ctx.flags;
-					// inherited verbose (inherit: true) should be present
-					type _checkVerbose = Expect<Equal<CtxFlags["verbose"], boolean | undefined>>;
-					// local output (required) should be present
-					type _checkOutput = Expect<Equal<CtxFlags["output"], string>>;
-				}),
-			),
-		);
+	it("run handler receives Context-owned and local EffectiveFlags", () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		new Crust("cli")
+			.flags({ name: "port", type: "number", default: 3000 })
+			.provide(logging())
+			.mount(
+				defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
+					cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
+						type CtxFlags = typeof _ctx.flags;
+						// Context-owned verbose should be present
+						type _checkVerbose = Expect<Equal<CtxFlags["verbose"], boolean | undefined>>;
+						// local output (required) should be present
+						type _checkOutput = Expect<Equal<CtxFlags["output"], string>>;
+					}),
+				),
+			);
 	});
 
 	it("declared flag requirements are visible in mounted handlers", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true, default: false });
-		new Crust("cli").flags(verbose).mount(
+		const verbose = defineFlag("verbose", { type: "boolean", default: false });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		new Crust("cli").provide(logging()).mount(
 			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((_ctx) => {
 					// The handler sees the required flag even though the
@@ -810,7 +753,7 @@ describe("Crust .handle() type-level tests", () => {
 	});
 
 	it("override flag shows overridden type in handler", () => {
-		new Crust("cli").flags({ name: "output", type: "string", inherit: true }).mount(
+		new Crust("cli").flags({ name: "output", type: "string" }).mount(
 			defineCommand("sub", (cmd) =>
 				cmd.flags({ name: "output", type: "number", default: 42 }).handle((_ctx) => {
 					type CtxFlags = typeof _ctx.flags;
@@ -948,7 +891,7 @@ describe("Extension application at prepare time", () => {
 	it("recursive Extension flags reach every command, including Extension commands", async () => {
 		const seen: Record<string, unknown>[] = [];
 		const debug = defineExtension("debug", {
-			flags: { debug: { type: "boolean", inherit: true } },
+			flags: { debug: { type: "boolean" } },
 		});
 
 		const app = new Crust("cli").extend(debug).mount(
@@ -1034,8 +977,8 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
 	});
 
-	it("Extension command requirements reject missing inherited flags", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+	it("Extension command requirements reject missing propagating flags", async () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		let recipeRan = false;
 		const tools = defineExtension("tools", {
 			commands: [
@@ -1049,7 +992,7 @@ describe("Extension application at prepare time", () => {
 		await expect(new Crust("cli").extend(tools).run(["status"])).rejects.toMatchObject({
 			code: "DEFINITION",
 			message:
-				'Extension "tools" command "status" requires flag "--verbose", which is not declared with inherit: true on application root "cli"',
+				'Extension "tools" command "status" requires flag "--verbose", which is not provided as a propagating Context-owned flag on application root "cli"',
 			details: { subject: "flag", name: "verbose", reason: "missing-required-flag" },
 		});
 		expect(recipeRan).toBe(false);
@@ -1596,14 +1539,14 @@ describe("Crust .execute()", () => {
 		expect(handlerRan).toBe("sub");
 	});
 
-	it("passes inherited flags to subcommand handler", async () => {
+	it("passes Context-owned flags but not parent-local flags to subcommand handlers", async () => {
 		let subFlags: Record<string, unknown> = {};
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
 
 		const app = new Crust("cli")
-			.flags(
-				{ name: "verbose", type: "boolean", inherit: true },
-				{ name: "port", type: "number", default: 3000 },
-			)
+			.flags({ name: "port", type: "number", default: 3000 })
+			.provide(logging())
 			.mount(
 				defineCommand("sub", (cmd) =>
 					cmd.handle((ctx) => {
@@ -1615,7 +1558,7 @@ describe("Crust .execute()", () => {
 		await app.execute({ argv: ["sub", "--verbose"] });
 
 		expect(subFlags.verbose).toBe(true);
-		// port is not inherited (no inherit: true)
+		// Parent-local flags never enter a descendant's parse surface.
 		expect(subFlags.port).toBeUndefined();
 	});
 
@@ -1808,7 +1751,7 @@ describe("Crust .execute()", () => {
 		let receivedFlags: Record<string, unknown> = {};
 
 		const helpLike = defineExtension("help-like", {
-			flags: { help: { type: "boolean", inherit: true } },
+			flags: { help: { type: "boolean" } },
 		});
 		const skillLike = defineExtension("inject-subcommand", {
 			commands: [
@@ -1837,7 +1780,7 @@ describe("Crust .execute()", () => {
 	it("deeply nested subcommand routing works", async () => {
 		let handlerRan = "";
 
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", inherit: true }).mount(
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).mount(
 			defineCommand("level1", (cmd) =>
 				cmd.mount(
 					defineCommand("level2", (cmd2) =>
@@ -1912,13 +1855,14 @@ describe("Crust .execute()", () => {
 
 	it("inherited flags work across file-boundary pattern", async () => {
 		let receivedVerbose: boolean | undefined;
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const sub = defineCommand("sub", { requires: { flags: [verbose] } }, (command) =>
 			command.handle(({ flags }) => {
 				receivedVerbose = flags.verbose;
 			}),
 		);
-		const app = new Crust("cli").flags(verbose).mount(sub);
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(logging()).mount(sub);
 
 		await app.execute({ argv: ["sub", "--verbose"] });
 
@@ -1927,9 +1871,10 @@ describe("Crust .execute()", () => {
 
 	it("default flag values work on subcommands", async () => {
 		let receivedPort: number | undefined;
-		const port = defineFlag("port", { type: "number", default: 3000, inherit: true });
+		const port = defineFlag("port", { type: "number", default: 3000 });
 
-		const app = new Crust("cli").flags(port).mount(
+		const ports = defineContext("ports", { flags: [port] }, () => ({}));
+		const app = new Crust("cli").provide(ports()).mount(
 			defineCommand("sub", { requires: { flags: [port] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					receivedPort = ctx.flags.port;
@@ -1944,9 +1889,10 @@ describe("Crust .execute()", () => {
 
 	it("inherited flag short alias works on subcommand", async () => {
 		let receivedVerbose: boolean | undefined;
-		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-		const app = new Crust("cli").flags(verbose).mount(
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(logging()).mount(
 			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					receivedVerbose = ctx.flags.verbose;

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -467,12 +467,6 @@ describe("Crust type-level tests", () => {
 			>
 		>;
 	});
-
-	it("ancestor-owned generic starts as {} for a root builder", () => {
-		const app = new Crust("test");
-		type AppAncestorOwned = (typeof app)["_types"]["ancestorOwned"];
-		type _check = Expect<Equal<AppAncestorOwned, {}>>;
-	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -613,24 +607,25 @@ describe("Crust .mount() with inline definitions", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("Crust .mount() type-level tests", () => {
-	it("types ancestor-owned and local values in handlers", () => {
+	it("types required capabilities and local values in handlers", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const output = defineFlag("output", { type: "string" });
-		const rootFlags = defineContext("root-flags", { flags: [verbose] }, () => ({}));
-		const levelFlags = defineContext("level-flags", { flags: [output] }, () => ({}));
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
 		new Crust("cli")
 			.flags({ name: "rootOnly", type: "string" })
-			.provide(rootFlags())
+			.provide(logging())
 			.mount(
-				defineCommand("level1", { requires: { flags: [verbose] } }, (command) =>
-					command.provide(levelFlags()).mount(
-						defineCommand("level2", { requires: { flags: [verbose, output] } }, (child) =>
+				defineCommand("level1", { requires: [logging] }, (command) =>
+					command.mount(
+						defineCommand("level2", { requires: [logging] }, (child) =>
 							child
 								.args({ name: "target", type: "string", required: true })
-								.handle(({ args, flags }) => {
+								.handle(({ args, flags, ctx }) => {
 									type _target = Expect<Equal<typeof args.target, string>>;
-									type _verbose = Expect<Equal<typeof flags.verbose, boolean | undefined>>;
-									type _output = Expect<Equal<typeof flags.output, string | undefined>>;
+									type _verbose = Expect<Equal<typeof ctx.logging.verbose, boolean>>;
+									// @ts-expect-error -- ancestor-owned flags are parsed but not handler-visible
+									void flags.verbose;
 									// @ts-expect-error -- root-local flags do not propagate
 									void flags.rootOnly;
 								}),
@@ -718,35 +713,18 @@ describe("Crust .handle() type-level tests", () => {
 			});
 	});
 
-	it("run handler receives Context-owned and local EffectiveFlags", () => {
+	it("run handler receives local flags and required capabilities", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
-		new Crust("cli")
-			.flags({ name: "port", type: "number", default: 3000 })
-			.provide(logging())
-			.mount(
-				defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-					cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
-						type CtxFlags = typeof _ctx.flags;
-						// Context-owned verbose should be present
-						type _checkVerbose = Expect<Equal<CtxFlags["verbose"], boolean | undefined>>;
-						// local output (required) should be present
-						type _checkOutput = Expect<Equal<CtxFlags["output"], string>>;
-					}),
-				),
-			);
-	});
-
-	it("declared flag requirements are visible in mounted handlers", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", default: false });
-		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
 		new Crust("cli").provide(logging()).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.handle((_ctx) => {
-					// The handler sees the required flag even though the
-					// subcommand has no local flags
-					type CtxFlags = typeof _ctx.flags;
-					type _checkVerbose = Expect<Equal<CtxFlags["verbose"], boolean>>;
+			defineCommand("sub", { requires: [logging] }, (cmd) =>
+				cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
+					type _checkOutput = Expect<Equal<typeof _ctx.flags.output, string>>;
+					type _checkVerbose = Expect<Equal<typeof _ctx.ctx.logging.verbose, boolean>>;
+					// @ts-expect-error -- cross-command values are capabilities, not raw flags
+					void _ctx.flags.verbose;
 				}),
 			),
 		);
@@ -965,33 +943,10 @@ describe("Extension application at prepare time", () => {
 		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
 	});
 
-	it("Extension command requirements reject missing propagating flags", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean" });
-		let recipeRan = false;
-		const tools = defineExtension("tools", {
-			commands: [
-				defineCommand("status", { requires: { flags: [verbose] } }, (command) => {
-					recipeRan = true;
-					return command.handle(() => {});
-				}),
-			],
-		});
-
-		await expect(new Crust("cli").extend(tools).run(["status"])).rejects.toMatchObject({
-			code: "DEFINITION",
-			message:
-				'Extension "tools" command "status" requires flag "--verbose", which is not provided as a propagating Context-owned flag on application root "cli"',
-			details: { subject: "flag", name: "verbose", reason: "missing-required-flag" },
-		});
-		expect(recipeRan).toBe(false);
-	});
-
 	it("Extension command requirements name the Extension and missing Context", async () => {
 		const db = defineContext("db", () => "database");
 		const databaseTools = defineExtension("database-tools", {
-			commands: [
-				defineCommand("users", { requires: { ctx: [db] } }, (command) => command.handle(() => {})),
-			],
+			commands: [defineCommand("users", { requires: [db] }, (command) => command.handle(() => {}))],
 		});
 
 		try {
@@ -1841,15 +1796,17 @@ describe("Crust .execute()", () => {
 		expect(handlerRan).toBe(false);
 	});
 
-	it("Context-owned flags work across file-boundary pattern", async () => {
-		let receivedVerbose: boolean | undefined;
+	it("Context capabilities work across file-boundary pattern", async () => {
+		let receivedVerbose = false;
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const sub = defineCommand("sub", { requires: { flags: [verbose] } }, (command) =>
-			command.handle(({ flags }) => {
-				receivedVerbose = flags.verbose;
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
+		const sub = defineCommand("sub", { requires: [logging] }, (command) =>
+			command.handle(({ ctx }) => {
+				receivedVerbose = ctx.logging.verbose;
 			}),
 		);
-		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
 		const app = new Crust("cli").provide(logging()).mount(sub);
 
 		await app.execute({ argv: ["sub", "--verbose"] });
@@ -1861,11 +1818,13 @@ describe("Crust .execute()", () => {
 		let receivedPort: number | undefined;
 		const port = defineFlag("port", { type: "number", default: 3000 });
 
-		const ports = defineContext("ports", { flags: [port] }, () => ({}));
+		const ports = defineContext("ports", { flags: [port] }, ({ flags }) => ({
+			port: flags.port,
+		}));
 		const app = new Crust("cli").provide(ports()).mount(
-			defineCommand("sub", { requires: { flags: [port] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					receivedPort = ctx.flags.port;
+			defineCommand("sub", { requires: [ports] }, (cmd) =>
+				cmd.handle(({ ctx }) => {
+					receivedPort = ctx.ports.port;
 				}),
 			),
 		);
@@ -1879,11 +1838,13 @@ describe("Crust .execute()", () => {
 		let receivedVerbose: boolean | undefined;
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 
-		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose,
+		}));
 		const app = new Crust("cli").provide(logging()).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					receivedVerbose = ctx.flags.verbose;
+			defineCommand("sub", { requires: [logging] }, (cmd) =>
+				cmd.handle(({ ctx }) => {
+					receivedVerbose = ctx.logging.verbose;
 				}),
 			),
 		);

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -673,9 +673,12 @@ export class Crust<
 				);
 			}
 			validateSchemaExclusivity("flag", name, rest as Record<string, unknown>);
+			// Include same-call siblings so short/alias collisions between two
+			// definitions in one .flags() call fail here (DEFINITION errors throw
+			// at the definition site), not at first run() via validateCommandTree.
 			validateIncomingFlag(
 				{ name, def: rest as FlagDef },
-				this._node.ownedFlags,
+				{ ...this._node.ownedFlags, ...copiedFlags },
 				`Command "${this._node.meta.name}"`,
 			);
 			copiedFlags[name] = rest as FlagDef;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -284,11 +284,12 @@ function freezeTree(node: CommandNode): void {
  * compile-time checks at `.mount()`; ctx requirement names are also
  * verified at runtime when the definition is mounted.
  *
- * Structurally identical to {@link ContextRequirements} — the shared
- * shape is defined once in `api/context.ts`. Both requirement kinds are
- * verified at runtime as a backstop for untyped mount sites.
+ * Both requirement kinds are grouped under `requires` and verified at runtime
+ * as a backstop for untyped mount sites.
  */
-export type CommandRequirements = ContextRequirements;
+export interface CommandRequirements {
+	readonly requires?: ContextRequirements;
+}
 
 type RequirementFlags<R extends CommandRequirements> = RequirementFlagsOf<R>;
 
@@ -567,26 +568,26 @@ export interface CommandDefinitionBuilder<
  * Define a reusable, inert command under a required name.
  *
  * The recipe runs once per `.mount()`, receiving a fresh builder typed by
- * the declared requirements: `requirements.flags` (named flag definitions
- * the mount site must provide as inheritable flags) and `requirements.ctx`
- * (Context factories whose instances must be provided on the mount path).
+ * the declared dependencies: `requires.flags` (named flag definitions the
+ * mount site must provide as inheritable flags) and `requires.ctx` (Context
+ * factories whose instances must be provided on the mount path).
  *
  * Use `.as(name)` to mount one definition under a different name.
  */
 export function defineCommand(name: string, recipe: CommandRecipe<{}>): CommandDefinition;
 export function defineCommand<const R extends CommandRequirements>(
 	name: string,
-	requirements: R,
+	config: R,
 	recipe: CommandRecipe<R>,
 ): CommandDefinition<R>;
 export function defineCommand(
 	name: string,
-	requirementsOrRecipe: CommandRequirements | CommandRecipe<CommandRequirements>,
+	configOrRecipe: CommandRequirements | CommandRecipe<CommandRequirements>,
 	maybeRecipe?: CommandRecipe<CommandRequirements>,
 ): CommandDefinition<CommandRequirements> {
-	const hasRequirements = typeof requirementsOrRecipe !== "function";
-	const requirements = hasRequirements ? requirementsOrRecipe : {};
-	const recipe = hasRequirements ? maybeRecipe : requirementsOrRecipe;
+	const hasConfig = typeof configOrRecipe !== "function";
+	const config = hasConfig ? configOrRecipe : {};
+	const recipe = hasConfig ? maybeRecipe : configOrRecipe;
 	if (typeof recipe !== "function") {
 		throw new CrustError("DEFINITION", `Command definition "${name}" requires a recipe function`, {
 			subject: "command",
@@ -596,8 +597,8 @@ export function defineCommand(
 	}
 	const internal: CommandDefinitionInternal = {
 		recipe: recipe as CommandDefinitionInternal["recipe"],
-		requiredFlagNames: (requirements.flags ?? []).map((flag) => flag.name),
-		requiredCtxNames: (requirements.ctx ?? []).map((dep) => dep.contextName),
+		requiredFlagNames: (config.requires?.flags ?? []).map((flag) => flag.name),
+		requiredCtxNames: (config.requires?.ctx ?? []).map((dep) => dep.contextName),
 	};
 	const named = (defName: string): CommandDefinition<CommandRequirements> => {
 		if (!defName.trim()) {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -159,14 +159,6 @@ function isAbortError(error: unknown): boolean {
 	return error.name === "AbortError";
 }
 
-function applyOwnedFlagsToSubtree(node: CommandNode): void {
-	node.effectiveFlags = computeEffectiveFlags(node.ownedFlags, node.localFlags);
-
-	for (const sub of Object.values(node.subCommands)) {
-		applyOwnedFlagsToSubtree(sub);
-	}
-}
-
 /**
  * Inject an Extension-owned flag into a node's effective flags (and, when
  * `recursive`, into every descendant). Name collisions with application or
@@ -195,7 +187,6 @@ function injectExtensionFlag(
 function applyExtensionCommands(root: CommandNode, ext: Extension): void {
 	for (const definition of ext.commands ?? []) {
 		const node = materializeCommandDefinition(definition, root, ext.name);
-		applyOwnedFlagsToSubtree(node);
 		root.subCommands[definition.name] = node;
 	}
 }

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -4,6 +4,7 @@ import {
 	type ContextMap,
 	type ContextRequirements,
 	type ContextsOutput,
+	type ContextsOwnedFlags,
 	type MergeContext,
 	type RequirementCtxOf,
 	type RequirementFlagsOf,
@@ -17,7 +18,11 @@ import {
 import { CrustError } from "../errors.ts";
 import { parseArgs, validateParsed } from "../parsing/parser.ts";
 import { applySchemas } from "../parsing/schema.ts";
-import { validateCommandTree, validateIncomingAliases } from "../parsing/validation.ts";
+import {
+	validateCommandTree,
+	validateIncomingAliases,
+	validateIncomingFlag,
+} from "../parsing/validation.ts";
 import type {
 	ArgDef,
 	ArgsDef,
@@ -25,9 +30,11 @@ import type {
 	EffectiveFlags,
 	FlagDef,
 	FlagsDef,
+	ForceInherit,
 	InferArgs,
 	InferFlags,
 	InheritableFlags,
+	MergeFlags,
 	NamedFlagDef,
 	NamedFlagsRecord,
 	ValidateNamedFlagDefs,
@@ -159,7 +166,7 @@ function isAbortError(error: unknown): boolean {
 }
 
 function applyInheritedFlagsToSubtree(node: CommandNode, inheritedFlags: FlagsDef): void {
-	node.effectiveFlags = computeEffectiveFlags(inheritedFlags, node.localFlags);
+	node.effectiveFlags = computeEffectiveFlags(inheritedFlags, node.localFlags, node.ownedFlags);
 
 	for (const sub of Object.values(node.subCommands)) {
 		applyInheritedFlagsToSubtree(sub, node.effectiveFlags);
@@ -178,30 +185,11 @@ function injectExtensionFlag(
 	recursive: boolean,
 	extensionName: string,
 ): void {
-	if (name in node.effectiveFlags) {
-		throw new CrustError(
-			"DEFINITION",
-			`Extension "${extensionName}" flag "--${name}" collides with an existing flag on "${node.meta.name}"`,
-			{ subject: "flag", name, reason: "extension-flag-collision" },
-		);
-	}
-	// Alias/short collisions are definition errors too (ADR-0001)
-	const incoming = new Set(
-		[def.short, ...(def.aliases ?? [])].filter((alias): alias is string => alias !== undefined),
+	validateIncomingFlag(
+		{ name, def },
+		node.effectiveFlags,
+		`Extension "${extensionName}" on "${node.meta.name}"`,
 	);
-	if (incoming.size > 0) {
-		for (const [existingName, existing] of Object.entries(node.effectiveFlags)) {
-			for (const alias of [existing.short, ...(existing.aliases ?? [])]) {
-				if (alias !== undefined && incoming.has(alias)) {
-					throw new CrustError(
-						"DEFINITION",
-						`Extension "${extensionName}" flag "--${name}" alias "${alias}" collides with flag "--${existingName}" on "${node.meta.name}"`,
-						{ subject: "flag", name, reason: "extension-flag-collision" },
-					);
-				}
-			}
-		}
-	}
 	node.effectiveFlags[name] = def;
 	if (!recursive) return;
 	for (const sub of Object.values(node.subCommands)) {
@@ -257,6 +245,7 @@ function deepCloneCommandNode(node: CommandNode): CommandNode {
 		...node,
 		meta: { ...node.meta },
 		localFlags: deepCloneFlags(node.localFlags),
+		ownedFlags: deepCloneFlags(node.ownedFlags),
 		effectiveFlags: deepCloneFlags(node.effectiveFlags),
 		args: node.args ? node.args.map((def) => ({ ...def })) : undefined,
 		subCommands,
@@ -272,6 +261,7 @@ function deepCloneCommandNode(node: CommandNode): CommandNode {
 function freezeTree(node: CommandNode): void {
 	Object.freeze(node);
 	Object.freeze(node.localFlags);
+	Object.freeze(node.ownedFlags);
 	Object.freeze(node.effectiveFlags);
 	Object.freeze(node.meta);
 	Object.freeze(node.contexts);
@@ -304,14 +294,15 @@ type RequirementFlags<R extends CommandRequirements> = RequirementFlagsOf<R>;
 
 type RequirementContext<R extends CommandRequirements> = RequirementCtxOf<R>;
 
-type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any>;
+type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any>;
 
 type CommandRecipe<R extends CommandRequirements> = (
 	command: CommandDefinitionBuilder<
-		RequirementFlags<R>,
+		ForceInherit<RequirementFlags<R>>,
+		{},
 		{},
 		[],
-		EffectiveFlags<RequirementFlags<R>, {}>,
+		EffectiveFlags<ForceInherit<RequirementFlags<R>>, {}>,
 		RequirementContext<R>
 	>,
 ) => AnyCommandDefinitionBuilder;
@@ -402,7 +393,8 @@ function materializeCommandDefinition(
 
 	const child = new Crust(name);
 	(child as { _inheritedFlags: FlagsDef })._inheritedFlags = parentEffective;
-	child._node.effectiveFlags = computeEffectiveFlags(parentEffective, {});
+	child._node.ownedFlags = { ...parent.ownedFlags };
+	child._node.effectiveFlags = computeEffectiveFlags(parentEffective, {}, child._node.ownedFlags);
 	(child._node as { contexts: ContextInstance[] }).contexts = [...parent.contexts];
 
 	const configured = internal.recipe(
@@ -517,7 +509,7 @@ type MountChecks<
 	Ds extends readonly CommandDefinition<any>[],
 > = { [I in keyof Ds]: Ds[I] & Mountable<ParentEff, Ctx, DefinitionRequirements<Ds[I]>> };
 
-type ContextRequiredFlags<C> = C extends ContextInstance<any, any, infer RF, any> ? RF : {};
+type ContextRequiredFlags<C> = C extends ContextInstance<any, any, infer RF, any, any> ? RF : {};
 
 /** Per-instance provide checks: declared flag requirements vs. the builder's inheritable flags. */
 type ProvideChecks<ParentEff extends FlagsDef, Cs extends readonly ContextInstance[]> = {
@@ -527,37 +519,48 @@ type ProvideChecks<ParentEff extends FlagsDef, Cs extends readonly ContextInstan
 export interface CommandDefinitionBuilder<
 	Inherited extends FlagsDef = FlagsDef,
 	Local extends FlagsDef = FlagsDef,
+	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Inherited, Local>,
+	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
 	Ctx extends ContextMap = {},
 > {
-	meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder<Inherited, Local, A, Eff, Ctx>;
+	meta(
+		meta: Omit<CommandMeta, "name">,
+	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
 
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
 	): CommandDefinitionBuilder<
 		Inherited,
 		NamedFlagsRecord<Defs>,
+		Owned,
 		A,
-		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>>,
+		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
 		Ctx
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & ValidateVariadicArgs<NewA>
-	): CommandDefinitionBuilder<Inherited, Local, NewA, Eff, Ctx>;
+	): CommandDefinitionBuilder<Inherited, Local, Owned, NewA, Eff, Ctx>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Eff, Cs>
-	): CommandDefinitionBuilder<Inherited, Local, A, Eff, MergeContext<Ctx, ContextsOutput<Cs>>>;
+	): CommandDefinitionBuilder<
+		Inherited,
+		Local,
+		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+		A,
+		EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+		MergeContext<Ctx, ContextsOutput<Cs>>
+	>;
 
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: MountChecks<Eff, Ctx, Ds>
-	): CommandDefinitionBuilder<Inherited, Local, A, Eff, Ctx>;
+	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
 
 	handle(
 		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Inherited, Local, A, Eff, Ctx>;
+	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
 }
 
 /**
@@ -622,8 +625,9 @@ export function defineCommand(
  * Generic parameters:
  * - `Inherited` — flags inherited from a parent command (populated when mounted)
  * - `Local` — flags defined on this command via `.flags()`
+ * - `Owned` — flags installed by Contexts provided on this command path
  * - `A` — positional argument definitions
- * - `Eff` — effective flags (merged inherited + local flags, computed internally)
+ * - `Eff` — effective flags (merged inherited + local + owned flags)
  *
  * @example
  * ```ts
@@ -638,14 +642,16 @@ export function defineCommand(
 export class Crust<
 	Inherited extends FlagsDef = FlagsDef,
 	Local extends FlagsDef = FlagsDef,
+	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Inherited, Local>,
+	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
 	Ctx extends ContextMap = {},
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
 		inherited: Inherited;
 		local: Local;
+		owned: Owned;
 		args: A;
 		effective: Eff;
 		ctx: Ctx;
@@ -680,6 +686,7 @@ export class Crust<
 			...this._node,
 			// Shallow copy collections so mutations don't affect the original
 			localFlags: { ...this._node.localFlags },
+			ownedFlags: { ...this._node.ownedFlags },
 			effectiveFlags: { ...this._node.effectiveFlags },
 			subCommands: { ...this._node.subCommands },
 			contexts: [...this._node.contexts],
@@ -711,10 +718,10 @@ export class Crust<
 	 * )
 	 * ```
 	 */
-	meta(meta: Omit<CommandMeta, "name">): Crust<Inherited, Local, A, Eff, Ctx> {
+	meta(meta: Omit<CommandMeta, "name">): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			meta: { ...this._node.meta, ...meta },
-		}) as Crust<Inherited, Local, A, Eff, Ctx>;
+		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -739,8 +746,9 @@ export class Crust<
 	): Crust<
 		Inherited,
 		NamedFlagsRecord<Defs>,
+		Owned,
 		A,
-		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>>,
+		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
 		Ctx
 	> {
 		const copiedFlags: FlagsDef = {};
@@ -761,17 +769,27 @@ export class Crust<
 				);
 			}
 			validateSchemaExclusivity("flag", name, rest as Record<string, unknown>);
+			validateIncomingFlag(
+				{ name, def: rest as FlagDef },
+				this._node.ownedFlags,
+				`Command "${this._node.meta.name}"`,
+			);
 			copiedFlags[name] = rest as FlagDef;
 		}
 
 		return this._clone({
 			localFlags: copiedFlags,
-			effectiveFlags: computeEffectiveFlags(this._inheritedFlags, copiedFlags),
+			effectiveFlags: computeEffectiveFlags(
+				this._inheritedFlags,
+				copiedFlags,
+				this._node.ownedFlags,
+			),
 		}) as unknown as Crust<
 			Inherited,
 			NamedFlagsRecord<Defs>,
+			Owned,
 			A,
-			EffectiveFlags<Inherited, NamedFlagsRecord<Defs>>,
+			EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
 			Ctx
 		>;
 	}
@@ -789,7 +807,7 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & ValidateVariadicArgs<NewA>
-	): Crust<Inherited, Local, NewA, Eff, Ctx> {
+	): Crust<Inherited, Local, Owned, NewA, Eff, Ctx> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
 			validateSchemaExclusivity("arg", (def as ArgDef).name, record);
@@ -807,7 +825,7 @@ export class Crust<
 
 		return this._clone({
 			args: copiedArgs,
-		}) as unknown as Crust<Inherited, Local, NewA, Eff, Ctx>;
+		}) as unknown as Crust<Inherited, Local, Owned, NewA, Eff, Ctx>;
 	}
 
 	/**
@@ -829,17 +847,32 @@ export class Crust<
 	 */
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Eff, Cs>
-	): Crust<Inherited, Local, A, Eff, MergeContext<Ctx, ContextsOutput<Cs>>> {
+	): Crust<
+		Inherited,
+		Local,
+		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+		A,
+		EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+		MergeContext<Ctx, ContextsOutput<Cs>>
+	> {
 		const contexts = [...this._node.contexts];
+		const ownedFlags = { ...this._node.ownedFlags };
+		let effectiveFlags = { ...this._node.effectiveFlags };
 		for (const instance of instances) {
 			this._assertContextProvidable(instance as ContextInstance, contexts);
+			for (const [name, def] of Object.entries(instance.ownedFlags)) {
+				validateIncomingFlag({ name, def }, effectiveFlags, `Context "${instance.name}"`);
+				ownedFlags[name] = def;
+				effectiveFlags[name] = def;
+			}
 			contexts.push(instance as ContextInstance);
 		}
-		return this._clone({ contexts }) as unknown as Crust<
+		return this._clone({ contexts, ownedFlags, effectiveFlags }) as unknown as Crust<
 			Inherited,
 			Local,
+			MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
 			A,
-			Eff,
+			EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>
 		>;
 	}
@@ -880,8 +913,7 @@ export class Crust<
 	 * command's behavior after its inputs and Contexts are ready.
 	 *
 	 * The handler receives a {@link CrustCommandContext} with `args` typed from
-	 * `.args()` and `flags` typed as `EffectiveFlags<Inherited, Local>` (inherited
-	 * flags merged with local flags).
+	 * `.args()` and `flags` typed as `EffectiveFlags<Inherited, Local, Owned>`.
 	 *
 	 * Returns a new builder with the handler stored. The original builder is
 	 * not mutated.
@@ -891,10 +923,10 @@ export class Crust<
 	 */
 	handle(
 		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Inherited, Local, A, Eff, Ctx> {
+	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			run: handler as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Inherited, Local, A, Eff, Ctx>;
+		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -903,10 +935,10 @@ export class Crust<
 	 * Extensions are application-wide: they own the flags and commands they
 	 * contribute. Command definition builders do not expose this method.
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Inherited, Local, A, Eff, Ctx> {
+	extend(...extensions: readonly Extension[]): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Inherited, Local, A, Eff, Ctx>;
+		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -918,21 +950,27 @@ export class Crust<
 	 */
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: MountChecks<Eff, Ctx, Ds>
-	): Crust<Inherited, Local, A, Eff, Ctx> {
-		let result = this as Crust<Inherited, Local, A, Eff, Ctx>;
+	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+		let result = this as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 		for (const definition of definitions) {
 			result = result._mountDefinition(definition as CommandDefinition);
 		}
 		return result;
 	}
 
-	private _mountDefinition(definition: CommandDefinition): Crust<Inherited, Local, A, Eff, Ctx> {
-		const parentEffective = computeEffectiveFlags(this._inheritedFlags, this._node.localFlags);
+	private _mountDefinition(
+		definition: CommandDefinition,
+	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+		const parentEffective = computeEffectiveFlags(
+			this._inheritedFlags,
+			this._node.localFlags,
+			this._node.ownedFlags,
+		);
 		const childNode = materializeCommandDefinition(definition, this._node, parentEffective);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Inherited, Local, A, Eff, Ctx>;
+		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1017,7 +1017,7 @@ export class Crust<
 			const context: CrustCommandContext = {
 				args: validated.args as CrustCommandContext["args"],
 				flags: validated.flags as CrustCommandContext["flags"],
-				// Context setups receive the same validated flags the handler gets
+				// Each Context setup receives its owned slice of the validated flags.
 				ctx: await buildContexts(
 					resolvedNode.contexts,
 					validated.flags as Record<string, unknown>,

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -17,12 +17,9 @@ import {
 } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
 import { parseArgs, validateParsed } from "../parsing/parser.ts";
+import { validateIncomingFlag } from "../parsing/flag-validation.ts";
 import { applySchemas } from "../parsing/schema.ts";
-import {
-	validateCommandTree,
-	validateIncomingAliases,
-	validateIncomingFlag,
-} from "../parsing/validation.ts";
+import { validateCommandTree, validateIncomingAliases } from "../parsing/validation.ts";
 import type {
 	ArgDef,
 	ArgsDef,
@@ -848,7 +845,7 @@ export class Crust<
 	> {
 		const contexts = [...this._node.contexts];
 		const ownedFlags = { ...this._node.ownedFlags };
-		let effectiveFlags = { ...this._node.effectiveFlags };
+		const effectiveFlags = { ...this._node.effectiveFlags };
 		for (const instance of instances) {
 			this._assertContextProvidable(instance as ContextInstance, contexts);
 			for (const [name, def] of Object.entries(instance.ownedFlags)) {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -30,10 +30,8 @@ import type {
 	EffectiveFlags,
 	FlagDef,
 	FlagsDef,
-	ForceInherit,
 	InferArgs,
 	InferFlags,
-	InheritableFlags,
 	MergeFlags,
 	NamedFlagDef,
 	NamedFlagsRecord,
@@ -54,7 +52,7 @@ import { type CommandSnapshot, snapshotCommand } from "./snapshot.ts";
  *
  * Generic parameters:
  * - `A` — positional argument definitions tuple
- * - `F` — the effective (inherited + local merged) flag definitions
+ * - `F` — the effective (Context-owned + local merged) flag definitions
  */
 export interface CrustCommandContext<
 	A extends ArgsDef = ArgsDef,
@@ -165,11 +163,11 @@ function isAbortError(error: unknown): boolean {
 	return error.name === "AbortError";
 }
 
-function applyInheritedFlagsToSubtree(node: CommandNode, inheritedFlags: FlagsDef): void {
-	node.effectiveFlags = computeEffectiveFlags(inheritedFlags, node.localFlags, node.ownedFlags);
+function applyOwnedFlagsToSubtree(node: CommandNode): void {
+	node.effectiveFlags = computeEffectiveFlags(node.ownedFlags, node.localFlags);
 
 	for (const sub of Object.values(node.subCommands)) {
-		applyInheritedFlagsToSubtree(sub, node.effectiveFlags);
+		applyOwnedFlagsToSubtree(sub);
 	}
 }
 
@@ -200,8 +198,8 @@ function injectExtensionFlag(
 /** Attach one Extension's owned root commands to a cloned tree. */
 function applyExtensionCommands(root: CommandNode, ext: Extension): void {
 	for (const definition of ext.commands ?? []) {
-		const node = materializeCommandDefinition(definition, root, root.effectiveFlags, ext.name);
-		applyInheritedFlagsToSubtree(node, root.effectiveFlags);
+		const node = materializeCommandDefinition(definition, root, ext.name);
+		applyOwnedFlagsToSubtree(node);
 		root.subCommands[definition.name] = node;
 	}
 }
@@ -278,8 +276,8 @@ function freezeTree(node: CommandNode): void {
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Requirements a command definition declares about its mount site: flags
- * it expects to inherit (as named flag definitions) and Contexts it
+ * Requirements a command definition declares about its mount site: propagating
+ * Context-owned flags (as named definitions) and Contexts it
  * expects on its path (as their factories). Flag requirements are
  * compile-time checks at `.mount()`; ctx requirement names are also
  * verified at runtime when the definition is mounted.
@@ -299,11 +297,11 @@ type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, 
 
 type CommandRecipe<R extends CommandRequirements> = (
 	command: CommandDefinitionBuilder<
-		ForceInherit<RequirementFlags<R>>,
+		RequirementFlags<R>,
 		{},
 		{},
 		[],
-		EffectiveFlags<ForceInherit<RequirementFlags<R>>, {}>,
+		EffectiveFlags<RequirementFlags<R>, {}>,
 		RequirementContext<R>
 	>,
 ) => AnyCommandDefinitionBuilder;
@@ -331,7 +329,6 @@ export interface CommandDefinition<R extends CommandRequirements = {}> {
 function materializeCommandDefinition(
 	definition: CommandDefinition,
 	parent: CommandNode,
-	parentEffective: FlagsDef,
 	extensionName?: string,
 ): CommandNode {
 	const internal = (definition as Partial<CommandDefinition> | null)?.[commandDefinitionInternal];
@@ -366,10 +363,10 @@ function materializeCommandDefinition(
 	}
 
 	for (const flagName of internal.requiredFlagNames) {
-		if (parentEffective[flagName]?.inherit !== true) {
+		if (!(flagName in parent.ownedFlags)) {
 			const message = extensionName
-				? `Extension "${extensionName}" command "${name}" requires flag "--${flagName}", which is not declared with inherit: true on application root "${parent.meta.name}"`
-				: `Command "${name}" requires flag "--${flagName}", which is not declared with inherit: true on "${parent.meta.name}" — declare flags before .mount()`;
+				? `Extension "${extensionName}" command "${name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on application root "${parent.meta.name}"`
+				: `Command "${name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on "${parent.meta.name}" — call .provide() before .mount()`;
 			throw new CrustError("DEFINITION", message, {
 				subject: "flag",
 				name: flagName,
@@ -393,15 +390,15 @@ function materializeCommandDefinition(
 	}
 
 	const child = new Crust(name);
-	(child as { _inheritedFlags: FlagsDef })._inheritedFlags = parentEffective;
+	(child as { _ancestorOwnedFlags: FlagsDef })._ancestorOwnedFlags = parent.ownedFlags;
 	child._node.ownedFlags = { ...parent.ownedFlags };
-	child._node.effectiveFlags = computeEffectiveFlags(parentEffective, {}, child._node.ownedFlags);
+	child._node.effectiveFlags = computeEffectiveFlags(child._node.ownedFlags, {});
 	(child._node as { contexts: ContextInstance[] }).contexts = [...parent.contexts];
 
 	const configured = internal.recipe(
 		child as unknown as AnyCommandDefinitionBuilder,
 	) as unknown as Crust;
-	if (configured?._inheritedFlags !== parentEffective) {
+	if (configured?._ancestorOwnedFlags !== parent.ownedFlags) {
 		if (extensionName) {
 			throw new CrustError(
 				"DEFINITION",
@@ -462,17 +459,15 @@ type IncompatibleFlagNames<Provided extends FlagsDef, Required extends FlagsDef>
 }[keyof Required & keyof Provided] &
 	string;
 
-/** Flag-requirement errors vs. the attach site's inheritable effective flags. */
-type FlagRequirementErrors<
-	ParentEff extends FlagsDef,
-	Required extends FlagsDef,
-	Provided extends FlagsDef = InheritableFlags<ParentEff>,
-> = ([MissingFlagNames<Provided, Required>] extends [never]
+/** Flag-requirement errors vs. the attach site's propagating Context-owned flags. */
+type FlagRequirementErrors<Provided extends FlagsDef, Required extends FlagsDef> = ([
+	MissingFlagNames<Provided, Required>,
+] extends [never]
 	? {}
-	: { readonly "missing inherited flags": MissingFlagNames<Provided, Required> }) &
+	: { readonly "missing propagating flags": MissingFlagNames<Provided, Required> }) &
 	([IncompatibleFlagNames<Provided, Required>] extends [never]
 		? {}
-		: { readonly "incompatible inherited flags": IncompatibleFlagNames<Provided, Required> });
+		: { readonly "incompatible propagating flags": IncompatibleFlagNames<Provided, Required> });
 
 type MissingContextNames<Ctx extends ContextMap, Required extends ContextMap> = Exclude<
 	keyof Required,
@@ -495,31 +490,31 @@ type ContextRequirementErrors<Ctx extends ContextMap, Required extends ContextMa
 		: { readonly "incompatible Contexts": IncompatibleContextNames<Ctx, Required> });
 
 type Mountable<
-	ParentEff extends FlagsDef,
+	Propagating extends FlagsDef,
 	Ctx extends ContextMap,
 	R extends CommandRequirements,
-> = FlagRequirementErrors<ParentEff, RequirementFlags<R>> &
+> = FlagRequirementErrors<Propagating, RequirementFlags<R>> &
 	ContextRequirementErrors<Ctx, RequirementContext<R>>;
 
 type DefinitionRequirements<D> = D extends CommandDefinition<infer R> ? R : never;
 
 /** Per-definition mount checks (compile-time counterpart of the runtime attach checks). */
 type MountChecks<
-	ParentEff extends FlagsDef,
+	Propagating extends FlagsDef,
 	Ctx extends ContextMap,
 	Ds extends readonly CommandDefinition<any>[],
-> = { [I in keyof Ds]: Ds[I] & Mountable<ParentEff, Ctx, DefinitionRequirements<Ds[I]>> };
+> = { [I in keyof Ds]: Ds[I] & Mountable<Propagating, Ctx, DefinitionRequirements<Ds[I]>> };
 
 type ContextRequiredFlags<C> = C extends ContextInstance<any, any, infer RF, any, any> ? RF : {};
 
-/** Per-instance provide checks: declared flag requirements vs. the builder's inheritable flags. */
-type ProvideChecks<ParentEff extends FlagsDef, Cs extends readonly ContextInstance[]> = {
-	[I in keyof Cs]: Cs[I] & FlagRequirementErrors<ParentEff, ContextRequiredFlags<Cs[I]>>;
+/** Per-instance provide checks: declared flag requirements vs. propagating flags. */
+type ProvideChecks<Propagating extends FlagsDef, Cs extends readonly ContextInstance[]> = {
+	[I in keyof Cs]: Cs[I] & FlagRequirementErrors<Propagating, ContextRequiredFlags<Cs[I]>>;
 };
 
 export interface CommandDefinitionBuilder<
-	Inherited extends FlagsDef = FlagsDef,
-	Local extends FlagsDef = FlagsDef,
+	Inherited extends FlagsDef = {},
+	Local extends FlagsDef = {},
 	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
 	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
@@ -545,7 +540,7 @@ export interface CommandDefinitionBuilder<
 	): CommandDefinitionBuilder<Inherited, Local, Owned, NewA, Eff, Ctx>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<Eff, Cs>
+		...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>
 	): CommandDefinitionBuilder<
 		Inherited,
 		Local,
@@ -556,7 +551,7 @@ export interface CommandDefinitionBuilder<
 	>;
 
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<Eff, Ctx, Ds>
+		...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>
 	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
 
 	handle(
@@ -569,7 +564,7 @@ export interface CommandDefinitionBuilder<
  *
  * The recipe runs once per `.mount()`, receiving a fresh builder typed by
  * the declared dependencies: `requires.flags` (named flag definitions the
- * mount site must provide as inheritable flags) and `requires.ctx` (Context
+ * mount site must provide as propagating Context-owned flags) and `requires.ctx` (Context
  * factories whose instances must be provided on the mount path).
  *
  * Use `.as(name)` to mount one definition under a different name.
@@ -624,16 +619,16 @@ export function defineCommand(
  * Chainable builder for defining CLI commands with full type inference.
  *
  * Generic parameters:
- * - `Inherited` — flags inherited from a parent command (populated when mounted)
+ * - `Inherited` — Context-owned flags propagated from ancestor commands
  * - `Local` — flags defined on this command via `.flags()`
  * - `Owned` — flags installed by Contexts provided on this command path
  * - `A` — positional argument definitions
- * - `Eff` — effective flags (merged inherited + local + owned flags)
+ * - `Eff` — effective flags (merged ancestor-owned + local + owned flags)
  *
  * @example
  * ```ts
  * const app = new Crust("my-cli")
- *   .flags({ name: "verbose", type: "boolean", short: "v", inherit: true })
+ *   .flags({ name: "verbose", type: "boolean", short: "v" })
  *   .args({ name: "file", type: "string", required: true })
  *   .handle(({ args, flags }) => {
  *     console.log(args.file, flags.verbose);
@@ -641,8 +636,8 @@ export function defineCommand(
  * ```
  */
 export class Crust<
-	Inherited extends FlagsDef = FlagsDef,
-	Local extends FlagsDef = FlagsDef,
+	Inherited extends FlagsDef = {},
+	Local extends FlagsDef = {},
 	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
 	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
@@ -650,7 +645,7 @@ export class Crust<
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
-		inherited: Inherited;
+		ancestorOwned: Inherited;
 		local: Local;
 		owned: Owned;
 		args: A;
@@ -661,8 +656,8 @@ export class Crust<
 	/** @internal */
 	readonly _node: CommandNode;
 
-	/** @internal — The inherited flags record (runtime counterpart of Inherited generic) */
-	readonly _inheritedFlags: FlagsDef;
+	/** @internal — Ancestor-owned flags (runtime counterpart of Inherited generic) */
+	readonly _ancestorOwnedFlags: FlagsDef;
 
 	/**
 	 * Create a new root command builder.
@@ -675,7 +670,7 @@ export class Crust<
 			throw new CrustError("DEFINITION", "meta.name must be a non-empty string");
 		}
 		this._node = createCommandNode(name);
-		this._inheritedFlags = {};
+		this._ancestorOwnedFlags = {};
 	}
 
 	/**
@@ -697,7 +692,7 @@ export class Crust<
 			...nodeOverrides,
 		};
 		(cloned as { _node: CommandNode })._node = newNode;
-		(cloned as { _inheritedFlags: FlagsDef })._inheritedFlags = this._inheritedFlags;
+		(cloned as { _ancestorOwnedFlags: FlagsDef })._ancestorOwnedFlags = this._ancestorOwnedFlags;
 		return cloned;
 	}
 
@@ -734,7 +729,7 @@ export class Crust<
 	 * builder with updated local flag types. The original builder is not
 	 * mutated.
 	 *
-	 * NOTE: Compile-time inherited/local cross-collision checks are intentionally
+	 * NOTE: Compile-time ancestor-owned/local cross-collision checks are intentionally
 	 * omitted here to reduce TypeScript type-check cost in large projects.
 	 * Runtime collision checks still run during parsing and command-tree validation.
 	 *
@@ -780,11 +775,7 @@ export class Crust<
 
 		return this._clone({
 			localFlags: copiedFlags,
-			effectiveFlags: computeEffectiveFlags(
-				this._inheritedFlags,
-				copiedFlags,
-				this._node.ownedFlags,
-			),
+			effectiveFlags: computeEffectiveFlags(this._node.ownedFlags, copiedFlags),
 		}) as unknown as Crust<
 			Inherited,
 			NamedFlagsRecord<Defs>,
@@ -840,14 +831,13 @@ export class Crust<
 	 * disposed in reverse construction order after success or failure.
 	 *
 	 * A Context's declared flag requirements are checked here: each
-	 * required flag must already be declared with `inherit: true` on this
-	 * builder — declare flags before `.provide()`.
+	 * required flag must already be supplied by a Context on this command path.
 	 *
 	 * @throws {CrustError} `DEFINITION` when a name is already provided on
 	 *                      this command path or a required flag is missing
 	 */
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<Eff, Cs>
+		...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>
 	): Crust<
 		Inherited,
 		Local,
@@ -899,10 +889,10 @@ export class Crust<
 			);
 		}
 		for (const flagName of Object.keys(instance.requiredFlags)) {
-			if (this._node.effectiveFlags[flagName]?.inherit !== true) {
+			if (!(flagName in this._node.ownedFlags)) {
 				throw new CrustError(
 					"DEFINITION",
-					`Context "${instance.name}" requires flag "--${flagName}", which is not declared with inherit: true on "${this._node.meta.name}" — declare flags before .provide()`,
+					`Context "${instance.name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on "${this._node.meta.name}"`,
 					{ subject: "context", name: instance.name, reason: "missing-required-flag" },
 				);
 			}
@@ -950,7 +940,7 @@ export class Crust<
 	 * on this builder's path — call `.provide()` before `.mount()`.
 	 */
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<Eff, Ctx, Ds>
+		...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>
 	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
 		let result = this as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
 		for (const definition of definitions) {
@@ -962,12 +952,7 @@ export class Crust<
 	private _mountDefinition(
 		definition: CommandDefinition,
 	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
-		const parentEffective = computeEffectiveFlags(
-			this._inheritedFlags,
-			this._node.localFlags,
-			this._node.ownedFlags,
-		);
-		const childNode = materializeCommandDefinition(definition, this._node, parentEffective);
+		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -28,6 +28,7 @@ import type {
 	FlagsDef,
 	InferArgs,
 	InferFlags,
+	InvocationIO,
 	MergeFlags,
 	NamedFlagDef,
 	NamedFlagsRecord,
@@ -54,7 +55,7 @@ export interface CrustCommandContext<
 	A extends ArgsDef = ArgsDef,
 	F extends FlagsDef = FlagsDef,
 	Ctx extends ContextMap = {},
-> {
+> extends InvocationIO {
 	/** Resolved positional arguments, keyed by arg name */
 	args: InferArgs<A>;
 	/** Resolved flags, keyed by flag name */
@@ -67,16 +68,6 @@ export interface CrustCommandContext<
 	command: CommandSnapshot;
 	/** Readonly snapshot of the application root, including Extension contributions */
 	rootCommand: CommandSnapshot;
-	/** Write a line of standard output (injectable text callback) */
-	stdout: (text: string) => void;
-	/** Write a line of diagnostic output (injectable text callback) */
-	stderr: (text: string) => void;
-}
-
-/** Injectable output callbacks threaded through one invocation. */
-interface InvocationIO {
-	stdout: (text: string) => void;
-	stderr: (text: string) => void;
 }
 
 /** Terminal defaults: line-oriented writes to the process streams. */
@@ -1015,6 +1006,7 @@ export class Crust<
 				ctx: await buildContexts(
 					resolvedNode.contexts,
 					validated.flags as Record<string, unknown>,
+					io,
 					disposal,
 					`"${resolved.commandPath.join(" ")}"`,
 				),

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1,13 +1,12 @@
 import {
 	buildContexts,
+	type AnyContextFactory,
 	type ContextInstance,
 	type ContextMap,
-	type ContextRequirements,
 	type ContextsOutput,
 	type ContextsOwnedFlags,
 	type MergeContext,
 	type RequirementCtxOf,
-	type RequirementFlagsOf,
 } from "../api/context.ts";
 import {
 	finishInvocation,
@@ -16,8 +15,8 @@ import {
 	type InvocationOutcome,
 } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
-import { parseArgs, validateParsed } from "../parsing/parser.ts";
 import { validateIncomingFlag } from "../parsing/flag-validation.ts";
+import { parseArgs, validateParsed } from "../parsing/parser.ts";
 import { applySchemas } from "../parsing/schema.ts";
 import { validateCommandTree, validateIncomingAliases } from "../parsing/validation.ts";
 import type {
@@ -272,35 +271,17 @@ function freezeTree(node: CommandNode): void {
 // Reusable command definitions
 // ────────────────────────────────────────────────────────────────────────────
 
-/**
- * Requirements a command definition declares about its mount site: propagating
- * Context-owned flags (as named definitions) and Contexts it
- * expects on its path (as their factories). Flag requirements are
- * compile-time checks at `.mount()`; ctx requirement names are also
- * verified at runtime when the definition is mounted.
- *
- * Both requirement kinds are grouped under `requires` and verified at runtime
- * as a backstop for untyped mount sites.
- */
+/** Context capabilities a command definition requires from its mount path. */
 export interface CommandRequirements {
-	readonly requires?: ContextRequirements;
+	readonly requires?: readonly AnyContextFactory[];
 }
-
-type RequirementFlags<R extends CommandRequirements> = RequirementFlagsOf<R>;
 
 type RequirementContext<R extends CommandRequirements> = RequirementCtxOf<R>;
 
-type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any>;
+type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any>;
 
 type CommandRecipe<R extends CommandRequirements> = (
-	command: CommandDefinitionBuilder<
-		RequirementFlags<R>,
-		{},
-		{},
-		[],
-		EffectiveFlags<RequirementFlags<R>, {}>,
-		RequirementContext<R>
-	>,
+	command: CommandDefinitionBuilder<{}, {}, [], EffectiveFlags<{}, {}>, RequirementContext<R>>,
 ) => AnyCommandDefinitionBuilder;
 
 const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
@@ -308,7 +289,6 @@ const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefini
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
 	/** Requirement names, runtime-checked at each mount site */
-	readonly requiredFlagNames: readonly string[];
 	readonly requiredCtxNames: readonly string[];
 }
 
@@ -357,19 +337,6 @@ function materializeCommandDefinition(
 			);
 		}
 		throw new CrustError("DEFINITION", `Subcommand "${name}" is already registered`);
-	}
-
-	for (const flagName of internal.requiredFlagNames) {
-		if (!(flagName in parent.ownedFlags)) {
-			const message = extensionName
-				? `Extension "${extensionName}" command "${name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on application root "${parent.meta.name}"`
-				: `Command "${name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on "${parent.meta.name}" — call .provide() before .mount()`;
-			throw new CrustError("DEFINITION", message, {
-				subject: "flag",
-				name: flagName,
-				reason: "missing-required-flag",
-			});
-		}
 	}
 
 	const providedNames = new Set(parent.contexts.map((context) => context.name));
@@ -441,31 +408,6 @@ function materializeCommandDefinition(
 	return childNode;
 }
 
-type FlagValue<D extends FlagDef> = InferFlags<{ value: D }>["value"];
-
-type MissingFlagNames<Provided extends FlagsDef, Required extends FlagsDef> = Exclude<
-	keyof Required,
-	keyof Provided
-> &
-	string;
-
-type IncompatibleFlagNames<Provided extends FlagsDef, Required extends FlagsDef> = {
-	[K in keyof Required & keyof Provided]: FlagValue<Provided[K]> extends FlagValue<Required[K]>
-		? never
-		: K;
-}[keyof Required & keyof Provided] &
-	string;
-
-/** Flag-requirement errors vs. the attach site's propagating Context-owned flags. */
-type FlagRequirementErrors<Provided extends FlagsDef, Required extends FlagsDef> = ([
-	MissingFlagNames<Provided, Required>,
-] extends [never]
-	? {}
-	: { readonly "missing propagating flags": MissingFlagNames<Provided, Required> }) &
-	([IncompatibleFlagNames<Provided, Required>] extends [never]
-		? {}
-		: { readonly "incompatible propagating flags": IncompatibleFlagNames<Provided, Required> });
-
 type MissingContextNames<Ctx extends ContextMap, Required extends ContextMap> = Exclude<
 	keyof Required,
 	keyof Ctx
@@ -484,85 +426,65 @@ type ContextRequirementErrors<Ctx extends ContextMap, Required extends ContextMa
 	: { readonly "missing Contexts": MissingContextNames<Ctx, Required> }) &
 	([IncompatibleContextNames<Ctx, Required>] extends [never]
 		? {}
-		: { readonly "incompatible Contexts": IncompatibleContextNames<Ctx, Required> });
-
-type Mountable<
-	Propagating extends FlagsDef,
-	Ctx extends ContextMap,
-	R extends CommandRequirements,
-> = FlagRequirementErrors<Propagating, RequirementFlags<R>> &
-	ContextRequirementErrors<Ctx, RequirementContext<R>>;
+		: {
+				readonly "incompatible Contexts": IncompatibleContextNames<Ctx, Required>;
+			});
 
 type DefinitionRequirements<D> = D extends CommandDefinition<infer R> ? R : never;
 
 /** Per-definition mount checks (compile-time counterpart of the runtime attach checks). */
-type MountChecks<
-	Propagating extends FlagsDef,
-	Ctx extends ContextMap,
-	Ds extends readonly CommandDefinition<any>[],
-> = { [I in keyof Ds]: Ds[I] & Mountable<Propagating, Ctx, DefinitionRequirements<Ds[I]>> };
-
-type ContextRequiredFlags<C> = C extends ContextInstance<any, any, infer RF, any, any> ? RF : {};
-
-/** Per-instance provide checks: declared flag requirements vs. propagating flags. */
-type ProvideChecks<Propagating extends FlagsDef, Cs extends readonly ContextInstance[]> = {
-	[I in keyof Cs]: Cs[I] & FlagRequirementErrors<Propagating, ContextRequiredFlags<Cs[I]>>;
+type MountChecks<Ctx extends ContextMap, Ds extends readonly CommandDefinition<any>[]> = {
+	[I in keyof Ds]: Ds[I] &
+		ContextRequirementErrors<Ctx, RequirementContext<DefinitionRequirements<Ds[I]>>>;
 };
 
 export interface CommandDefinitionBuilder<
-	Inherited extends FlagsDef = {},
 	Local extends FlagsDef = {},
 	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
+	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
 > {
-	meta(
-		meta: Omit<CommandMeta, "name">,
-	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
+	meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
 	): CommandDefinitionBuilder<
-		Inherited,
 		NamedFlagsRecord<Defs>,
 		Owned,
 		A,
-		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
+		EffectiveFlags<NamedFlagsRecord<Defs>, Owned>,
 		Ctx
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & ValidateVariadicArgs<NewA>
-	): CommandDefinitionBuilder<Inherited, Local, Owned, NewA, Eff, Ctx>;
+	): CommandDefinitionBuilder<Local, Owned, NewA, Eff, Ctx>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>
+		...instances: Cs
 	): CommandDefinitionBuilder<
-		Inherited,
 		Local,
 		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
 		A,
-		EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>
 	>;
 
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>
-	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
+		...definitions: MountChecks<Ctx, Ds>
+	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 
 	handle(
 		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Inherited, Local, Owned, A, Eff, Ctx>;
+	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 }
 
 /**
  * Define a reusable, inert command under a required name.
  *
  * The recipe runs once per `.mount()`, receiving a fresh builder typed by
- * the declared dependencies: `requires.flags` (named flag definitions the
- * mount site must provide as propagating Context-owned flags) and `requires.ctx` (Context
- * factories whose instances must be provided on the mount path).
+ * the declared Context capabilities, which must be provided on the mount path.
  *
  * Use `.as(name)` to mount one definition under a different name.
  */
@@ -589,8 +511,7 @@ export function defineCommand(
 	}
 	const internal: CommandDefinitionInternal = {
 		recipe: recipe as CommandDefinitionInternal["recipe"],
-		requiredFlagNames: (config.requires?.flags ?? []).map((flag) => flag.name),
-		requiredCtxNames: (config.requires?.ctx ?? []).map((dep) => dep.contextName),
+		requiredCtxNames: (config.requires ?? []).map((dep) => dep.contextName),
 	};
 	const named = (defName: string): CommandDefinition<CommandRequirements> => {
 		if (!defName.trim()) {
@@ -616,11 +537,10 @@ export function defineCommand(
  * Chainable builder for defining CLI commands with full type inference.
  *
  * Generic parameters:
- * - `Inherited` — Context-owned flags propagated from ancestor commands
  * - `Local` — flags defined on this command via `.flags()`
  * - `Owned` — flags installed by Contexts provided on this command path
  * - `A` — positional argument definitions
- * - `Eff` — effective flags (merged ancestor-owned + local + owned flags)
+ * - `Eff` — effective flags (merged local + owned flags)
  *
  * @example
  * ```ts
@@ -633,16 +553,14 @@ export function defineCommand(
  * ```
  */
 export class Crust<
-	Inherited extends FlagsDef = {},
 	Local extends FlagsDef = {},
 	Owned extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Inherited, Local, Owned>,
+	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
-		ancestorOwned: Inherited;
 		local: Local;
 		owned: Owned;
 		args: A;
@@ -653,7 +571,7 @@ export class Crust<
 	/** @internal */
 	readonly _node: CommandNode;
 
-	/** @internal — Ancestor-owned flags (runtime counterpart of Inherited generic) */
+	/** @internal — Runtime identity anchor for the ancestor-owned flag carrier */
 	readonly _ancestorOwnedFlags: FlagsDef;
 
 	/**
@@ -711,10 +629,10 @@ export class Crust<
 	 * )
 	 * ```
 	 */
-	meta(meta: Omit<CommandMeta, "name">): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+	meta(meta: Omit<CommandMeta, "name">): Crust<Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			meta: { ...this._node.meta, ...meta },
-		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
+		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -736,14 +654,7 @@ export class Crust<
 	 */
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
-	): Crust<
-		Inherited,
-		NamedFlagsRecord<Defs>,
-		Owned,
-		A,
-		EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
-		Ctx
-	> {
+	): Crust<NamedFlagsRecord<Defs>, Owned, A, EffectiveFlags<NamedFlagsRecord<Defs>, Owned>, Ctx> {
 		const copiedFlags: FlagsDef = {};
 		for (const def of defs) {
 			// Destructuring also decouples the stored def from the caller's object
@@ -774,11 +685,10 @@ export class Crust<
 			localFlags: copiedFlags,
 			effectiveFlags: computeEffectiveFlags(this._node.ownedFlags, copiedFlags),
 		}) as unknown as Crust<
-			Inherited,
 			NamedFlagsRecord<Defs>,
 			Owned,
 			A,
-			EffectiveFlags<Inherited, NamedFlagsRecord<Defs>, Owned>,
+			EffectiveFlags<NamedFlagsRecord<Defs>, Owned>,
 			Ctx
 		>;
 	}
@@ -796,7 +706,7 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & ValidateVariadicArgs<NewA>
-	): Crust<Inherited, Local, Owned, NewA, Eff, Ctx> {
+	): Crust<Local, Owned, NewA, Eff, Ctx> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
 			validateSchemaExclusivity("arg", (def as ArgDef).name, record);
@@ -805,7 +715,11 @@ export class Crust<
 				throw new CrustError(
 					"DEFINITION",
 					`arg "${(def as ArgDef).name}" mixes core option "type" with a schema — schema args receive the raw string token`,
-					{ subject: "arg", name: (def as ArgDef).name, reason: "schema-exclusive" },
+					{
+						subject: "arg",
+						name: (def as ArgDef).name,
+						reason: "schema-exclusive",
+					},
 				);
 			}
 		}
@@ -814,33 +728,29 @@ export class Crust<
 
 		return this._clone({
 			args: copiedArgs,
-		}) as unknown as Crust<Inherited, Local, Owned, NewA, Eff, Ctx>;
+		}) as unknown as Crust<Local, Owned, NewA, Eff, Ctx>;
 	}
 
 	/**
 	 * Attach Contexts — named command dependencies — to this command.
 	 *
 	 * Contexts are inherited by descendant commands, constructed
-	 * topologically (by declared ctx requirements) only for the resolved
+	 * topologically (by declared capability requirements) only for the resolved
 	 * command path, and exposed to the Command Handler as `ctx`. Provide
 	 * order is free: dependencies may be provided after their dependents.
 	 * Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are
 	 * disposed in reverse construction order after success or failure.
 	 *
-	 * A Context's declared flag requirements are checked here: each
-	 * required flag must already be supplied by a Context on this command path.
-	 *
 	 * @throws {CrustError} `DEFINITION` when a name is already provided on
-	 *                      this command path or a required flag is missing
+	 *                      this command path
 	 */
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<MergeFlags<Inherited, Owned>, Cs>
+		...instances: Cs
 	): Crust<
-		Inherited,
 		Local,
 		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
 		A,
-		EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>
 	> {
 		const contexts = [...this._node.contexts];
@@ -855,12 +765,15 @@ export class Crust<
 			}
 			contexts.push(instance as ContextInstance);
 		}
-		return this._clone({ contexts, ownedFlags, effectiveFlags }) as unknown as Crust<
-			Inherited,
+		return this._clone({
+			contexts,
+			ownedFlags,
+			effectiveFlags,
+		}) as unknown as Crust<
 			Local,
 			MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
 			A,
-			EffectiveFlags<Inherited, Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
+			EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>
 		>;
 	}
@@ -882,17 +795,12 @@ export class Crust<
 			throw new CrustError(
 				"DEFINITION",
 				`Context "${instance.name}" is already provided on this command path`,
-				{ subject: "context", name: instance.name, reason: "duplicate-context" },
+				{
+					subject: "context",
+					name: instance.name,
+					reason: "duplicate-context",
+				},
 			);
-		}
-		for (const flagName of Object.keys(instance.requiredFlags)) {
-			if (!(flagName in this._node.ownedFlags)) {
-				throw new CrustError(
-					"DEFINITION",
-					`Context "${instance.name}" requires flag "--${flagName}", which is not provided as a propagating Context-owned flag on "${this._node.meta.name}"`,
-					{ subject: "context", name: instance.name, reason: "missing-required-flag" },
-				);
-			}
 		}
 	}
 
@@ -901,7 +809,7 @@ export class Crust<
 	 * command's behavior after its inputs and Contexts are ready.
 	 *
 	 * The handler receives a {@link CrustCommandContext} with `args` typed from
-	 * `.args()` and `flags` typed as `EffectiveFlags<Inherited, Local, Owned>`.
+	 * `.args()` and `flags` typed as `EffectiveFlags<Local, Owned>`.
 	 *
 	 * Returns a new builder with the handler stored. The original builder is
 	 * not mutated.
@@ -911,10 +819,10 @@ export class Crust<
 	 */
 	handle(
 		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+	): Crust<Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			run: handler as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
+		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -923,10 +831,10 @@ export class Crust<
 	 * Extensions are application-wide: they own the flags and commands they
 	 * contribute. Command definition builders do not expose this method.
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx> {
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
+		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**
@@ -937,23 +845,21 @@ export class Crust<
 	 * on this builder's path — call `.provide()` before `.mount()`.
 	 */
 	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<MergeFlags<Inherited, Owned>, Ctx, Ds>
-	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
-		let result = this as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
+		...definitions: MountChecks<Ctx, Ds>
+	): Crust<Local, Owned, A, Eff, Ctx> {
+		let result = this as Crust<Local, Owned, A, Eff, Ctx>;
 		for (const definition of definitions) {
 			result = result._mountDefinition(definition as CommandDefinition);
 		}
 		return result;
 	}
 
-	private _mountDefinition(
-		definition: CommandDefinition,
-	): Crust<Inherited, Local, Owned, A, Eff, Ctx> {
+	private _mountDefinition(definition: CommandDefinition): Crust<Local, Owned, A, Eff, Ctx> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Inherited, Local, Owned, A, Eff, Ctx>;
+		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -57,14 +57,17 @@ describe("command definitions", () => {
 	it("propagates Context-owned flags only to definitions mounted after provide()", async () => {
 		const calls: string[] = [];
 		const apiKey = defineFlag("api-key", { type: "string" });
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
 		const before = defineCommand("before", (command) => command.handle(() => {}));
-		const after = defineCommand("after", { flags: [apiKey], ctx: [auth] }, (command) =>
-			command.handle(({ flags, ctx }) => {
-				calls.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
-			}),
+		const after = defineCommand(
+			"after",
+			{ requires: { flags: [apiKey], ctx: [auth] } },
+			(command) =>
+				command.handle(({ flags, ctx }) => {
+					calls.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
+				}),
 		);
 		const outer = defineCommand("outer", (command) =>
 			command.mount(before).provide(auth()).mount(after),
@@ -82,13 +85,18 @@ describe("command definitions", () => {
 		const calls: string[] = [];
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const db = defineContext("db", () => "database");
-		const status = defineCommand("status", { flags: [verbose], ctx: [db] }, (command) =>
-			command.handle(({ flags, ctx }) => {
-				calls.push(`${ctx.db}:${String(flags.verbose)}`);
-			}),
+		const status = defineCommand(
+			"status",
+			{ requires: { flags: [verbose], ctx: [db] } },
+			(command) =>
+				command.handle(({ flags, ctx }) => {
+					calls.push(`${ctx.db}:${String(flags.verbose)}`);
+				}),
 		);
-		const deploy = defineCommand("deploy", { flags: [verbose], ctx: [db] }, (command) =>
-			command.mount(status),
+		const deploy = defineCommand(
+			"deploy",
+			{ requires: { flags: [verbose], ctx: [db] } },
+			(command) => command.mount(status),
 		);
 		const app = new Crust("cli").flags(verbose).provide(db()).mount(deploy);
 
@@ -217,7 +225,9 @@ describe("command definitions", () => {
 
 	it("checks Context requirement names at the mount call at runtime", () => {
 		const db = defineContext("db", () => "database");
-		const definition = defineCommand("users", { ctx: [db] }, (command) => command.handle(() => {}));
+		const definition = defineCommand("users", { requires: { ctx: [db] } }, (command) =>
+			command.handle(() => {}),
+		);
 
 		expect(() => new Crust("cli").provide(db()).mount(definition)).not.toThrow();
 		expect(() => new Crust("cli").mount(definition as never)).toThrow(
@@ -228,18 +238,21 @@ describe("command definitions", () => {
 	it("checks requirements while preserving fluent handler types", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const auth = defineContext("auth", () => ({ user: "yan" }));
-		const definition = defineCommand("deploy", { flags: [verbose], ctx: [auth] }, (command) =>
-			command
-				.args({ name: "target", type: "string", required: true })
-				.flags({ name: "force", type: "boolean", required: true })
-				.provide(defineContext("region", () => "us-east-1")())
-				.handle(({ args, flags, ctx }) => {
-					type _Target = Assert<IsEqual<typeof args.target, string>>;
-					type _Verbose = Assert<IsEqual<typeof flags.verbose, boolean | undefined>>;
-					type _Force = Assert<IsEqual<typeof flags.force, boolean>>;
-					type _Auth = Assert<IsEqual<typeof ctx.auth, { user: string }>>;
-					type _Region = Assert<IsEqual<typeof ctx.region, string>>;
-				}),
+		const definition = defineCommand(
+			"deploy",
+			{ requires: { flags: [verbose], ctx: [auth] } },
+			(command) =>
+				command
+					.args({ name: "target", type: "string", required: true })
+					.flags({ name: "force", type: "boolean", required: true })
+					.provide(defineContext("region", () => "us-east-1")())
+					.handle(({ args, flags, ctx }) => {
+						type _Target = Assert<IsEqual<typeof args.target, string>>;
+						type _Verbose = Assert<IsEqual<typeof flags.verbose, boolean | undefined>>;
+						type _Force = Assert<IsEqual<typeof flags.force, boolean>>;
+						type _Auth = Assert<IsEqual<typeof ctx.auth, { user: string }>>;
+						type _Region = Assert<IsEqual<typeof ctx.region, string>>;
+					}),
 		);
 
 		new Crust("cli").flags(verbose).provide(auth()).mount(definition);
@@ -256,7 +269,7 @@ describe("command definitions", () => {
 		});
 		const strictDefinition = defineCommand(
 			"strict",
-			{ flags: [requiredToken] },
+			{ requires: { flags: [requiredToken] } },
 			(command) => command,
 		);
 		new Crust("cli")
@@ -327,9 +340,13 @@ describe("command definitions", () => {
 
 	it("checks nested requirements at the enclosing mount point", () => {
 		const required = defineFlag("verbose", { type: "boolean", inherit: true });
-		const nested = defineCommand("nested", { flags: [required] }, (command) => command);
+		const nested = defineCommand(
+			"nested",
+			{ requires: { flags: [required] } },
+			(command) => command,
+		);
 
-		defineCommand("outer", { flags: [required] }, (command) => command.mount(nested));
+		defineCommand("outer", { requires: { flags: [required] } }, (command) => command.mount(nested));
 		defineCommand("outer", (command) => {
 			// @ts-expect-error -- missing inherited flags: verbose
 			return command.mount(nested);

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -134,7 +134,7 @@ describe("command definitions", () => {
 		);
 	});
 
-	it("excludes non-inheritable parent flags from mounted commands", async () => {
+	it("excludes parent local flags from mounted commands", async () => {
 		const definition = defineCommand("users", (command) => command.handle(() => {}));
 		const app = new Crust("cli").flags({ name: "secret", type: "string" }).mount(definition);
 

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -270,7 +270,6 @@ describe("command definitions", () => {
 
 		const requiredToken = defineFlag("token", {
 			type: "string",
-
 			required: true,
 			parse: (raw: string) => Number(raw),
 		});

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -54,6 +54,30 @@ describe("command definitions", () => {
 		await expect(app.run(["outer", "nested", "--late"])).rejects.toThrow(/Unknown flag/);
 	});
 
+	it("propagates Context-owned flags only to definitions mounted after provide()", async () => {
+		const calls: string[] = [];
+		const apiKey = defineFlag("api-key", { type: "string" });
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+			apiKey: flags["api-key"],
+		}));
+		const before = defineCommand("before", (command) => command.handle(() => {}));
+		const after = defineCommand("after", { flags: [apiKey], ctx: [auth] }, (command) =>
+			command.handle(({ flags, ctx }) => {
+				calls.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
+			}),
+		);
+		const outer = defineCommand("outer", (command) =>
+			command.mount(before).provide(auth()).mount(after),
+		);
+		const app = new Crust("cli").mount(outer);
+
+		await expect(app.run(["outer", "before", "--api-key", "secret"])).rejects.toThrow(
+			/Unknown flag/,
+		);
+		await app.run(["outer", "after", "--api-key", "secret"]);
+		expect(calls).toEqual(["secret:secret"]);
+	});
+
 	it("inherits flags and Contexts through nested definitions", async () => {
 		const calls: string[] = [];
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -47,7 +47,7 @@ describe("command definitions", () => {
 	it("does not backfill nested definitions with later inheritable flags", async () => {
 		const nested = defineCommand("nested", (command) => command.handle(() => {}));
 		const outer = defineCommand("outer", (command) =>
-			command.mount(nested).flags({ name: "late", type: "boolean", inherit: true }),
+			command.mount(nested).flags({ name: "late", type: "boolean" }),
 		);
 		const app = new Crust("cli").mount(outer);
 
@@ -83,7 +83,7 @@ describe("command definitions", () => {
 
 	it("inherits flags and Contexts through nested definitions", async () => {
 		const calls: string[] = [];
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const db = defineContext("db", () => "database");
 		const status = defineCommand(
 			"status",
@@ -98,7 +98,8 @@ describe("command definitions", () => {
 			{ requires: { flags: [verbose], ctx: [db] } },
 			(command) => command.mount(status),
 		);
-		const app = new Crust("cli").flags(verbose).provide(db()).mount(deploy);
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).provide(db()).mount(deploy);
 
 		await app.run(["deploy", "status", "--verbose"]);
 
@@ -236,7 +237,7 @@ describe("command definitions", () => {
 	});
 
 	it("checks requirements while preserving fluent handler types", () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean" });
 		const auth = defineContext("auth", () => ({ user: "yan" }));
 		const definition = defineCommand(
 			"deploy",
@@ -255,15 +256,21 @@ describe("command definitions", () => {
 					}),
 		);
 
-		new Crust("cli").flags(verbose).provide(auth()).mount(definition);
+		const verboseOwner = defineContext("verbose-owner", { flags: [verbose] }, () => ({}));
+		new Crust("cli").provide(verboseOwner()).provide(auth()).mount(definition);
+		const requiredVerboseOwner = defineContext(
+			"verbose-owner",
+			{ flags: [{ ...verbose, required: true }] },
+			() => ({}),
+		);
 		new Crust("other")
-			.flags({ ...verbose, required: true })
+			.provide(requiredVerboseOwner())
 			.provide(defineContext("auth", () => ({ user: "other", admin: true }))())
 			.mount(definition);
 
 		const requiredToken = defineFlag("token", {
 			type: "string",
-			inherit: true,
+
 			required: true,
 			parse: (raw: string) => Number(raw),
 		});
@@ -272,42 +279,58 @@ describe("command definitions", () => {
 			{ requires: { flags: [requiredToken] } },
 			(command) => command,
 		);
+		const strictTokenOwner = defineContext(
+			"token-owner",
+			{
+				flags: [
+					{
+						name: "token",
+						type: "string",
+						required: true,
+						parse: () => 1 as const,
+					},
+				],
+			},
+			() => ({}),
+		);
+		new Crust("cli").provide(strictTokenOwner()).mount(strictDefinition);
+		const optionalTokenOwner = defineContext(
+			"token-owner",
+			{ flags: [{ name: "token", type: "string", parse: Number }] },
+			() => ({}),
+		);
 		new Crust("cli")
-			.flags({
-				name: "token",
-				type: "string",
-				inherit: true,
-				required: true,
-				parse: () => 1 as const,
-			})
-			.mount(strictDefinition);
-		new Crust("cli")
-			.flags({ name: "token", type: "string", inherit: true, parse: Number })
-			// @ts-expect-error -- an optional parent flag cannot satisfy a required requirement
+			.provide(optionalTokenOwner())
+			// @ts-expect-error -- an optional owned flag cannot satisfy a required requirement
 			.mount(strictDefinition);
 
 		expect(() =>
-			// @ts-expect-error -- missing inherited flags: verbose
+			// @ts-expect-error -- missing propagating flags: verbose
 			new Crust("cli").provide(auth()).mount(definition),
 		).toThrow(/requires flag "--verbose"/);
 		expect(() =>
 			new Crust("cli")
 				.flags({ name: "verbose", type: "boolean" })
 				.provide(auth())
-				// @ts-expect-error -- missing inherited flags: verbose
+				// @ts-expect-error -- missing propagating flags: verbose
 				.mount(definition),
 		).toThrow(/requires flag "--verbose"/);
+		const wrongVerboseOwner = defineContext(
+			"verbose-owner",
+			{ flags: [{ name: "verbose", type: "string" }] },
+			() => ({}),
+		);
 		new Crust("cli")
-			.flags({ name: "verbose", type: "string", inherit: true })
+			.provide(wrongVerboseOwner())
 			.provide(auth())
-			// @ts-expect-error -- incompatible inherited flags: verbose
+			// @ts-expect-error -- incompatible propagating flags: verbose
 			.mount(definition);
 		expect(() =>
 			// @ts-expect-error -- missing Contexts: auth
-			new Crust("cli").flags(verbose).mount(definition),
+			new Crust("cli").provide(verboseOwner()).mount(definition),
 		).toThrow(/requires Context "auth"/);
 		new Crust("cli")
-			.flags(verbose)
+			.provide(verboseOwner())
 			.provide(defineContext("auth", () => "wrong")())
 			// @ts-expect-error -- incompatible Contexts: auth
 			.mount(definition);
@@ -339,7 +362,7 @@ describe("command definitions", () => {
 	});
 
 	it("checks nested requirements at the enclosing mount point", () => {
-		const required = defineFlag("verbose", { type: "boolean", inherit: true });
+		const required = defineFlag("verbose", { type: "boolean" });
 		const nested = defineCommand(
 			"nested",
 			{ requires: { flags: [required] } },
@@ -348,7 +371,7 @@ describe("command definitions", () => {
 
 		defineCommand("outer", { requires: { flags: [required] } }, (command) => command.mount(nested));
 		defineCommand("outer", (command) => {
-			// @ts-expect-error -- missing inherited flags: verbose
+			// @ts-expect-error -- missing propagating flags: verbose
 			return command.mount(nested);
 		});
 	});

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -61,13 +61,10 @@ describe("command definitions", () => {
 			apiKey: flags["api-key"],
 		}));
 		const before = defineCommand("before", (command) => command.handle(() => {}));
-		const after = defineCommand(
-			"after",
-			{ requires: { flags: [apiKey], ctx: [auth] } },
-			(command) =>
-				command.handle(({ flags, ctx }) => {
-					calls.push(`${flags["api-key"]}:${ctx.auth.apiKey}`);
-				}),
+		const after = defineCommand("after", { requires: [auth] }, (command) =>
+			command.handle(({ ctx }) => {
+				calls.push(String(ctx.auth.apiKey));
+			}),
 		);
 		const outer = defineCommand("outer", (command) =>
 			command.mount(before).provide(auth()).mount(after),
@@ -78,28 +75,25 @@ describe("command definitions", () => {
 			/Unknown flag/,
 		);
 		await app.run(["outer", "after", "--api-key", "secret"]);
-		expect(calls).toEqual(["secret:secret"]);
+		expect(calls).toEqual(["secret"]);
 	});
 
-	it("inherits flags and Contexts through nested definitions", async () => {
+	it("inherits capabilities through nested definitions", async () => {
 		const calls: string[] = [];
 		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
 		const db = defineContext("db", () => "database");
-		const status = defineCommand(
-			"status",
-			{ requires: { flags: [verbose], ctx: [db] } },
-			(command) =>
-				command.handle(({ flags, ctx }) => {
-					calls.push(`${ctx.db}:${String(flags.verbose)}`);
-				}),
+		const status = defineCommand("status", { requires: [logging, db] }, (command) =>
+			command.handle(({ ctx }) => {
+				calls.push(`${ctx.db}:${String(ctx.logging.verbose)}`);
+			}),
 		);
-		const deploy = defineCommand(
-			"deploy",
-			{ requires: { flags: [verbose], ctx: [db] } },
-			(command) => command.mount(status),
+		const deploy = defineCommand("deploy", { requires: [logging, db] }, (command) =>
+			command.mount(status),
 		);
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).provide(db()).mount(deploy);
+		const app = new Crust("cli").provide(logging(), db()).mount(deploy);
 
 		await app.run(["deploy", "status", "--verbose"]);
 
@@ -226,7 +220,7 @@ describe("command definitions", () => {
 
 	it("checks Context requirement names at the mount call at runtime", () => {
 		const db = defineContext("db", () => "database");
-		const definition = defineCommand("users", { requires: { ctx: [db] } }, (command) =>
+		const definition = defineCommand("users", { requires: [db] }, (command) =>
 			command.handle(() => {}),
 		);
 
@@ -237,99 +231,27 @@ describe("command definitions", () => {
 	});
 
 	it("checks requirements while preserving fluent handler types", () => {
-		const verbose = defineFlag("verbose", { type: "boolean" });
 		const auth = defineContext("auth", () => ({ user: "yan" }));
-		const definition = defineCommand(
-			"deploy",
-			{ requires: { flags: [verbose], ctx: [auth] } },
-			(command) =>
-				command
-					.args({ name: "target", type: "string", required: true })
-					.flags({ name: "force", type: "boolean", required: true })
-					.provide(defineContext("region", () => "us-east-1")())
-					.handle(({ args, flags, ctx }) => {
-						type _Target = Assert<IsEqual<typeof args.target, string>>;
-						type _Verbose = Assert<IsEqual<typeof flags.verbose, boolean | undefined>>;
-						type _Force = Assert<IsEqual<typeof flags.force, boolean>>;
-						type _Auth = Assert<IsEqual<typeof ctx.auth, { user: string }>>;
-						type _Region = Assert<IsEqual<typeof ctx.region, string>>;
-					}),
+		const region = defineContext("region", () => "us-east-1");
+		const definition = defineCommand("deploy", { requires: [auth] }, (command) =>
+			command
+				.args({ name: "target", type: "string", required: true })
+				.flags({ name: "force", type: "boolean", required: true })
+				.provide(region())
+				.handle(({ args, flags, ctx }) => {
+					type _Target = Assert<IsEqual<typeof args.target, string>>;
+					type _Force = Assert<IsEqual<typeof flags.force, boolean>>;
+					type _Auth = Assert<IsEqual<typeof ctx.auth, { user: string }>>;
+					type _Region = Assert<IsEqual<typeof ctx.region, string>>;
+				}),
 		);
 
-		const verboseOwner = defineContext("verbose-owner", { flags: [verbose] }, () => ({}));
-		new Crust("cli").provide(verboseOwner()).provide(auth()).mount(definition);
-		const requiredVerboseOwner = defineContext(
-			"verbose-owner",
-			{ flags: [{ ...verbose, required: true }] },
-			() => ({}),
-		);
-		new Crust("other")
-			.provide(requiredVerboseOwner())
-			.provide(defineContext("auth", () => ({ user: "other", admin: true }))())
-			.mount(definition);
-
-		const requiredToken = defineFlag("token", {
-			type: "string",
-			required: true,
-			parse: (raw: string) => Number(raw),
-		});
-		const strictDefinition = defineCommand(
-			"strict",
-			{ requires: { flags: [requiredToken] } },
-			(command) => command,
-		);
-		const strictTokenOwner = defineContext(
-			"token-owner",
-			{
-				flags: [
-					{
-						name: "token",
-						type: "string",
-						required: true,
-						parse: () => 1 as const,
-					},
-				],
-			},
-			() => ({}),
-		);
-		new Crust("cli").provide(strictTokenOwner()).mount(strictDefinition);
-		const optionalTokenOwner = defineContext(
-			"token-owner",
-			{ flags: [{ name: "token", type: "string", parse: Number }] },
-			() => ({}),
-		);
-		new Crust("cli")
-			.provide(optionalTokenOwner())
-			// @ts-expect-error -- an optional owned flag cannot satisfy a required requirement
-			.mount(strictDefinition);
-
-		expect(() =>
-			// @ts-expect-error -- missing propagating flags: verbose
-			new Crust("cli").provide(auth()).mount(definition),
-		).toThrow(/requires flag "--verbose"/);
-		expect(() =>
-			new Crust("cli")
-				.flags({ name: "verbose", type: "boolean" })
-				.provide(auth())
-				// @ts-expect-error -- missing propagating flags: verbose
-				.mount(definition),
-		).toThrow(/requires flag "--verbose"/);
-		const wrongVerboseOwner = defineContext(
-			"verbose-owner",
-			{ flags: [{ name: "verbose", type: "string" }] },
-			() => ({}),
-		);
-		new Crust("cli")
-			.provide(wrongVerboseOwner())
-			.provide(auth())
-			// @ts-expect-error -- incompatible propagating flags: verbose
-			.mount(definition);
+		new Crust("cli").provide(auth()).mount(definition);
 		expect(() =>
 			// @ts-expect-error -- missing Contexts: auth
-			new Crust("cli").provide(verboseOwner()).mount(definition),
+			new Crust("cli").mount(definition),
 		).toThrow(/requires Context "auth"/);
 		new Crust("cli")
-			.provide(verboseOwner())
 			.provide(defineContext("auth", () => "wrong")())
 			// @ts-expect-error -- incompatible Contexts: auth
 			.mount(definition);
@@ -361,16 +283,12 @@ describe("command definitions", () => {
 	});
 
 	it("checks nested requirements at the enclosing mount point", () => {
-		const required = defineFlag("verbose", { type: "boolean" });
-		const nested = defineCommand(
-			"nested",
-			{ requires: { flags: [required] } },
-			(command) => command,
-		);
+		const auth = defineContext("auth", () => ({ user: "yan" }));
+		const nested = defineCommand("nested", { requires: [auth] }, (command) => command);
 
-		defineCommand("outer", { requires: { flags: [required] } }, (command) => command.mount(nested));
+		defineCommand("outer", { requires: [auth] }, (command) => command.mount(nested));
 		defineCommand("outer", (command) => {
-			// @ts-expect-error -- missing propagating flags: verbose
+			// @ts-expect-error -- missing Contexts: auth
 			return command.mount(nested);
 		});
 	});

--- a/packages/core/src/command/node.test.ts
+++ b/packages/core/src/command/node.test.ts
@@ -13,6 +13,7 @@ describe("createCommandNode", () => {
 
 		expect(node.meta).toEqual({ name: "serve" });
 		expect(node.localFlags).toEqual({});
+		expect(node.ownedFlags).toEqual({});
 		expect(node.effectiveFlags).toEqual({});
 		expect(node.args).toBeUndefined();
 		expect(node.subCommands).toEqual({});
@@ -93,6 +94,20 @@ describe("computeEffectiveFlags", () => {
 
 		expect(result).toEqual({
 			output: { type: "string", description: "Output path" },
+		});
+	});
+
+	it("merges Context-owned flags after local flags", () => {
+		const result = computeEffectiveFlags(
+			{ verbose: { type: "boolean", inherit: true } },
+			{ output: { type: "string" } },
+			{ apiKey: { type: "string", inherit: true } },
+		);
+
+		expect(result).toEqual({
+			verbose: { type: "boolean", inherit: true },
+			output: { type: "string" },
+			apiKey: { type: "string", inherit: true },
 		});
 	});
 

--- a/packages/core/src/command/node.test.ts
+++ b/packages/core/src/command/node.test.ts
@@ -58,16 +58,6 @@ describe("computeEffectiveFlags", () => {
 		});
 	});
 
-	it("does not receive or propagate a parent local flag", () => {
-		const parentLocal: FlagsDef = { verbose: { type: "boolean" } };
-		const childLocal: FlagsDef = { output: { type: "string" } };
-
-		const child = computeEffectiveFlags({}, childLocal);
-		expect(child).toEqual({ output: { type: "string" } });
-		expect(child).not.toHaveProperty("verbose");
-		expect(parentLocal).toHaveProperty("verbose");
-	});
-
 	it("returns fresh output for empty inputs", () => {
 		expect(computeEffectiveFlags({}, {})).toEqual({});
 	});

--- a/packages/core/src/command/node.test.ts
+++ b/packages/core/src/command/node.test.ts
@@ -48,147 +48,27 @@ describe("createCommandNode", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("computeEffectiveFlags", () => {
-	it("merges inherited (inherit: true) flags with local flags", () => {
-		const inherited: FlagsDef = {
-			verbose: { type: "boolean", inherit: true },
-			port: { type: "number" },
-		};
-		const local: FlagsDef = {
-			output: { type: "string" },
-		};
+	it("merges Context-owned flags with local flags", () => {
+		const owned: FlagsDef = { apiKey: { type: "string" } };
+		const local: FlagsDef = { output: { type: "string" } };
 
-		const result = computeEffectiveFlags(inherited, local);
-
-		expect(result).toEqual({
-			verbose: { type: "boolean", inherit: true },
+		expect(computeEffectiveFlags(owned, local)).toEqual({
+			apiKey: { type: "string" },
 			output: { type: "string" },
 		});
 	});
 
-	it("filters out non-inherit flags from parent", () => {
-		const inherited: FlagsDef = {
-			verbose: { type: "boolean", inherit: true },
-			port: { type: "number" },
-			host: { type: "string" },
-		};
-		const local: FlagsDef = {};
+	it("does not receive or propagate a parent local flag", () => {
+		const parentLocal: FlagsDef = { verbose: { type: "boolean" } };
+		const childLocal: FlagsDef = { output: { type: "string" } };
 
-		const result = computeEffectiveFlags(inherited, local);
-
-		expect(result).toEqual({
-			verbose: { type: "boolean", inherit: true },
-		});
-		expect(result).not.toHaveProperty("port");
-		expect(result).not.toHaveProperty("host");
+		const child = computeEffectiveFlags({}, childLocal);
+		expect(child).toEqual({ output: { type: "string" } });
+		expect(child).not.toHaveProperty("verbose");
+		expect(parentLocal).toHaveProperty("verbose");
 	});
 
-	it("local flags override inherited flags with the same key", () => {
-		const inherited: FlagsDef = {
-			output: { type: "boolean", inherit: true },
-		};
-		const local: FlagsDef = {
-			output: { type: "string", description: "Output path" },
-		};
-
-		const result = computeEffectiveFlags(inherited, local);
-
-		expect(result).toEqual({
-			output: { type: "string", description: "Output path" },
-		});
-	});
-
-	it("merges Context-owned flags after local flags", () => {
-		const result = computeEffectiveFlags(
-			{ verbose: { type: "boolean", inherit: true } },
-			{ output: { type: "string" } },
-			{ apiKey: { type: "string", inherit: true } },
-		);
-
-		expect(result).toEqual({
-			verbose: { type: "boolean", inherit: true },
-			output: { type: "string" },
-			apiKey: { type: "string", inherit: true },
-		});
-	});
-
-	it("returns empty object when both inherited and local are empty", () => {
-		const result = computeEffectiveFlags({}, {});
-		expect(result).toEqual({});
-	});
-
-	it("returns only local flags when inherited is empty", () => {
-		const local: FlagsDef = {
-			verbose: { type: "boolean" },
-			port: { type: "number", default: 3000 },
-		};
-
-		const result = computeEffectiveFlags({}, local);
-
-		expect(result).toEqual({
-			verbose: { type: "boolean" },
-			port: { type: "number", default: 3000 },
-		});
-	});
-
-	it("returns only inheritable flags when local is empty", () => {
-		const inherited: FlagsDef = {
-			verbose: { type: "boolean", inherit: true },
-			debug: { type: "boolean", inherit: true },
-			port: { type: "number" },
-		};
-
-		const result = computeEffectiveFlags(inherited, {});
-
-		expect(result).toEqual({
-			verbose: { type: "boolean", inherit: true },
-			debug: { type: "boolean", inherit: true },
-		});
-	});
-
-	it("preserves all flag properties during merge", () => {
-		const inherited: FlagsDef = {
-			verbose: {
-				type: "boolean",
-				inherit: true,
-				short: "v",
-				description: "Enable verbose logging",
-			},
-		};
-		const local: FlagsDef = {
-			output: {
-				type: "string",
-				short: "o",
-				required: true,
-				description: "Output file",
-			},
-		};
-
-		const result = computeEffectiveFlags(inherited, local);
-
-		expect(result.verbose).toEqual({
-			type: "boolean",
-			inherit: true,
-			short: "v",
-			description: "Enable verbose logging",
-		});
-		expect(result.output).toEqual({
-			type: "string",
-			short: "o",
-			required: true,
-			description: "Output file",
-		});
-	});
-
-	it("handles multiple-value inherited flags", () => {
-		const inherited: FlagsDef = {
-			tags: { type: "string", multiple: true, inherit: true },
-		};
-		const local: FlagsDef = {};
-
-		const result = computeEffectiveFlags(inherited, local);
-
-		expect(result).toEqual({
-			tags: { type: "string", multiple: true, inherit: true },
-		});
+	it("returns fresh output for empty inputs", () => {
+		expect(computeEffectiveFlags({}, {})).toEqual({});
 	});
 });

--- a/packages/core/src/command/node.ts
+++ b/packages/core/src/command/node.ts
@@ -19,7 +19,9 @@ export interface CommandNode {
 	meta: CommandMeta;
 	/** Flags defined directly on this command via `.flags()` */
 	localFlags: FlagsDef;
-	/** Inherited flags merged with local flags (used by the parser) */
+	/** Inheritable flags installed by Contexts provided on this command */
+	ownedFlags: FlagsDef;
+	/** Inherited, local, and Context-owned flags merged for parsing */
 	effectiveFlags: FlagsDef;
 	/** Positional argument definitions */
 	args: ArgsDef | undefined;
@@ -48,6 +50,7 @@ export function createCommandNode(name: string): CommandNode {
 	return {
 		meta: { name },
 		localFlags: {},
+		ownedFlags: {},
 		effectiveFlags: {},
 		args: undefined,
 		subCommands: {},
@@ -62,10 +65,9 @@ export function createCommandNode(name: string): CommandNode {
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Merges inherited flags (only those with `inherit: true`) with local flags.
- *
- * Local flags override inherited flags with the same key. Non-inheritable
- * flags from the parent are excluded entirely.
+ * Merges inherited flags (only those with `inherit: true`) with local and
+ * Context-owned flags. Owned flags are stored with `inherit: true` and take
+ * precedence after collision validation.
  *
  * This is the runtime counterpart of the `EffectiveFlags` utility type.
  *
@@ -73,7 +75,11 @@ export function createCommandNode(name: string): CommandNode {
  * @param local - The current command's locally-defined flags.
  * @returns A new `FlagsDef` containing inherited+local merged flags.
  */
-export function computeEffectiveFlags(inherited: FlagsDef, local: FlagsDef): FlagsDef {
+export function computeEffectiveFlags(
+	inherited: FlagsDef,
+	local: FlagsDef,
+	owned: FlagsDef = {},
+): FlagsDef {
 	const result: Record<string, FlagDef> = {};
 
 	// Copy only inheritable flags from parent
@@ -85,6 +91,10 @@ export function computeEffectiveFlags(inherited: FlagsDef, local: FlagsDef): Fla
 
 	// Local flags override inherited flags with the same key
 	for (const [key, def] of Object.entries(local)) {
+		result[key] = def;
+	}
+
+	for (const [key, def] of Object.entries(owned)) {
 		result[key] = def;
 	}
 

--- a/packages/core/src/command/node.ts
+++ b/packages/core/src/command/node.ts
@@ -1,6 +1,6 @@
 import type { ContextInstance } from "../api/context.ts";
 import type { Extension } from "../api/extension.ts";
-import type { ArgsDef, CommandMeta, FlagDef, FlagsDef } from "../types.ts";
+import type { ArgsDef, CommandMeta, FlagsDef } from "../types.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // CommandNode — Internal command tree node
@@ -11,7 +11,7 @@ import type { ArgsDef, CommandMeta, FlagDef, FlagsDef } from "../types.ts";
  *
  * Built by the `Crust` builder class; not part of the public API.
  * Each node carries its own local flags, the pre-computed effective
- * (inherited + local merged) flags, positional args, subcommands,
+ * (Context-owned + local merged) flags, positional args, subcommands,
  * plugins, and the Command Handler.
  */
 export interface CommandNode {
@@ -19,9 +19,9 @@ export interface CommandNode {
 	meta: CommandMeta;
 	/** Flags defined directly on this command via `.flags()` */
 	localFlags: FlagsDef;
-	/** Inheritable flags installed by Contexts provided on this command */
+	/** Accumulated flags owned by Contexts provided on this command path */
 	ownedFlags: FlagsDef;
-	/** Inherited, local, and Context-owned flags merged for parsing */
+	/** Context-owned and local flags merged for parsing */
 	effectiveFlags: FlagsDef;
 	/** Positional argument definitions */
 	args: ArgsDef | undefined;
@@ -61,42 +61,15 @@ export function createCommandNode(name: string): CommandNode {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// computeEffectiveFlags — Runtime flag inheritance merge
+// computeEffectiveFlags — Runtime effective flag merge
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Merges inherited flags (only those with `inherit: true`) with local and
- * Context-owned flags. Owned flags are stored with `inherit: true` and take
- * precedence after collision validation.
+ * Merges the accumulated Context-owned flag carrier with a command's local
+ * flags. Collisions are rejected before this merge.
  *
  * This is the runtime counterpart of the `EffectiveFlags` utility type.
- *
- * @param inherited - The parent's effective flags (or any FlagsDef).
- * @param local - The current command's locally-defined flags.
- * @returns A new `FlagsDef` containing inherited+local merged flags.
  */
-export function computeEffectiveFlags(
-	inherited: FlagsDef,
-	local: FlagsDef,
-	owned: FlagsDef = {},
-): FlagsDef {
-	const result: Record<string, FlagDef> = {};
-
-	// Copy only inheritable flags from parent
-	for (const [key, def] of Object.entries(inherited)) {
-		if (def.inherit === true) {
-			result[key] = def;
-		}
-	}
-
-	// Local flags override inherited flags with the same key
-	for (const [key, def] of Object.entries(local)) {
-		result[key] = def;
-	}
-
-	for (const [key, def] of Object.entries(owned)) {
-		result[key] = def;
-	}
-
-	return result;
+export function computeEffectiveFlags(ownedFlags: FlagsDef, localFlags: FlagsDef): FlagsDef {
+	return { ...localFlags, ...ownedFlags };
 }

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -566,7 +566,7 @@ describe("resolveCommand — aliases", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Known-flag skipping — inherited/root flags before a subcommand
+// Known-flag skipping — Context-owned flags before a subcommand
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("resolveCommand — known-flag skipping", () => {

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
+import { defineContext } from "../api/context.ts";
+import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
 import type { ArgsDef, CommandMeta, FlagsDef } from "../types.ts";
+import { Crust, defineCommand } from "./crust.ts";
 import type { CommandNode } from "./node.ts";
 import { createCommandNode } from "./node.ts";
 import { resolveCommand } from "./router.ts";
@@ -567,6 +570,44 @@ describe("resolveCommand — aliases", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("resolveCommand — known-flag skipping", () => {
+	function makeContextOwnedRoot(): CommandNode {
+		const apiKey = defineFlag("api-key", {
+			type: "string",
+			short: "k",
+			aliases: ["token"],
+		});
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		return new Crust("app")
+			.provide(auth())
+			.mount(
+				defineCommand("deploy", (command) =>
+					command.mount(defineCommand("service", (child) => child.handle(() => {}))),
+				),
+			)._node;
+	}
+
+	it.each([
+		["separate value", ["--api-key", "secret", "deploy"]],
+		["equals form", ["--api-key=secret", "deploy"]],
+		["short form", ["-ksecret", "deploy"]],
+		["alias form", ["--token=secret", "deploy"]],
+	] as const)("routes past a Context-owned flag in %s", (_label, argv) => {
+		const result = resolveCommand(makeContextOwnedRoot(), [...argv]);
+		expect(result.commandPath).toEqual(["app", "deploy"]);
+		expect(result.argv).toEqual(argv.slice(0, -1));
+	});
+
+	it("routes a Context-owned flag through nested descendants", () => {
+		const result = resolveCommand(makeContextOwnedRoot(), [
+			"--api-key",
+			"secret",
+			"deploy",
+			"service",
+		]);
+		expect(result.commandPath).toEqual(["app", "deploy", "service"]);
+		expect(result.argv).toEqual(["--api-key", "secret"]);
+	});
+
 	function makeRoot(): CommandNode {
 		const translate = makeNode({
 			meta: "translate",

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -576,7 +576,7 @@ describe("resolveCommand — known-flag skipping", () => {
 			short: "k",
 			aliases: ["token"],
 		});
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		return new Crust("app")
 			.provide(auth())
 			.mount(

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -71,7 +71,6 @@ describe("snapshotCommand", () => {
 		expect(snapshot.flags["api-key"]).toEqual({
 			type: "string",
 			short: "k",
-			inherit: true,
 		});
 		expect(snapshot.subCommands.deploy?.flags["api-key"]).toEqual(snapshot.flags["api-key"]);
 		expect(Object.isFrozen(snapshot.subCommands.deploy?.flags["api-key"])).toBe(true);

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
+import { defineContext } from "../api/context.ts";
+import { defineFlag } from "../api/flags.ts";
+import { Crust, defineCommand, prepareCommandSnapshot } from "./crust.ts";
 import { createCommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
 
@@ -55,6 +58,24 @@ describe("snapshotCommand", () => {
 		const clone = structuredClone(snapshot);
 		expect(clone.args[0]?.name).toBe("file");
 		expect("parse" in (clone.args[0] as object)).toBe(false);
+	});
+
+	it("projects Context-owned flags at the provider and later descendants", async () => {
+		const apiKey = defineFlag("api-key", { type: "string", short: "k" });
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const app = new Crust("cli")
+			.provide(auth())
+			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+
+		const snapshot = await prepareCommandSnapshot(app);
+		expect(snapshot.flags["api-key"]).toEqual({
+			type: "string",
+			short: "k",
+			inherit: true,
+		});
+		expect(snapshot.subCommands.deploy?.flags["api-key"]).toEqual(snapshot.flags["api-key"]);
+		expect(Object.isFrozen(snapshot.subCommands.deploy?.flags["api-key"])).toBe(true);
+		expect(() => structuredClone(snapshot)).not.toThrow();
 	});
 
 	it("is deeply frozen", () => {

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -62,7 +62,7 @@ describe("snapshotCommand", () => {
 
 	it("projects Context-owned flags at the provider and later descendants", async () => {
 		const apiKey = defineFlag("api-key", { type: "string", short: "k" });
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
 			.mount(defineCommand("deploy", (command) => command.handle(() => {})));

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -28,7 +28,6 @@ export interface FlagSnapshot {
 	readonly short?: string;
 	readonly aliases?: readonly string[];
 	readonly required?: boolean;
-	readonly inherit?: boolean;
 	readonly multiple?: boolean;
 	readonly noNegate?: boolean;
 	readonly choices?: readonly string[];
@@ -40,7 +39,7 @@ export interface FlagSnapshot {
  * API boundaries (Command Handler context, Extension hooks, and
  * `COMMAND_NOT_FOUND` error details) instead of internal command nodes.
  *
- * `flags` contains the effective (inherited + local merged) flags — the same
+ * `flags` contains the effective (Context-owned + local merged) flags — the same
  * set the parser accepts for the command.
  */
 export interface CommandSnapshot {
@@ -99,7 +98,6 @@ function snapshotFlag(def: FlagDef): FlagSnapshot {
 		short?: string;
 		aliases?: readonly string[];
 		required?: boolean;
-		inherit?: boolean;
 		multiple?: boolean;
 		noNegate?: boolean;
 		choices?: readonly string[];
@@ -111,7 +109,6 @@ function snapshotFlag(def: FlagDef): FlagSnapshot {
 		short: d.short,
 		aliases: d.aliases ? Object.freeze([...d.aliases]) : undefined,
 		required: d.required,
-		inherit: d.inherit,
 		multiple: d.multiple,
 		noNegate: d.noNegate,
 		choices: d.choices ? Object.freeze([...d.choices]) : undefined,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export type {
 	CommandMeta,
 	FlagDef,
 	FlagsDef,
+	InvocationIO,
 	NamedFlagDef,
 	ValueType,
 } from "./types.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // Contexts and Extensions
 export type {
 	AnyContextFactory,
+	ContextConfig,
 	ContextFactory,
 	ContextInstance,
 	ContextMap,

--- a/packages/core/src/parsing/flag-validation.ts
+++ b/packages/core/src/parsing/flag-validation.ts
@@ -1,0 +1,37 @@
+import { CrustError } from "../errors.ts";
+import type { FlagDef, FlagsDef } from "../types.ts";
+
+function flagSpellings(name: string, def: FlagDef): string[] {
+	return [name, ...(def.short ? [def.short] : []), ...(def.aliases ?? [])];
+}
+
+/** Validate one flag against the complete canonical/short/alias namespace. */
+export function validateIncomingFlag(
+	incoming: { name: string; def: FlagDef },
+	existing: FlagsDef,
+	ownerLabel: string,
+): void {
+	const incomingSpellings = flagSpellings(incoming.name, incoming.def);
+	const duplicate = incomingSpellings.find(
+		(spelling, index) => incomingSpellings.indexOf(spelling) !== index,
+	);
+	if (duplicate !== undefined) {
+		throw new CrustError(
+			"DEFINITION",
+			`${ownerLabel} flag "--${incoming.name}" repeats spelling "${duplicate}"`,
+			{ subject: "flag", name: incoming.name, reason: "flag-collision" },
+		);
+	}
+
+	for (const [existingName, existingDef] of Object.entries(existing)) {
+		const existingSpellings = new Set(flagSpellings(existingName, existingDef));
+		const collision = incomingSpellings.find((spelling) => existingSpellings.has(spelling));
+		if (collision !== undefined) {
+			throw new CrustError(
+				"DEFINITION",
+				`${ownerLabel} flag "--${incoming.name}" spelling "${collision}" collides with flag "--${existingName}"`,
+				{ subject: "flag", name: incoming.name, reason: "flag-collision" },
+			);
+		}
+	}
+}

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -1028,7 +1028,7 @@ describe("parseArgs — no- prefix defense-in-depth", () => {
 describe("parseArgs — CommandNode with effective flags", () => {
 	it("parses inherited flag from effectiveFlags", () => {
 		const parentFlags = {
-			verbose: { type: "boolean" as const, inherit: true as const },
+			verbose: { type: "boolean" as const },
 		};
 		const localFlags = {
 			output: { type: "string" as const },
@@ -1043,34 +1043,11 @@ describe("parseArgs — CommandNode with effective flags", () => {
 		expect(result.flags.output).toBe("./dist");
 	});
 
-	it("overridden flag uses local type, not inherited type", () => {
-		const parentFlags = {
-			level: {
-				type: "boolean" as const,
-				inherit: true as const,
-			},
-		};
-		const localFlags = {
-			level: {
-				type: "number" as const,
-			},
-		};
-
-		const node = createCommandNode("child");
-		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
-
-		// level is now a number flag (local override), not boolean
-		const result = parseArgs(node, ["--level", "5"]);
-		expect(result.flags.level).toBe(5);
-	});
-
 	it("inherited required flag is enforced by validateParsed", () => {
 		const parentFlags = {
 			config: {
 				type: "string" as const,
 				required: true as const,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {};
@@ -1099,7 +1076,6 @@ describe("parseArgs — CommandNode with effective flags", () => {
 			verbose: {
 				type: "boolean" as const,
 				short: "v" as const,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {};
@@ -1112,30 +1088,11 @@ describe("parseArgs — CommandNode with effective flags", () => {
 		expect(result.flags.verbose).toBe(true);
 	});
 
-	it("non-inherit parent flags are excluded from effectiveFlags", () => {
-		const parentFlags = {
-			verbose: { type: "boolean" as const, inherit: true as const },
-			debug: { type: "boolean" as const }, // no inherit
-		};
-		const localFlags = {};
-
+	it("rejects parent-local flags omitted from a child's effective flags", () => {
 		const node = createCommandNode("child");
-		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags({}, {});
 
-		// verbose is inherited, debug is not
-		const result = parseArgs(node, ["--verbose"]);
-		expect(result.flags.verbose).toBe(true);
-
-		// --debug should be unknown since it's not inherited
-		try {
-			parseArgs(node, ["--debug"]);
-			expect.unreachable("should have thrown");
-		} catch (err) {
-			expect(err).toBeInstanceOf(CrustError);
-			expect((err as CrustError).code).toBe("PARSE");
-			expect((err as CrustError).message).toContain("Unknown flag");
-		}
+		expect(() => parseArgs(node, ["--debug"])).toThrow(/Unknown flag/);
 	});
 
 	it("inherited flag with default value works on subcommand", () => {
@@ -1143,7 +1100,6 @@ describe("parseArgs — CommandNode with effective flags", () => {
 			port: {
 				type: "number" as const,
 				default: 3000,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {};
@@ -1171,10 +1127,7 @@ describe("parseArgs — CommandNode with effective flags", () => {
 	it("CommandNode with args parses positionals correctly", () => {
 		const node = createCommandNode("child");
 		node.args = [{ name: "file", type: "string", required: true }];
-		node.effectiveFlags = computeEffectiveFlags(
-			{ verbose: { type: "boolean" as const, inherit: true as const } },
-			{},
-		);
+		node.effectiveFlags = computeEffectiveFlags({ verbose: { type: "boolean" as const } }, {});
 
 		const result = parseArgs(node, ["--verbose", "input.ts"]);
 		expect(result.flags.verbose).toBe(true);
@@ -1186,7 +1139,6 @@ describe("parseArgs — CommandNode with effective flags", () => {
 			minify: {
 				type: "boolean" as const,
 				default: true,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {};
@@ -1204,7 +1156,6 @@ describe("parseArgs — CommandNode with effective flags", () => {
 			include: {
 				type: "string" as const,
 				multiple: true as const,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {};

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -1026,8 +1026,8 @@ describe("parseArgs — no- prefix defense-in-depth", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("parseArgs — CommandNode with effective flags", () => {
-	it("parses inherited flag from effectiveFlags", () => {
-		const parentFlags = {
+	it("parses an ancestor-owned flag from effectiveFlags", () => {
+		const ancestorOwnedFlags = {
 			verbose: { type: "boolean" as const },
 		};
 		const localFlags = {
@@ -1036,15 +1036,15 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		const result = parseArgs(node, ["--verbose", "--output", "./dist"]);
 		expect(result.flags.verbose).toBe(true);
 		expect(result.flags.output).toBe("./dist");
 	});
 
-	it("inherited required flag is enforced by validateParsed", () => {
-		const parentFlags = {
+	it("required ancestor-owned flag is enforced by validateParsed", () => {
+		const ancestorOwnedFlags = {
 			config: {
 				type: "string" as const,
 				required: true as const,
@@ -1054,7 +1054,7 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		// parseArgs does not throw — validation is separate
 		const parsed = parseArgs(node, []);
@@ -1071,8 +1071,8 @@ describe("parseArgs — CommandNode with effective flags", () => {
 		}
 	});
 
-	it("inherited alias works on subcommand", () => {
-		const parentFlags = {
+	it("ancestor-owned alias works on subcommand", () => {
+		const ancestorOwnedFlags = {
 			verbose: {
 				type: "boolean" as const,
 				short: "v" as const,
@@ -1082,7 +1082,7 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		const result = parseArgs(node, ["-v"]);
 		expect(result.flags.verbose).toBe(true);
@@ -1095,8 +1095,8 @@ describe("parseArgs — CommandNode with effective flags", () => {
 		expect(() => parseArgs(node, ["--debug"])).toThrow(/Unknown flag/);
 	});
 
-	it("inherited flag with default value works on subcommand", () => {
-		const parentFlags = {
+	it("ancestor-owned flag with default value works on subcommand", () => {
+		const ancestorOwnedFlags = {
 			port: {
 				type: "number" as const,
 				default: 3000,
@@ -1106,7 +1106,7 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		// Default should apply when not provided
 		const result1 = parseArgs(node, []);
@@ -1134,8 +1134,8 @@ describe("parseArgs — CommandNode with effective flags", () => {
 		expect((result.args as Record<string, unknown>).file).toBe("input.ts");
 	});
 
-	it("inherited boolean negation works on subcommand", () => {
-		const parentFlags = {
+	it("ancestor-owned boolean negation works on subcommand", () => {
+		const ancestorOwnedFlags = {
 			minify: {
 				type: "boolean" as const,
 				default: true,
@@ -1145,14 +1145,14 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		const result = parseArgs(node, ["--no-minify"]);
 		expect(result.flags.minify).toBe(false);
 	});
 
-	it("inherited multiple flag works on subcommand", () => {
-		const parentFlags = {
+	it("ancestor-owned multiple flag works on subcommand", () => {
+		const ancestorOwnedFlags = {
 			include: {
 				type: "string" as const,
 				multiple: true as const,
@@ -1162,7 +1162,7 @@ describe("parseArgs — CommandNode with effective flags", () => {
 
 		const node = createCommandNode("child");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		const result = parseArgs(node, ["--include", "src", "--include", "lib"]);
 		expect(result.flags.include).toEqual(["src", "lib"]);

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import { defineContext } from "../api/context.ts";
 import { computeEffectiveFlags, createCommandNode } from "../command/node.ts";
-import { validateCommandTree, validateIncomingFlag } from "./validation.ts";
+import { validateIncomingFlag } from "./flag-validation.ts";
+import { validateCommandTree } from "./validation.ts";
 
 describe("validateIncomingFlag", () => {
 	it("rejects canonical names that collide with an existing short or alias", () => {

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -103,7 +103,7 @@ describe("validateCommandTree", () => {
 
 	it("throws when a Context dependency is missing from a node's path", () => {
 		const config = defineContext("config", () => ({}));
-		const client = defineContext("client", { requires: { ctx: [config] } }, () => ({}));
+		const client = defineContext("client", { requires: [config] }, () => ({}));
 
 		const node = createCommandNode("root");
 		node.contexts = [client()];

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -150,8 +150,8 @@ describe("validateCommandTree — CommandNode tree", () => {
 
 	it("passes a valid CommandNode with effective flags (inherited + local)", () => {
 		const parentFlags = {
-			verbose: { type: "boolean" as const, short: "v", inherit: true as const },
-			debug: { type: "boolean" as const, inherit: true as const },
+			verbose: { type: "boolean" as const, short: "v" },
+			debug: { type: "boolean" as const },
 		};
 		const localFlags = {
 			output: { type: "string" as const, short: "o" },
@@ -168,7 +168,6 @@ describe("validateCommandTree — CommandNode tree", () => {
 			token: {
 				type: "string" as const,
 				required: true as const,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {
@@ -195,8 +194,8 @@ describe("validateCommandTree — CommandNode tree", () => {
 	it("detects collisions involving Context-owned flags as a build-validation backstop", () => {
 		const node = createCommandNode("sub");
 		node.localFlags = { verbose: { type: "boolean", short: "v" } };
-		node.ownedFlags = { version: { type: "boolean", short: "v", inherit: true } };
-		node.effectiveFlags = computeEffectiveFlags({}, node.localFlags, node.ownedFlags);
+		node.ownedFlags = { version: { type: "boolean", short: "v" } };
+		node.effectiveFlags = computeEffectiveFlags(node.ownedFlags, node.localFlags);
 
 		expect(() => validateCommandTree(node)).toThrow('Command "sub" failed runtime validation');
 		expect(() => validateCommandTree(node)).toThrow("Alias collision");
@@ -204,7 +203,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 
 	it("detects alias collision in effective flags (inherited alias collides with local)", () => {
 		const parentFlags = {
-			verbose: { type: "boolean" as const, short: "v", inherit: true as const },
+			verbose: { type: "boolean" as const, short: "v" },
 		};
 		const localFlags = {
 			version: { type: "boolean" as const, short: "v" },
@@ -219,7 +218,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 
 	it("detects alias collision between inherited flag name and local alias", () => {
 		const parentFlags = {
-			out: { type: "string" as const, inherit: true as const },
+			out: { type: "string" as const },
 		};
 		const localFlags = {
 			output: { type: "string" as const, aliases: ["out"] },
@@ -285,10 +284,10 @@ describe("validateCommandTree — CommandNode tree", () => {
 	});
 
 	it("overridden flag validated with local definition (no collision)", () => {
-		// Parent has inherit:true flag "verbose" with short "v"
+		// Effective flags include Context-owned "verbose" with short "v"
 		// Child overrides "verbose" with a different short — no collision
 		const parentFlags = {
-			verbose: { type: "boolean" as const, short: "v", inherit: true as const },
+			verbose: { type: "boolean" as const, short: "v" },
 		};
 		const localFlags = {
 			verbose: { type: "string" as const, short: "V" },
@@ -308,7 +307,6 @@ describe("validateCommandTree — CommandNode tree", () => {
 			token: {
 				type: "string" as const,
 				required: true as const,
-				inherit: true as const,
 			},
 		};
 		const localFlags = {
@@ -327,7 +325,6 @@ describe("validateCommandTree — CommandNode tree", () => {
 			verbose: {
 				type: "boolean" as const,
 				short: "v",
-				inherit: true as const,
 			},
 		};
 		const localFlags = {

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -2,7 +2,56 @@ import { describe, expect, it } from "bun:test";
 
 import { defineContext } from "../api/context.ts";
 import { computeEffectiveFlags, createCommandNode } from "../command/node.ts";
-import { validateCommandTree } from "./validation.ts";
+import { validateCommandTree, validateIncomingFlag } from "./validation.ts";
+
+describe("validateIncomingFlag", () => {
+	it("rejects canonical names that collide with an existing short or alias", () => {
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "v", def: { type: "boolean" } },
+				{ verbose: { type: "boolean", short: "v" } },
+				'Context "logger"',
+			),
+		).toThrow(/collides with flag "--verbose"/);
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "out", def: { type: "string" } },
+				{ output: { type: "string", aliases: ["out"] } },
+				'Context "writer"',
+			),
+		).toThrow(/collides with flag "--output"/);
+	});
+
+	it("rejects incoming short and aliases that collide with existing spellings", () => {
+		const existing = {
+			verbose: { type: "boolean", short: "v", aliases: ["loud"] },
+		} satisfies import("../types.ts").FlagsDef;
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "version", def: { type: "boolean", short: "v" } },
+				existing,
+				'Context "release"',
+			),
+		).toThrow(/spelling "v"/);
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "log", def: { type: "string", aliases: ["loud"] } },
+				existing,
+				'Context "logger"',
+			),
+		).toThrow(/spelling "loud"/);
+	});
+
+	it("rejects duplicate spellings within the incoming definition", () => {
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "output", def: { type: "string", short: "o", aliases: ["o"] } },
+				{},
+				'Context "writer"',
+			),
+		).toThrow(/repeats spelling "o"/);
+	});
+});
 
 describe("validateCommandTree", () => {
 	it("passes commands with required args and flags", () => {
@@ -141,6 +190,16 @@ describe("validateCommandTree — CommandNode tree", () => {
 		];
 
 		expect(() => validateCommandTree(node)).not.toThrow();
+	});
+
+	it("detects collisions involving Context-owned flags as a build-validation backstop", () => {
+		const node = createCommandNode("sub");
+		node.localFlags = { verbose: { type: "boolean", short: "v" } };
+		node.ownedFlags = { version: { type: "boolean", short: "v", inherit: true } };
+		node.effectiveFlags = computeEffectiveFlags({}, node.localFlags, node.ownedFlags);
+
+		expect(() => validateCommandTree(node)).toThrow('Command "sub" failed runtime validation');
+		expect(() => validateCommandTree(node)).toThrow("Alias collision");
 	});
 
 	it("detects alias collision in effective flags (inherited alias collides with local)", () => {

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -148,8 +148,8 @@ describe("validateCommandTree — CommandNode tree", () => {
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 
-	it("passes a valid CommandNode with effective flags (inherited + local)", () => {
-		const parentFlags = {
+	it("passes a valid CommandNode with effective flags (ancestor-owned + local)", () => {
+		const ancestorOwnedFlags = {
 			verbose: { type: "boolean" as const, short: "v" },
 			debug: { type: "boolean" as const },
 		};
@@ -158,13 +158,13 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 
 	it("passes a valid CommandNode with required effective flags", () => {
-		const parentFlags = {
+		const ancestorOwnedFlags = {
 			token: {
 				type: "string" as const,
 				required: true as const,
@@ -175,7 +175,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		// Should pass because createValidationArgv generates --token sample
 		expect(() => validateCommandTree(node)).not.toThrow();
@@ -201,8 +201,8 @@ describe("validateCommandTree — CommandNode tree", () => {
 		expect(() => validateCommandTree(node)).toThrow("Alias collision");
 	});
 
-	it("detects alias collision in effective flags (inherited alias collides with local)", () => {
-		const parentFlags = {
+	it("detects alias collision in effective flags (ancestor-owned alias collides with local)", () => {
+		const ancestorOwnedFlags = {
 			verbose: { type: "boolean" as const, short: "v" },
 		};
 		const localFlags = {
@@ -210,14 +210,14 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		expect(() => validateCommandTree(node)).toThrow('Command "sub" failed runtime validation');
 		expect(() => validateCommandTree(node)).toThrow("Alias collision");
 	});
 
-	it("detects alias collision between inherited flag name and local alias", () => {
-		const parentFlags = {
+	it("detects alias collision between ancestor-owned flag name and local alias", () => {
+		const ancestorOwnedFlags = {
 			out: { type: "string" as const },
 		};
 		const localFlags = {
@@ -225,14 +225,14 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		expect(() => validateCommandTree(node)).toThrow('Command "sub" failed runtime validation');
 		expect(() => validateCommandTree(node)).toThrow("Alias collision");
 	});
 
-	it("detects no-prefix violation in effective flags from inherited flag", () => {
-		// Construct a node with an inherited flag that has no- prefix
+	it("detects no-prefix violation in effective flags from an ancestor-owned flag", () => {
+		// Construct a node with an ancestor-owned flag that has no- prefix
 		// (this wouldn't pass compile-time checks but tests runtime validation)
 		const node = createCommandNode("sub");
 		node.effectiveFlags = {
@@ -283,27 +283,9 @@ describe("validateCommandTree — CommandNode tree", () => {
 		);
 	});
 
-	it("overridden flag validated with local definition (no collision)", () => {
-		// Effective flags include Context-owned "verbose" with short "v"
-		// Child overrides "verbose" with a different short — no collision
-		const parentFlags = {
-			verbose: { type: "boolean" as const, short: "v" },
-		};
-		const localFlags = {
-			verbose: { type: "string" as const, short: "V" },
-		};
-		const node = createCommandNode("sub");
-		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
-
-		// The local definition completely replaces the inherited one
-		// "verbose" is now type string with alias "V" — no collision
-		expect(() => validateCommandTree(node)).not.toThrow();
-	});
-
-	it("inherited required flag included in validation argv", () => {
-		// Parent has a required inherited string flag
-		const parentFlags = {
+	it("required ancestor-owned flag included in validation argv", () => {
+		// The ancestor-owned flags include a required string flag
+		const ancestorOwnedFlags = {
 			token: {
 				type: "string" as const,
 				required: true as const,
@@ -314,14 +296,14 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
 		// Should NOT throw — createValidationArgv includes --token sample
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 
-	it("inherited alias works during validation", () => {
-		const parentFlags = {
+	it("ancestor-owned alias works during validation", () => {
+		const ancestorOwnedFlags = {
 			verbose: {
 				type: "boolean" as const,
 				short: "v",
@@ -332,9 +314,9 @@ describe("validateCommandTree — CommandNode tree", () => {
 		};
 		const node = createCommandNode("sub");
 		node.localFlags = localFlags;
-		node.effectiveFlags = computeEffectiveFlags(parentFlags, localFlags);
+		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
-		// Both inherited alias "v" and local alias "o" should be accepted
+		// Both ancestor-owned alias "v" and local alias "o" should be accepted
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -102,7 +102,7 @@ describe("validateCommandTree", () => {
 
 	it("throws when a Context dependency is missing from a node's path", () => {
 		const config = defineContext("config", () => ({}));
-		const client = defineContext("client", { ctx: [config] }, () => ({}));
+		const client = defineContext("client", { requires: { ctx: [config] } }, () => ({}));
 
 		const node = createCommandNode("root");
 		node.contexts = [client()];

--- a/packages/core/src/parsing/validation.ts
+++ b/packages/core/src/parsing/validation.ts
@@ -4,6 +4,8 @@ import { CrustError } from "../errors.ts";
 import type { ArgDef, FlagDef } from "../types.ts";
 import { parseArgs, validateParsed } from "./parser.ts";
 
+export { validateIncomingFlag } from "./flag-validation.ts";
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Alias collision policy: aliases share a namespace with canonical names,
 // so a value collides with any sibling's canonical name or alias.

--- a/packages/core/src/parsing/validation.ts
+++ b/packages/core/src/parsing/validation.ts
@@ -157,7 +157,7 @@ function sampleToken(def: ArgDef | FlagDef): string {
 /**
  * Build a synthetic argv that satisfies `parseArgs` for the given command.
  *
- * Uses `effectiveFlags` so inherited required flags are included in the
+ * Uses `effectiveFlags` so propagated required flags are included in the
  * synthetic argv.
  */
 function createValidationArgv(command: CommandNode): string[] {
@@ -199,13 +199,13 @@ function createValidationArgv(command: CommandNode): string[] {
  * with a synthetic argv derived from the node's flag/arg definitions.
  *
  * This catches:
- * - Alias collisions (including between inherited and local flags)
+ * - Alias collisions (including between Context-owned and local flags)
  * - `no-` prefix violations
  * - Required flag/arg validation
  * - Variadic arg position violations
  *
- * Uses `effectiveFlags` (inherited + local merged) so alias collisions
- * between an inherited flag and a local flag are caught.
+ * Uses `effectiveFlags` (Context-owned + local merged) so alias collisions
+ * between a Context-owned flag and a local flag are caught.
  *
  * @param root - The root command node to validate
  * @throws {CrustError} `DEFINITION` with the full command path on failure

--- a/packages/core/src/parsing/validation.ts
+++ b/packages/core/src/parsing/validation.ts
@@ -4,8 +4,6 @@ import { CrustError } from "../errors.ts";
 import type { ArgDef, FlagDef } from "../types.ts";
 import { parseArgs, validateParsed } from "./parser.ts";
 
-export { validateIncomingFlag } from "./flag-validation.ts";
-
 // ──────────────────────────────────────────────────────────────────────────────
 // Alias collision policy: aliases share a namespace with canonical names,
 // so a value collides with any sibling's canonical name or alias.

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -834,6 +834,26 @@ describe("EffectiveFlags type inference", () => {
 		expect(true).toBe(true);
 	});
 
+	it("merges owned flags and forces inherit: true", () => {
+		type Result = EffectiveFlags<
+			{ verbose: { type: "boolean"; inherit: true } },
+			{ output: { type: "string" } },
+			{ apiKey: { type: "string"; short: "k" } }
+		>;
+		type _check = Expect<
+			Equal<
+				Result,
+				{
+					verbose: { type: "boolean"; inherit: true };
+					output: { type: "string" };
+					apiKey: { type: "string"; short: "k"; inherit: true };
+				}
+			>
+		>;
+
+		expect(true).toBe(true);
+	});
+
 	it("short-circuits to local when inherited is wide FlagsDef", () => {
 		type Local = {
 			output: { type: "string" };

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -687,9 +687,8 @@ describe("ValidateVariadicArgs type inference", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("EffectiveFlags type inference", () => {
-	it("merges ancestor-owned, local, and current Context-owned flags", () => {
+	it("merges local and current Context-owned flags", () => {
 		type Result = EffectiveFlags<
-			{ verbose: { type: "boolean" } },
 			{ output: { type: "string" } },
 			{ apiKey: { type: "string"; short: "k" } }
 		>;
@@ -697,7 +696,6 @@ describe("EffectiveFlags type inference", () => {
 			Equal<
 				Result,
 				{
-					verbose: { type: "boolean" };
 					output: { type: "string" };
 					apiKey: { type: "string"; short: "k" };
 				}

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -711,12 +711,6 @@ describe("EffectiveFlags type inference", () => {
 		type _check = Expect<Equal<Result, {}>>;
 		expect(true).toBe(true);
 	});
-
-	it("rejects the removed inherit field", () => {
-		// @ts-expect-error — flag propagation belongs to Context-owned flags
-		const _bad: FlagDef = { type: "boolean", inherit: true };
-		expect(true).toBe(true);
-	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -9,7 +9,6 @@ import type {
 	FlagsDef,
 	InferArgs,
 	InferFlags,
-	InheritableFlags,
 	ValidateVariadicArgs,
 } from "./types.ts";
 
@@ -684,159 +683,13 @@ describe("ValidateVariadicArgs type inference", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// InheritableFlags type-level tests
-// ────────────────────────────────────────────────────────────────────────────
-
-describe("InheritableFlags type inference", () => {
-	it("picks only flags with inherit: true", () => {
-		type Flags = {
-			verbose: { type: "boolean"; inherit: true };
-			port: { type: "number" };
-			output: { type: "string"; inherit: true };
-		};
-		type Result = InheritableFlags<Flags>;
-		type _check = Expect<
-			Equal<
-				Result,
-				{
-					verbose: { type: "boolean"; inherit: true };
-					output: { type: "string"; inherit: true };
-				}
-			>
-		>;
-
-		expect(true).toBe(true);
-	});
-
-	it("returns empty object when no flags have inherit: true", () => {
-		type Flags = {
-			verbose: { type: "boolean" };
-			port: { type: "number" };
-		};
-		type Result = InheritableFlags<Flags>;
-		type _check = Expect<Equal<Result, {}>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("returns empty object for empty flags", () => {
-		type Result = InheritableFlags<{}>;
-		type _check = Expect<Equal<Result, {}>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("picks all flags when all have inherit: true", () => {
-		type Flags = {
-			verbose: { type: "boolean"; inherit: true };
-			port: { type: "number"; inherit: true };
-		};
-		type Result = InheritableFlags<Flags>;
-		type _check = Expect<Equal<Result, Flags>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("preserves full flag definition including short, required, etc.", () => {
-		type Flags = {
-			verbose: {
-				type: "boolean";
-				inherit: true;
-				short: "v";
-				description: "Enable verbose";
-			};
-		};
-		type Result = InheritableFlags<Flags>;
-		type _check = Expect<Equal<Result, Flags>>;
-
-		expect(true).toBe(true);
-	});
-});
-
-// ────────────────────────────────────────────────────────────────────────────
 // EffectiveFlags type-level tests
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("EffectiveFlags type inference", () => {
-	it("filters inherited to inherit:true and merges with local", () => {
-		type Inherited = {
-			verbose: { type: "boolean"; inherit: true };
-			port: { type: "number" };
-		};
-		type Local = {
-			output: { type: "string" };
-		};
-		type Result = EffectiveFlags<Inherited, Local>;
-		type _check = Expect<
-			Equal<
-				Result,
-				{
-					verbose: { type: "boolean"; inherit: true };
-					output: { type: "string" };
-				}
-			>
-		>;
-
-		expect(true).toBe(true);
-	});
-
-	it("local overrides inherited flag with same key", () => {
-		type Inherited = {
-			verbose: { type: "boolean"; inherit: true };
-			port: { type: "number"; inherit: true };
-		};
-		type Local = {
-			port: { type: "string" };
-		};
-		type Result = EffectiveFlags<Inherited, Local>;
-		type _check = Expect<
-			Equal<
-				Result,
-				{
-					verbose: { type: "boolean"; inherit: true };
-					port: { type: "string" };
-				}
-			>
-		>;
-
-		expect(true).toBe(true);
-	});
-
-	it("returns only local when no inherited flags have inherit: true", () => {
-		type Inherited = {
-			verbose: { type: "boolean" };
-			port: { type: "number" };
-		};
-		type Local = {
-			output: { type: "string" };
-		};
-		type Result = EffectiveFlags<Inherited, Local>;
-		type _check = Expect<Equal<Result, { output: { type: "string" } }>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("returns only inheritable flags when local is empty", () => {
-		type Inherited = {
-			verbose: { type: "boolean"; inherit: true };
-			port: { type: "number" };
-		};
-		type Result = EffectiveFlags<Inherited, {}>;
-		type _check = Expect<Equal<Result, { verbose: { type: "boolean"; inherit: true } }>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("returns empty when both inherited and local are empty", () => {
-		type Result = EffectiveFlags<{}, {}>;
-		type _check = Expect<Equal<Result, {}>>;
-
-		expect(true).toBe(true);
-	});
-
-	it("merges owned flags and forces inherit: true", () => {
+	it("merges ancestor-owned, local, and current Context-owned flags", () => {
 		type Result = EffectiveFlags<
-			{ verbose: { type: "boolean"; inherit: true } },
+			{ verbose: { type: "boolean" } },
 			{ output: { type: "string" } },
 			{ apiKey: { type: "string"; short: "k" } }
 		>;
@@ -844,67 +697,24 @@ describe("EffectiveFlags type inference", () => {
 			Equal<
 				Result,
 				{
-					verbose: { type: "boolean"; inherit: true };
+					verbose: { type: "boolean" };
 					output: { type: "string" };
-					apiKey: { type: "string"; short: "k"; inherit: true };
+					apiKey: { type: "string"; short: "k" };
 				}
 			>
 		>;
-
 		expect(true).toBe(true);
 	});
 
-	it("short-circuits to local when inherited is wide FlagsDef", () => {
-		type Local = {
-			output: { type: "string" };
-		};
-		type Result = EffectiveFlags<FlagsDef, Local>;
-		type _check = Expect<Equal<Result, Local>>;
-
-		expect(true).toBe(true);
-	});
-});
-
-// ────────────────────────────────────────────────────────────────────────────
-// FlagDef inherit toggle field tests
-// ────────────────────────────────────────────────────────────────────────────
-
-describe("FlagDef inherit toggle field", () => {
-	it("accepts inherit: true on flag definitions", () => {
-		const flag: FlagDef = { type: "boolean", inherit: true };
-		expect(flag.inherit).toBe(true);
-	});
-
-	it("accepts inherit: true alongside other fields", () => {
-		const flag: FlagDef = {
-			type: "string",
-			inherit: true,
-			short: "v",
-			required: true,
-		};
-		expect(flag.inherit).toBe(true);
-		expect(flag.required).toBe(true);
-	});
-
-	it("accepts inherit: true on multi-value flags", () => {
-		const flag: FlagDef = {
-			type: "string",
-			multiple: true,
-			inherit: true,
-		};
-		expect(flag.inherit).toBe(true);
-		expect(flag.multiple).toBe(true);
-	});
-
-	it("rejects inherit: false at type level", () => {
-		// @ts-expect-error — toggle fields only accept `true`, not `false`
-		const _bad: FlagDef = { type: "boolean", inherit: false };
+	it("returns empty when all inputs are empty", () => {
+		type Result = EffectiveFlags<{}, {}>;
+		type _check = Expect<Equal<Result, {}>>;
 		expect(true).toBe(true);
 	});
 
-	it("rejects non-boolean values for inherit", () => {
-		// @ts-expect-error — toggle fields only accept `true`, not string
-		const _bad: FlagDef = { type: "boolean", inherit: "yes" };
+	it("rejects the removed inherit field", () => {
+		// @ts-expect-error — flag propagation belongs to Context-owned flags
+		const _bad: FlagDef = { type: "boolean", inherit: true };
 		expect(true).toBe(true);
 	});
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -702,18 +702,18 @@ export type ValidateVariadicArgs<A extends readonly object[]> = A extends readon
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Merges parent flags with local flags, where local keys override parent keys.
+ * Merges two flag sets, where `Override` keys win over `Base` keys.
  *
  * @example
  * ```ts
- * type Parent = { verbose: { type: "boolean" }; port: { type: "number" } };
- * type Local = { port: { type: "string" } };
- * type Result = MergeFlags<Parent, Local>;
+ * type Base = { verbose: { type: "boolean" }; port: { type: "number" } };
+ * type Override = { port: { type: "string" } };
+ * type Result = MergeFlags<Base, Override>;
  * // Result = { verbose: { type: "boolean" }; port: { type: "string" } }
  * ```
  */
-export type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simplify<
-	Omit<Parent, keyof Local> & Local
+export type MergeFlags<Base extends FlagsDef, Override extends FlagsDef> = Simplify<
+	Omit<Base, keyof Override> & Override
 >;
 
 /** Computes a command's handler-visible flags from local and Context-owned definitions. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -735,9 +735,20 @@ export type InheritableFlags<F extends FlagsDef> = {
  * // Result = { verbose: { type: "boolean" }; port: { type: "string" } }
  * ```
  */
-type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simplify<
+export type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simplify<
 	Omit<Parent, keyof Local> & Local
 >;
+
+type WithInherit<D extends FlagDef> = D extends FlagDef
+	? Simplify<Omit<D, "inherit"> & { inherit: true }>
+	: never;
+
+/** Mark every flag in a record as inheritable without changing its value shape. */
+export type ForceInherit<F extends FlagsDef> = {
+	[K in keyof F]: WithInherit<F[K]>;
+} extends infer R extends FlagsDef
+	? R
+	: never;
 
 /**
  * Computes the effective flags for a command by filtering the inherited flags
@@ -759,7 +770,14 @@ type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simplify<
 export type EffectiveFlags<
 	Inherited extends FlagsDef,
 	Local extends FlagsDef,
-> = string extends keyof Inherited ? Local : MergeFlags<InheritableFlags<Inherited>, Local>;
+	Owned extends FlagsDef = {},
+> =
+	MergeFlags<
+		string extends keyof Inherited ? Local : MergeFlags<InheritableFlags<Inherited>, Local>,
+		ForceInherit<Owned>
+	> extends infer R extends FlagsDef
+		? R
+		: never;
 
 // ────────────────────────────────────────────────────────────────────────────
 // InferArgs / InferFlags — Type inference utilities

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -233,8 +233,6 @@ interface FlagDefBase {
 	aliases?: string[];
 	/** When `true`, the parser throws if the flag is not provided */
 	required?: true;
-	/** When `true`, the flag is inherited by subcommands */
-	inherit?: true;
 	/** Not supported with core value options — see {@link SchemaStringFlagDef} */
 	schema?: never;
 }
@@ -426,8 +424,6 @@ interface SchemaFlagBase {
 	short?: string;
 	/** Additional long aliases (e.g. `["out"]` → `--out`) */
 	aliases?: string[];
-	/** When `true`, the flag is inherited by subcommands */
-	inherit?: true;
 	/** Standard Schema that owns coercion, defaults, requiredness, and validation */
 	schema: StandardSchema;
 	required?: never;
@@ -702,27 +698,8 @@ export type ValidateVariadicArgs<A extends readonly object[]> = A extends readon
 	: A;
 
 // ────────────────────────────────────────────────────────────────────────────
-// Flag inheritance utility types
+// Effective flag utility types
 // ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Picks only the flags from `F` that have `inherit: true`.
- *
- * Flags without `inherit` (or with `inherit` omitted) are excluded.
- *
- * @example
- * ```ts
- * type Flags = {
- *   verbose: { type: "boolean"; inherit: true };
- *   port: { type: "number" };
- * };
- * type Result = InheritableFlags<Flags>;
- * // Result = { verbose: { type: "boolean"; inherit: true } }
- * ```
- */
-export type InheritableFlags<F extends FlagsDef> = {
-	[K in keyof F as F[K] extends { inherit: true } ? K : never]: F[K];
-};
 
 /**
  * Merges parent flags with local flags, where local keys override parent keys.
@@ -739,45 +716,16 @@ export type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simpli
 	Omit<Parent, keyof Local> & Local
 >;
 
-type WithInherit<D extends FlagDef> = D extends FlagDef
-	? Simplify<Omit<D, "inherit"> & { inherit: true }>
-	: never;
-
-/** Mark every flag in a record as inheritable without changing its value shape. */
-export type ForceInherit<F extends FlagsDef> = {
-	[K in keyof F]: WithInherit<F[K]>;
-} extends infer R extends FlagsDef
-	? R
-	: never;
-
 /**
- * Computes the effective flags for a command by filtering the inherited flags
- * (only those with `inherit: true`) and merging them with local flags.
- *
- * Local flags override inherited flags with the same key.
- *
- * @example
- * ```ts
- * type Inherited = {
- *   verbose: { type: "boolean"; inherit: true };
- *   port: { type: "number" };
- * };
- * type Local = { output: { type: "string" } };
- * type Result = EffectiveFlags<Inherited, Local>;
- * // Result = { verbose: { type: "boolean"; inherit: true }; output: { type: "string" } }
- * ```
+ * Computes a command's effective flags from ancestor-owned, local, and
+ * Context-owned definitions. `Inherited` contains only flags owned by
+ * Contexts provided on ancestor commands.
  */
 export type EffectiveFlags<
 	Inherited extends FlagsDef,
 	Local extends FlagsDef,
 	Owned extends FlagsDef = {},
-> =
-	MergeFlags<
-		string extends keyof Inherited ? Local : MergeFlags<InheritableFlags<Inherited>, Local>,
-		ForceInherit<Owned>
-	> extends infer R extends FlagsDef
-		? R
-		: never;
+> = MergeFlags<MergeFlags<Inherited, Local>, Owned> extends infer R extends FlagsDef ? R : never;
 
 // ────────────────────────────────────────────────────────────────────────────
 // InferArgs / InferFlags — Type inference utilities

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,14 @@ import type { InferOutput, StandardSchema } from "@crustjs/utils/schema";
 
 import type { Simplify } from "./api/context.ts";
 
+/** Injectable output callbacks threaded through one invocation. */
+export interface InvocationIO {
+	/** Write a line of standard output (injectable text callback) */
+	stdout: (text: string) => void;
+	/** Write a line of diagnostic output (injectable text callback) */
+	stderr: (text: string) => void;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Primitive type vocabulary
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -716,16 +716,9 @@ export type MergeFlags<Parent extends FlagsDef, Local extends FlagsDef> = Simpli
 	Omit<Parent, keyof Local> & Local
 >;
 
-/**
- * Computes a command's effective flags from ancestor-owned, local, and
- * Context-owned definitions. `Inherited` contains only flags owned by
- * Contexts provided on ancestor commands.
- */
-export type EffectiveFlags<
-	Inherited extends FlagsDef,
-	Local extends FlagsDef,
-	Owned extends FlagsDef = {},
-> = MergeFlags<MergeFlags<Inherited, Local>, Owned> extends infer R extends FlagsDef ? R : never;
+/** Computes a command's handler-visible flags from local and Context-owned definitions. */
+export type EffectiveFlags<Local extends FlagsDef, Owned extends FlagsDef = {}> =
+	MergeFlags<Local, Owned> extends infer R extends FlagsDef ? R : never;
 
 // ────────────────────────────────────────────────────────────────────────────
 // InferArgs / InferFlags — Type inference utilities

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -33,11 +33,19 @@ export const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 	apiKey: flags["api-key"],
 }));
 
+// Inferred CommandDefinition<R> embeds the required ContextFactory shape
+export const deploy = defineCommand("deploy", { requires: [auth] }, (cmd) =>
+	cmd.handle(({ ctx }) => {
+		void ctx.auth;
+	}),
+);
+
 // Inferred builder type references EffectiveFlags / Context-owned flag shapes
 export const app = new Crust("consumer-cli")
 	.flags(...flags)
 	.provide(auth())
-	.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+	.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
+	.mount(deploy);
 `;
 
 let fixtureDir: string;

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -29,7 +29,7 @@ export const flags = [
 ];
 
 export const apiKey = defineFlag("api-key", { type: "string", short: "k" });
-export const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+export const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 	apiKey: flags["api-key"],
 }));
 

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -15,7 +15,7 @@ const repoRoot = resolve(import.meta.dir, "../../..");
 const corePkg = resolve(import.meta.dir, "..");
 const tscBin = join(repoRoot, "node_modules/.bin/tsc");
 
-const CONSUMER_SOURCE = `import { Crust, defineCommand, defineFlag } from "@crustjs/core";
+const CONSUMER_SOURCE = `import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 
 // Inferred defineFlag element type references Simplify
 export const configFlag = defineFlag("config", {
@@ -28,9 +28,15 @@ export const flags = [
 	defineFlag("quiet", { type: "boolean", short: "q", description: "Quiet mode" }),
 ];
 
-// Inferred builder type references EffectiveFlags / flag def shapes
+export const apiKey = defineFlag("api-key", { type: "string", short: "k" });
+export const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+	apiKey: flags["api-key"],
+}));
+
+// Inferred builder type references EffectiveFlags / Context-owned flag shapes
 export const app = new Crust("consumer-cli")
 	.flags(...flags)
+	.provide(auth())
 	.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
 `;
 

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -24,7 +24,7 @@ export interface RunResult {
  *   expect(result.exitCode).toBe(0);
  */
 export async function executeCrust(
-	builder: Crust<any, any, any, any, any, any>,
+	builder: Crust<any, any, any, any, any>,
 	argv?: string[],
 ): Promise<RunResult> {
 	const stdoutChunks: string[] = [];

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -24,7 +24,7 @@ export interface RunResult {
  *   expect(result.exitCode).toBe(0);
  */
 export async function executeCrust(
-	builder: Crust<any, any, any>,
+	builder: Crust<any, any, any, any, any, any>,
 	argv?: string[],
 ): Promise<RunResult> {
 	const stdoutChunks: string[] = [];

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 
+import type { StandardSchema } from "@crustjs/utils/schema";
+
 import { resolveCommand, type CommandRoute } from "../src/command/router";
 import type {
 	ArgDef,
@@ -10,7 +12,14 @@ import type {
 	FlagsDef,
 	NamedFlagDef,
 } from "../src/index";
-import { Crust, defineArg, defineCommand, defineExtension, defineFlag } from "../src/index";
+import {
+	Crust,
+	defineArg,
+	defineCommand,
+	defineContext,
+	defineExtension,
+	defineFlag,
+} from "../src/index";
 import { parseArgs } from "../src/parsing/parser";
 import type { InferArgs, ParseResult } from "../src/types";
 import { executeCrust } from "./helpers";
@@ -429,6 +438,41 @@ describe("integration: .execute() full pipeline with argv override", () => {
 
 		const result = await executeCrust(app, ["service", "api", "--env", "production", "--dryRun"]);
 		expect(result.stdout).toContain("deploy service=api env=production dryRun=true");
+		expect(result.exitCode).toBe(0);
+	});
+});
+
+describe("integration: Context-owned flag → derived Context and descendant", () => {
+	beforeEach(() => {
+		process.exitCode = 0;
+	});
+
+	it("routes before the subcommand and passes schema output to setup and handler", async () => {
+		const schema: StandardSchema<string | undefined, number> = {
+			"~standard": {
+				version: 1,
+				vendor: "test",
+				validate: (value) => ({ value: Number(value) }),
+			},
+		};
+		const apiKey = defineFlag("api-key", {
+			type: "string",
+			short: "k",
+			aliases: ["token"],
+			schema,
+		});
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+			credential: flags["api-key"],
+		}));
+		const deploy = defineCommand("deploy", { flags: [apiKey], ctx: [auth] }, (command) =>
+			command.handle(({ flags, ctx }) => {
+				console.log(`${typeof flags["api-key"]}:${ctx.auth.credential}`);
+			}),
+		);
+		const app = new Crust("cli").provide(auth()).mount(deploy);
+
+		const result = await executeCrust(app, ["--token=42", "deploy"]);
+		expect(result.stdout).toContain("number:42");
 		expect(result.exitCode).toBe(0);
 	});
 });

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -138,7 +138,7 @@ describe("integration: inherited boolean flag → subcommand receives it", () =>
 
 	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 	const app = new Crust("cli").flags(verbose).mount(
-		defineCommand("sub", { flags: [verbose] }, (cmd) =>
+		defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 			cmd.handle((ctx) => {
 				console.log(`verbose=${ctx.flags.verbose}`);
 			}),
@@ -203,11 +203,11 @@ describe("integration: deeply nested subcommand (3 levels) inherits flags", () =
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const format = defineFlag("format", { type: "string", inherit: true });
 		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("level1", { flags: [verbose] }, (cmd) =>
+			defineCommand("level1", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.flags(format).mount(
-					defineCommand("level2", { flags: [verbose, format] }, (cmd2) =>
+					defineCommand("level2", { requires: { flags: [verbose, format] } }, (cmd2) =>
 						cmd2.mount(
-							defineCommand("level3", { flags: [verbose, format] }, (cmd3) =>
+							defineCommand("level3", { requires: { flags: [verbose, format] } }, (cmd3) =>
 								cmd3.handle((ctx) => {
 									console.log(`verbose=${ctx.flags.verbose}`);
 									console.log(`format=${ctx.flags.format}`);
@@ -236,11 +236,11 @@ describe("integration: deeply nested subcommand (3 levels) inherits flags", () =
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const l1Inherit = defineFlag("l1Inherit", { type: "string", inherit: true });
 		const app = new Crust("cli").flags(verbose, { name: "rootOnly", type: "string" }).mount(
-			defineCommand("level1", { flags: [verbose] }, (cmd) =>
+			defineCommand("level1", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.flags(l1Inherit, { name: "l1Only", type: "number" }).mount(
-					defineCommand("level2", { flags: [verbose, l1Inherit] }, (cmd2) =>
+					defineCommand("level2", { requires: { flags: [verbose, l1Inherit] } }, (cmd2) =>
 						cmd2.mount(
-							defineCommand("level3", { flags: [verbose, l1Inherit] }, (cmd3) =>
+							defineCommand("level3", { requires: { flags: [verbose, l1Inherit] } }, (cmd3) =>
 								cmd3.handle((ctx) => {
 									console.log(`verbose=${ctx.flags.verbose}`);
 									console.log(`l1Inherit=${ctx.flags.l1Inherit}`);
@@ -322,7 +322,7 @@ describe("integration: required inherited flag enforced on subcommand", () => {
 
 	const token = defineFlag("token", { type: "string", required: true, inherit: true });
 	const app = new Crust("cli").flags(token).mount(
-		defineCommand("sub", { flags: [token] }, (cmd) =>
+		defineCommand("sub", { requires: { flags: [token] } }, (cmd) =>
 			cmd.handle((ctx) => {
 				console.log(`token=${ctx.flags.token}`);
 			}),
@@ -349,7 +349,7 @@ describe("integration: inherited flag with default value on subcommand", () => {
 
 	const port = defineFlag("port", { type: "number", default: 3000, inherit: true });
 	const app = new Crust("cli").flags(port).mount(
-		defineCommand("sub", { flags: [port] }, (cmd) =>
+		defineCommand("sub", { requires: { flags: [port] } }, (cmd) =>
 			cmd.handle((ctx) => {
 				console.log(`port=${ctx.flags.port}`);
 			}),
@@ -377,7 +377,7 @@ describe("integration: inherited flag alias works on subcommand", () => {
 	it("inherited single-char alias is recognized on subcommand", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
 		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`verbose=${ctx.flags.verbose}`);
 				}),
@@ -397,7 +397,7 @@ describe("integration: inherited flag alias works on subcommand", () => {
 			inherit: true,
 		});
 		const app = new Crust("cli").flags(output).mount(
-			defineCommand("sub", { flags: [output] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [output] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`output=${ctx.flags.output}`);
 				}),
@@ -427,7 +427,7 @@ describe("integration: .execute() full pipeline with argv override", () => {
 		const env = defineFlag("env", { type: "string", default: "staging", inherit: true });
 		const dryRun = defineFlag("dryRun", { type: "boolean", inherit: true });
 		const app = new Crust("deploy").flags(env, dryRun).mount(
-			defineCommand("service", { flags: [env, dryRun] }, (cmd) =>
+			defineCommand("service", { requires: { flags: [env, dryRun] } }, (cmd) =>
 				cmd.args(defineArg("name", { type: "string", required: true })).handle((ctx) => {
 					console.log(
 						`deploy service=${ctx.args.name} env=${ctx.flags.env} dryRun=${ctx.flags.dryRun}`,
@@ -461,13 +461,16 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 			aliases: ["token"],
 			schema,
 		});
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, ({ flags }) => ({
+		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			credential: flags["api-key"],
 		}));
-		const deploy = defineCommand("deploy", { flags: [apiKey], ctx: [auth] }, (command) =>
-			command.handle(({ flags, ctx }) => {
-				console.log(`${typeof flags["api-key"]}:${ctx.auth.credential}`);
-			}),
+		const deploy = defineCommand(
+			"deploy",
+			{ requires: { flags: [apiKey], ctx: [auth] } },
+			(command) =>
+				command.handle(({ flags, ctx }) => {
+					console.log(`${typeof flags["api-key"]}:${ctx.auth.credential}`);
+				}),
 		);
 		const app = new Crust("cli").provide(auth()).mount(deploy);
 
@@ -536,9 +539,9 @@ describe("integration: nested mounted definitions end-to-end", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
 		const timeout = defineFlag("timeout", { type: "number", default: 30, inherit: true });
 		const app = new Crust("git").flags(verbose).mount(
-			defineCommand("remote", { flags: [verbose] }, (cmd) =>
+			defineCommand("remote", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.flags(timeout).mount(
-					defineCommand("add", { flags: [verbose, timeout] }, (cmd2) =>
+					defineCommand("add", { requires: { flags: [verbose, timeout] } }, (cmd2) =>
 						cmd2.args({ name: "name", type: "string", required: true }).handle((ctx) => {
 							console.log(
 								`add remote=${ctx.args.name} verbose=${ctx.flags.verbose} timeout=${ctx.flags.timeout}`,
@@ -588,7 +591,7 @@ describe("integration: split-file definitions end-to-end", () => {
 	});
 
 	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-	const listCommand = defineCommand("list", { flags: [verbose] }, (command) =>
+	const listCommand = defineCommand("list", { requires: { flags: [verbose] } }, (command) =>
 		command
 			.flags({ name: "format", type: "string", default: "table" })
 			.args({ name: "resource", type: "string", required: true })
@@ -596,7 +599,7 @@ describe("integration: split-file definitions end-to-end", () => {
 				console.log(`list ${args.resource} format=${flags.format} verbose=${flags.verbose}`);
 			}),
 	);
-	const getCommand = defineCommand("get", { flags: [verbose] }, (command) =>
+	const getCommand = defineCommand("get", { requires: { flags: [verbose] } }, (command) =>
 		command
 			.args(
 				{ name: "resource", type: "string", required: true },
@@ -639,12 +642,12 @@ describe("integration: mounted definitions", () => {
 
 	it("mounts nested definitions end-to-end", async () => {
 		const env = defineFlag("env", { type: "string", inherit: true });
-		const status = defineCommand("status", { flags: [verbose, env] }, (command) =>
+		const status = defineCommand("status", { requires: { flags: [verbose, env] } }, (command) =>
 			command.handle(({ flags }) => {
 				console.log(`verbose=${flags.verbose} env=${flags.env}`);
 			}),
 		);
-		const deploy = defineCommand("deploy", { flags: [verbose] }, (command) =>
+		const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
 			command.flags(env).mount(status),
 		);
 		const app = new Crust("cli").flags(verbose).mount(deploy);
@@ -664,10 +667,10 @@ describe("integration: mounted definitions", () => {
 	});
 
 	it("mounts multiple definitions in one call", async () => {
-		const deploy = defineCommand("deploy", { flags: [verbose] }, (command) =>
+		const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
 			command.handle(({ flags }) => console.log(`deploy verbose=${flags.verbose}`)),
 		);
-		const status = defineCommand("status", { flags: [verbose] }, (command) =>
+		const status = defineCommand("status", { requires: { flags: [verbose] } }, (command) =>
 			command.handle(({ flags }) => console.log(`status verbose=${flags.verbose}`)),
 		);
 		const app = new Crust("cli").flags(verbose).mount(status, deploy);
@@ -689,7 +692,7 @@ describe("integration: inherited boolean flag negation", () => {
 	it("--no-verbose negates inherited boolean flag on subcommand", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", default: true, inherit: true });
 		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`verbose=${ctx.flags.verbose}`);
 				}),
@@ -714,7 +717,7 @@ describe("integration: inherited multiple-value flag", () => {
 	it("inherited multiple-value flag collects values on subcommand", async () => {
 		const tag = defineFlag("tag", { type: "string", multiple: true, inherit: true });
 		const app = new Crust("cli").flags(tag).mount(
-			defineCommand("sub", { flags: [tag] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [tag] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					const tags = ctx.flags.tag;
 					console.log(`tags=${JSON.stringify(tags)}`);
@@ -740,7 +743,7 @@ describe("integration: separator (--) with subcommand and inherited flags", () =
 	it("rawArgs captured correctly on subcommand with inherited flags", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
 		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { flags: [verbose] }, (cmd) =>
+			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`verbose=${ctx.flags.verbose}`);
 					console.log(`rawArgs=${JSON.stringify(ctx.rawArgs)}`);
@@ -782,7 +785,7 @@ describe("integration: complex real-world CLI scenario", () => {
 			.flags(verbose, config)
 			.extend(auditExtension)
 			.mount(
-				defineCommand("deploy", { flags: [verbose, config] }, (cmd) =>
+				defineCommand("deploy", { requires: { flags: [verbose, config] } }, (cmd) =>
 					cmd.flags({ name: "env", type: "string", required: true }).handle((ctx) => {
 						order.push("deploy:run");
 						console.log(
@@ -790,7 +793,7 @@ describe("integration: complex real-world CLI scenario", () => {
 						);
 					}),
 				),
-				defineCommand("status", { flags: [verbose, config] }, (cmd) =>
+				defineCommand("status", { requires: { flags: [verbose, config] } }, (cmd) =>
 					cmd.handle((ctx) => {
 						order.push("status:run");
 						console.log(`status verbose=${ctx.flags.verbose} config=${ctx.flags.config}`);

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -139,12 +139,12 @@ describe("integration: .execute() full pipeline with argv override", () => {
 	it("full pipeline: root flags + args + subcommand routing + execution", async () => {
 		const env = defineFlag("env", { type: "string", default: "staging" });
 		const dryRun = defineFlag("dryRun", { type: "boolean" });
-		const globalFlags = defineContext("global-flags", { flags: [env, dryRun] }, () => ({}));
-		const app = new Crust("deploy").provide(globalFlags()).mount(
-			defineCommand("service", { requires: { flags: [env, dryRun] } }, (cmd) =>
-				cmd.args(defineArg("name", { type: "string", required: true })).handle((ctx) => {
+		const deployment = defineContext("deployment", { flags: [env, dryRun] }, ({ flags }) => flags);
+		const app = new Crust("deploy").provide(deployment()).mount(
+			defineCommand("service", { requires: [deployment] }, (cmd) =>
+				cmd.args(defineArg("name", { type: "string", required: true })).handle(({ args, ctx }) => {
 					console.log(
-						`deploy service=${ctx.args.name} env=${ctx.flags.env} dryRun=${ctx.flags.dryRun}`,
+						`deploy service=${args.name} env=${ctx.deployment.env} dryRun=${ctx.deployment.dryRun}`,
 					);
 				}),
 			),
@@ -178,13 +178,10 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			credential: flags["api-key"],
 		}));
-		const deploy = defineCommand(
-			"deploy",
-			{ requires: { flags: [apiKey], ctx: [auth] } },
-			(command) =>
-				command.handle(({ flags, ctx }) => {
-					console.log(`${typeof flags["api-key"]}:${ctx.auth.credential}`);
-				}),
+		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
+			command.handle(({ ctx }) => {
+				console.log(`${typeof ctx.auth.credential}:${ctx.auth.credential}`);
+			}),
 		);
 		const app = new Crust("cli").provide(auth()).mount(deploy);
 
@@ -195,15 +192,17 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 
 	it("routes Context-owned flags at a mid-path position without propagating parent locals", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
+			verbose: flags.verbose === true,
+		}));
 		const app = new Crust("cli")
 			.flags({ name: "root-only", type: "boolean" })
 			.provide(logging())
 			.mount(
-				defineCommand("group", { requires: { flags: [verbose] } }, (group) =>
+				defineCommand("group", { requires: [logging] }, (group) =>
 					group.mount(
-						defineCommand("deploy", { requires: { flags: [verbose] } }, (deploy) =>
-							deploy.handle(({ flags }) => console.log(`verbose=${flags.verbose}`)),
+						defineCommand("deploy", { requires: [logging] }, (deploy) =>
+							deploy.handle(({ ctx }) => console.log(`verbose=${ctx.logging.verbose}`)),
 						),
 					),
 				),
@@ -231,12 +230,12 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 
 	it("parses a Context-owned long alias on a descendant", async () => {
 		const output = defineFlag("output", { type: "string", aliases: ["out"] });
-		const outputFlags = defineContext("output-flags", { flags: [output] }, () => ({}));
+		const outputConfig = defineContext("output-config", { flags: [output] }, ({ flags }) => flags);
 		const app = new Crust("cli")
-			.provide(outputFlags())
+			.provide(outputConfig())
 			.mount(
-				defineCommand("render", { requires: { flags: [output] } }, (command) =>
-					command.handle(({ flags }) => console.log(`output=${flags.output}`)),
+				defineCommand("render", { requires: [outputConfig] }, (command) =>
+					command.handle(({ ctx }) => console.log(`output=${ctx["output-config"].output}`)),
 				),
 			);
 
@@ -304,15 +303,15 @@ describe("integration: nested mounted definitions end-to-end", () => {
 	it("3-level nested definitions execute correctly", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 		const timeout = defineFlag("timeout", { type: "number", default: 30 });
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const remoteFlags = defineContext("remote-flags", { flags: [timeout] }, () => ({}));
-		const app = new Crust("git").provide(globalFlags()).mount(
-			defineCommand("remote", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.provide(remoteFlags()).mount(
-					defineCommand("add", { requires: { flags: [verbose, timeout] } }, (cmd2) =>
-						cmd2.args({ name: "name", type: "string", required: true }).handle((ctx) => {
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+		const remoteConfig = defineContext("remote-config", { flags: [timeout] }, ({ flags }) => flags);
+		const app = new Crust("git").provide(logging()).mount(
+			defineCommand("remote", { requires: [logging] }, (cmd) =>
+				cmd.provide(remoteConfig()).mount(
+					defineCommand("add", { requires: [logging, remoteConfig] }, (cmd2) =>
+						cmd2.args({ name: "name", type: "string", required: true }).handle(({ args, ctx }) => {
 							console.log(
-								`add remote=${ctx.args.name} verbose=${ctx.flags.verbose} timeout=${ctx.flags.timeout}`,
+								`add remote=${args.name} verbose=${ctx.logging.verbose} timeout=${ctx["remote-config"].timeout}`,
 							);
 						}),
 					),
@@ -359,28 +358,28 @@ describe("integration: split-file definitions end-to-end", () => {
 	});
 
 	const verbose = defineFlag("verbose", { type: "boolean" });
-	const listCommand = defineCommand("list", { requires: { flags: [verbose] } }, (command) =>
+	const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+	const listCommand = defineCommand("list", { requires: [logging] }, (command) =>
 		command
 			.flags({ name: "format", type: "string", default: "table" })
 			.args({ name: "resource", type: "string", required: true })
-			.handle(({ args, flags }) => {
-				console.log(`list ${args.resource} format=${flags.format} verbose=${flags.verbose}`);
+			.handle(({ args, flags, ctx }) => {
+				console.log(`list ${args.resource} format=${flags.format} verbose=${ctx.logging.verbose}`);
 			}),
 	);
-	const getCommand = defineCommand("get", { requires: { flags: [verbose] } }, (command) =>
+	const getCommand = defineCommand("get", { requires: [logging] }, (command) =>
 		command
 			.args(
 				{ name: "resource", type: "string", required: true },
 				{ name: "id", type: "string", required: true },
 			)
-			.handle(({ args, flags }) => {
-				console.log(`get ${args.resource}/${args.id} verbose=${flags.verbose}`);
+			.handle(({ args, ctx }) => {
+				console.log(`get ${args.resource}/${args.id} verbose=${ctx.logging.verbose}`);
 			}),
 	);
 
 	it("runs standalone definitions through the full pipeline", async () => {
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("kubectl").provide(globalFlags()).mount(listCommand, getCommand);
+		const app = new Crust("kubectl").provide(logging()).mount(listCommand, getCommand);
 
 		const listResult = await executeCrust(app, ["list", "pods", "--verbose", "--format", "json"]);
 		expect(listResult.stdout).toContain("list pods format=json verbose=true");
@@ -392,14 +391,13 @@ describe("integration: split-file definitions end-to-end", () => {
 	});
 
 	it("reuses a definition across satisfying parents, renamed via .as()", async () => {
-		const firstFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const secondFlags = defineContext(
-			"global-flags",
+		const first = new Crust("first").provide(logging()).mount(listCommand);
+		const defaultLogging = defineContext(
+			"logging",
 			{ flags: [{ ...verbose, default: true }] },
-			() => ({}),
+			({ flags }) => flags,
 		);
-		const first = new Crust("first").provide(firstFlags()).mount(listCommand);
-		const second = new Crust("second").provide(secondFlags()).mount(listCommand.as("show"));
+		const second = new Crust("second").provide(defaultLogging()).mount(listCommand.as("show"));
 
 		expect((await executeCrust(first, ["list", "pods"])).stdout).toContain("verbose=undefined");
 		expect((await executeCrust(second, ["show", "pods"])).stdout).toContain("verbose=true");
@@ -415,17 +413,17 @@ describe("integration: mounted definitions", () => {
 
 	it("mounts nested definitions end-to-end", async () => {
 		const env = defineFlag("env", { type: "string" });
-		const status = defineCommand("status", { requires: { flags: [verbose, env] } }, (command) =>
-			command.handle(({ flags }) => {
-				console.log(`verbose=${flags.verbose} env=${flags.env}`);
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+		const deployment = defineContext("deployment", { flags: [env] }, ({ flags }) => flags);
+		const status = defineCommand("status", { requires: [logging, deployment] }, (command) =>
+			command.handle(({ ctx }) => {
+				console.log(`verbose=${ctx.logging.verbose} env=${ctx.deployment.env}`);
 			}),
 		);
-		const deployFlags = defineContext("deploy-flags", { flags: [env] }, () => ({}));
-		const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-			command.provide(deployFlags()).mount(status),
+		const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
+			command.provide(deployment()).mount(status),
 		);
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).mount(deploy);
+		const app = new Crust("cli").provide(logging()).mount(deploy);
 
 		const result = await executeCrust(app, ["deploy", "status", "--verbose", "--env", "staging"]);
 		expect(result.stdout).toContain("verbose=true env=staging");
@@ -442,14 +440,14 @@ describe("integration: mounted definitions", () => {
 	});
 
 	it("mounts multiple definitions in one call", async () => {
-		const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-			command.handle(({ flags }) => console.log(`deploy verbose=${flags.verbose}`)),
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+		const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
+			command.handle(({ ctx }) => console.log(`deploy verbose=${ctx.logging.verbose}`)),
 		);
-		const status = defineCommand("status", { requires: { flags: [verbose] } }, (command) =>
-			command.handle(({ flags }) => console.log(`status verbose=${flags.verbose}`)),
+		const status = defineCommand("status", { requires: [logging] }, (command) =>
+			command.handle(({ ctx }) => console.log(`status verbose=${ctx.logging.verbose}`)),
 		);
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).mount(status, deploy);
+		const app = new Crust("cli").provide(logging()).mount(status, deploy);
 
 		expect((await executeCrust(app, ["deploy", "--verbose"])).stdout).toContain(
 			"deploy verbose=true",
@@ -467,11 +465,11 @@ describe("integration: Context-owned boolean flag negation", () => {
 
 	it("--no-verbose negates a Context-owned boolean flag on a subcommand", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", default: true });
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					console.log(`verbose=${ctx.flags.verbose}`);
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+		const app = new Crust("cli").provide(logging()).mount(
+			defineCommand("sub", { requires: [logging] }, (cmd) =>
+				cmd.handle(({ ctx }) => {
+					console.log(`verbose=${ctx.logging.verbose}`);
 				}),
 			),
 		);
@@ -493,12 +491,11 @@ describe("integration: Context-owned multiple-value flag", () => {
 
 	it("Context-owned multiple-value flag collects values on a subcommand", async () => {
 		const tag = defineFlag("tag", { type: "string", multiple: true });
-		const globalFlags = defineContext("global-flags", { flags: [tag] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).mount(
-			defineCommand("sub", { requires: { flags: [tag] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					const tags = ctx.flags.tag;
-					console.log(`tags=${JSON.stringify(tags)}`);
+		const tags = defineContext("tags", { flags: [tag] }, ({ flags }) => flags);
+		const app = new Crust("cli").provide(tags()).mount(
+			defineCommand("sub", { requires: [tags] }, (cmd) =>
+				cmd.handle(({ ctx }) => {
+					console.log(`tags=${JSON.stringify(ctx.tags.tag)}`);
 				}),
 			),
 		);
@@ -520,12 +517,12 @@ describe("integration: separator (--) with subcommand and Context-owned flags", 
 
 	it("rawArgs captured correctly on a subcommand with Context-owned flags", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
-		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
-		const app = new Crust("cli").provide(globalFlags()).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					console.log(`verbose=${ctx.flags.verbose}`);
-					console.log(`rawArgs=${JSON.stringify(ctx.rawArgs)}`);
+		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
+		const app = new Crust("cli").provide(logging()).mount(
+			defineCommand("sub", { requires: [logging] }, (cmd) =>
+				cmd.handle(({ ctx, rawArgs }) => {
+					console.log(`verbose=${ctx.logging.verbose}`);
+					console.log(`rawArgs=${JSON.stringify(rawArgs)}`);
 				}),
 			),
 		);
@@ -560,23 +557,23 @@ describe("integration: complex real-world CLI scenario", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 		const config = defineFlag("config", { type: "string", default: "~/.myctl" });
 
-		const globalFlags = defineContext("global-flags", { flags: [verbose, config] }, () => ({}));
+		const settings = defineContext("settings", { flags: [verbose, config] }, ({ flags }) => flags);
 		const app = new Crust("myctl")
-			.provide(globalFlags())
+			.provide(settings())
 			.extend(auditExtension)
 			.mount(
-				defineCommand("deploy", { requires: { flags: [verbose, config] } }, (cmd) =>
-					cmd.flags({ name: "env", type: "string", required: true }).handle((ctx) => {
+				defineCommand("deploy", { requires: [settings] }, (cmd) =>
+					cmd.flags({ name: "env", type: "string", required: true }).handle(({ flags, ctx }) => {
 						order.push("deploy:run");
 						console.log(
-							`deploy env=${ctx.flags.env} verbose=${ctx.flags.verbose} config=${ctx.flags.config}`,
+							`deploy env=${flags.env} verbose=${ctx.settings.verbose} config=${ctx.settings.config}`,
 						);
 					}),
 				),
-				defineCommand("status", { requires: { flags: [verbose, config] } }, (cmd) =>
-					cmd.handle((ctx) => {
+				defineCommand("status", { requires: [settings] }, (cmd) =>
+					cmd.handle(({ ctx }) => {
 						order.push("status:run");
-						console.log(`status verbose=${ctx.flags.verbose} config=${ctx.flags.config}`);
+						console.log(`status verbose=${ctx.settings.verbose} config=${ctx.settings.config}`);
 					}),
 				),
 			);

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -128,7 +128,7 @@ describe("integration: exported types", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Inherited flag behavior — full pipeline integration tests
+// Context-owned flag behavior — full pipeline integration tests
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("integration: .execute() full pipeline with argv override", () => {
@@ -215,6 +215,34 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const localResult = await executeCrust(app, ["group", "deploy", "--root-only"]);
 		expect(localResult.exitCode).toBe(1);
 		expect(localResult.stderr).toContain("Unknown flag");
+	});
+
+	it("enforces a required Context-owned flag on a descendant", async () => {
+		const token = defineFlag("token", { type: "string", required: true });
+		const auth = defineContext("auth", { flags: [token] }, () => ({}));
+		const app = new Crust("cli")
+			.provide(auth())
+			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+
+		const result = await executeCrust(app, ["deploy"]);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain('Missing required flag "--token"');
+	});
+
+	it("parses a Context-owned long alias on a descendant", async () => {
+		const output = defineFlag("output", { type: "string", aliases: ["out"] });
+		const outputFlags = defineContext("output-flags", { flags: [output] }, () => ({}));
+		const app = new Crust("cli")
+			.provide(outputFlags())
+			.mount(
+				defineCommand("render", { requires: { flags: [output] } }, (command) =>
+					command.handle(({ flags }) => console.log(`output=${flags.output}`)),
+				),
+			);
+
+		const result = await executeCrust(app, ["render", "--out", "json"]);
+		expect(result.stdout).toContain("output=json");
+		expect(result.exitCode).toBe(0);
 	});
 });
 
@@ -404,7 +432,7 @@ describe("integration: mounted definitions", () => {
 		expect(result.exitCode).toBe(0);
 	});
 
-	it("excludes non-inheritable flags from mounted commands", async () => {
+	it("excludes parent-local flags from mounted commands", async () => {
 		const sub = defineCommand("sub", (command) => command.handle(() => console.log("sub ran")));
 		const app = new Crust("cli").flags({ name: "rootOnly", type: "string" }).mount(sub);
 
@@ -432,12 +460,12 @@ describe("integration: mounted definitions", () => {
 	});
 });
 
-describe("integration: inherited boolean flag negation", () => {
+describe("integration: Context-owned boolean flag negation", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
-	it("--no-verbose negates inherited boolean flag on subcommand", async () => {
+	it("--no-verbose negates a Context-owned boolean flag on a subcommand", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", default: true });
 		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
 		const app = new Crust("cli").provide(globalFlags()).mount(
@@ -455,15 +483,15 @@ describe("integration: inherited boolean flag negation", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Multiple value flags with inheritance
+// Multiple-value Context-owned flags
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("integration: inherited multiple-value flag", () => {
+describe("integration: Context-owned multiple-value flag", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
-	it("inherited multiple-value flag collects values on subcommand", async () => {
+	it("Context-owned multiple-value flag collects values on a subcommand", async () => {
 		const tag = defineFlag("tag", { type: "string", multiple: true });
 		const globalFlags = defineContext("global-flags", { flags: [tag] }, () => ({}));
 		const app = new Crust("cli").provide(globalFlags()).mount(
@@ -482,15 +510,15 @@ describe("integration: inherited multiple-value flag", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Separator (--) with inherited flags
+// Separator (--) with Context-owned flags
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("integration: separator (--) with subcommand and inherited flags", () => {
+describe("integration: separator (--) with subcommand and Context-owned flags", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
-	it("rawArgs captured correctly on subcommand with inherited flags", async () => {
+	it("rawArgs captured correctly on a subcommand with Context-owned flags", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
 		const app = new Crust("cli").provide(globalFlags()).mount(

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -131,302 +131,16 @@ describe("integration: exported types", () => {
 // Inherited flag behavior — full pipeline integration tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("integration: inherited boolean flag → subcommand receives it", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-	const app = new Crust("cli").flags(verbose).mount(
-		defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-			cmd.handle((ctx) => {
-				console.log(`verbose=${ctx.flags.verbose}`);
-			}),
-		),
-	);
-
-	it("subcommand handler receives inherited boolean flag value", async () => {
-		const result = await executeCrust(app, ["sub", "--verbose"]);
-		expect(result.stdout).toContain("verbose=true");
-		expect(result.exitCode).toBe(0);
-	});
-
-	it("inherited boolean flag defaults to undefined when not passed", async () => {
-		const result = await executeCrust(app, ["sub"]);
-		expect(result.stdout).toContain("verbose=undefined");
-		expect(result.exitCode).toBe(0);
-	});
-});
-
-describe("integration: inherited flag overridden by subcommand local flag", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	it("child override replaces inherited flag type (string → number)", async () => {
-		const app = new Crust("cli").flags({ name: "output", type: "string", inherit: true }).mount(
-			defineCommand("sub", (cmd) =>
-				cmd.flags({ name: "output", type: "number", default: 42 }).handle((ctx) => {
-					console.log(`output=${ctx.flags.output}`);
-					console.log(`type=${typeof ctx.flags.output}`);
-				}),
-			),
-		);
-
-		const result = await executeCrust(app, ["sub"]);
-		expect(result.stdout).toContain("output=42");
-		expect(result.stdout).toContain("type=number");
-		expect(result.exitCode).toBe(0);
-	});
-
-	it("child override replaces inherited flag and accepts new type value", async () => {
-		const app = new Crust("cli").flags({ name: "output", type: "string", inherit: true }).mount(
-			defineCommand("sub", (cmd) =>
-				cmd.flags({ name: "output", type: "number" }).handle((ctx) => {
-					console.log(`output=${ctx.flags.output}`);
-				}),
-			),
-		);
-
-		const result = await executeCrust(app, ["sub", "--output", "99"]);
-		expect(result.stdout).toContain("output=99");
-		expect(result.exitCode).toBe(0);
-	});
-});
-
-describe("integration: deeply nested subcommand (3 levels) inherits flags", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	it("3-level deep subcommand receives root inherited flag", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const format = defineFlag("format", { type: "string", inherit: true });
-		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("level1", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.flags(format).mount(
-					defineCommand("level2", { requires: { flags: [verbose, format] } }, (cmd2) =>
-						cmd2.mount(
-							defineCommand("level3", { requires: { flags: [verbose, format] } }, (cmd3) =>
-								cmd3.handle((ctx) => {
-									console.log(`verbose=${ctx.flags.verbose}`);
-									console.log(`format=${ctx.flags.format}`);
-								}),
-							),
-						),
-					),
-				),
-			),
-		);
-
-		const result = await executeCrust(app, [
-			"level1",
-			"level2",
-			"level3",
-			"--verbose",
-			"--format",
-			"json",
-		]);
-		expect(result.stdout).toContain("verbose=true");
-		expect(result.stdout).toContain("format=json");
-		expect(result.exitCode).toBe(0);
-	});
-
-	it("3-level deep subcommand only inherits flags marked inherit: true", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const l1Inherit = defineFlag("l1Inherit", { type: "string", inherit: true });
-		const app = new Crust("cli").flags(verbose, { name: "rootOnly", type: "string" }).mount(
-			defineCommand("level1", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.flags(l1Inherit, { name: "l1Only", type: "number" }).mount(
-					defineCommand("level2", { requires: { flags: [verbose, l1Inherit] } }, (cmd2) =>
-						cmd2.mount(
-							defineCommand("level3", { requires: { flags: [verbose, l1Inherit] } }, (cmd3) =>
-								cmd3.handle((ctx) => {
-									console.log(`verbose=${ctx.flags.verbose}`);
-									console.log(`l1Inherit=${ctx.flags.l1Inherit}`);
-								}),
-							),
-						),
-					),
-				),
-			),
-		);
-
-		// verbose and l1Inherit should be recognized at level3
-		const result = await executeCrust(app, [
-			"level1",
-			"level2",
-			"level3",
-			"--verbose",
-			"--l1Inherit",
-			"hello",
-		]);
-		expect(result.stdout).toContain("verbose=true");
-		expect(result.stdout).toContain("l1Inherit=hello");
-		expect(result.exitCode).toBe(0);
-	});
-});
-
-describe("integration: non-inherit flag not visible to subcommand", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	it("passing non-inherited parent flag to subcommand causes error", async () => {
-		const app = new Crust("cli")
-			.flags(
-				{ name: "verbose", type: "boolean", inherit: true },
-				{ name: "rootOnly", type: "string" },
-			)
-			.mount(
-				defineCommand("sub", (cmd) =>
-					cmd.handle(() => {
-						console.log("should not reach here");
-					}),
-				),
-			);
-
-		const result = await executeCrust(app, ["sub", "--rootOnly", "something"]);
-		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain("Unknown flag");
-	});
-
-	it("non-inherited flag from level1 not visible to level2", async () => {
-		const app = new Crust("cli").flags({ name: "global", type: "boolean", inherit: true }).mount(
-			defineCommand("level1", (cmd) =>
-				cmd
-					.flags(
-						{ name: "l1Local", type: "string" },
-						{ name: "l1Shared", type: "string", inherit: true },
-					)
-					.mount(
-						defineCommand("level2", (cmd2) =>
-							cmd2.handle(() => {
-								console.log("should not reach here");
-							}),
-						),
-					),
-			),
-		);
-
-		const result = await executeCrust(app, ["level1", "level2", "--l1Local", "val"]);
-		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain("Unknown flag");
-	});
-});
-
-describe("integration: required inherited flag enforced on subcommand", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	const token = defineFlag("token", { type: "string", required: true, inherit: true });
-	const app = new Crust("cli").flags(token).mount(
-		defineCommand("sub", { requires: { flags: [token] } }, (cmd) =>
-			cmd.handle((ctx) => {
-				console.log(`token=${ctx.flags.token}`);
-			}),
-		),
-	);
-
-	it("missing required inherited flag on subcommand produces error", async () => {
-		const result = await executeCrust(app, ["sub"]);
-		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain("Missing required");
-	});
-
-	it("providing required inherited flag on subcommand succeeds", async () => {
-		const result = await executeCrust(app, ["sub", "--token", "secret123"]);
-		expect(result.stdout).toContain("token=secret123");
-		expect(result.exitCode).toBe(0);
-	});
-});
-
-describe("integration: inherited flag with default value on subcommand", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	const port = defineFlag("port", { type: "number", default: 3000, inherit: true });
-	const app = new Crust("cli").flags(port).mount(
-		defineCommand("sub", { requires: { flags: [port] } }, (cmd) =>
-			cmd.handle((ctx) => {
-				console.log(`port=${ctx.flags.port}`);
-			}),
-		),
-	);
-
-	it("subcommand receives inherited flag default when not explicitly passed", async () => {
-		const result = await executeCrust(app, ["sub"]);
-		expect(result.stdout).toContain("port=3000");
-		expect(result.exitCode).toBe(0);
-	});
-
-	it("subcommand inherits default and allows override", async () => {
-		const result = await executeCrust(app, ["sub", "--port", "8080"]);
-		expect(result.stdout).toContain("port=8080");
-		expect(result.exitCode).toBe(0);
-	});
-});
-
-describe("integration: inherited flag alias works on subcommand", () => {
-	beforeEach(() => {
-		process.exitCode = 0;
-	});
-
-	it("inherited single-char alias is recognized on subcommand", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
-		const app = new Crust("cli").flags(verbose).mount(
-			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					console.log(`verbose=${ctx.flags.verbose}`);
-				}),
-			),
-		);
-
-		const result = await executeCrust(app, ["sub", "-v"]);
-		expect(result.stdout).toContain("verbose=true");
-		expect(result.exitCode).toBe(0);
-	});
-
-	it("inherited multi-alias flag is recognized on subcommand", async () => {
-		const output = defineFlag("output", {
-			type: "string",
-			short: "o",
-			aliases: ["out"],
-			inherit: true,
-		});
-		const app = new Crust("cli").flags(output).mount(
-			defineCommand("sub", { requires: { flags: [output] } }, (cmd) =>
-				cmd.handle((ctx) => {
-					console.log(`output=${ctx.flags.output}`);
-				}),
-			),
-		);
-
-		const resultO = await executeCrust(app, ["sub", "-o", "file.txt"]);
-		expect(resultO.stdout).toContain("output=file.txt");
-		expect(resultO.exitCode).toBe(0);
-
-		const resultOut = await executeCrust(app, ["sub", "--out", "file.txt"]);
-		expect(resultOut.stdout).toContain("output=file.txt");
-		expect(resultOut.exitCode).toBe(0);
-	});
-});
-
-// ────────────────────────────────────────────────────────────────────────────
-// Full pipeline integration tests
-// ────────────────────────────────────────────────────────────────────────────
-
 describe("integration: .execute() full pipeline with argv override", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
 	it("full pipeline: root flags + args + subcommand routing + execution", async () => {
-		const env = defineFlag("env", { type: "string", default: "staging", inherit: true });
-		const dryRun = defineFlag("dryRun", { type: "boolean", inherit: true });
-		const app = new Crust("deploy").flags(env, dryRun).mount(
+		const env = defineFlag("env", { type: "string", default: "staging" });
+		const dryRun = defineFlag("dryRun", { type: "boolean" });
+		const globalFlags = defineContext("global-flags", { flags: [env, dryRun] }, () => ({}));
+		const app = new Crust("deploy").provide(globalFlags()).mount(
 			defineCommand("service", { requires: { flags: [env, dryRun] } }, (cmd) =>
 				cmd.args(defineArg("name", { type: "string", required: true })).handle((ctx) => {
 					console.log(
@@ -477,6 +191,30 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const result = await executeCrust(app, ["--token=42", "deploy"]);
 		expect(result.stdout).toContain("number:42");
 		expect(result.exitCode).toBe(0);
+	});
+
+	it("routes Context-owned flags at a mid-path position without propagating parent locals", async () => {
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli")
+			.flags({ name: "root-only", type: "boolean" })
+			.provide(logging())
+			.mount(
+				defineCommand("group", { requires: { flags: [verbose] } }, (group) =>
+					group.mount(
+						defineCommand("deploy", { requires: { flags: [verbose] } }, (deploy) =>
+							deploy.handle(({ flags }) => console.log(`verbose=${flags.verbose}`)),
+						),
+					),
+				),
+			);
+
+		expect((await executeCrust(app, ["group", "--verbose", "deploy"])).stdout).toContain(
+			"verbose=true",
+		);
+		const localResult = await executeCrust(app, ["group", "deploy", "--root-only"]);
+		expect(localResult.exitCode).toBe(1);
+		expect(localResult.stderr).toContain("Unknown flag");
 	});
 });
 
@@ -536,11 +274,13 @@ describe("integration: nested mounted definitions end-to-end", () => {
 	});
 
 	it("3-level nested definitions execute correctly", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
-		const timeout = defineFlag("timeout", { type: "number", default: 30, inherit: true });
-		const app = new Crust("git").flags(verbose).mount(
+		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
+		const timeout = defineFlag("timeout", { type: "number", default: 30 });
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const remoteFlags = defineContext("remote-flags", { flags: [timeout] }, () => ({}));
+		const app = new Crust("git").provide(globalFlags()).mount(
 			defineCommand("remote", { requires: { flags: [verbose] } }, (cmd) =>
-				cmd.flags(timeout).mount(
+				cmd.provide(remoteFlags()).mount(
 					defineCommand("add", { requires: { flags: [verbose, timeout] } }, (cmd2) =>
 						cmd2.args({ name: "name", type: "string", required: true }).handle((ctx) => {
 							console.log(
@@ -590,7 +330,7 @@ describe("integration: split-file definitions end-to-end", () => {
 		process.exitCode = 0;
 	});
 
-	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+	const verbose = defineFlag("verbose", { type: "boolean" });
 	const listCommand = defineCommand("list", { requires: { flags: [verbose] } }, (command) =>
 		command
 			.flags({ name: "format", type: "string", default: "table" })
@@ -611,7 +351,8 @@ describe("integration: split-file definitions end-to-end", () => {
 	);
 
 	it("runs standalone definitions through the full pipeline", async () => {
-		const app = new Crust("kubectl").flags(verbose).mount(listCommand, getCommand);
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("kubectl").provide(globalFlags()).mount(listCommand, getCommand);
 
 		const listResult = await executeCrust(app, ["list", "pods", "--verbose", "--format", "json"]);
 		expect(listResult.stdout).toContain("list pods format=json verbose=true");
@@ -623,10 +364,14 @@ describe("integration: split-file definitions end-to-end", () => {
 	});
 
 	it("reuses a definition across satisfying parents, renamed via .as()", async () => {
-		const first = new Crust("first").flags(verbose).mount(listCommand);
-		const second = new Crust("second")
-			.flags({ ...verbose, default: true })
-			.mount(listCommand.as("show"));
+		const firstFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const secondFlags = defineContext(
+			"global-flags",
+			{ flags: [{ ...verbose, default: true }] },
+			() => ({}),
+		);
+		const first = new Crust("first").provide(firstFlags()).mount(listCommand);
+		const second = new Crust("second").provide(secondFlags()).mount(listCommand.as("show"));
 
 		expect((await executeCrust(first, ["list", "pods"])).stdout).toContain("verbose=undefined");
 		expect((await executeCrust(second, ["show", "pods"])).stdout).toContain("verbose=true");
@@ -638,19 +383,21 @@ describe("integration: mounted definitions", () => {
 		process.exitCode = 0;
 	});
 
-	const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
+	const verbose = defineFlag("verbose", { type: "boolean" });
 
 	it("mounts nested definitions end-to-end", async () => {
-		const env = defineFlag("env", { type: "string", inherit: true });
+		const env = defineFlag("env", { type: "string" });
 		const status = defineCommand("status", { requires: { flags: [verbose, env] } }, (command) =>
 			command.handle(({ flags }) => {
 				console.log(`verbose=${flags.verbose} env=${flags.env}`);
 			}),
 		);
+		const deployFlags = defineContext("deploy-flags", { flags: [env] }, () => ({}));
 		const deploy = defineCommand("deploy", { requires: { flags: [verbose] } }, (command) =>
-			command.flags(env).mount(status),
+			command.provide(deployFlags()).mount(status),
 		);
-		const app = new Crust("cli").flags(verbose).mount(deploy);
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).mount(deploy);
 
 		const result = await executeCrust(app, ["deploy", "status", "--verbose", "--env", "staging"]);
 		expect(result.stdout).toContain("verbose=true env=staging");
@@ -673,7 +420,8 @@ describe("integration: mounted definitions", () => {
 		const status = defineCommand("status", { requires: { flags: [verbose] } }, (command) =>
 			command.handle(({ flags }) => console.log(`status verbose=${flags.verbose}`)),
 		);
-		const app = new Crust("cli").flags(verbose).mount(status, deploy);
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).mount(status, deploy);
 
 		expect((await executeCrust(app, ["deploy", "--verbose"])).stdout).toContain(
 			"deploy verbose=true",
@@ -690,8 +438,9 @@ describe("integration: inherited boolean flag negation", () => {
 	});
 
 	it("--no-verbose negates inherited boolean flag on subcommand", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", default: true, inherit: true });
-		const app = new Crust("cli").flags(verbose).mount(
+		const verbose = defineFlag("verbose", { type: "boolean", default: true });
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).mount(
 			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`verbose=${ctx.flags.verbose}`);
@@ -715,8 +464,9 @@ describe("integration: inherited multiple-value flag", () => {
 	});
 
 	it("inherited multiple-value flag collects values on subcommand", async () => {
-		const tag = defineFlag("tag", { type: "string", multiple: true, inherit: true });
-		const app = new Crust("cli").flags(tag).mount(
+		const tag = defineFlag("tag", { type: "string", multiple: true });
+		const globalFlags = defineContext("global-flags", { flags: [tag] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).mount(
 			defineCommand("sub", { requires: { flags: [tag] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					const tags = ctx.flags.tag;
@@ -741,8 +491,9 @@ describe("integration: separator (--) with subcommand and inherited flags", () =
 	});
 
 	it("rawArgs captured correctly on subcommand with inherited flags", async () => {
-		const verbose = defineFlag("verbose", { type: "boolean", inherit: true });
-		const app = new Crust("cli").flags(verbose).mount(
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const globalFlags = defineContext("global-flags", { flags: [verbose] }, () => ({}));
+		const app = new Crust("cli").provide(globalFlags()).mount(
 			defineCommand("sub", { requires: { flags: [verbose] } }, (cmd) =>
 				cmd.handle((ctx) => {
 					console.log(`verbose=${ctx.flags.verbose}`);
@@ -778,11 +529,12 @@ describe("integration: complex real-world CLI scenario", () => {
 			},
 		});
 
-		const verbose = defineFlag("verbose", { type: "boolean", short: "v", inherit: true });
-		const config = defineFlag("config", { type: "string", default: "~/.myctl", inherit: true });
+		const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
+		const config = defineFlag("config", { type: "string", default: "~/.myctl" });
 
+		const globalFlags = defineContext("global-flags", { flags: [verbose, config] }, () => ({}));
 		const app = new Crust("myctl")
-			.flags(verbose, config)
+			.provide(globalFlags())
 			.extend(auditExtension)
 			.mount(
 				defineCommand("deploy", { requires: { flags: [verbose, config] } }, (cmd) =>

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -80,7 +80,7 @@ function renderForShell(
  * which emits a tab-completion script for bash, zsh, or fish.
  *
  * **Strategy: pure-static.** The handler walks the final root snapshot, so
- * registration order is irrelevant — any commands or inherited flags added
+ * registration order is irrelevant — any commands or recursive flags added
  * by other Extensions are visible by the time we generate the script. The
  * walker projects the root snapshot to a small `CompletionSpec`; per-shell
  * renderers turn that into a self-contained shell script with no runtime

--- a/packages/extensions/src/completion/spec.ts
+++ b/packages/extensions/src/completion/spec.ts
@@ -130,7 +130,7 @@ export interface CompletionCommand {
 	description?: string;
 	/**
 	 * Flags visible on this command. Walker captures `effectiveFlags` (not
-	 * `localFlags`), so inherited flags appear at every depth — matching
+	 * `localFlags`), so propagating flags appear at every depth — matching
 	 * what the parser actually accepts at this level.
 	 */
 	flags: readonly CompletionFlag[];

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -165,16 +165,16 @@ describe("walkCommandNode", () => {
 			// (mimics what `computeEffectiveFlags` does at build time).
 			localFlags: { local: { type: "boolean" } },
 			effectiveFlags: {
-				verbose: { type: "boolean", short: "v", inherit: true },
+				verbose: { type: "boolean", short: "v" },
 				local: { type: "boolean" },
 			},
 		});
 
 		const root = makeNode({
 			name: "mycli",
-			localFlags: { verbose: { type: "boolean", short: "v", inherit: true } },
+			localFlags: { verbose: { type: "boolean", short: "v" } },
 			effectiveFlags: {
-				verbose: { type: "boolean", short: "v", inherit: true },
+				verbose: { type: "boolean", short: "v" },
 			},
 			subCommands: { child },
 		});

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -12,7 +12,7 @@ import { walkCommandNode } from "./walker.ts";
  * `createCommandNode`/`computeEffectiveFlags` are not exported from
  * `@crustjs/core`. Constructing literal nodes is the cleanest way to keep
  * walker tests focused on the walker — we don't want to be coupled to the
- * `Crust` builder's internal flag-inheritance plumbing here. For each node
+ * `Crust` builder's internal Context-owned flag propagation here. For each node
  * we set `effectiveFlags` explicitly so the walker observes exactly the set
  * of flags we intend.
  */
@@ -157,12 +157,12 @@ describe("walkCommandNode", () => {
 		expect(spec.root.args[0]?.choices).toEqual(["bash", "zsh", "fish"]);
 	});
 
-	it("walks nested subcommands recursively, surfacing inherited flags via effectiveFlags", () => {
+	it("walks nested subcommands recursively, surfacing Context-owned flags via effectiveFlags", () => {
 		const child = makeNode({
 			name: "child",
 			meta: { name: "child", description: "Child command" },
-			// Local flag plus an *inherited* parent flag pre-merged into effectiveFlags
-			// (mimics what `computeEffectiveFlags` does at build time).
+			// Local flag plus a Context-owned ancestor flag pre-merged into effectiveFlags
+			// (mimics what Core does at build time).
 			localFlags: { local: { type: "boolean" } },
 			effectiveFlags: {
 				verbose: { type: "boolean", short: "v" },
@@ -186,7 +186,7 @@ describe("walkCommandNode", () => {
 		if (!childSpec) throw new Error("missing child");
 		expect(childSpec.name).toBe("child");
 		expect(childSpec.description).toBe("Child command");
-		// Inherited "verbose" must surface on the child too.
+		// Context-owned "verbose" must surface on the child too.
 		const flagNames = childSpec.flags.map((f) => f.name).sort();
 		expect(flagNames).toEqual(["local", "verbose"]);
 	});

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -92,7 +92,7 @@ describe("walkCommandNode", () => {
 
 	it("captures Context-owned flags from a Core-built provider tree", () => {
 		const apiKey = defineFlag("api-key", { type: "string", short: "k" });
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("mycli")
 			.provide(auth())
 			.mount(defineCommand("deploy", (command) => command.handle(() => {})));

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import type { FlagsDef } from "@crustjs/core";
+import { Crust, defineCommand, defineContext, defineFlag, type FlagsDef } from "@crustjs/core";
 import { snapshotCommand } from "@crustjs/core/tooling";
 type CommandNode = Parameters<typeof snapshotCommand>[0];
 
@@ -21,6 +21,7 @@ function makeNode(partial: Partial<CommandNode> & { name: string }): CommandNode
 	return {
 		meta: { name: partial.name, ...(partial.meta ?? {}) },
 		localFlags: flags,
+		ownedFlags: partial.ownedFlags ?? {},
 		effectiveFlags: partial.effectiveFlags ?? flags,
 		args: partial.args,
 		subCommands: partial.subCommands ?? {},
@@ -87,6 +88,18 @@ describe("walkCommandNode", () => {
 			takesValue: true,
 			multiple: true,
 		});
+	});
+
+	it("captures Context-owned flags from a Core-built provider tree", () => {
+		const apiKey = defineFlag("api-key", { type: "string", short: "k" });
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const app = new Crust("mycli")
+			.provide(auth())
+			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+
+		const spec = walkCommandNode(snapshotCommand(app._node));
+		expect(spec.root.flags.map((flag) => flag.name)).toContain("api-key");
+		expect(spec.root.subCommands[0]?.flags.map((flag) => flag.name)).toContain("api-key");
 	});
 
 	it("captures positional args with required, variadic, type, and description", () => {

--- a/packages/extensions/src/completion/walker.ts
+++ b/packages/extensions/src/completion/walker.ts
@@ -17,7 +17,7 @@ function normaliseDescription(value: string | undefined): string | undefined {
 /**
  * Project a single `FlagDef` (keyed by `name` in the snapshot `flags`) onto a
  * `CompletionFlag`. The walker calls this for every entry of every visible
- * command's `flags` map so inherited flags surface at the right
+ * command's `flags` map so propagating flags surface at the right
  * depth.
  */
 function walkFlag(name: string, def: FlagSnapshot): CompletionFlag {

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -199,7 +199,6 @@ export function helpExtension(): Extension {
 				type: "boolean",
 				short: "h",
 				noNegate: true,
-				inherit: true,
 				description: "Show help",
 			},
 		},

--- a/packages/extensions/src/no-color.ts
+++ b/packages/extensions/src/no-color.ts
@@ -9,7 +9,7 @@ function setEnv(name: string, value: string | undefined): void {
 }
 
 /**
- * Adds an inheritable `--color` / `--no-color` flag pair that scopes the
+ * Adds a recursive `--color` / `--no-color` flag pair that scopes the
  * standard color environment variables around command execution:
  *
  * - `--color` sets `FORCE_COLOR=3` (and clears `NO_COLOR`, so strict
@@ -41,7 +41,6 @@ export function noColorExtension(): Extension {
 		flags: {
 			color: {
 				type: "boolean",
-				inherit: true,
 				description: "Enable colored output",
 			},
 		},

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -424,7 +424,7 @@ describe("built-in plugins", () => {
 			type: "string",
 			description: "API credential",
 		});
-		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("app")
 			.provide(auth())
 			.extend(helpExtension())

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 
-import { Crust, defineCommand, defineExtension } from "@crustjs/core";
+import { Crust, defineCommand, defineContext, defineExtension, defineFlag } from "@crustjs/core";
 import { snapshotCommand } from "@crustjs/core/tooling";
 
 import { helpExtension, renderHelp } from "./help.ts";
@@ -417,6 +417,28 @@ describe("built-in plugins", () => {
 
 		expect(getStdout()).toBe("");
 		expect(capturedRawArgs).toEqual(["--help"]);
+	});
+
+	it("help renders Context-owned flags on providers and descendants", async () => {
+		const apiKey = defineFlag("api-key", {
+			type: "string",
+			description: "API credential",
+		});
+		const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+		const app = new Crust("app")
+			.provide(auth())
+			.extend(helpExtension())
+			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+
+		await app.run(["--help"]);
+		const rootHelp = stripAnsi(getStdout());
+		expect(rootHelp).toContain("--api-key");
+
+		stdoutChunks = [];
+		await app.run(["deploy", "--help"]);
+		const childHelp = stripAnsi(getStdout());
+		expect(childHelp).toContain("--api-key");
+		expect(childHelp).toContain("API credential");
 	});
 
 	it("help plugin supports subcommands injected after its setup", async () => {

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -216,6 +216,43 @@ describe("built-in plugins", () => {
 		expect(output).not.toContain("--no-help");
 	});
 
+	it("help reaches nested subcommands", async () => {
+		const app = new Crust("app")
+			.extend(helpExtension())
+			.mount(
+				defineCommand("group", (group) =>
+					group.mount(defineCommand("build", (build) => build.handle(() => {}))),
+				),
+			);
+
+		await app.execute({ argv: ["group", "build", "--help"] });
+
+		const output = stripAnsi(getStdout());
+		expect(output).toContain("app group build");
+		expect(output).toContain("-h, --help");
+	});
+
+	it("help reaches Extension-contributed commands regardless of registration order", async () => {
+		const app = new Crust("app").extend(helpExtension()).extend(lateSkillExtension());
+
+		await app.execute({ argv: ["skill", "update", "--help"] });
+
+		const output = stripAnsi(getStdout());
+		expect(output).toContain("app skill update");
+		expect(output).toContain("-h, --help");
+	});
+
+	it("recursive false Extension flags stay root-only", async () => {
+		const rootOnly = defineExtension("root-only", {
+			flags: { root: { type: "boolean", recursive: false } },
+		});
+		const app = new Crust("app")
+			.extend(rootOnly)
+			.mount(defineCommand("build", (build) => build.handle(() => {})));
+
+		await expect(app.run(["build", "--root"])).rejects.toMatchObject({ code: "PARSE" });
+	});
+
 	it("noColorExtension injects --color and --no-color into help output", async () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -388,7 +388,7 @@ describe("built-in plugins", () => {
 		expect(output).not.toContain("\x1b[33m");
 	});
 
-	it("noColorExtension flag is inherited by subcommands", async () => {
+	it("noColorExtension flag is recursive on subcommands", async () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())
 			.extend(helpExtension())

--- a/packages/skills/src/annotations.ts
+++ b/packages/skills/src/annotations.ts
@@ -16,7 +16,7 @@ export interface SkillCommandAnnotations {
 	instructions?: string[];
 }
 
-type SkillCommandTarget = CommandNode | Crust<any, any, any>;
+type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any, any>;
 
 const SKILL_COMMAND_ANNOTATIONS = Symbol("crust.skill.commandAnnotations");
 

--- a/packages/skills/src/annotations.ts
+++ b/packages/skills/src/annotations.ts
@@ -16,7 +16,7 @@ export interface SkillCommandAnnotations {
 	instructions?: string[];
 }
 
-type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any, any>;
+type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any>;
 
 const SKILL_COMMAND_ANNOTATIONS = Symbol("crust.skill.commandAnnotations");
 

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -702,7 +702,7 @@ describe("renderSkill", () => {
 				type: "string",
 				description: "API credential",
 			});
-			const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+			const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 			const app = new Crust("test-cli")
 				.provide(auth())
 				.mount(defineCommand("deploy", (command) => command.handle(() => {})));

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import type { ArgDef, FlagDef } from "@crustjs/core";
-import { Crust } from "@crustjs/core";
+import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
 import { snapshotCommand } from "@crustjs/core/tooling";
 type CommandNode = Parameters<typeof snapshotCommand>[0];
 
@@ -695,6 +695,22 @@ describe("renderSkill", () => {
 			const serve = findFile(files, "commands/serve.md");
 
 			expect(serve?.content).toContain("Default: `3000`");
+		});
+
+		it("renders Context-owned flags from a Core-built command tree", () => {
+			const apiKey = defineFlag("api-key", {
+				type: "string",
+				description: "API credential",
+			});
+			const auth = defineContext("auth", { ownFlags: [apiKey] }, () => ({}));
+			const app = new Crust("test-cli")
+				.provide(auth())
+				.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+			const files = renderSkill(buildManifest(snapshotCommand(app._node)), baseMeta);
+			const deploy = findFile(files, "commands/deploy.md");
+
+			expect(deploy?.content).toContain("--api-key");
+			expect(deploy?.content).toContain("API credential");
 		});
 
 		it("renders a flags table with aliases and defaults", () => {


### PR DESCRIPTION
## Summary

This PR reshapes how flags and dependencies travel through a command tree, in four stacked changes:

1. **Context-owned flags** (`12a3fde0`) — a Context declares the flags that feed it; `.provide()` installs them as propagating flags on the subtree and hands the validated values to the Context's `setup`.
2. **`requires` reshape** (`60c3f657`) — definition APIs group by relationship direction: `flags` = "this definition owns/parses these", `requires` = "dependencies the mount path must supply".
3. **Remove flag inheritance** (`d746511c`, **BREAKING**) — public `FlagDef.inherit` is gone. Context-owned flags are the *only* application-level propagation mechanism.
4. **Capabilities-only requirements** (`0648af22`, **BREAKING**) — `requires.flags` is gone too; `requires` is now a plain array of Context factories. The only cross-command dependency is a capability.
5. **Invocation io for Contexts** (`c4164290`) — `ContextSetup` receives the invocation's injected `stdout`/`stderr` (shared `InvocationIO` interface, same callbacks the handler gets), so Contexts can wrap behavior — a real `ctx.logging.debug()` instead of a derived boolean every handler re-gates.

The end state is a two-sentence model: **`flags` = what you own and parse. `requires` = capabilities the path must provide.**

## The model after this PR

| Flag kind | Declared via | Parsed by | Propagates |
|---|---|---|---|
| **Local** | `.flags()` | that command only | never |
| **Context-owned** | `defineContext(name, { flags: [...] })` + `.provide()` | provider command + descendants mounted afterward | subtree-wide |
| **Extension** | `ExtensionFlagDef` (`recursive: true` by default) | every command (or root-only with `recursive: false`) | extension injection |

### API surface (after)

```ts
const verbose = defineFlag("verbose", { type: "boolean", default: false });

// The Context OWNS the flag that feeds it AND wraps the behavior —
// setup receives the invocation's injected io (same callbacks as handlers)
const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({
  debug(message: string) {
    if (flags.verbose) stderr(message);
  },
}));

// requires = capabilities the mount path must provide (plain array of Context factories)
const deploy = defineCommand("deploy", { requires: [logging] }, (cmd) =>
  cmd.handle(({ ctx }) => ctx.logging.debug("deploying…")), // zero gating in handlers
);

const app = new Crust("cli").provide(logging()).mount(deploy);
```

- `defineContext(name, { flags?, requires? }, setup)` — `flags` it owns, `requires` = Context factories it depends on (values via `ctx`, constructed topologically, cycles are `DEFINITION` errors)
- `defineCommand(name, { requires? }, recipe)` — Context factories the mount path must `.provide()`
- Builder: `.flags()` (local) · `.provide()` (contexts + their owned flags) · `.mount()` (checked against the path) · `.handle()`
- `setup` receives only the Context's **own** flags; dependency values arrive via `ctx`; invocation io arrives via `stdout`/`stderr` (`InvocationIO` — single shared type with `CrustCommandContext`, single runtime callbacks)

## Before → After

### Sharing a flag down a subtree

**Before** (`main`):

```ts
const app = new Crust("cli")
  .flags({ name: "verbose", type: "boolean", inherit: true }) // pushed to every descendant
  .mount(deploy); // deploy parses --verbose whether it uses it or not
```

- The flag silently lands in every descendant's parse surface.
- Requirements were typing-only: deleting one changed nothing at runtime.
- A child local flag could shadow a same-named inherited flag.
- Handlers read raw flags; renaming a flag touched every consumer.

**After:**

```ts
const app = new Crust("cli")
  .provide(logging()) // context owns --verbose and consumes it
  .mount(deploy);     // deploy declares requires: [logging]
```

- The flag propagates because a Context *consumes* it. Handlers call `ctx.logging.debug(...)` — the gating, the stream choice, and the flag name live in one place; adding log levels later touches only the Context.
- `requires` is load-bearing at **both** boundaries: a missing provision is a TS error at `.mount()` via `MountChecks` *and* a runtime `DEFINITION` error at build validation/dispatch.
- One dependency concept: there is no second typed channel to the same value that can drift.
- No shadowing: owned-flag name/short/alias collisions are `DEFINITION` errors in either registration order.

### Dependency semantics

| | Before | After |
|---|---|---|
| Dependency kinds | inherited flags (typing-only) | Context capabilities (one concept) |
| Satisfied by | any ancestor flag with `inherit: true` | a Context instance `.provide()`d on the mount path |
| Forgetting to provide | flag still parsed silently | TS error at `.mount()` + runtime `DEFINITION` error |
| Raw flag access in handlers | `flags.verbose` anywhere in the subtree | the owning Context exposes what consumers need — single source of truth |
| Shared behavior (logging etc.) | gating duplicated in every handler | Context wraps injected io once; handlers call the capability |

### Removed public surface

- `FlagDef.inherit` (+ schema counterpart), `InheritableFlags`, `ForceInherit`, `FlagSnapshot.inherit`
- `requires: { flags, ctx }` object shape → `requires: [contextFactory, ...]`
- The builder's `Inherited` generic slot (`EffectiveFlags` is now local + owned)
- local-overrides-inherited behavior (no longer constructible)
- `defineCommand` flat `{ flags, ctx }` and `defineContext` `{ ownFlags, flags, ctx }` shapes

## DX notes

- **One blessed way to share flags** (contexts) + one escape hatch (define a descriptor once with `defineFlag()`, attach with `.flags()` per command — no propagation, no checks).
- **Flag positioning unchanged**: context-owned flags still parse at root, mid-path, and leaf positions (`cli --verbose deploy` ≡ `cli deploy --verbose`); the router is untouched by this PR.
- `.of(value)` test doubles retain owned flags, so test and production command grammars match.
- Extensions (`--help`, `--no-color`) unaffected: they use their own `recursive` channel.

## Migration

| Previous usage | Migration |
|---|---|
| `inherit: true` feeding shared behavior | Move the flag into `defineContext(name, { flags: [...] }, setup)`; `.provide()` before mounting; handlers consume the capability |
| Each command reads a raw flag directly | Define once with `defineFlag()`; attach with `.flags()` per command |
| `requires: { flags: [x], ctx: [c] }` | `requires: [c]` — the Context owning `x` exposes whatever consumers need |
| `defineContext(name, { ownFlags, flags, ctx }, …)` | `defineContext(name, { flags, requires }, …)` |
| Positional type args on `Crust`/builder/`ContextInstance` | Account for the changed generic parameters (`Inherited` slot removed, `Owned`/owned-flags added) |

## Validation

- `bun run test` — 21/21 tasks · `bun run check:types` — 21/21 · `bun run build:docs` — 55 pages
- Context-wrapped `stderr` and handler `stderr` verified to write through the **same injected callback** in one invocation; `.of()` test doubles unaffected (setup skipped)
- Pipeline per change: recon → plan → implementation → **3 independent fresh-context reviews** (correctness, tests, docs/API) → verified fix pass
- Backward-compat audit: two independent auditors confirmed zero compat shims — old shapes are hard compile errors, no deprecated aliases, no runtime fallbacks
- Known pre-existing, unrelated: `bun run check` format failure in `scripts/package-size-report.mjs`

