### PR TITLE
chore: remove dangling ADR references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,4 @@ Default five-role vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Create `CONTEXT.md` and `docs/adr/` at the repo root lazily when domain terms or architecture decisions need recording. See `docs/agents/domain.md`.

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -5,7 +5,7 @@ import type { FlagDef, InvocationIO } from "../types.ts";
 import type { Awaitable } from "./context.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
-// Extension — the public integration contract (ADR-0001)
+// Extension — the public integration contract
 // ────────────────────────────────────────────────────────────────────────────
 
 const finishedBrand: unique symbol = Symbol("crust.finished");

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -88,7 +88,7 @@ interface PreparedInvocation {
 
 /**
  * Runtime guard for untyped callers: schema mode is exclusive — the schema
- * owns coercion, defaults, requiredness, choices, and validation (ADR-0005).
+ * owns coercion, defaults, requiredness, choices, and validation.
  * The type system already rejects mixing; this catches plain-JS misuse.
  */
 function validateSchemaExclusivity(
@@ -153,7 +153,7 @@ function isAbortError(error: unknown): boolean {
 /**
  * Inject an Extension-owned flag into a node's effective flags (and, when
  * `recursive`, into every descendant). Name collisions with application or
- * other Extension definitions are definition errors (ADR-0001).
+ * other Extension definitions are definition errors.
  */
 function injectExtensionFlag(
 	node: CommandNode,
@@ -944,7 +944,7 @@ export class Crust<
 				return;
 			}
 			// Core always preserves a nonzero failure outcome, regardless of
-			// what Extension onError hooks do (ADR-0001).
+			// what Extension onError hooks do.
 			process.exitCode = 1;
 			await renderFailure(error, argv, prepared, io, extensionContext);
 		}
@@ -991,7 +991,7 @@ export class Crust<
 			if (!resolvedNode.run) return;
 
 			// Standard Schemas on arg/flag definitions own value validation and
-			// transformation (ADR-0005); the handler receives schema outputs.
+			// transformation; the handler receives schema outputs.
 			const validated = await applySchemas(resolvedNode, parsed);
 
 			// Native resource protocol: Context values implementing
@@ -1124,7 +1124,7 @@ function prepareInvocation(node: CommandNode): PreparedInvocation {
  * Prepare a frozen, validated Command Snapshot of an application with all
  * Extension contributions applied. Does not call Command Handlers.
  *
- * Explicitly unsupported tooling bridge (ADR-0006), exposed only via
+ * Explicitly unsupported tooling bridge, exposed only via
  * `@crustjs/core/tooling` for man-page/skill generators and build tooling.
  * The parameter is structural so any `Crust` builder satisfies it.
  */

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -462,7 +462,7 @@ function resolveArgs(argsDef: ArgsDef | undefined, positionals: string[]): Recor
  * Enforce `noNegate` at parse time.
  *
  * `--no-<spelling>` works for the canonical name and every long alias
- * (an alias is a perfect synonym — see ADR 0001), but a boolean that
+ * (an alias is a perfect synonym), but a boolean that
  * opted out via `noNegate` rejects every negated spelling. Without this
  * pre-scan, `util.parseArgs` (`allowNegative`) would silently accept it.
  */

--- a/packages/core/src/parsing/schema.ts
+++ b/packages/core/src/parsing/schema.ts
@@ -25,7 +25,7 @@ async function runSchema(
 }
 
 /**
- * Apply Standard Schemas declared on arg/flag definitions (ADR-0005).
+ * Apply Standard Schemas declared on arg/flag definitions.
  *
  * Runs after syntax parsing and structural validation: each schema receives
  * the raw parsed value (`string | undefined` for args, the raw token value


### PR DESCRIPTION
## Summary
- remove dangling ADR-0001/0005/0006 citations while preserving their rationale
- document that `CONTEXT.md` and `docs/adr/` are created lazily when needed

## Verification
- `bun run build` — passed (13 tasks)
- `bun run check:types -- --filter=@crustjs/core` — passed
- `bun run test -- --filter=@crustjs/core` — passed (543 tests)
- `bun run lint` — passed with 10 pre-existing warnings
- `bunx oxfmt --check AGENTS.md packages/core/src/api/extension.ts packages/core/src/command/crust.ts packages/core/src/parsing/parser.ts packages/core/src/parsing/schema.ts` — passed
- `bun run format` — repository-wide check remains red on pre-existing `scripts/package-size-report.mjs`; changed files pass the targeted format gate
