### PR TITLE
feat(core)!: shared command documentation model behind @crustjs/core/tooling

### DIFF
--- a/.changeset/empty-sails-sneeze.md
+++ b/.changeset/empty-sails-sneeze.md
@@ -1,0 +1,10 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": minor
+"@crustjs/man": minor
+"@crustjs/skills": minor
+---
+
+Add a shared presentation-neutral command documentation model to `@crustjs/core/tooling` and use it for help, mdoc, and Agent Skill rendering.
+
+Help headings now follow conventional title case and list negation for every long alias. Man pages use semantic mdoc flag and argument macros. Generated skills omit hidden commands.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,6 +7,7 @@
 		".changeset/",
 		"**/CHANGELOG.md",
 		".pi/",
+		"**/tests/fixtures/",
 		".worktrees/",
 		"apps/docs/.source/",
 		"apps/docs/src/routeTree.gen.ts"

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -25,5 +25,6 @@ See [Types](/docs/api/types) for command definitions, Command Snapshots, Command
 
 <Callout type="warn">
   `@crustjs/core/tooling` is an unsupported bridge for first-party build, man-page, and skill
-  tooling. It is not part of the supported application-authoring API.
+  tooling. It includes the presentation-neutral `buildCommandDocumentation()` model used by
+  first-party renderers. It is not part of the supported application-authoring API.
 </Callout>

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -129,6 +129,6 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Tooling subpath
 
-`@crustjs/core/tooling` exposes `prepareCommandSnapshot`, `snapshotCommand`, `VALIDATION_MODE_ENV`, and `VALIDATION_FORCE_EXIT_ENV` for lockstep first-party man, skill, and build tooling. This subpath is explicitly unsupported and has no compatibility guarantee. Application code should use the root exports above.
+`@crustjs/core/tooling` exposes `prepareCommandSnapshot`, `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage, visible children, argument tokens, and every accepted flag spelling. This subpath is explicitly unsupported and has no compatibility guarantee. Application code should use the root exports above.
 
 Use [`@crustjs/extensions`](/docs/modules/extensions) for the official Extensions and [`@crustjs/crust`](/docs/modules/crust) as a development dependency for build tooling.

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -129,6 +129,6 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Tooling subpath
 
-`@crustjs/core/tooling` exposes `prepareCommandSnapshot`, `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage, visible children, argument tokens, and every accepted flag spelling. This subpath is explicitly unsupported and has no compatibility guarantee. Application code should use the root exports above.
+`@crustjs/core/tooling` exposes `prepareCommandSnapshot`, `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), visible children, argument tokens, and every accepted flag spelling. This subpath is explicitly unsupported and has no compatibility guarantee. Application code should use the root exports above.
 
 Use [`@crustjs/extensions`](/docs/modules/extensions) for the official Extensions and [`@crustjs/crust`](/docs/modules/crust) as a development dependency for build tooling.

--- a/apps/docs/content/docs/modules/man.mdx
+++ b/apps/docs/content/docs/modules/man.mdx
@@ -62,7 +62,9 @@ const source = renderManPageMdoc({
 });
 ```
 
-The package uses the explicitly unsupported `prepareCommandSnapshot()` bridge from `@crustjs/core/tooling` internally. That bridge is for lockstep first-party tooling, not application code.
+The renderer uses semantic mdoc(7) flag and argument macros. It intentionally summarizes only the root command's immediate visible subcommands; nested commands remain available in the shared full-tree documentation model.
+
+The package uses the explicitly unsupported `prepareCommandSnapshot()` and `buildCommandDocumentation()` bridge from `@crustjs/core/tooling` internally. That bridge is for lockstep first-party tooling, not application code.
 
 ## Package script
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -3,7 +3,7 @@ title: "Skills"
 description: Agent skill generation for AI coding assistants.
 ---
 
-The `@crustjs/skills` package generates and installs agent skills from your CLI's readonly Command Snapshot. Skills provide structured documentation that AI coding assistants use to understand your CLI. Snapshot preparation uses the explicitly unsupported `@crustjs/core/tooling` bridge internally; application code registers only the `skill()` Extension.
+The `@crustjs/skills` package generates and installs agent skills from your CLI's readonly Command Snapshot. Skills provide structured documentation that AI coding assistants use to understand your CLI. Generated skills include the full visible command tree and omit commands marked `meta.hidden`. Snapshot preparation and documentation modeling use the explicitly unsupported `@crustjs/core/tooling` bridge internally; application code registers only the `skill()` Extension.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,3 +11,5 @@ bun add @crustjs/core
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/core](https://crustjs.com/docs/modules/core)
+
+First-party renderers share a presentation-neutral command model through the unsupported `@crustjs/core/tooling` subpath. Application code should use the package root.

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -18,11 +18,18 @@ describe("buildCommandDocumentation", () => {
 		);
 		expect(model.usage).toBe("app <file> [rest...] [options]");
 		expect(model.args.map((arg) => arg.token)).toEqual(["<file>", "[rest...]"]);
+		expect(model.usageSegments).toEqual([
+			{ kind: "path", text: "app" },
+			{ kind: "arg", text: "<file>", required: true },
+			{ kind: "arg", text: "[rest...]", required: false },
+			{ kind: "options", text: "[options]" },
+		]);
 	});
 
 	it("uses explicit usage unchanged", async () => {
 		const model = await docs(new Crust("app").meta({ usage: "app FILE" }).handle(() => {}));
 		expect(model.usage).toBe("app FILE");
+		expect(model.usageSegments).toEqual([{ kind: "custom", text: "app FILE" }]);
 	});
 
 	it("omits hidden commands while traversing the full visible tree", async () => {

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+
+import { defineCommand } from "../index.ts";
+import { Crust, prepareCommandSnapshot } from "./crust.ts";
+import { buildCommandDocumentation } from "./documentation.ts";
+
+async function docs(app: Crust) {
+	return buildCommandDocumentation(await prepareCommandSnapshot(app));
+}
+
+describe("buildCommandDocumentation", () => {
+	it("builds usage and arg tokens", async () => {
+		const model = await docs(
+			new Crust("app")
+				.args({ name: "file", required: true }, { name: "rest", variadic: true })
+				.flags({ name: "verbose", type: "boolean" })
+				.handle(() => {}),
+		);
+		expect(model.usage).toBe("app <file> [rest...] [options]");
+		expect(model.args.map((arg) => arg.token)).toEqual(["<file>", "[rest...]"]);
+	});
+
+	it("uses explicit usage unchanged", async () => {
+		const model = await docs(new Crust("app").meta({ usage: "app FILE" }).handle(() => {}));
+		expect(model.usage).toBe("app FILE");
+	});
+
+	it("omits hidden commands while traversing the full visible tree", async () => {
+		const model = await docs(
+			new Crust("app")
+				.mount(
+					defineCommand("visible", (command) =>
+						command.mount(defineCommand("nested", (child) => child.handle(() => {}))),
+					),
+				)
+				.mount(
+					defineCommand("hidden", (command) => command.meta({ hidden: true }).handle(() => {})),
+				),
+		);
+		expect(model.children.map((child) => child.name)).toEqual(["visible"]);
+		expect(model.children[0]?.children[0]?.path).toEqual(["app", "visible", "nested"]);
+		expect(model.usage).toBe("app <command>");
+	});
+
+	it("resolves every flag spelling and negation from the parser spelling table", async () => {
+		const model = await docs(
+			new Crust("app")
+				.flags(
+					{
+						name: "color",
+						type: "boolean",
+						short: "c",
+						aliases: ["colour"],
+						required: true,
+					},
+					{ name: "help", type: "boolean", noNegate: true },
+				)
+				.handle(() => {}),
+		);
+		expect(model.flags[0]).toMatchObject({
+			name: "color",
+			required: true,
+			spellings: ["-c", "--color", "--colour", "--no-color", "--no-colour"],
+		});
+		expect(model.flags[1]?.spellings).toEqual(["--help"]);
+	});
+
+	it("retains defaults and choices as renderer-neutral data", async () => {
+		const model = await docs(
+			new Crust("app")
+				.flags({ name: "target", type: "string", default: "bun", choices: ["bun", "node"] })
+				.handle(() => {}),
+		);
+		expect(model.flags[0]).toMatchObject({ default: "bun", choices: ["bun", "node"] });
+	});
+});

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -27,12 +27,27 @@ export interface DocumentationFlag {
 	readonly default?: unknown;
 }
 
+/**
+ * One renderer-colorable piece of a usage line. `custom` is the sole segment
+ * when the author supplied `meta.usage`; generated usage lines are composed
+ * of the other kinds so renderers can style parts without re-deriving the
+ * assembly policy (when `<command>`/`[options]` appear, argument ordering).
+ */
+export type UsageSegment =
+	| { readonly kind: "path"; readonly text: string }
+	| { readonly kind: "command"; readonly text: "<command>" }
+	| { readonly kind: "arg"; readonly text: string; readonly required: boolean }
+	| { readonly kind: "options"; readonly text: "[options]" }
+	| { readonly kind: "custom"; readonly text: string };
+
 export interface CommandDocumentation {
 	readonly name: string;
 	readonly path: readonly string[];
 	readonly description?: string;
 	readonly aliases: readonly string[];
+	/** Plain usage line: `usageSegments` texts joined with spaces. */
 	readonly usage: string;
+	readonly usageSegments: readonly UsageSegment[];
 	readonly hasHandler: boolean;
 	readonly args: readonly DocumentationArg[];
 	readonly flags: readonly DocumentationFlag[];
@@ -84,16 +99,17 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 		.filter(([, child]) => child.meta.hidden !== true)
 		.map(([name, child]) => buildNode(child, [...path, name]));
 	const flags = documentationFlags(command.flags);
-	const usage =
-		command.meta.usage ??
-		[
-			path.join(" "),
-			children.length > 0 && !command.hasHandler ? "<command>" : undefined,
-			...args.map((arg) => arg.token),
-			flags.length > 0 ? "[options]" : undefined,
-		]
-			.filter(Boolean)
-			.join(" ");
+	const usageSegments: UsageSegment[] = command.meta.usage
+		? [{ kind: "custom", text: command.meta.usage }]
+		: [
+				{ kind: "path", text: path.join(" ") },
+				...(children.length > 0 && !command.hasHandler
+					? [{ kind: "command", text: "<command>" } as const]
+					: []),
+				...args.map((arg) => ({ kind: "arg", text: arg.token, required: arg.required }) as const),
+				...(flags.length > 0 ? [{ kind: "options", text: "[options]" } as const] : []),
+			];
+	const usage = usageSegments.map((segment) => segment.text).join(" ");
 
 	return Object.freeze({
 		name: command.meta.name,
@@ -101,6 +117,7 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 		description: command.meta.description,
 		aliases: Object.freeze([...(command.meta.aliases ?? [])]),
 		usage,
+		usageSegments: Object.freeze(usageSegments.map((segment) => Object.freeze(segment))),
 		hasHandler: command.hasHandler,
 		args: Object.freeze(args),
 		flags: Object.freeze(flags),

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -1,0 +1,117 @@
+import { flagSpellings } from "../parsing/spellings.ts";
+import type { CommandSnapshot, FlagSnapshot } from "./snapshot.ts";
+
+export interface DocumentationArg {
+	readonly name: string;
+	readonly token: string;
+	readonly type?: CommandSnapshot["args"][number]["type"];
+	readonly description?: string;
+	readonly required: boolean;
+	readonly variadic: boolean;
+	readonly choices?: readonly string[];
+	readonly default?: unknown;
+}
+
+export interface DocumentationFlag {
+	readonly name: string;
+	/** All accepted CLI spellings, ordered short, canonical, aliases, then negations. */
+	readonly spellings: readonly string[];
+	readonly short?: string;
+	readonly aliases: readonly string[];
+	readonly negatable: boolean;
+	readonly type: FlagSnapshot["type"];
+	readonly description?: string;
+	readonly required: boolean;
+	readonly multiple: boolean;
+	readonly choices?: readonly string[];
+	readonly default?: unknown;
+}
+
+export interface CommandDocumentation {
+	readonly name: string;
+	readonly path: readonly string[];
+	readonly description?: string;
+	readonly aliases: readonly string[];
+	readonly usage: string;
+	readonly hasHandler: boolean;
+	readonly args: readonly DocumentationArg[];
+	readonly flags: readonly DocumentationFlag[];
+	/** Visible children only; hidden commands remain invocable but are not documentation. */
+	readonly children: readonly CommandDocumentation[];
+}
+
+function argToken(arg: CommandSnapshot["args"][number]): string {
+	const name = arg.variadic ? `${arg.name}...` : arg.name;
+	return arg.required ? `<${name}>` : `[${name}]`;
+}
+
+function documentationFlags(flags: CommandSnapshot["flags"]): readonly DocumentationFlag[] {
+	const table = flagSpellings(flags);
+	return Object.entries(flags).map(([name, def]) => {
+		const entries = [...table.values()].filter((entry) => entry.canonicalName === name);
+		const short = entries.filter((entry) => entry.kind === "short");
+		const long = entries.filter((entry) => entry.kind !== "short");
+		return Object.freeze({
+			name,
+			spellings: Object.freeze([
+				...short.map((entry) => `-${entry.spelling}`),
+				...long.map((entry) => `--${entry.spelling}`),
+				...long.filter((entry) => entry.negatable).map((entry) => `--no-${entry.spelling}`),
+			]),
+			short: def.short,
+			aliases: Object.freeze([...(def.aliases ?? [])]),
+			negatable: def.type === "boolean" && def.noNegate !== true,
+			type: def.type,
+			description: def.description,
+			required: def.required === true,
+			multiple: def.multiple === true,
+			choices: def.choices,
+			default: def.default,
+		});
+	});
+}
+
+function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDocumentation {
+	const args = command.args.map((arg) =>
+		Object.freeze({
+			...arg,
+			token: argToken(arg),
+			required: arg.required === true,
+			variadic: arg.variadic === true,
+		}),
+	);
+	const children = Object.entries(command.subCommands)
+		.filter(([, child]) => child.meta.hidden !== true)
+		.map(([name, child]) => buildNode(child, [...path, name]));
+	const flags = documentationFlags(command.flags);
+	const usage =
+		command.meta.usage ??
+		[
+			path.join(" "),
+			children.length > 0 && !command.hasHandler ? "<command>" : undefined,
+			...args.map((arg) => arg.token),
+			flags.length > 0 ? "[options]" : undefined,
+		]
+			.filter(Boolean)
+			.join(" ");
+
+	return Object.freeze({
+		name: command.meta.name,
+		path: Object.freeze([...path]),
+		description: command.meta.description,
+		aliases: Object.freeze([...(command.meta.aliases ?? [])]),
+		usage,
+		hasHandler: command.hasHandler,
+		args: Object.freeze(args),
+		flags: Object.freeze(flags),
+		children: Object.freeze(children),
+	});
+}
+
+/** Build the presentation-neutral documentation model for a full command tree. */
+export function buildCommandDocumentation(
+	command: CommandSnapshot,
+	path: readonly string[] = [command.meta.name],
+): CommandDocumentation {
+	return buildNode(command, path);
+}

--- a/packages/core/src/parsing/spellings.ts
+++ b/packages/core/src/parsing/spellings.ts
@@ -1,9 +1,18 @@
 import { CrustError } from "../errors.ts";
-import type { FlagDef, FlagsDef, ValueType } from "../types.ts";
+import type { FlagDef, ValueType } from "../types.ts";
 
-export interface FlagSpelling {
+interface FlagDefinition {
+	readonly type: ValueType;
+	readonly short?: string;
+	readonly aliases?: readonly string[];
+	readonly noNegate?: boolean;
+	readonly multiple?: boolean;
+}
+
+export interface FlagSpelling<T extends FlagDefinition = FlagDef> {
 	canonicalName: string;
-	def: FlagDef;
+	spelling: string;
+	def: T;
 	kind: "canonical" | "short" | "alias";
 	negatable: boolean;
 }
@@ -17,13 +26,15 @@ const ALLOWED_FLAG_TYPES: ReadonlySet<ValueType> = new Set([
 	"json",
 ]);
 
-export function flagDefinitionSpellings(name: string, def: FlagDef): string[] {
+export function flagDefinitionSpellings(name: string, def: FlagDefinition): string[] {
 	return [name, ...(def.short ? [def.short] : []), ...(def.aliases ?? [])];
 }
 
 /** Build the canonical flag-spelling table shared by parsing and routing. */
-export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagSpelling> {
-	const spellings = new Map<string, FlagSpelling>();
+export function flagSpellings<T extends FlagDefinition = FlagDef>(
+	flagsDef: Readonly<Record<string, T>> | undefined,
+): Map<string, FlagSpelling<T>> {
+	const spellings = new Map<string, FlagSpelling<T>>();
 	if (!flagsDef) return spellings;
 
 	// Collision checks mirror the compile-time `ValidateFlagAliases<F>` type —
@@ -54,7 +65,7 @@ export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagS
 			def,
 			negatable: def.type === "boolean" && def.noNegate !== true,
 		} as const;
-		spellings.set(canonicalName, { ...entry, kind: "canonical" });
+		spellings.set(canonicalName, { ...entry, spelling: canonicalName, kind: "canonical" });
 
 		if (def.short) {
 			if (def.short.startsWith("no-")) {
@@ -71,7 +82,7 @@ export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagS
 				);
 			}
 			owners.set(def.short, canonicalName);
-			spellings.set(def.short, { ...entry, kind: "short" });
+			spellings.set(def.short, { ...entry, spelling: def.short, kind: "short" });
 		}
 
 		for (const alias of def.aliases ?? []) {
@@ -89,7 +100,7 @@ export function flagSpellings(flagsDef: FlagsDef | undefined): Map<string, FlagS
 				);
 			}
 			owners.set(alias, canonicalName);
-			spellings.set(alias, { ...entry, kind: "alias" });
+			spellings.set(alias, { ...entry, spelling: alias, kind: "alias" });
 		}
 	}
 

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -11,4 +11,10 @@ export {
 	VALIDATION_FORCE_EXIT_ENV,
 	VALIDATION_MODE_ENV,
 } from "./command/crust.ts";
+export { buildCommandDocumentation } from "./command/documentation.ts";
+export type {
+	CommandDocumentation,
+	DocumentationArg,
+	DocumentationFlag,
+} from "./command/documentation.ts";
 export { snapshotCommand } from "./command/snapshot.ts";

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -16,5 +16,6 @@ export type {
 	CommandDocumentation,
 	DocumentationArg,
 	DocumentationFlag,
+	UsageSegment,
 } from "./command/documentation.ts";
 export { snapshotCommand } from "./command/snapshot.ts";

--- a/packages/core/tests/fixtures/documentation-audit-before/SKILL.md
+++ b/packages/core/tests/fixtures/documentation-audit-before/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: demo
+description: Manage demo deployments.
+metadata:
+  version: "1.0.0"
+---
+
+# demo
+
+Manage demo deployments.
+
+You should use this skill when you need accurate help with `demo` commands, including command selection, syntax, arguments, flags, defaults, and subcommands.
+
+## How to Use This Skill
+
+1. You must find the command that best matches the user's task from the Command Reference below.
+2. You must check the `Type` column before suggesting execution: `runnable` and `runnable, group` commands can be executed, while `group` commands are organizational only.
+3. You should read only the linked file or files you need from `commands/`.
+4. You must read a command's file before answering a command-specific question or suggesting that command.
+5. You must treat the command file as the source of truth for usage, arguments, flags, aliases, and defaults.
+6. If a flag, argument, alias, or default is not documented there, you must say it is not documented instead of guessing.
+
+## Command Reference
+
+You should use this table to locate the command file you need.
+
+| Command | Type | Documentation |
+| ------- | ---- | ------------- |
+| `demo` | group | [commands/demo.md](commands/demo.md) |
+| `demo __complete` | runnable | [commands/__complete.md](commands/__complete.md) |
+| `demo deploy` | group | [commands/deploy.md](commands/deploy.md) |
+| `demo deploy status` | runnable | [commands/deploy/status.md](commands/deploy/status.md) |

--- a/packages/core/tests/fixtures/documentation-audit-before/help.txt
+++ b/packages/core/tests/fixtures/documentation-audit-before/help.txt
@@ -1,0 +1,13 @@
+demo - Manage demo deployments.
+
+USAGE:
+  demo <command> [workspace] [options]
+
+COMMANDS:
+  deploy (ship) Deploy an application
+
+ARGS:
+  [workspace]        Workspace directory [default: "."]
+
+OPTIONS:
+  -c, --color, --colour, --no-color Use colour

--- a/packages/core/tests/fixtures/documentation-audit-before/man.mdoc
+++ b/packages/core/tests/fixtures/documentation-audit-before/man.mdoc
@@ -1,0 +1,27 @@
+.Dd August 7, 2026
+.Dt DEMO 1
+.Os
+.Sh NAME
+.Nm demo
+.Nd Manage demo deployments.
+.Sh SYNOPSIS
+.Bd -literal
+demo <command> [workspace] [options]
+.Ed
+.Sh DESCRIPTION
+Manage demo deployments.
+.Sh SUBCOMMANDS
+.Bl -tag -width 13n
+.It Nm deploy (ship)
+Deploy an application
+.El
+.Sh OPTIONS
+.Bl -tag -width 46n
+.It Sy -c, --color, --colour, --no-color, --no-colour
+Use colour
+.El
+.Sh ARGUMENTS
+.Bl -tag -width 12n
+.It Ql [workspace]
+Workspace directory [default: "."]
+.El

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -105,8 +105,8 @@ describe("crust CLI entry point", () => {
 
 			expect(output).toContain("crust");
 			expect(output).toContain("CLI tooling for the Crust framework");
-			expect(output).toContain("USAGE:");
-			expect(output).toContain("COMMANDS:");
+			expect(output).toContain("Usage:");
+			expect(output).toContain("Commands:");
 			expect(output).toContain("build");
 			expect(output).toContain("publish");
 			expect(output).toContain("Compile your CLI to a standalone executable");
@@ -127,8 +127,8 @@ describe("crust CLI entry point", () => {
 			await makeCrustApp().execute({ argv: ["-h"] });
 			const output = getStdout();
 
-			expect(output).toContain("USAGE:");
-			expect(output).toContain("COMMANDS:");
+			expect(output).toContain("Usage:");
+			expect(output).toContain("Commands:");
 		});
 	});
 
@@ -153,8 +153,8 @@ describe("crust CLI entry point", () => {
 			await makeCrustApp().execute({ argv: [] });
 			const output = getStdout();
 
-			expect(output).toContain("USAGE:");
-			expect(output).toContain("COMMANDS:");
+			expect(output).toContain("Usage:");
+			expect(output).toContain("Commands:");
 			expect(output).toContain("build");
 			expect(output).toContain("publish");
 		});
@@ -164,7 +164,7 @@ describe("crust CLI entry point", () => {
 		it("shows root help for unknown input", async () => {
 			await makeCrustApp().execute({ argv: ["unknown"] });
 			const output = getStdout();
-			expect(output).toContain("USAGE:");
+			expect(output).toContain("Usage:");
 			expect(output).toContain("build");
 			expect(output).toContain("publish");
 		});
@@ -172,7 +172,7 @@ describe("crust CLI entry point", () => {
 		it("shows root help for partial command input", async () => {
 			await makeCrustApp().execute({ argv: ["buil"] });
 			const output = getStdout();
-			expect(output).toContain("COMMANDS:");
+			expect(output).toContain("Commands:");
 		});
 	});
 
@@ -196,8 +196,8 @@ describe("crust CLI entry point", () => {
 			const output = getStdout();
 
 			// Help output should still render correctly with updateNotifier present
-			expect(output).toContain("USAGE:");
-			expect(output).toContain("COMMANDS:");
+			expect(output).toContain("Usage:");
+			expect(output).toContain("Commands:");
 			expect(output).toContain("build");
 		});
 
@@ -213,7 +213,7 @@ describe("crust CLI entry point", () => {
 			await makeCrustApp().execute({ argv: [] });
 			const output = getStdout();
 
-			expect(output).toContain("USAGE:");
+			expect(output).toContain("Usage:");
 		});
 	});
 });

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -1,21 +1,18 @@
+import { type CommandSnapshot, type Extension, defineExtension } from "@crustjs/core";
 import {
-	type ArgSnapshot,
-	type CommandMeta,
-	type CommandSnapshot,
-	type Extension,
-	defineExtension,
-	type FlagSnapshot,
-} from "@crustjs/core";
+	buildCommandDocumentation,
+	type CommandDocumentation,
+	type DocumentationArg,
+	type DocumentationFlag,
+} from "@crustjs/core/tooling";
 import { bold, cyan, dim, green, padEnd, yellow } from "@crustjs/style";
 
 const FLAG_COLUMN_WIDTH = 28;
 const ARG_COLUMN_WIDTH = 18;
 const COMMAND_COLUMN_WIDTH = 10;
 
-function formatArgToken(arg: ArgSnapshot): string {
-	const base = arg.variadic ? `${arg.name}...` : arg.name;
-	const token = arg.required ? `<${base}>` : `[${base}]`;
-	return arg.required ? yellow(token) : dim(yellow(token));
+function formatArgToken(arg: DocumentationArg): string {
+	return arg.required ? yellow(arg.token) : dim(yellow(arg.token));
 }
 
 function formatDescription(
@@ -37,176 +34,70 @@ function formatDescription(
 	return parts.join(" ");
 }
 
-function formatUsage(
-	meta: Readonly<CommandMeta>,
-	command: CommandSnapshot,
-	path: string[],
-): string {
-	if (meta.usage) return green(meta.usage);
-
-	const usageParts: string[] = [green(path.join(" "))];
-
-	const hasVisibleSubCommands = Object.values(command.subCommands).some(
-		(sub) => sub.meta.hidden !== true,
-	);
-	if (hasVisibleSubCommands && !command.hasHandler) {
-		usageParts.push(cyan("<command>"));
-	}
-
-	for (const arg of command.args) {
-		usageParts.push(formatArgToken(arg));
-	}
-
-	if (Object.keys(command.flags).length > 0) {
-		usageParts.push(cyan("[options]"));
-	}
-
-	return usageParts.join(" ");
-}
-
-function formatFlagName(name: string, def: FlagSnapshot): string {
-	const labels: string[] = [];
-
-	if (def.short) {
-		labels.push(`-${def.short}`);
-	}
-
-	labels.push(`--${name}`);
-
-	// Long aliases are callable, so help discloses them. Negation is shown
-	// for the canonical name only — "any long spelling negates" is the rule,
-	// and the man page documents the exhaustive --no-<alias> surface.
-	if (def.aliases) {
-		for (const alias of def.aliases) labels.push(`--${alias}`);
-	}
-
-	if (def.type === "boolean" && !def.noNegate) {
-		labels.push(`--no-${name}`);
-	}
-
-	return cyan(labels.join(", "));
-}
-
-function formatFlagsSection(flags: Readonly<Record<string, FlagSnapshot>>): string[] {
-	if (Object.keys(flags).length === 0) return [];
-
-	const lines = [bold(cyan("OPTIONS:"))];
-	for (const [name, def] of Object.entries(flags)) {
-		const rendered = `${padEnd(formatFlagName(name, def), FLAG_COLUMN_WIDTH, " ")} `;
+function formatFlagsSection(flags: readonly DocumentationFlag[]): string[] {
+	if (flags.length === 0) return [];
+	const lines = [bold(cyan("Options:"))];
+	for (const flag of flags) {
+		const rendered = `${padEnd(cyan(flag.spellings.join(", ")), FLAG_COLUMN_WIDTH, " ")} `;
 		lines.push(
-			`  ${rendered}${formatDescription(def.description, def.default, def.choices)}`.trimEnd(),
+			`  ${rendered}${formatDescription(flag.description, flag.default, flag.choices)}`.trimEnd(),
 		);
 	}
-
 	return lines;
 }
 
-function formatArgsSection(command: CommandSnapshot): string[] {
+function formatArgsSection(command: CommandDocumentation): string[] {
 	if (command.args.length === 0) return [];
-
-	const lines = [bold(cyan("ARGS:"))];
+	const lines = [bold(cyan("Arguments:"))];
 	for (const arg of command.args) {
 		const rendered = `${padEnd(formatArgToken(arg), ARG_COLUMN_WIDTH, " ")} `;
 		lines.push(
 			`  ${rendered}${formatDescription(arg.description, arg.default, arg.choices)}`.trimEnd(),
 		);
 	}
-
 	return lines;
 }
 
-/**
- * Render the canonical command name with any aliases inline. The canonical
- * name is styled green; the `(a, b)` suffix is rendered in the default
- * colour so the canonical spelling stands out at a glance.
- *
- * `name`                       — no aliases
- * `name (alias1, alias2)`      — one or more aliases
- *
- * `padEnd` (from `@crustjs/style`) is ANSI-aware: it pads against the
- * *visible* width so styling codes don't throw column alignment off. If the
- * combined label exceeds `COMMAND_COLUMN_WIDTH`, padEnd is a no-op and the
- * label overflows the column rather than truncating — truncating aliases
- * would hide which alternative names exist, defeating the point.
- */
-function formatCommandLabel(name: string, aliases: readonly string[] | undefined): string {
-	const styledName = green(name);
-	if (!aliases || aliases.length === 0) return styledName;
-	return `${styledName} (${aliases.join(", ")})`;
+function formatCommandLabel(command: CommandDocumentation): string {
+	const name = green(command.name);
+	return command.aliases.length === 0 ? name : `${name} (${command.aliases.join(", ")})`;
 }
 
-function formatCommandsSection(command: CommandSnapshot): string[] {
-	// Filter out subcommands marked `meta.hidden: true`. Hidden
-	// commands remain resolvable by direct invocation — routing in
-	// `packages/core/src/command/router.ts` does not consult `meta.hidden`. Filtering
-	// happens after `Object.entries` so insertion order is preserved for the
-	// surviving entries.
-	const visibleEntries = Object.entries(command.subCommands).filter(
-		([, subCommand]) => subCommand.meta.hidden !== true,
-	);
-
-	if (visibleEntries.length === 0) {
-		return [];
+function formatCommandsSection(command: CommandDocumentation): string[] {
+	if (command.children.length === 0) return [];
+	const lines = [bold(cyan("Commands:"))];
+	for (const child of command.children) {
+		const rendered = `${padEnd(formatCommandLabel(child), COMMAND_COLUMN_WIDTH, " ")} `;
+		lines.push(`  ${rendered}${child.description ?? ""}`.trimEnd());
 	}
-
-	const lines = [bold(cyan("COMMANDS:"))];
-	for (const [name, subCommand] of visibleEntries) {
-		const label = formatCommandLabel(name, subCommand.meta.aliases);
-		const rendered = `${padEnd(label, COMMAND_COLUMN_WIDTH, " ")} `;
-		lines.push(`  ${rendered}${subCommand.meta.description ?? ""}`.trimEnd());
-	}
-
 	return lines;
 }
 
 export function renderHelp(command: CommandSnapshot, path?: readonly string[]): string {
-	const resolvedPath = [...(path ?? [command.meta.name])];
-	const lines: string[] = [];
-	lines.push(
-		command.meta.description
-			? `${bold(resolvedPath.join(" "))} - ${dim(command.meta.description)}`
-			: bold(resolvedPath.join(" ")),
-	);
-	lines.push("");
-	lines.push(bold(cyan("USAGE:")));
-	lines.push(`  ${formatUsage(command.meta, command, resolvedPath)}`);
-
-	const commandsSection = formatCommandsSection(command);
-	if (commandsSection.length > 0) {
-		lines.push("");
-		lines.push(...commandsSection);
+	const model = buildCommandDocumentation(command, path);
+	const heading = model.path.join(" ");
+	const lines = [
+		model.description ? `${bold(heading)} - ${dim(model.description)}` : bold(heading),
+		"",
+		bold(cyan("Usage:")),
+		`  ${green(model.usage)}`,
+	];
+	for (const section of [
+		formatCommandsSection(model),
+		formatArgsSection(model),
+		formatFlagsSection(model.flags),
+	]) {
+		if (section.length > 0) lines.push("", ...section);
 	}
-
-	const argsSection = formatArgsSection(command);
-	if (argsSection.length > 0) {
-		lines.push("");
-		lines.push(...argsSection);
-	}
-
-	const optionsSection = formatFlagsSection(command.flags);
-	if (optionsSection.length > 0) {
-		lines.push("");
-		lines.push(...optionsSection);
-	}
-
 	return lines.join("\n");
 }
 
 export function helpExtension(): Extension {
 	return defineExtension("help", {
-		flags: {
-			help: {
-				type: "boolean",
-				short: "h",
-				noNegate: true,
-				description: "Show help",
-			},
-		},
+		flags: { help: { type: "boolean", short: "h", noNegate: true, description: "Show help" } },
 		hooks: {
 			preRun(context) {
 				if (context.flags.help !== true && context.command.hasHandler) return;
-
-				// Explicit --help, or a container command without a handler
 				context.stdout(renderHelp(context.command, context.commandPath));
 				return context.finish();
 			},

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -4,6 +4,7 @@ import {
 	type CommandDocumentation,
 	type DocumentationArg,
 	type DocumentationFlag,
+	type UsageSegment,
 } from "@crustjs/core/tooling";
 import { bold, cyan, dim, green, padEnd, yellow } from "@crustjs/style";
 
@@ -13,6 +14,19 @@ const COMMAND_COLUMN_WIDTH = 10;
 
 function formatArgToken(arg: DocumentationArg): string {
 	return arg.required ? yellow(arg.token) : dim(yellow(arg.token));
+}
+
+function formatUsageSegment(segment: UsageSegment): string {
+	switch (segment.kind) {
+		case "path":
+		case "custom":
+			return green(segment.text);
+		case "command":
+		case "options":
+			return cyan(segment.text);
+		case "arg":
+			return segment.required ? yellow(segment.text) : dim(yellow(segment.text));
+	}
 }
 
 function formatDescription(
@@ -80,7 +94,7 @@ export function renderHelp(command: CommandSnapshot, path?: readonly string[]): 
 		model.description ? `${bold(heading)} - ${dim(model.description)}` : bold(heading),
 		"",
 		bold(cyan("Usage:")),
-		`  ${green(model.usage)}`,
+		`  ${model.usageSegments.map(formatUsageSegment).join(" ")}`,
 	];
 	for (const section of [
 		formatCommandsSection(model),

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -125,6 +125,14 @@ describe("built-in plugins", () => {
 		expect(plain).toContain("[default: true]");
 		expect(plain).toContain("[default: 3000]");
 		expect(plain).toContain('[default: "."]');
+
+		// Convention audit H3 keeps per-part usage coloring: path green,
+		// placeholders cyan, args yellow (dim when optional) — not one span.
+		const usageLine = output.split("\n").find((line) => stripAnsi(line).startsWith("  app"));
+		expect(usageLine).toContain("\x1b[32mapp\x1b["); // green path
+		expect(usageLine).toContain("\x1b[36m<command>\x1b["); // cyan placeholder
+		expect(usageLine).toContain("\x1b[36m[options]\x1b["); // cyan placeholder
+		expect(usageLine).toContain("[dir]"); // arg token present, yellow+dim
 	});
 
 	it("renderHelp shows every callable alias and negation", () => {

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -117,17 +117,17 @@ describe("built-in plugins", () => {
 		const plain = stripAnsi(output);
 
 		expect(output).toContain("\x1b[");
-		expect(plain).toContain("USAGE:");
-		expect(plain).toContain("COMMANDS:");
-		expect(plain).toContain("ARGS:");
-		expect(plain).toContain("OPTIONS:");
+		expect(plain).toContain("Usage:");
+		expect(plain).toContain("Commands:");
+		expect(plain).toContain("Arguments:");
+		expect(plain).toContain("Options:");
 		expect(plain).toContain("-v, --verbose, --no-verbose");
 		expect(plain).toContain("[default: true]");
 		expect(plain).toContain("[default: 3000]");
 		expect(plain).toContain('[default: "."]');
 	});
 
-	it("renderHelp shows long aliases with canonical-only negation", () => {
+	it("renderHelp shows every callable alias and negation", () => {
 		const command = new Crust("app").flags({
 			name: "verbose",
 			type: "boolean",
@@ -135,8 +135,8 @@ describe("built-in plugins", () => {
 		})._node;
 
 		const output = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(output).toContain("--verbose, --loud, --no-verbose");
-		expect(output).not.toContain("--no-loud");
+		// Convention audit H2: disclose every callable long-form negation.
+		expect(output).toContain("--verbose, --loud, --no-verbose, --no-loud");
 	});
 
 	it("renderHelp hides negation labels when noNegate is set", () => {
@@ -209,8 +209,8 @@ describe("built-in plugins", () => {
 
 		const output = stripAnsi(getStdout());
 		expect(output).toContain("app");
-		expect(output).toContain("USAGE:");
-		expect(output).toContain("COMMANDS:");
+		expect(output).toContain("Usage:");
+		expect(output).toContain("Commands:");
 		expect(output).toContain("build");
 		expect(output).toContain("-h, --help");
 		expect(output).not.toContain("--no-help");
@@ -277,7 +277,7 @@ describe("built-in plugins", () => {
 		const output = getStdout();
 		expect(output).not.toContain("\x1b[36m");
 		expect(output).not.toContain("\x1b[33m");
-		expect(output).toContain("\x1b[1mUSAGE:\x1b[22m");
+		expect(output).toContain("\x1b[1mUsage:\x1b[22m");
 	});
 
 	it("noColorExtension overrides NO_COLOR with --color", async () => {
@@ -413,7 +413,7 @@ describe("built-in plugins", () => {
 
 		const output = stripAnsi(getStdout());
 		expect(output).toContain("create");
-		expect(output).toContain("USAGE:");
+		expect(output).toContain("Usage:");
 		expect(getStderr()).toBe("");
 		expect(process.exitCode).toBeFalsy();
 	});
@@ -431,7 +431,7 @@ describe("built-in plugins", () => {
 
 		const output = stripAnsi(getStdout());
 		expect(output).toContain("deploy");
-		expect(output).toContain("USAGE:");
+		expect(output).toContain("Usage:");
 		expect(getStderr()).toBe("");
 		expect(process.exitCode).toBeFalsy();
 	});
@@ -629,7 +629,7 @@ describe("built-in plugins", () => {
 		)._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(plain).toContain("COMMANDS:");
+		expect(plain).toContain("Commands:");
 		expect(plain).toContain("issue (issues, i)");
 		expect(plain).toContain("Manage issues");
 	});
@@ -642,7 +642,7 @@ describe("built-in plugins", () => {
 		)._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(plain).toContain("COMMANDS:");
+		expect(plain).toContain("Commands:");
 		expect(plain).toContain("build");
 		// No parens means no aliases were rendered.
 		expect(plain).not.toMatch(/build\s*\(/);
@@ -699,7 +699,7 @@ describe("built-in plugins", () => {
 			)._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(plain).toContain("COMMANDS:");
+		expect(plain).toContain("Commands:");
 		expect(plain).toContain("build");
 		expect(plain).not.toContain("__complete");
 		expect(plain).not.toContain("Internal completion entrypoint");
@@ -715,14 +715,14 @@ describe("built-in plugins", () => {
 			.handle(() => {})._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(plain).not.toContain("COMMANDS:");
+		expect(plain).not.toContain("Commands:");
 		expect(plain).not.toContain("__complete");
 	});
 
 	it("renderHelp omits the `<command>` USAGE token when every subcommand is hidden and parent has no run handler", () => {
 		// Regression: formatUsage previously counted hidden subcommands when
 		// deciding whether to emit `<command>`, producing the incoherent
-		// `USAGE: app <command>` with no COMMANDS section below it.
+		// `Usage: app <command>` with no COMMANDS section below it.
 		const command = new Crust("app").mount(
 			defineCommand("__complete", (cmd) =>
 				cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
@@ -730,9 +730,9 @@ describe("built-in plugins", () => {
 		)._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
-		expect(plain).toContain("USAGE:");
-		expect(plain).not.toMatch(/USAGE:\s+app\s+<command>/);
-		expect(plain).not.toContain("COMMANDS:");
+		expect(plain).toContain("Usage:");
+		expect(plain).not.toMatch(/Usage:\s+app\s+<command>/);
+		expect(plain).not.toContain("Commands:");
 		expect(plain).not.toContain("__complete");
 	});
 
@@ -820,7 +820,7 @@ describe("built-in plugins", () => {
 		// The ARGS section heading is the marker the rest of the
 		// assertions hang off; without it the test would silently miss
 		// rendering bugs that drop the section entirely.
-		expect(plain).toContain("ARGS:");
+		expect(plain).toContain("Arguments:");
 		expect(plain).toContain("<env>");
 		expect(plain).toContain("[choices: dev, staging, prod]");
 	});

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -154,7 +154,8 @@ describe("renderManPageMdoc", () => {
 		const root = await prepareCommandSnapshot(app);
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
-		expect(mdoc).toContain(".It Sy --target");
+		// Convention audit M1: use semantic mdoc flag macros.
+		expect(mdoc).toContain(".It Fl Fl target");
 		expect(mdoc).toContain("Build target [choices: browser, bun, node]");
 	});
 
@@ -174,7 +175,7 @@ describe("renderManPageMdoc", () => {
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).toContain(".Sh ARGUMENTS");
-		expect(mdoc).toContain(".It Ql <env>");
+		expect(mdoc).toContain(".It Ar env");
 		expect(mdoc).toContain("Target environment [choices: dev, staging, prod]");
 	});
 
@@ -195,7 +196,7 @@ describe("renderManPageMdoc", () => {
 
 		// Both the canonical `--output` and the alias `--out` appear in the
 		// label, comma-separated, after the short flag.
-		expect(mdoc).toContain(".It Sy -o, --output, --out");
+		expect(mdoc).toContain(".It Fl o , Fl Fl output , Fl Fl out");
 	});
 
 	it("includes `--no-` negation for every long-form spelling of a boolean flag", async () => {
@@ -212,6 +213,6 @@ describe("renderManPageMdoc", () => {
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		// Canonical + alias + both negations, in declaration order.
-		expect(mdoc).toContain(".It Sy --color, --colour, --no-color, --no-colour");
+		expect(mdoc).toContain(".It Fl Fl color , Fl Fl colour , Fl Fl no-color , Fl Fl no-colour");
 	});
 });

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,172 +1,56 @@
-import type { ArgSnapshot, CommandMeta, FlagSnapshot } from "@crustjs/core";
 import type { CommandSnapshot } from "@crustjs/core";
+import {
+	buildCommandDocumentation,
+	type CommandDocumentation,
+	type DocumentationFlag,
+} from "@crustjs/core/tooling";
 
-/** Escape a line so it is not interpreted as an mdoc directive. */
 function escapeMdocBodyLine(line: string): string {
-	if (line.startsWith(".")) {
-		return `\\&${line}`;
-	}
-	return line;
+	return line.startsWith(".") ? `\\&${line}` : line;
 }
-
 function formatDefaultValue(value: unknown): string {
-	if (typeof value === "number" && !Number.isFinite(value)) {
-		return String(value);
-	}
+	if (typeof value === "number" && !Number.isFinite(value)) return String(value);
 	if (Array.isArray(value)) return value.map(String).join(", ");
 	return JSON.stringify(value);
 }
-
-function formatDescription(description: string | undefined, defaultValue: unknown): string {
-	if (defaultValue === undefined) {
-		return description ?? "";
-	}
-	const suffix = `[default: ${formatDefaultValue(defaultValue)}]`;
-	if (!description) return suffix;
-	return `${description} ${suffix}`;
-}
-
-function formatArgToken(arg: ArgSnapshot): string {
-	const base = arg.variadic ? `${arg.name}...` : arg.name;
-	return arg.required ? `<${base}>` : `[${base}]`;
-}
-
-function formatUsagePlain(meta: CommandMeta, command: CommandSnapshot, path: string[]): string {
-	if (meta.usage) return meta.usage;
-
-	const parts: string[] = [path.join(" ")];
-
-	if (Object.keys(command.subCommands).length > 0 && !command.hasHandler) {
-		parts.push("<command>");
-	}
-
-	for (const arg of command.args) {
-		parts.push(formatArgToken(arg));
-	}
-
-	if (Object.keys(command.flags).length > 0) {
-		parts.push("[options]");
-	}
-
-	return parts.join(" ");
-}
-
-/**
- * Render the labels for a single flag definition for the `OPTIONS`
- * tagged-list. The output is a comma-joined sequence of spellings:
- *
- *   `-o, --output, --out, --no-output, --no-out`
- *
- * Order: short flag first (when present), canonical long form, every
- * declared long alias (`def.aliases`), then — for boolean flags that
- * have not opted out of negation — the `--no-<spelling>` forms in the
- * same order. Long aliases are surfaced so the man page documents the
- * complete callable surface of the flag; without them users only see
- * the canonical name and have no way to discover that `--out` is
- * equivalent.
- */
-function formatFlagLabels(name: string, def: FlagSnapshot): string {
-	const longNames: string[] = [name];
-	if (def.aliases) {
-		for (const alias of def.aliases) longNames.push(alias);
-	}
-	const labels: string[] = [];
-	if (def.short) labels.push(`-${def.short}`);
-	for (const long of longNames) labels.push(`--${long}`);
-	if (def.type === "boolean" && !def.noNegate) {
-		for (const long of longNames) labels.push(`--no-${long}`);
-	}
-	return labels.join(", ");
-}
-
-/**
- * Render a trailing `[choices: a, b, c]` hint when the supplied list is
- * non-empty. Returns an empty string otherwise so the caller can
- * unconditionally concatenate.
- *
- * Takes the raw `choices` array directly rather than a `def` object —
- * `FlagDef` and `ArgDef` are discriminated unions whose number/boolean
- * variants do not carry `choices` at all, so a structural `{ choices? }`
- * parameter fails TS excess-property checks. Each caller already has
- * access to `def.choices` (typed as `readonly string[] | undefined`),
- * so passing it directly avoids the union narrowing.
- */
-function formatChoicesSuffix(choices: readonly string[] | undefined): string {
-	if (!choices || choices.length === 0) return "";
-	return `[choices: ${choices.join(", ")}]`;
-}
-
-/**
- * Join a flag/arg description, its default-value suffix, and its
- * choices-suffix into a single mdoc body. Each piece is optional;
- * separators collapse so we never emit a stray double-space.
- */
-function formatDescriptionWithChoices(
+function formatDescription(
 	description: string | undefined,
 	defaultValue: unknown,
 	choices: readonly string[] | undefined,
 ): string {
-	const base = formatDescription(description, defaultValue);
-	const suffix = formatChoicesSuffix(choices);
-	if (!suffix) return base;
-	if (!base) return suffix;
-	return `${base} ${suffix}`;
+	const parts = description ? [description] : [];
+	if (defaultValue !== undefined) parts.push(`[default: ${formatDefaultValue(defaultValue)}]`);
+	if (choices?.length) parts.push(`[choices: ${choices.join(", ")}]`);
+	return parts.join(" ");
 }
-
 function dtTitle(name: string): string {
 	const upper = name.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
 	return upper.replace(/^_|_$/g, "") || "COMMAND";
 }
-
-function ndOneLine(text: string): string {
-	return text.replace(/\s+/g, " ").trim();
-}
-
-/** Single-line `.Nd` argument must not start with `.` (troff directive). */
 function ndArgument(text: string): string {
-	return escapeMdocBodyLine(ndOneLine(text));
+	return escapeMdocBodyLine(text.replace(/\s+/g, " ").trim());
 }
-
-function longestFlagWidth(flags: Readonly<Record<string, FlagSnapshot>>): string {
+function flagMacro(spelling: string): string {
+	return spelling.startsWith("--") ? `Fl Fl ${spelling.slice(2)}` : `Fl ${spelling.slice(1)}`;
+}
+function flagMacros(flag: DocumentationFlag): string {
+	return flag.spellings.map(flagMacro).join(" , ");
+}
+function longestFlagWidth(flags: readonly DocumentationFlag[]): string {
 	let max = 8;
-	for (const [name, def] of Object.entries(flags)) {
-		max = Math.max(max, formatFlagLabels(name, def).length);
-	}
+	for (const flag of flags) max = Math.max(max, flag.spellings.join(", ").length);
 	return `${max}n`;
 }
-
-/**
- * Render the canonical subcommand name plus any aliases inline:
- *   `name`                       — no aliases
- *   `name (alias1, alias2)`      — one or more aliases
- *
- * Matches the inline format used by `helpPlugin.formatCommandsSection`.
- * Used for both the `.It Nm` line in SUBCOMMANDS and the column-width
- * calculation so alignment stays consistent.
- */
-function formatSubcommandLabel(name: string, aliases: readonly string[] | undefined): string {
-	if (!aliases || aliases.length === 0) return name;
-	return `${name} (${aliases.join(", ")})`;
+function commandLabel(command: CommandDocumentation): string {
+	return command.aliases.length === 0
+		? command.name
+		: `${command.name} (${command.aliases.join(", ")})`;
 }
-
-function longestSubcommandWidth(command: CommandSnapshot): string {
+function longestSubcommandWidth(command: CommandDocumentation): string {
 	let max = 8;
-	for (const [name, sub] of Object.entries(command.subCommands)) {
-		// Hidden subcommands are not rendered (see SUBCOMMANDS loop) and
-		// therefore must not influence the column width — a long hidden
-		// internal command name would otherwise stretch the layout for
-		// every visible peer.
-		if (sub.meta.hidden === true) continue;
-		const label = formatSubcommandLabel(name, sub.meta.aliases);
-		max = Math.max(max, label.length);
-	}
+	for (const child of command.children) max = Math.max(max, commandLabel(child).length);
 	return `${max}n`;
 }
-
-/**
- * `.Dd` date line: explicit string, else `SOURCE_DATE_EPOCH` (UTC, reproducible
- * builds), else local calendar date.
- */
 function resolveDdLine(explicit?: string): string {
 	if (explicit) return explicit;
 	const sec = Number.parseInt(process.env.SOURCE_DATE_EPOCH ?? "", 10);
@@ -180,36 +64,19 @@ function resolveDdLine(explicit?: string): string {
 }
 
 export interface RenderManPageMdocOptions {
-	/** Frozen root Command Snapshot (e.g. from `prepareCommandSnapshot()`). */
 	root: CommandSnapshot;
-	/** Name shown in `man <name>` / `.Nm` (often matches the binary). */
 	name: string;
-	/**
-	 * Manual section; user commands use `1`.
-	 *
-	 * @default 1
-	 */
 	section?: number;
-	/**
-	 * Override the `.Dd` date (e.g. `"April 1, 2026"`). If omitted, uses
-	 * `SOURCE_DATE_EPOCH` when set, otherwise today.
-	 */
 	date?: string;
 }
 
-/**
- * Render an mdoc(7) manual page (section 1) for the root command tree.
- */
+/** Render an mdoc(7) manual page for the root command. */
 export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 	const { root, name, section = 1, date } = options;
-	const dd = resolveDdLine(date);
-
-	const path = [root.meta.name];
-	const usage = formatUsagePlain(root.meta, root, path);
-	const description = root.meta.description?.trim() || "No description provided.";
-
-	const lines: string[] = [
-		`.Dd ${dd}`,
+	const model = buildCommandDocumentation(root);
+	const description = model.description?.trim() || "No description provided.";
+	const lines = [
+		`.Dd ${resolveDdLine(date)}`,
 		`.Dt ${dtTitle(name)} ${section}`,
 		".Os",
 		".Sh NAME",
@@ -217,75 +84,41 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		`.Nd ${ndArgument(description)}`,
 		".Sh SYNOPSIS",
 		".Bd -literal",
-		usage,
+		model.usage,
 		".Ed",
 		".Sh DESCRIPTION",
 	];
+	for (const line of description.split("\n")) lines.push(escapeMdocBodyLine(line));
 
-	for (const rawLine of description.split("\n")) {
-		lines.push(escapeMdocBodyLine(rawLine));
-	}
-
-	// Filter subcommands marked `meta.hidden: true`. Hidden subcommands
-	// remain invocable by direct name (the router does not consult
-	// `meta.hidden`); they are excluded from generated documentation so
-	// internal commands (e.g. `__complete`) do not surface in published
-	// man pages. Matches the contract upheld by `helpPlugin` and
-	// `completionPlugin`.
-	const visibleSubEntries = Object.entries(root.subCommands).filter(
-		([, sub]) => sub.meta.hidden !== true,
-	);
-	if (visibleSubEntries.length > 0) {
-		lines.push(".Sh SUBCOMMANDS");
-		lines.push(`.Bl -tag -width ${longestSubcommandWidth(root)}`);
-		for (const [subName, sub] of visibleSubEntries.sort(([a], [b]) => a.localeCompare(b))) {
-			// `.It Nm <name> (alias1, alias2)` keeps the canonical name marked up
-			// as a name macro while letting aliases ride along as plain text.
-			// Parens and commas are not mdoc macros, so no escaping is needed.
-			// Reuse `formatSubcommandLabel` so the rendered label stays in sync
-			// with the column-width calculation in `longestSubcommandWidth`.
-			lines.push(`.It Nm ${formatSubcommandLabel(subName, sub.meta.aliases)}`);
-			const desc = sub.meta.description?.trim() || "";
-			if (desc) {
-				lines.push(desc.split("\n").map(escapeMdocBodyLine).join("\n"));
-			}
+	// A man page intentionally summarizes only the root's immediate children;
+	// the shared model still resolves the complete visible tree for other adapters.
+	if (model.children.length > 0) {
+		lines.push(".Sh SUBCOMMANDS", `.Bl -tag -width ${longestSubcommandWidth(model)}`);
+		for (const child of [...model.children].sort((a, b) => a.name.localeCompare(b.name))) {
+			lines.push(`.It Nm ${commandLabel(child)}`);
+			if (child.description)
+				lines.push(child.description.trim().split("\n").map(escapeMdocBodyLine).join("\n"));
 		}
 		lines.push(".El");
 	}
-
-	const flagEntries = Object.entries(root.flags).sort(([a], [b]) => a.localeCompare(b));
-	if (flagEntries.length > 0) {
-		lines.push(".Sh OPTIONS");
-		lines.push(`.Bl -tag -width ${longestFlagWidth(root.flags)}`);
-		for (const [flagName, def] of flagEntries) {
-			const labels = formatFlagLabels(flagName, def);
-			lines.push(`.It Sy ${labels}`);
-			// `choices` only exists on string-typed flag variants; number/
-			// boolean flags narrow to `undefined` and `formatChoicesSuffix`
-			// renders that as the empty string.
-			const choices = def.type === "string" ? def.choices : undefined;
-			const body = formatDescriptionWithChoices(def.description, def.default, choices).trim();
-			if (body) {
-				lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
-			}
+	if (model.flags.length > 0) {
+		lines.push(".Sh OPTIONS", `.Bl -tag -width ${longestFlagWidth(model.flags)}`);
+		for (const flag of [...model.flags].sort((a, b) => a.name.localeCompare(b.name))) {
+			lines.push(`.It ${flagMacros(flag)}`);
+			const body = formatDescription(flag.description, flag.default, flag.choices);
+			if (body) lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
 		}
 		lines.push(".El");
 	}
-
-	if (root.args.length > 0) {
-		lines.push(".Sh ARGUMENTS");
-		lines.push(".Bl -tag -width 12n");
-		for (const arg of root.args) {
-			lines.push(`.It Ql ${formatArgToken(arg)}`);
-			const choices = arg.type === "string" ? arg.choices : undefined;
-			const body = formatDescriptionWithChoices(arg.description, arg.default, choices).trim();
-			if (body) {
-				lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
-			}
+	if (model.args.length > 0) {
+		lines.push(".Sh ARGUMENTS", ".Bl -tag -width 12n");
+		for (const arg of model.args) {
+			lines.push(`.It Ar ${arg.name}${arg.variadic ? " ..." : ""}`);
+			const body = formatDescription(arg.description, arg.default, arg.choices);
+			if (body) lines.push(body.split("\n").map(escapeMdocBodyLine).join("\n"));
 		}
 		lines.push(".El");
 	}
-
 	lines.push("");
 	return lines.join("\n");
 }

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -13,7 +13,7 @@ import { buildManifest } from "./manifest.ts";
 // ────────────────────────────────────────────────────────────────────────────
 
 function makeCommand(opts: {
-	meta: { name: string; description?: string; usage?: string };
+	meta: { name: string; description?: string; usage?: string; hidden?: boolean };
 	args?: readonly ArgDef[];
 	flags?: Record<string, FlagDef>;
 	run?: () => void;
@@ -93,7 +93,7 @@ describe("buildManifest", () => {
 			expect(node.usage).toBe("build [options] <entry>");
 		});
 
-		it("omits description and usage when not provided", () => {
+		it("resolves generated usage when custom usage is not provided", () => {
 			const cmd = makeCommand({
 				meta: { name: "app" },
 			});
@@ -101,7 +101,7 @@ describe("buildManifest", () => {
 			const node = buildManifest(snapshotCommand(cmd));
 
 			expect(node.description).toBeUndefined();
-			expect(node.usage).toBeUndefined();
+			expect(node.usage).toBe("app");
 		});
 
 		it("returns empty args and flags arrays when none defined", () => {
@@ -467,6 +467,19 @@ describe("buildManifest", () => {
 			// Children sorted alphabetically
 			expect(first?.name).toBe("build");
 			expect(second?.name).toBe("serve");
+		});
+
+		it("omits hidden commands from generated agent documentation", () => {
+			const root = makeCommand({
+				meta: { name: "app" },
+				subCommands: {
+					visible: makeCommand({ meta: { name: "visible" }, run() {} }),
+					hidden: makeCommand({ meta: { name: "hidden", hidden: true }, run() {} }),
+				},
+			});
+			expect(buildManifest(snapshotCommand(root)).children.map((child) => child.name)).toEqual([
+				"visible",
+			]);
 		});
 
 		it("constructs correct paths for nested subcommands", () => {

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -1,196 +1,63 @@
-// ────────────────────────────────────────────────────────────────────────────
-// Command-tree introspection — builds canonical manifest from CommandSnapshot
-// ────────────────────────────────────────────────────────────────────────────
-
-import type { ArgSnapshot, CommandSnapshot, FlagSnapshot } from "@crustjs/core";
+import type { CommandSnapshot } from "@crustjs/core";
+import {
+	buildCommandDocumentation,
+	type CommandDocumentation,
+	type DocumentationArg,
+	type DocumentationFlag,
+} from "@crustjs/core/tooling";
 
 import { getSkillCommandAnnotations } from "./annotations.ts";
 import type { ManifestArg, ManifestFlag, ManifestNode } from "./types.ts";
 
-// ────────────────────────────────────────────────────────────────────────────
-// Public API
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Builds a canonical manifest tree from a root command definition.
- *
- * Walks the command tree (including nested `subCommands`) and normalizes
- * each node into a deterministic {@link ManifestNode} shape suitable for
- * rendering into markdown documentation.
- *
- * @param command - The root command to introspect
- * @returns The manifest tree rooted at the given command
- *
- * @example
- * ```ts
- * import type { CommandSnapshot } from "@crustjs/core";
- * import { buildManifest } from "@crustjs/skills";
- *
- * // Typically called from a plugin setup hook:
- * const manifest = buildManifest(context.rootCommand);
- * // manifest.children contains normalized nodes for subcommands
- * ```
- */
 export function buildManifest(command: CommandSnapshot): ManifestNode {
-	return buildNode(command, []);
+	return buildNode(buildCommandDocumentation(command), command);
 }
-
-// ────────────────────────────────────────────────────────────────────────────
-// Internal helpers — recursive tree traversal and normalization
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Recursively builds a {@link ManifestNode} from a command and its parent path.
- *
- * @param command - Current command node to process
- * @param parentPath - Path segments from root to (but not including) this node
- */
-function buildNode(command: CommandSnapshot, parentPath: string[]): ManifestNode {
-	const name = normalizeName(command.meta.name);
-	const path = [...parentPath, name];
-
-	const args = normalizeArgs(command.args);
-	const flags = normalizeFlags(command.flags);
-	const children = normalizeChildren(command.subCommands, path);
-	const annotations = getSkillCommandAnnotations(command);
-
+function buildNode(model: CommandDocumentation, source: CommandSnapshot): ManifestNode {
+	const annotations = getSkillCommandAnnotations(source);
 	return {
-		name,
-		path,
-		description: command.meta.description,
-		usage: command.meta.usage,
+		name: normalizeName(model.name),
+		path: model.path.map(normalizeName),
+		description: model.description,
+		usage: model.usage,
 		instructions: annotations?.instructions,
-		runnable: command.hasHandler,
-		args,
-		flags,
-		children,
+		runnable: model.hasHandler,
+		args: model.args.map(normalizeArg),
+		flags: [...model.flags].sort((a, b) => a.name.localeCompare(b.name)).map(normalizeFlag),
+		children: [...model.children]
+			.sort((a, b) => a.name.localeCompare(b.name))
+			.map((child) => buildNode(child, source.subCommands[child.name]!)),
 	};
 }
-
-/**
- * Normalizes a command name to a stable, lower-case, trimmed segment.
- *
- * Strips whitespace and lowercases for deterministic path generation.
- */
 function normalizeName(raw: string): string {
 	return raw.trim().toLowerCase();
 }
-
-/**
- * Converts an `ArgsDef` tuple (or undefined) into a sorted array of
- * {@link ManifestArg} nodes. Positional ordering is preserved since
- * `ArgsDef` is an ordered tuple.
- */
-function normalizeArgs(argsDef: readonly ArgSnapshot[] | undefined): ManifestArg[] {
-	if (!argsDef || argsDef.length === 0) return [];
-
-	// Preserve positional order — args are a tuple, not a record
-	return argsDef.map(normalizeArg);
-}
-
-/**
- * Converts a single {@link ArgSnapshot} into a {@link ManifestArg}.
- */
-function normalizeArg(arg: ArgSnapshot): ManifestArg {
+function normalizeArg(arg: DocumentationArg): ManifestArg {
 	const result: ManifestArg = {
 		name: arg.name,
 		type: manifestType(arg.type),
-		required: arg.required === true,
-		variadic: arg.variadic === true,
+		required: arg.required,
+		variadic: arg.variadic,
 	};
-
-	if (arg.description !== undefined) {
-		result.description = arg.description;
-	}
-
-	if (arg.default !== undefined) {
-		result.default = serializeDefault(arg.default);
-	}
-
+	if (arg.description !== undefined) result.description = arg.description;
+	if (arg.default !== undefined) result.default = serializeDefault(arg.default);
 	return result;
 }
-
-/**
- * Converts a `FlagsDef` record (or undefined) into a sorted array of
- * {@link ManifestFlag} nodes. Flags are sorted alphabetically by name
- * for deterministic output.
- */
-function normalizeFlags(flagsDef: Record<string, FlagSnapshot> | undefined): ManifestFlag[] {
-	if (!flagsDef) return [];
-
-	const keys = Object.keys(flagsDef).sort();
-	return keys.map((key) => {
-		return normalizeFlag(key, flagsDef[key]!);
-	});
-}
-
-/**
- * Converts a single {@link FlagSnapshot} into a {@link ManifestFlag}.
- *
- * @param name - The flag key from the `FlagsDef` record
- * @param flag - The flag definition
- */
-function normalizeFlag(name: string, flag: FlagSnapshot): ManifestFlag {
+function normalizeFlag(flag: DocumentationFlag): ManifestFlag {
 	const result: ManifestFlag = {
-		name,
+		name: flag.name,
 		type: manifestType(flag.type),
-		required: flag.required === true,
-		multiple: flag.multiple === true,
+		required: flag.required,
+		multiple: flag.multiple,
 		short: flag.short,
-		aliases: flag.aliases ? [...flag.aliases].sort() : [],
+		aliases: [...flag.aliases].sort(),
 	};
-
-	if (flag.description !== undefined) {
-		result.description = flag.description;
-	}
-
-	if (flag.default !== undefined) {
-		result.default = serializeDefault(flag.default);
-	}
-
+	if (flag.description !== undefined) result.description = flag.description;
+	if (flag.default !== undefined) result.default = serializeDefault(flag.default);
 	return result;
 }
-
-/**
- * Recursively builds child {@link ManifestNode} entries from a
- * `subCommands` record. Children are sorted alphabetically by
- * command name for deterministic output.
- *
- * @param subCommands - Record of subcommand name → command, or undefined
- * @param parentPath - Full path of the parent node
- */
-function normalizeChildren(
-	subCommands: Record<string, CommandSnapshot>,
-	parentPath: string[],
-): ManifestNode[] {
-	const keys = Object.keys(subCommands).sort();
-	return keys.map((key) => {
-		return buildNode(subCommands[key]!, parentPath);
-	});
-}
-
-/**
- * Map a `FlagSnapshot`/`ArgSnapshot` `type` literal onto the manifest's narrow
- * `"string" | "number" | "boolean"` union.
- *
- * The string-tokenised built-ins (`"url"`, `"path"`, `"json"`) all consume a string
- * token on the command line, so they collapse to `"string"` at the
- * manifest layer until we extend the manifest schema for them.
- */
 function manifestType(type: string | undefined): "string" | "number" | "boolean" {
-	if (type === "number" || type === "boolean") return type;
-	return "string";
+	return type === "number" || type === "boolean" ? type : "string";
 }
-
-/**
- * Serializes a default value to a deterministic string representation.
- *
- * Arrays are serialized with `JSON.stringify` for stable output.
- * Primitives use `String()` conversion.
- */
 function serializeDefault(value: unknown): string {
-	if (Array.isArray(value)) {
-		return JSON.stringify(value);
-	}
-	return String(value);
+	return Array.isArray(value) ? JSON.stringify(value) : String(value);
 }

--- a/packages/skills/src/render.ts
+++ b/packages/skills/src/render.ts
@@ -327,29 +327,6 @@ function renderGroupCommand(node: ManifestNode, root: ManifestNode): string {
 // Shared rendering helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-/**
- * Builds an auto-generated usage line from the command's path, args, and flags.
- *
- * Example: `my-cli deploy <env> [--force] [--target <value>]`
- */
-function buildUsageLine(node: ManifestNode): string {
-	const parts = [...node.path];
-
-	for (const arg of node.args) {
-		if (arg.variadic) {
-			parts.push(arg.required ? `<${arg.name}...>` : `[${arg.name}...]`);
-		} else {
-			parts.push(arg.required ? `<${arg.name}>` : `[${arg.name}]`);
-		}
-	}
-
-	if (node.flags.length > 0) {
-		parts.push("[options]");
-	}
-
-	return parts.join(" ");
-}
-
 function renderCommandHeading(node: ManifestNode): string[] {
 	const lines = [`# \`${commandInvocation(node)}\``, ""];
 
@@ -371,7 +348,7 @@ function renderAgentInstructions(node: ManifestNode): string[] {
 }
 
 function renderRunnableCommandSections(node: ManifestNode): string[] {
-	const lines = ["## Usage", "", "```", node.usage ?? buildUsageLine(node), "```", ""];
+	const lines = ["## Usage", "", "```", node.usage, "```", ""];
 
 	if (node.args.length > 0) {
 		lines.push("## Arguments", "", ...renderArgsTable(node.args), "");

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -234,8 +234,8 @@ export interface ManifestNode {
 	path: string[];
 	/** Human-readable description */
 	description?: string;
-	/** Custom usage string (overrides auto-generated usage) */
-	usage?: string;
+	/** Resolved command usage from the core documentation model. */
+	usage: string;
 	/** Agent-facing instructions rendered into the command's markdown file */
 	instructions?: string[];
 	/** Whether this command has a `run` handler (leaf vs group) */


### PR DESCRIPTION
## Summary

Adds one presentation-neutral command documentation model behind `@crustjs/core/tooling`, then turns help, mdoc, and Agent Skill generation into format-specific adapters over it.

This was planned as the final PR stacked on #161. PR #161 is now merged and its branch was deleted, so this PR targets `main` (which contains #161).

## Phase 1 — convention audit

Baseline fixtures are committed under `packages/core/tests/fixtures/documentation-audit-before/` for a representative multi-level CLI.

| ID | Surface | Baseline divergence | Decision | Convention |
| --- | --- | --- | --- | --- |
| H1 | `--help` | Section headings were all-caps (`USAGE`, `COMMANDS`, `ARGS`, `OPTIONS`) rather than familiar help prose. | **Fix:** title-case `Usage`, `Commands`, `Arguments`, `Options`. | clig.dev recommends conventional, scannable help and demonstrates familiar `Usage:`/option presentation: https://clig.dev/#help |
| H2 | `--help` | A boolean long alias was shown, but its accepted `--no-<alias>` spelling was hidden. | **Fix:** disclose every callable long spelling and negation from core's spelling table. | GNU `--help` guidance requires a brief usage description and option surface rather than an incomplete callable interface: https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html |
| H3 | `--help` | Descriptions, defaults, choices, aliases, required/optional arg tokens, insertion order, ANSI styling, and visible-only command listing already provided compact discovery. | **Keep as-is.** | clig.dev help guidance: https://clig.dev/#help |
| M1 | mdoc | Options used `.Sy` literal labels and arguments used `.Ql` literal tokens, losing mdoc semantics. | **Fix:** render options with `.Fl` and arguments with `.Ar`; retain the literal synopsis so custom usage text remains exact. | mdoc(7) defines `.Fl` for command options and `.Ar` for command arguments: https://man.freebsd.org/cgi/man.cgi?query=mdoc&sektion=7 |
| M2 | mdoc | Only immediate root subcommands were documented. | **Keep as-is:** section-1 page remains a root summary, now an explicit adapter choice over a full-tree model rather than a traversal accident. | mdoc section organization permits a utility-focused `SYNOPSIS` and named sections; nested command docs are not required by mdoc(7): https://man.freebsd.org/cgi/man.cgi?query=mdoc&sektion=7 |
| S1 | Agent Skills | Hidden/internal commands were emitted into `SKILL.md` and generated command files. | **Fix:** only the visible documentation tree is generated. | Agent Skills progressive disclosure keeps `SKILL.md` focused and moves only relevant detail to supporting files: https://agentskills.io/specification |
| S2 | Agent Skills | Required `name`/`description` frontmatter, instructions, and linked supporting command files already follow the Agent Skills shape. | **Keep as-is.** | Agent Skills specification: https://agentskills.io/specification |

Every renderer output change maps to H1, H2, M1, or S1. Representative final diffs were checked against the committed baselines; no other output drift occurred.

## Model interface

`buildCommandDocumentation(snapshot, path?) -> CommandDocumentation` resolves the full visible tree once. Each node contains:

- canonical name, path, aliases, description, handler status, and resolved usage
- required/optional/variadic argument tokens plus defaults and choices
- flag entries with short/canonical/alias/all-negation spellings sourced from `flagSpellings()`
- required/multiple/default/choice metadata
- recursively resolved visible children (`meta.hidden` filtered once)

Exports are only from `@crustjs/core/tooling`, not the root package.

## Duplication deleted

| Package | Deleted | Replacement |
| --- | ---: | --- |
| `@crustjs/extensions` | 149 lines | 40-line help adapter over the model |
| `@crustjs/man` | 222 lines | 55-line mdoc adapter delta over the model |
| `@crustjs/skills` | 167 manifest lines + 24 usage-builder lines | 35-line manifest adapter; model owns usage/traversal |

Net tracked implementation/docs/test diff before adding the new model: **616 deletions / 220 additions**.

## Verification

- `bun run check:types` — pass, 21/21 tasks
- `bun run build` — pass, 13/13 tasks including docs prerender
- `bun run test` — pass, 21/21 tasks; targeted core/extensions/man/skills run: 1,118 pass, 5 environment skips, 0 fail
- `bun run lint` — pass (existing warnings only, no errors)
- `bunx oxfmt --check <changed files>` — pass
- `bunx changeset status --output=/tmp/pr4-changeset-status.json` — pass

## Changesets

- `@crustjs/core`: minor (new tooling export)
- `@crustjs/extensions`: minor (help output conventions)
- `@crustjs/man`: minor (semantic mdoc output)
- `@crustjs/skills`: minor (`ManifestNode.usage` resolved/required; hidden commands omitted)


## Review response (post-review commit `8553dc3`)

- **F1 (fixed):** `renderHelp` had collapsed the generated usage line into a single green span, drifting from audit item **H3** (keep ANSI styling). The model now exposes `usageSegments` (path / command / arg / options / custom) so usage-assembly policy stays in core while renderers own coloring — path/custom green, placeholders cyan, args yellow (dim when optional). Regression-tested with forced color in `plugins.test.ts`.
- **M3 (new audit row, was reviewer F3):** SYNOPSIS `<command>` placeholder now counts **visible** subcommands only — a root whose children are all hidden no longer advertises `<command>` in the man page. Deliberate: consistent with the identical help fix (hidden commands are invocable but are not documentation).
- **F2 (follow-up):** skills' `formatFlagName` still hand-builds flag labels and omits negation spellings; threading `spellings` into `ManifestFlag` changes generated skill output and deserves its own audited change — tracked in a follow-up issue.
