### PR TITLE
fix(ci): externalize peer dependencies in bundle-cost measurement

### DIFF
--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -7,6 +7,8 @@
 // Usage:
 //   bun scripts/package-size-report.mjs sizes [rootDir] > sizes.json
 //   bun scripts/package-size-report.mjs compare base.json head.json > tables.md
+// Local runs: rm -rf packages/*/dist first — turbo cache restore doesn't prune
+// stray dist files from other branches, which inflates install sizes.
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -49,6 +51,10 @@ async function measure(root) {
 			entries[entry] = size;
 		}
 
+		// TODO: switch to `bun pm pack` (the tool we publish with) once it has
+		// machine-readable output — https://github.com/oven-sh/bun/issues/14155.
+		// npm is safe meanwhile: file selection and unpacked bytes match bun's
+		// exactly; only tarball gzip bytes differ slightly.
 		const [packed] = JSON.parse(
 			execFileSync("npm", ["pack", "--dry-run", "--json"], {
 				cwd: pkgDir,

--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -35,6 +35,9 @@ async function measure(root) {
 				entrypoints: [resolve(pkgDir, file)],
 				target: "bun",
 				minify: true,
+				// Peers are provided by the consumer and measured in their own row;
+				// inlining them would double-count and make this row churn on their PRs.
+				external: Object.keys(pkg.peerDependencies ?? {}),
 			});
 			if (!result.success) {
 				throw new AggregateError(result.logs, `Bun.build failed for ${pkg.name}${entry.slice(1)}`);
@@ -68,7 +71,10 @@ const delta = (b, h) => {
 	if (h == null) return "removed";
 	if (h === b) return "±0";
 	const d = h - b;
-	return `${d > 0 ? "+" : "-"}${kb(Math.abs(d))} (${d > 0 ? "+" : ""}${((d / b) * 100).toFixed(1)}%)`;
+	// sub-0.01 KB deltas render in bytes instead of a misleading "+0.00 KB"
+	const abs = Math.abs(d);
+	const size = abs < 5.12 ? `${abs} B` : kb(abs);
+	return `${d > 0 ? "+" : "-"}${size} (${d > 0 ? "+" : ""}${((d / b) * 100).toFixed(1)}%)`;
 };
 
 if (mode === "sizes") {


### PR DESCRIPTION
## Why

Verifying the new package-size CI against real PR runs (#158/#159) showed the bundle-cost numbers for packages with peer dependencies were wrong:

- `Bun.build` resolved `peerDependencies` (e.g. `@crustjs/core` in `man`/`extensions`/`skills`/`testing`) through the workspace and **inlined** them. `@crustjs/man`'s 8.72 KB was ~83% core code.
- This double-counts peers (they're already measured in their own row) and makes untouched packages churn on every core PR — the `+0.03 KB` noise rows on `man`/`extensions`/`skills` in #158/#159.

Regular `dependencies` stay inlined: consumers pay for those.

## What

- Pass `external: Object.keys(pkg.peerDependencies ?? {})` to `Bun.build`.
- Render sub-0.01 KB deltas in bytes (`+3 B (+0.0%)`) instead of a misleading `+0.00 KB (+0.0%)`.

## Effect on current numbers (base = main)

| Entry | Before | After |
|---|---:|---:|
| `@crustjs/man` | 8.72 KB | 1.48 KB (-83%) |
| `@crustjs/testing` | 4.42 KB | 0.69 KB (-84%) |
| `@crustjs/extensions` | 12.17 KB | 11.79 KB |
| `@crustjs/skills` | 17.31 KB | 16.97 KB |

All other rows unchanged.

## Verification

- Clean rebuild on main reproduces CI-posted numbers exactly (bundle sizes and `npm pack` unpacked byte-identical; tarball ±0.1 KB from npm gzip version differences, irrelevant to in-CI deltas)
- `dist` output confirmed to externalize `@crustjs/*` imports (bunup), so inlining happened only in the measurement step
- `bun lint` / `bun format` clean