### PR TITLE
ci: measure per-entry bundle cost and install size instead of dist gzip

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -72,7 +72,7 @@ jobs:
           marker='<!-- package-size-report -->'
           {
             echo "$marker"
-            echo '## 📦 Package size (runtime JS, gzip)'
+            echo '## 📦 Package size'
             echo
             bun scripts/package-size-report.mjs compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json"
           } > "$RUNNER_TEMP/comment.md"

--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -105,7 +105,7 @@ if (mode === "sizes") {
 		const b = base[name];
 		const h = head[name];
 		install.push(
-			`| \`${name}\` | ${fmt(h?.tarball ?? b?.tarball)} | ${fmt(h?.unpacked ?? b?.unpacked)} | ${delta(b?.unpacked, h?.unpacked)} |`,
+			`| \`${name}\` | ${fmt(h?.tarball)} | ${fmt(h?.unpacked)} | ${delta(b?.unpacked, h?.unpacked)} |`,
 		);
 	}
 	console.log([...bundle, ...install].join("\n"));

--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -1,64 +1,114 @@
-// Report gzipped runtime JS sizes (dist/**/*.js) for publishable library
-// packages — CLI packages (with a bin field) are excluded since their size
-// is install cost, not runtime code shipped to consumers.
+// Measure what consumers actually pay for publishable library packages:
+//   - bundle: each public `exports` entrypoint bundled with Bun.build
+//     (tree-shaken, minified) and gzipped — the cost of importing that entry.
+//   - install: tarball and unpacked size from `npm pack --dry-run`.
+// CLI packages (with a bin field) are excluded since their size is install
+// cost, not runtime code shipped to consumers.
 // Usage:
 //   bun scripts/package-size-report.mjs sizes [rootDir] > sizes.json
-//   bun scripts/package-size-report.mjs compare base.json head.json > table.md
+//   bun scripts/package-size-report.mjs compare base.json head.json > tables.md
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 
 const [mode, ...args] = process.argv.slice(2);
 
-if (mode === "sizes") {
-	const root = args[0] ?? ".";
+async function measure(root) {
 	const out = {};
 	for (const dir of readdirSync(join(root, "packages"))) {
+		const pkgDir = join(root, "packages", dir);
 		let pkg;
 		try {
-			pkg = JSON.parse(
-				readFileSync(join(root, "packages", dir, "package.json"), "utf8"),
-			);
+			pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 		} catch {
 			// not a package dir (no package.json)
 			continue;
 		}
 		if (pkg.private || pkg.bin) continue;
-		const dist = join(root, "packages", dir, "dist");
-		let size = 0;
-		for (const file of readdirSync(dist, { recursive: true })) {
-			if (!/\.(js|mjs|cjs)$/.test(file)) continue;
-			size += gzipSync(readFileSync(join(dist, file))).length;
+
+		const entries = {};
+		for (const [entry, target] of Object.entries(pkg.exports ?? {})) {
+			const file = typeof target === "string" ? target : target.import;
+			if (!file || !/\.(js|mjs|cjs)$/.test(file)) continue;
+			const result = await Bun.build({
+				entrypoints: [resolve(pkgDir, file)],
+				target: "bun",
+				minify: true,
+			});
+			if (!result.success) {
+				throw new AggregateError(result.logs, `Bun.build failed for ${pkg.name}${entry.slice(1)}`);
+			}
+			let size = 0;
+			for (const artifact of result.outputs) {
+				size += gzipSync(Buffer.from(await artifact.arrayBuffer())).length;
+			}
+			entries[entry] = size;
 		}
-		out[pkg.name] = { size };
+
+		const [packed] = JSON.parse(
+			execFileSync("npm", ["pack", "--dry-run", "--json"], {
+				cwd: pkgDir,
+				stdio: ["ignore", "pipe", "ignore"],
+			}),
+		);
+		out[pkg.name] = {
+			entries,
+			tarball: packed.size,
+			unpacked: packed.unpackedSize,
+		};
 	}
-	console.log(JSON.stringify(out, null, 2));
+	return out;
+}
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(2)} KB`;
+const fmt = (bytes) => (bytes == null ? "—" : kb(bytes));
+const delta = (b, h) => {
+	if (b == null) return "new";
+	if (h == null) return "removed";
+	if (h === b) return "±0";
+	const d = h - b;
+	return `${d > 0 ? "+" : "-"}${kb(Math.abs(d))} (${d > 0 ? "+" : ""}${((d / b) * 100).toFixed(1)}%)`;
+};
+
+if (mode === "sizes") {
+	console.log(JSON.stringify(await measure(args[0] ?? "."), null, 2));
 } else if (mode === "compare") {
 	const [base, head] = args.map((f) => JSON.parse(readFileSync(f, "utf8")));
-	const kb = (bytes) => `${(bytes / 1024).toFixed(2)} KB`;
-	const names = [
-		...new Set([...Object.keys(base), ...Object.keys(head)]),
-	].sort();
-	const lines = [
-		"| Package | Base | Head | Δ (JS, gzip) |",
+	const names = [...new Set([...Object.keys(base), ...Object.keys(head)])].sort();
+
+	const bundle = [
+		"### Bundle cost (per entrypoint, minified + gzip)",
+		"",
+		"| Entry | Base | Head | Δ |",
+		"|---|---:|---:|---:|",
+	];
+	const install = [
+		"",
+		"### Install size (`npm pack`)",
+		"",
+		"| Package | Tarball | Unpacked | Δ unpacked |",
 		"|---|---:|---:|---:|",
 	];
 	for (const name of names) {
-		const b = base[name]?.size;
-		const h = head[name]?.size;
-		let delta;
-		if (b == null) delta = "new";
-		else if (h == null) delta = "removed";
-		else if (h === b) delta = "±0";
-		else {
-			const d = h - b;
-			delta = `${d > 0 ? "+" : "-"}${kb(Math.abs(d))} (${d > 0 ? "+" : ""}${((d / b) * 100).toFixed(1)}%)`;
+		const entryNames = [
+			...new Set([
+				...Object.keys(base[name]?.entries ?? {}),
+				...Object.keys(head[name]?.entries ?? {}),
+			]),
+		].sort();
+		for (const entry of entryNames) {
+			const b = base[name]?.entries?.[entry];
+			const h = head[name]?.entries?.[entry];
+			bundle.push(`| \`${name}${entry.slice(1)}\` | ${fmt(b)} | ${fmt(h)} | ${delta(b, h)} |`);
 		}
-		lines.push(
-			`| \`${name}\` | ${b == null ? "—" : kb(b)} | ${h == null ? "—" : kb(h)} | ${delta} |`,
+		const b = base[name];
+		const h = head[name];
+		install.push(
+			`| \`${name}\` | ${fmt(h?.tarball ?? b?.tarball)} | ${fmt(h?.unpacked ?? b?.unpacked)} | ${delta(b?.unpacked, h?.unpacked)} |`,
 		);
 	}
-	console.log(lines.join("\n"));
+	console.log([...bundle, ...install].join("\n"));
 } else {
 	console.error("usage: package-size-report.mjs sizes [rootDir] | compare <base.json> <head.json>");
 	process.exit(1);


### PR DESCRIPTION
## Why

The package-size CI summed gzipped `dist/*.js` per package — a weak proxy that misses tree-shaking, minification, and dependencies pulled into consumer bundles. A PR could keep dist flat while making every consumer bundle heavier (or vice versa).

## What

Rewrites `scripts/package-size-report.mjs` to report two consumer-facing metrics (same approach as [Effect's bundle-size CI](https://github.com/Effect-TS/effect/blob/main/.github/workflows/bundle-comment.yml), minus per-API usage fixtures):

- **Bundle cost** — each public `exports` entrypoint bundled with `Bun.build` (tree-shaken, minified, node/bun builtins external), then gzipped. Catches broken tree-shaking and accidental dependency bloat.
- **Install size** — tarball + unpacked bytes from `npm pack --dry-run --json`. Catches publishing junk into the tarball.

The sticky PR comment now shows a per-entrypoint bundle table and a per-package install-size table. Workflow logic is unchanged apart from the comment heading; `bin` and private packages remain excluded.

## Sample output

```
### Bundle cost (per entrypoint, minified + gzip)
| Entry | Base | Head | Δ |
| @crustjs/core          | 8.79 KB | 7.80 KB | -0.99 KB (-11.2%) |
| @crustjs/core/tooling  | 7.53 KB | 7.53 KB | ±0 |
...
### Install size (npm pack)
| Package | Tarball | Unpacked | Δ unpacked |
| @crustjs/core | 52.17 KB | 210.60 KB | +15.29 KB (+7.8%) |
```

## Verification

- `bun scripts/package-size-report.mjs sizes` run locally against built packages — all 10 publishable packages measured
- `compare` tested with synthetic base including changed, new, and removed entries/packages
- `bun lint` / `bun format` clean

Follow-up (when needed): usage fixtures à la Effect for per-API tree-shaking granularity.