### PR TITLE
refactor(core): centralize flag spelling policy

### DIFF
--- a/.changeset/real-windows-hear.md
+++ b/.changeset/real-windows-hear.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Refactor flag parsing and command routing to share one canonical flag-spelling table.

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -1,5 +1,5 @@
 import { CrustError } from "../errors.ts";
-import type { FlagDef, FlagsDef } from "../types.ts";
+import { flagSpellings, type FlagSpelling } from "../parsing/spellings.ts";
 import type { CommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
 
@@ -49,40 +49,26 @@ function findAliasMatch(
 	return null;
 }
 
-/** Find a flag def by any spelling: canonical name, short, or long alias. */
-function lookupFlag(flags: FlagsDef, spelling: string): FlagDef | undefined {
-	for (const [name, def] of Object.entries(flags)) {
-		if (name === spelling || def.short === spelling || def.aliases?.includes(spelling)) {
-			return def;
-		}
-	}
-	return undefined;
-}
-
 /**
- * Match a dash token against a command's effective flags.
+ * Match a dash token against the parser's shared spelling table.
  *
- * Returns `null` when the token is not a known flag of this command (routing
- * then stops, preserving the pre-existing fallback behavior), otherwise
- * whether the flag consumes the following argv token as its value.
- *
- * Mirrors the parser's accepted spellings: `--name`, `--name=value`,
- * `--no-name` (boolean negation unless `noNegate`), `-s`, inline short
- * values (`-svalue`), and bundled short flags (`-absvalue`).
+ * The token walk stays here because routing stops at unknown flags while
+ * parsing reports them as errors; only spelling and negation policy is shared.
  */
-function matchKnownFlagToken(flags: FlagsDef, token: string): { consumesValue: boolean } | null {
+function matchKnownFlagToken(
+	spellings: ReadonlyMap<string, FlagSpelling>,
+	token: string,
+): { consumesValue: boolean } | null {
 	if (token === "--") return null;
 
 	if (token.startsWith("--")) {
 		const eq = token.indexOf("=");
 		const spelling = eq === -1 ? token.slice(2) : token.slice(2, eq);
-		const def = lookupFlag(flags, spelling);
-		if (def) return { consumesValue: def.type !== "boolean" && eq === -1 };
+		const entry = spellings.get(spelling);
+		if (entry) return { consumesValue: entry.def.type !== "boolean" && eq === -1 };
 		if (spelling.startsWith("no-")) {
-			const base = lookupFlag(flags, spelling.slice(3));
-			if (base && base.type === "boolean" && !base.noNegate) {
-				return { consumesValue: false };
-			}
+			const base = spellings.get(spelling.slice(3));
+			if (base?.negatable) return { consumesValue: false };
 		}
 		return null;
 	}
@@ -91,9 +77,9 @@ function matchKnownFlagToken(flags: FlagsDef, token: string): { consumesValue: b
 	const chars = token.slice(1);
 	if (chars.length === 0) return null;
 	for (let index = 0; index < chars.length; index++) {
-		const def = lookupFlag(flags, chars[index]!);
-		if (!def) return null;
-		if (def.type !== "boolean") {
+		const entry = spellings.get(chars[index]!);
+		if (!entry) return null;
+		if (entry.def.type !== "boolean") {
 			return { consumesValue: index === chars.length - 1 };
 		}
 	}
@@ -154,7 +140,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 		// `app --quiet translate` must run `translate`, not silently resolve the
 		// root. Unknown flags and `--` stop routing (parser reports them).
 		if (candidate.startsWith("-")) {
-			const match = matchKnownFlagToken(current.effectiveFlags, candidate);
+			const match = matchKnownFlagToken(flagSpellings(current.effectiveFlags), candidate);
 			if (!match) break;
 			skippedFlagTokens.push(candidate);
 			routedArgv = routedArgv.slice(1);

--- a/packages/core/src/parsing/flag-validation.ts
+++ b/packages/core/src/parsing/flag-validation.ts
@@ -1,9 +1,6 @@
 import { CrustError } from "../errors.ts";
 import type { FlagDef, FlagsDef } from "../types.ts";
-
-function flagSpellings(name: string, def: FlagDef): string[] {
-	return [name, ...(def.short ? [def.short] : []), ...(def.aliases ?? [])];
-}
+import { flagDefinitionSpellings } from "./spellings.ts";
 
 /** Validate one flag against the complete canonical/short/alias namespace. */
 export function validateIncomingFlag(
@@ -11,7 +8,7 @@ export function validateIncomingFlag(
 	existing: FlagsDef,
 	ownerLabel: string,
 ): void {
-	const incomingSpellings = flagSpellings(incoming.name, incoming.def);
+	const incomingSpellings = flagDefinitionSpellings(incoming.name, incoming.def);
 	const duplicate = incomingSpellings.find(
 		(spelling, index) => incomingSpellings.indexOf(spelling) !== index,
 	);
@@ -24,7 +21,7 @@ export function validateIncomingFlag(
 	}
 
 	for (const [existingName, existingDef] of Object.entries(existing)) {
-		const existingSpellings = new Set(flagSpellings(existingName, existingDef));
+		const existingSpellings = new Set(flagDefinitionSpellings(existingName, existingDef));
 		const collision = incomingSpellings.find((spelling) => existingSpellings.has(spelling));
 		if (collision !== undefined) {
 			throw new CrustError(

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -6,6 +6,7 @@ import type { CommandNode } from "../command/node.ts";
 import { CrustError } from "../errors.ts";
 import type { ArgDef, ArgsDef, FlagDef, FlagsDef, ParseResult, ValueType } from "../types.ts";
 import { coerceJson, coercePath, coerceUrl } from "./coercers.ts";
+import { flagSpellings, type FlagSpelling } from "./spellings.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Internal types
@@ -26,115 +27,31 @@ type ParseArgsToken = NonNullable<ReturnType<typeof nodeParseArgs>["tokens"]>[nu
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Build the options config for `util.parseArgs` from Crust's flag definitions.
+ * Build the options config for `util.parseArgs` from the shared spelling table.
  * Also returns a reverse alias→name mapping for resolving parsed results.
  */
-function buildParseArgsOptionDescriptor(flagsDef: FlagsDef | undefined) {
+function buildParseArgsOptionDescriptor(spellings: ReadonlyMap<string, FlagSpelling>) {
 	const options: Record<string, ParseArgsOptionDescriptor> = {};
 	const aliasToName: Record<string, string> = {};
 
-	if (!flagsDef) return { options, aliasToName };
+	for (const [spelling, entry] of spellings) {
+		const descriptor: ParseArgsOptionDescriptor = {
+			type: entry.def.type === "boolean" ? "boolean" : "string",
+		};
+		if (entry.def.multiple) descriptor.multiple = true;
 
-	// Runtime alias collision check — mirrors the compile-time
-	// ValidateFlagAliases<F> type (which catches both alias→flag-name
-	// and alias→alias collisions). Kept as defense-in-depth against type
-	// erasure (dynamic construction, `as any` casts, widened generics).
-	const aliasRegistry = new Map<string, string>();
-	for (const name of Object.keys(flagsDef)) {
-		aliasRegistry.set(name, name);
-	}
-
-	for (const [name, def] of Object.entries(flagsDef)) {
-		// Defense-in-depth: reject "no-" prefixed names even when bypassing the builder
-		if (name.startsWith("no-")) {
-			const base = name.slice(3);
-			throw new CrustError(
-				"DEFINITION",
-				`Flag "--${name}" must not use "no-" prefix; define "${base}" and negate with "--no-${base}"`,
-			);
+		if (entry.kind === "canonical") {
+			if (entry.def.short) descriptor.short = entry.def.short;
+			options[spelling] = descriptor;
+			continue;
 		}
 
-		if (!ALLOWED_FLAG_TYPES.has(def.type)) {
-			throw new CrustError(
-				"DEFINITION",
-				`Flag "--${name}" must declare a parser type ("string", "number", "boolean", "url", "path", or "json")`,
-			);
-		}
-
-		// All non-boolean types consume the next token as a raw string; the
-		// Crust-level coercion (url/path/json/number) runs in coerceValue.
-		const parseType = def.type === "boolean" ? "boolean" : "string";
-		const opt: ParseArgsOptionDescriptor = { type: parseType };
-
-		if (def.multiple) {
-			opt.multiple = true;
-		}
-
-		// Handle short alias
-		if (def.short) {
-			// Defense-in-depth: reject "no-" prefixed short alias
-			if (def.short.startsWith("no-")) {
-				throw new CrustError(
-					"DEFINITION",
-					`Short alias "-${def.short}" on "--${name}" must not use "no-" prefix (reserved for negation)`,
-				);
-			}
-
-			const existing = aliasRegistry.get(def.short);
-			if (existing) {
-				throw new CrustError(
-					"DEFINITION",
-					`Alias collision: "-${def.short}" is used by both "--${existing}" and "--${name}"`,
-				);
-			}
-			aliasRegistry.set(def.short, name);
-			aliasToName[def.short] = name;
-			opt.short = def.short;
-		}
-
-		// Handle long aliases
-		if (def.aliases) {
-			for (const alias of def.aliases) {
-				// Defense-in-depth: reject "no-" prefixed aliases
-				if (alias.startsWith("no-")) {
-					throw new CrustError(
-						"DEFINITION",
-						`Alias "--${alias}" on "--${name}" must not use "no-" prefix (reserved for negation)`,
-					);
-				}
-
-				const existing = aliasRegistry.get(alias);
-				if (existing) {
-					throw new CrustError(
-						"DEFINITION",
-						`Alias collision: "${alias.length === 1 ? "-" : "--"}${alias}" is used by both "--${existing}" and "--${name}"`,
-					);
-				}
-				aliasRegistry.set(alias, name);
-				aliasToName[alias] = name;
-
-				const aliasOpt: ParseArgsOptionDescriptor = { type: parseType };
-				if (def.multiple) {
-					aliasOpt.multiple = true;
-				}
-				options[alias] = aliasOpt;
-			}
-		}
-
-		options[name] = opt;
+		aliasToName[spelling] = entry.canonicalName;
+		if (entry.kind === "alias") options[spelling] = descriptor;
 	}
 
 	return { options, aliasToName };
 }
-
-const ALLOWED_FLAG_TYPES: ReadonlySet<ValueType> = new Set([
-	"string",
-	"number",
-	"boolean",
-	"url",
-	"path",
-	"json",
-]);
 
 /**
  * Coerce a string value to the expected type based on the type literal.
@@ -466,13 +383,7 @@ function resolveArgs(argsDef: ArgsDef | undefined, positionals: string[]): Recor
  * opted out via `noNegate` rejects every negated spelling. Without this
  * pre-scan, `util.parseArgs` (`allowNegative`) would silently accept it.
  */
-function validateNoNegateUsage(
-	argv: string[],
-	flagsDef: FlagsDef | undefined,
-	aliasToName: Record<string, string>,
-): void {
-	if (!flagsDef) return;
-
+function validateNoNegateUsage(argv: string[], spellings: ReadonlyMap<string, FlagSpelling>): void {
 	for (const arg of argv) {
 		if (arg === "--") return;
 		if (!arg.startsWith("--no-")) continue;
@@ -482,18 +393,12 @@ function validateNoNegateUsage(
 			assignmentIndex === -1
 				? arg.slice("--no-".length)
 				: arg.slice("--no-".length, assignmentIndex);
-
-		if (!rawName) continue;
-
-		const canonical = aliasToName[rawName] ?? (rawName in flagsDef ? rawName : undefined);
-		if (!canonical) continue;
-
-		const def = flagsDef[canonical];
-		if (def?.type !== "boolean" || def.noNegate !== true) continue;
+		const spelling = spellings.get(rawName);
+		if (!spelling || spelling.def.type !== "boolean" || spelling.negatable) continue;
 
 		throw new CrustError(
 			"PARSE",
-			`Flag "--${canonical}" does not support negation ("--no-${rawName}")`,
+			`Flag "--${spelling.canonicalName}" does not support negation ("--no-${rawName}")`,
 		);
 	}
 }
@@ -529,9 +434,10 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 	// never sees a Promise where a value was expected.
 	validateAsyncParse(flagsDef, argsDef);
 
-	const { options: parseOptions, aliasToName } = buildParseArgsOptionDescriptor(flagsDef);
+	const spellings = flagSpellings(flagsDef);
+	const { options: parseOptions, aliasToName } = buildParseArgsOptionDescriptor(spellings);
 
-	validateNoNegateUsage(argv, flagsDef, aliasToName);
+	validateNoNegateUsage(argv, spellings);
 
 	let parsed: ReturnType<typeof nodeParseArgs>;
 

--- a/packages/core/src/parsing/spellings.test.ts
+++ b/packages/core/src/parsing/spellings.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { createCommandNode } from "../command/node.ts";
+import { resolveCommand } from "../command/router.ts";
+import type { FlagsDef } from "../types.ts";
+import { parseArgs } from "./parser.ts";
+import { flagSpellings } from "./spellings.ts";
+
+const flags = {
+	quiet: { type: "boolean", short: "q", aliases: ["silent"] },
+	config: { type: "string", short: "c", aliases: ["config-file"] },
+	verbose: { type: "boolean", aliases: ["chatty"], noNegate: true },
+} satisfies FlagsDef;
+
+describe("flagSpellings", () => {
+	it.each([
+		["quiet", "quiet", "canonical"],
+		["q", "quiet", "short"],
+		["silent", "quiet", "alias"],
+		["config-file", "config", "alias"],
+	] as const)("maps %s to its canonical flag", (spelling, canonicalName, kind) => {
+		expect(flagSpellings(flags).get(spelling)).toMatchObject({ canonicalName, kind });
+	});
+
+	it("records negation policy for canonical names and aliases", () => {
+		const spellings = flagSpellings(flags);
+		expect(spellings.get("quiet")?.negatable).toBe(true);
+		expect(spellings.get("silent")?.negatable).toBe(true);
+		expect(spellings.get("verbose")?.negatable).toBe(false);
+		expect(spellings.get("chatty")?.negatable).toBe(false);
+	});
+
+	it("drives parsing and routing for equals values and short bundles", () => {
+		const root = createCommandNode("app");
+		root.localFlags = flags;
+		root.effectiveFlags = flags;
+		root.subCommands.run = createCommandNode("run");
+
+		expect(resolveCommand(root, ["--config=app.json", "run"])).toMatchObject({
+			commandPath: ["app", "run"],
+			argv: ["--config=app.json"],
+		});
+		expect(resolveCommand(root, ["-qcapp.json", "run"])).toMatchObject({
+			commandPath: ["app", "run"],
+			argv: ["-qcapp.json"],
+		});
+
+		expect(parseArgs(root, ["--config=app.json"]).flags.config).toBe("app.json");
+		expect(parseArgs(root, ["-qcapp.json"]).flags).toMatchObject({
+			quiet: true,
+			config: "app.json",
+		});
+	});
+
+	it("rejects collisions across canonical, short, and alias spellings", () => {
+		expect(() =>
+			flagSpellings({
+				quiet: { type: "boolean", short: "q" },
+				query: { type: "string", aliases: ["q"] },
+			}),
+		).toThrow('Alias collision: "-q" is used by both "--quiet" and "--query"');
+	});
+});

--- a/packages/core/src/parsing/spellings.ts
+++ b/packages/core/src/parsing/spellings.ts
@@ -26,8 +26,10 @@ export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagS
 	const spellings = new Map<string, FlagSpelling>();
 	if (!flagsDef) return spellings;
 
-	// Reserve canonical names before aliases so collisions report the canonical
-	// owner regardless of definition order.
+	// Collision checks mirror the compile-time `ValidateFlagAliases<F>` type —
+	// defense-in-depth against type erasure (dynamic construction, `as any`
+	// casts, widened generics). Reserve canonical names before aliases so
+	// collisions report the canonical owner regardless of definition order.
 	const owners = new Map<string, string>();
 	for (const name of Object.keys(flagsDef)) owners.set(name, name);
 

--- a/packages/core/src/parsing/spellings.ts
+++ b/packages/core/src/parsing/spellings.ts
@@ -1,0 +1,95 @@
+import { CrustError } from "../errors.ts";
+import type { FlagDef, FlagsDef, ValueType } from "../types.ts";
+
+export interface FlagSpelling {
+	canonicalName: string;
+	def: FlagDef;
+	kind: "canonical" | "short" | "alias";
+	negatable: boolean;
+}
+
+const ALLOWED_FLAG_TYPES: ReadonlySet<ValueType> = new Set([
+	"string",
+	"number",
+	"boolean",
+	"url",
+	"path",
+	"json",
+]);
+
+export function flagDefinitionSpellings(name: string, def: FlagDef): string[] {
+	return [name, ...(def.short ? [def.short] : []), ...(def.aliases ?? [])];
+}
+
+/** Build the canonical flag-spelling table shared by parsing and routing. */
+export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagSpelling> {
+	const spellings = new Map<string, FlagSpelling>();
+	if (!flagsDef) return spellings;
+
+	// Reserve canonical names before aliases so collisions report the canonical
+	// owner regardless of definition order.
+	const owners = new Map<string, string>();
+	for (const name of Object.keys(flagsDef)) owners.set(name, name);
+
+	for (const [canonicalName, def] of Object.entries(flagsDef)) {
+		if (canonicalName.startsWith("no-")) {
+			const base = canonicalName.slice(3);
+			throw new CrustError(
+				"DEFINITION",
+				`Flag "--${canonicalName}" must not use "no-" prefix; define "${base}" and negate with "--no-${base}"`,
+			);
+		}
+
+		if (!ALLOWED_FLAG_TYPES.has(def.type)) {
+			throw new CrustError(
+				"DEFINITION",
+				`Flag "--${canonicalName}" must declare a parser type ("string", "number", "boolean", "url", "path", or "json")`,
+			);
+		}
+
+		const entry = {
+			canonicalName,
+			def,
+			negatable: def.type === "boolean" && def.noNegate !== true,
+		} as const;
+		spellings.set(canonicalName, { ...entry, kind: "canonical" });
+
+		if (def.short) {
+			if (def.short.startsWith("no-")) {
+				throw new CrustError(
+					"DEFINITION",
+					`Short alias "-${def.short}" on "--${canonicalName}" must not use "no-" prefix (reserved for negation)`,
+				);
+			}
+			const existing = owners.get(def.short);
+			if (existing) {
+				throw new CrustError(
+					"DEFINITION",
+					`Alias collision: "-${def.short}" is used by both "--${existing}" and "--${canonicalName}"`,
+				);
+			}
+			owners.set(def.short, canonicalName);
+			spellings.set(def.short, { ...entry, kind: "short" });
+		}
+
+		for (const alias of def.aliases ?? []) {
+			if (alias.startsWith("no-")) {
+				throw new CrustError(
+					"DEFINITION",
+					`Alias "--${alias}" on "--${canonicalName}" must not use "no-" prefix (reserved for negation)`,
+				);
+			}
+			const existing = owners.get(alias);
+			if (existing) {
+				throw new CrustError(
+					"DEFINITION",
+					`Alias collision: "${alias.length === 1 ? "-" : "--"}${alias}" is used by both "--${existing}" and "--${canonicalName}"`,
+				);
+			}
+			owners.set(alias, canonicalName);
+			spellings.set(alias, { ...entry, kind: "alias" });
+		}
+	}
+
+	return spellings;
+}

--- a/packages/core/src/parsing/validation.ts
+++ b/packages/core/src/parsing/validation.ts
@@ -55,7 +55,7 @@ function validateAliasString(alias: unknown, canonicalName: string, subjectLabel
  * Validate that adding `incoming` (its canonical name and aliases) to a
  * sibling map containing `existing` introduces no name/alias collisions.
  *
- * Checks performed (mirroring `parser.ts` flag-alias collision detection):
+ * Checks performed (mirroring `spellings.ts` flag-alias collision detection):
  *  1. Each alias in `incoming.aliases` is shape-valid.
  *  2. No duplicate aliases within `incoming.aliases` itself.
  *  3. `incoming.canonicalName` is not already a sibling's alias


### PR DESCRIPTION
## Summary
- add one internal flag-spelling table for canonical names, short names, aliases, negation policy, collision checks, and reserved `no-` validation
- keep Node's `util.parseArgs` as the parser while deriving its descriptors and alias map from the shared table
- make command routing consult the same table while retaining its distinct stop-on-unknown token walk
- reuse the shared spelling enumeration in registration-time collision validation

## Tests
- add table-driven coverage for canonical/short/alias entries, negation and `noNegate`, equals values, short bundles, and collisions
- all 543 pre-existing core tests pass unedited; 7 new tests bring the suite to 550

## Verification
- `bun run build` — passed (13 tasks)
- `bun run check:types -- --filter=@crustjs/core` — passed
- `bun run test -- --filter=@crustjs/core` — passed (550 tests)
- `bun run lint` — passed with 10 pre-existing warnings
- targeted `bunx oxfmt --check` for all changed files — passed
- `bun run format` — repository-wide check remains red on pre-existing `scripts/package-size-report.mjs`; changed files pass the targeted format gate
- `bunx changeset status --since=chore/remove-dangling-adr-refs` — passed; fixed release group recorded at patch

## Stack
Depends on #156.
