### PR TITLE
refactor(progress): inject spinner terminal sink

### DIFF
--- a/.changeset/progress-spinner-sink.md
+++ b/.changeset/progress-spinner-sink.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/progress": patch
+---
+
+Refactor spinner terminal lifecycle behind an internal injectable sink for deterministic cleanup and SIGINT testing.

--- a/packages/progress/src/progress.test.ts
+++ b/packages/progress/src/progress.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { progress as createProgressBar } from "./progress.ts";
+import { createProgressHandle, progress as createProgressBar } from "./progress.ts";
+import type { SpinnerSink } from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -30,6 +31,25 @@ afterEach(() => {
 });
 
 describe("progress — determinate", () => {
+	it("threads the internal terminal sink through the spinner handle", () => {
+		const writes: string[] = [];
+		const sink: SpinnerSink = {
+			isTTY: false,
+			write: (text) => writes.push(text),
+			exit: (code): never => {
+				throw new Error(`exit:${code}`);
+			},
+		};
+		const progress = createProgressHandle({ total: 2, message: "Files" }, sink);
+
+		progress.start();
+		progress.advance();
+		progress.stop();
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toContain("Files (1/2)");
+	});
+
 	it("renders current/total alongside the message", () => {
 		const progress = createProgressBar({ total: 10, message: "Translating" });
 

--- a/packages/progress/src/progress.ts
+++ b/packages/progress/src/progress.ts
@@ -6,6 +6,7 @@ import {
 	type SpinnerHandle,
 	type SpinnerHandleOptions,
 	type SpinnerOutcome,
+	type SpinnerSink,
 	createSpinnerHandle,
 } from "./spinner.ts";
 
@@ -28,21 +29,21 @@ export interface ProgressHandle {
 	stop: (outcome?: SpinnerOutcome, message?: string) => void;
 }
 
-/**
- * Create a determinate progress indicator rendered as
- * `⠋ <message> (<current>/<total>)` on the spinner line.
- */
-export function progress(options: ProgressOptions): ProgressHandle {
+/** Internal progress constructor that threads the spinner terminal sink through. */
+export function createProgressHandle(options: ProgressOptions, sink?: SpinnerSink): ProgressHandle {
 	const { total } = options;
 	let current = 0;
 	let message = options.message;
 
 	const format = (msg: string): string => `${msg} (${current}/${total})`;
 
-	const handle: SpinnerHandle = createSpinnerHandle({
-		...options,
-		message: format(message),
-	});
+	const handle: SpinnerHandle = createSpinnerHandle(
+		{
+			...options,
+			message: format(message),
+		},
+		sink,
+	);
 
 	return {
 		start: handle.start,
@@ -55,4 +56,12 @@ export function progress(options: ProgressOptions): ProgressHandle {
 			handle.stop(outcome, format(finalMessage ?? message));
 		},
 	};
+}
+
+/**
+ * Create a determinate progress indicator rendered as
+ * `⠋ <message> (<current>/<total>)` on the spinner line.
+ */
+export function progress(options: ProgressOptions): ProgressHandle {
+	return createProgressHandle(options);
 }

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { type SpinnerController, spinner } from "./spinner.ts";
+import {
+	type SpinnerController,
+	type SpinnerSink,
+	createSpinnerHandle,
+	spinner,
+} from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
-const originalProcessOnce = process.once.bind(process);
-const originalProcessRemoveListener = process.removeListener.bind(process);
-const originalProcessExit = process.exit;
 
 let stderrOutput: string;
 
@@ -34,14 +36,88 @@ function restoreMocks(): void {
 		writable: true,
 		configurable: true,
 	});
-	process.once = originalProcessOnce;
-	process.removeListener = originalProcessRemoveListener;
-	process.exit = originalProcessExit;
 }
 
 function tick(ms = 10): Promise<void> {
 	return new Promise((r) => setTimeout(r, ms));
 }
+
+function createFakeSink(isTTY: boolean) {
+	const writes: string[] = [];
+	const exits: number[] = [];
+	const sink: SpinnerSink = {
+		isTTY,
+		write(text) {
+			writes.push(text);
+		},
+		exit(code): never {
+			exits.push(code);
+			throw new Error(`exit:${code}`);
+		},
+	};
+	return { sink, writes, exits };
+}
+
+describe("createSpinnerHandle — terminal sink", () => {
+	it("hides and restores the cursor in TTY mode", () => {
+		const { sink, writes } = createFakeSink(true);
+		const handle = createSpinnerHandle({ message: "Working" }, sink);
+
+		handle.start();
+		handle.stop();
+
+		expect(writes[0]).toBe("\x1B[?25l");
+		expect(writes).toContain("\x1B[?25h");
+	});
+
+	it("restores the cursor and exits with 130 on SIGINT", () => {
+		const { sink, writes, exits } = createFakeSink(true);
+		const previousHandlers = new Set(process.listeners("SIGINT"));
+		const handle = createSpinnerHandle({ message: "Working" }, sink);
+		handle.start();
+		const handler = process.listeners("SIGINT").find((listener) => !previousHandlers.has(listener));
+
+		expect(handler).toBeDefined();
+		expect(() => handler?.("SIGINT")).toThrow("exit:130");
+		expect(writes.at(-1)).toBe("\x1B[?25h");
+		expect(exits).toEqual([130]);
+		expect(process.listeners("SIGINT")).not.toContain(handler);
+	});
+
+	it("writes only the final line in non-TTY mode", () => {
+		const { sink, writes } = createFakeSink(false);
+		const handle = createSpinnerHandle({ message: "Working" }, sink);
+
+		handle.start();
+		handle.stop();
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toContain("✓ Working\n");
+		expect(writes[0]).not.toContain("\x1B[");
+	});
+
+	it("finalizes once", () => {
+		const { sink, writes } = createFakeSink(false);
+		const handle = createSpinnerHandle({ message: "Working" }, sink);
+
+		handle.start();
+		handle.stop("success");
+		const finalOutput = [...writes];
+		handle.stop("error");
+
+		expect(writes).toEqual(finalOutput);
+	});
+
+	it("leaves SIGINT to the application when disabled", () => {
+		const { sink } = createFakeSink(true);
+		const previousHandlers = process.listeners("SIGINT");
+		const handle = createSpinnerHandle({ message: "Working", sigint: false }, sink);
+
+		handle.start();
+		expect(process.listeners("SIGINT")).toEqual(previousHandlers);
+		handle.stop();
+	});
+});
 
 describe("spinner — task result", () => {
 	beforeEach(setupMocks);
@@ -426,50 +502,6 @@ describe("spinner — cleanup", () => {
 		const beforeCursor = stderrOutput.slice(0, lastCursorShow);
 		expect(beforeCursor.endsWith("\n")).toBe(true);
 	});
-
-	it("restores cursor on SIGINT", async () => {
-		let registeredSigint: (() => void) | undefined;
-		let removedSigint: (() => void) | undefined;
-
-		process.once = ((event: string | symbol, listener: (...args: [] | [unknown]) => void) => {
-			if (event === "SIGINT") {
-				registeredSigint = listener;
-			}
-			return process;
-		}) as typeof process.once;
-
-		process.removeListener = ((
-			event: string | symbol,
-			listener: (...args: [] | [unknown]) => void,
-		) => {
-			if (event === "SIGINT") {
-				removedSigint = listener;
-			}
-			return process;
-		}) as typeof process.removeListener;
-
-		process.exit = (code?: number) => {
-			throw new Error(`exit:${code}`);
-		};
-
-		try {
-			await spinner({
-				message: "Interrupting...",
-				task: async () => {
-					registeredSigint?.();
-					await tick(50);
-					return "ok";
-				},
-			});
-			expect.unreachable();
-		} catch (error) {
-			expect((error as Error).message).toBe("exit:130");
-		}
-
-		expect(registeredSigint).toBeDefined();
-		expect(removedSigint).toBe(registeredSigint);
-		expect(stderrOutput).toContain("\x1B[?25h");
-	});
 });
 
 describe("spinner — non-interactive", () => {
@@ -674,40 +706,5 @@ describe("spinner — imperative handle", () => {
 		handle.stop("error", "again");
 
 		expect(stderrOutput).not.toContain("✗");
-	});
-
-	it("sigint: false installs no SIGINT handler", async () => {
-		let registered = false;
-		process.once = ((event: string | symbol, _listener: unknown) => {
-			if (event === "SIGINT") registered = true;
-			return process;
-		}) as typeof process.once;
-
-		const handle = spinner({ message: "No sigint", sigint: false });
-		handle.start();
-		handle.stop();
-
-		expect(registered).toBe(false);
-	});
-});
-
-describe("spinner — sigint option", () => {
-	beforeEach(setupMocks);
-	afterEach(restoreMocks);
-
-	it("sigint: false leaves SIGINT to the application", async () => {
-		let registered = false;
-		process.once = ((event: string | symbol, _listener: unknown) => {
-			if (event === "SIGINT") registered = true;
-			return process;
-		}) as typeof process.once;
-
-		await spinner({
-			message: "App-owned SIGINT",
-			sigint: false,
-			task: async () => "ok",
-		});
-
-		expect(registered).toBe(false);
 	});
 });

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -128,10 +128,32 @@ function renderFinal(
 	return erase ? ERASE_LINE + CURSOR_TO_START + line : line;
 }
 
+/** Terminal operations used by the internal spinner lifecycle. */
+export interface SpinnerSink {
+	readonly isTTY: boolean;
+	write: (text: string) => void;
+	exit: (code: number) => never;
+}
+
+const processSpinnerSink: SpinnerSink = {
+	get isTTY() {
+		return process.stderr.isTTY ?? false;
+	},
+	write(text) {
+		process.stderr.write(text);
+	},
+	exit(code): never {
+		process.exit(code);
+	},
+};
+
 /** Internal handle constructor shared by both `spinner()` modes and `progress()`. */
-export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandle {
+export function createSpinnerHandle(
+	options: SpinnerHandleOptions,
+	sink: SpinnerSink = processSpinnerSink,
+): SpinnerHandle {
 	const theme = resolveTheme(options.theme);
-	const isInteractive = process.stderr.isTTY;
+	const isInteractive = sink.isTTY;
 	const { frames, interval } = resolveSpinner(options.spinner);
 	const sigint = options.sigint ?? "exit";
 
@@ -159,19 +181,19 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 			started = true;
 			if (!isInteractive) return;
 
-			process.stderr.write(HIDE_CURSOR);
-			process.stderr.write(renderFrame(frames[0] as string, currentMessage, theme));
+			sink.write(HIDE_CURSOR);
+			sink.write(renderFrame(frames[0] as string, currentMessage, theme));
 
 			timerId = setInterval(() => {
 				frameIndex = (frameIndex + 1) % frames.length;
-				process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
+				sink.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
 			}, interval);
 
 			if (sigint === "exit") {
 				sigintHandler = () => {
 					cleanup();
-					process.stderr.write(SHOW_CURSOR);
-					process.exit(130);
+					sink.write(SHOW_CURSOR);
+					sink.exit(130);
 				};
 				process.once("SIGINT", sigintHandler);
 			}
@@ -181,7 +203,7 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 			if (finished) return;
 			currentMessage = message;
 			if (started && isInteractive) {
-				process.stderr.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
+				sink.write(renderFrame(frames[frameIndex] as string, currentMessage, theme));
 			}
 		},
 
@@ -190,9 +212,9 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 			finished = true;
 			if (message !== undefined) currentMessage = message;
 			cleanup();
-			process.stderr.write(renderFinal(currentMessage, theme, outcome, isInteractive));
+			sink.write(renderFinal(currentMessage, theme, outcome, isInteractive));
 			if (isInteractive) {
-				process.stderr.write(SHOW_CURSOR);
+				sink.write(SHOW_CURSOR);
 			}
 		},
 	};


### PR DESCRIPTION
## Summary

- route spinner TTY detection, writes, and exit behavior through an internal injectable `SpinnerSink`
- keep the public `spinner()` and `progress()` interfaces unchanged
- thread the sink through the internal determinate progress constructor
- cover SIGINT exit policy, cursor lifecycle, non-TTY output, idempotent finalization, and progress delegation with fake sinks
- replace SIGINT global monkey-patching in tests with direct internal-seam coverage

## Verification

- `bun install --frozen-lockfile` — passed
- `bun run --cwd packages/progress check:types` — passed
- `bun run --cwd packages/progress test` — passed (58 tests)
- `bun run --cwd packages/progress build` — passed
- `bun run build` — passed (13 tasks)
- `bun run check:types` — passed (21 tasks)
- `bun run test` — passed (21 tasks)
- `bun run lint` — passed (existing warnings only)
- `bunx oxfmt --check packages/progress/src/spinner.ts packages/progress/src/spinner.test.ts packages/progress/src/progress.ts packages/progress/src/progress.test.ts` — passed
- `bun run format` — repository-wide check remains red on unchanged `scripts/package-size-report.mjs`; no changed progress file is affected
- `bunx changeset status` — changeset accepted
- `git diff --check` — passed

## Public surface

`packages/progress/src/index.ts` is unchanged. The built public declarations contain no `SpinnerSink`, `createSpinnerHandle`, or `createProgressHandle` exports.
