### PR TITLE
ci: report package sizes vs latest npm release on changeset PRs

### DIFF
--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -48,8 +48,10 @@ jobs:
           restore-keys: |
             turbo-packages-${{ runner.os }}-
 
-      - name: Build, type check, and test (packages)
-        run: bun turbo run build check:types test --filter='./packages/*'
+      - name: Build, type check, and test
+        run: |
+          bun turbo run build check:types test --filter='./packages/*'
+          bun test scripts
 
       - name: Lint and format check (packages)
         run: |

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -22,6 +22,9 @@ permissions:
 
 jobs:
   package-size:
+    # Release PRs get their own report (vs npm) from release.yml; runs here
+    # would stall at action_required anyway (bot-created PR, GITHUB_TOKEN).
+    if: github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
     timeout-minutes: 15
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      prNumber: ${{ steps.changesets.outputs.pr-number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -66,6 +67,65 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-pr-size:
+    needs: release
+    # Runs when changesets created/updated the release PR (not on publish).
+    # This job posts the size comment because pull_request workflows on
+    # GITHUB_TOKEN-created PRs never auto-run (recursive-trigger prevention).
+    if: needs.release.outputs.prNumber != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v7
+        with:
+          ref: changeset-release/main
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache Turbo
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: turbo-packages-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-packages-${{ runner.os }}-
+
+      - name: Build and measure
+        run: |
+          bun ci
+          bun turbo run build --filter='./packages/*'
+          bun scripts/package-size-report.mjs sizes > "$RUNNER_TEMP/head.json"
+          bun scripts/package-size-report.mjs sizes-published > "$RUNNER_TEMP/base.json"
+
+      - name: Comment release size report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ needs.release.outputs.prNumber }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker='<!-- package-size-release-report -->'
+          {
+            echo "$marker"
+            echo '## 📦 Package size since last release'
+            echo
+            echo 'Base = latest published versions on npm; head = this release.'
+            echo
+            bun scripts/package-size-report.mjs compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json"
+          } > "$RUNNER_TEMP/comment.md"
+          comment_id=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- package-size-release-report -->")))][0].id // empty')
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$comment_id" -F "body=@$RUNNER_TEMP/comment.md"
+          else
+            gh api "repos/$REPO/issues/$PR/comments" -F "body=@$RUNNER_TEMP/comment.md"
+          fi
 
   deploy-docs:
     needs: release

--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -6,18 +6,24 @@
 // cost, not runtime code shipped to consumers.
 // Usage:
 //   bun scripts/package-size-report.mjs sizes [rootDir] > sizes.json
+//   bun scripts/package-size-report.mjs sizes-published [rootDir] > base.json
 //   bun scripts/package-size-report.mjs compare base.json head.json > tables.md
+// `sizes-published` measures the latest npm-published version of each
+// workspace package (used on changeset release PRs, where the code diff
+// against main is empty and the meaningful base is the last release).
 // Local runs: rm -rf packages/*/dist first — turbo cache restore doesn't prune
 // stray dist files from other branches, which inflates install sizes.
 import { execFileSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 
 const [mode, ...args] = process.argv.slice(2);
 
-async function measure(root) {
-	const out = {};
+// Publishable workspace packages: [pkgDir, parsed package.json] pairs.
+function workspacePackages(root) {
+	const out = [];
 	for (const dir of readdirSync(join(root, "packages"))) {
 		const pkgDir = join(root, "packages", dir);
 		let pkg;
@@ -28,44 +34,100 @@ async function measure(root) {
 			continue;
 		}
 		if (pkg.private || pkg.bin) continue;
+		out.push([pkgDir, pkg]);
+	}
+	return out;
+}
 
-		const entries = {};
-		for (const [entry, target] of Object.entries(pkg.exports ?? {})) {
-			const file = typeof target === "string" ? target : target.import;
-			if (!file || !/\.(js|mjs|cjs)$/.test(file)) continue;
-			const result = await Bun.build({
-				entrypoints: [resolve(pkgDir, file)],
-				target: "bun",
-				minify: true,
-				// Peers are provided by the consumer and measured in their own row;
-				// inlining them would double-count and make this row churn on their PRs.
-				external: Object.keys(pkg.peerDependencies ?? {}),
-			});
-			if (!result.success) {
-				throw new AggregateError(result.logs, `Bun.build failed for ${pkg.name}${entry.slice(1)}`);
-			}
-			let size = 0;
-			for (const artifact of result.outputs) {
-				size += gzipSync(Buffer.from(await artifact.arrayBuffer())).length;
-			}
-			entries[entry] = size;
+// Gzipped size of each public `exports` entrypoint, bundled from pkgDir.
+async function bundleEntries(pkgDir, pkg) {
+	const entries = {};
+	for (const [entry, target] of Object.entries(pkg.exports ?? {})) {
+		const file = typeof target === "string" ? target : target.import;
+		if (!file || !/\.(js|mjs|cjs)$/.test(file)) continue;
+		const result = await Bun.build({
+			entrypoints: [resolve(pkgDir, file)],
+			target: "bun",
+			minify: true,
+			// Peers are provided by the consumer and measured in their own row;
+			// inlining them would double-count and make this row churn on their PRs.
+			external: Object.keys(pkg.peerDependencies ?? {}),
+		});
+		if (!result.success) {
+			throw new AggregateError(result.logs, `Bun.build failed for ${pkg.name}${entry.slice(1)}`);
 		}
+		let size = 0;
+		for (const artifact of result.outputs) {
+			size += gzipSync(Buffer.from(await artifact.arrayBuffer())).length;
+		}
+		entries[entry] = size;
+	}
+	return entries;
+}
 
-		// TODO: switch to `bun pm pack` (the tool we publish with) once it has
-		// machine-readable output — https://github.com/oven-sh/bun/issues/14155.
-		// npm is safe meanwhile: file selection and unpacked bytes match bun's
-		// exactly; only tarball gzip bytes differ slightly.
-		const [packed] = JSON.parse(
-			execFileSync("npm", ["pack", "--dry-run", "--json"], {
-				cwd: pkgDir,
-				stdio: ["ignore", "pipe", "ignore"],
-			}),
-		);
+// TODO: switch to `bun pm pack` (the tool we publish with) once it has
+// machine-readable output — https://github.com/oven-sh/bun/issues/14155.
+// npm is safe meanwhile: file selection and unpacked bytes match bun's
+// exactly; only tarball gzip bytes differ slightly.
+const npmPack = (extraArgs, cwd) =>
+	JSON.parse(
+		execFileSync("npm", ["pack", "--dry-run", "--json", ...extraArgs], {
+			cwd,
+			stdio: ["ignore", "pipe", "ignore"],
+		}),
+	);
+
+async function measure(root) {
+	const out = {};
+	for (const [pkgDir, pkg] of workspacePackages(root)) {
+		const [packed] = npmPack([], pkgDir);
 		out[pkg.name] = {
-			entries,
+			entries: await bundleEntries(pkgDir, pkg),
 			tarball: packed.size,
 			unpacked: packed.unpackedSize,
 		};
+	}
+	return out;
+}
+
+async function measurePublished(root) {
+	const out = {};
+	const published = [];
+	for (const [, pkg] of workspacePackages(root)) {
+		let packed;
+		try {
+			[packed] = npmPack([`${pkg.name}@latest`], root);
+		} catch {
+			// E404: not yet published — omit so compare renders it as "new"
+			continue;
+		}
+		out[pkg.name] = { tarball: packed.size, unpacked: packed.unpackedSize };
+		published.push(pkg.name);
+	}
+	if (published.length === 0) return out;
+
+	// Install the published versions in a throwaway project so bundling
+	// resolves real released code and dependency versions, not the workspace.
+	const tmp = mkdtempSync(join(tmpdir(), "pkg-size-published-"));
+	try {
+		writeFileSync(
+			join(tmp, "package.json"),
+			JSON.stringify({
+				name: "published-size-probe",
+				dependencies: Object.fromEntries(published.map((n) => [n, "latest"])),
+			}),
+		);
+		execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
+			cwd: tmp,
+			stdio: ["ignore", "ignore", "inherit"],
+		});
+		for (const name of published) {
+			const pkgDir = join(tmp, "node_modules", name);
+			const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+			out[name].entries = await bundleEntries(pkgDir, pkg);
+		}
+	} finally {
+		rmSync(tmp, { recursive: true, force: true });
 	}
 	return out;
 }
@@ -85,6 +147,8 @@ const delta = (b, h) => {
 
 if (mode === "sizes") {
 	console.log(JSON.stringify(await measure(args[0] ?? "."), null, 2));
+} else if (mode === "sizes-published") {
+	console.log(JSON.stringify(await measurePublished(args[0] ?? "."), null, 2));
 } else if (mode === "compare") {
 	const [base, head] = args.map((f) => JSON.parse(readFileSync(f, "utf8")));
 	const names = [...new Set([...Object.keys(base), ...Object.keys(head)])].sort();
@@ -122,6 +186,8 @@ if (mode === "sizes") {
 	}
 	console.log([...bundle, ...install].join("\n"));
 } else {
-	console.error("usage: package-size-report.mjs sizes [rootDir] | compare <base.json> <head.json>");
+	console.error(
+		"usage: package-size-report.mjs sizes|sizes-published [rootDir] | compare <base.json> <head.json>",
+	);
 	process.exit(1);
 }

--- a/scripts/package-size-report.mjs
+++ b/scripts/package-size-report.mjs
@@ -97,9 +97,9 @@ async function measurePublished(root) {
 		let packed;
 		try {
 			[packed] = npmPack([`${pkg.name}@latest`], root);
-		} catch {
-			// E404: not yet published — omit so compare renders it as "new"
-			continue;
+		} catch (error) {
+			if (error.stdout && JSON.parse(error.stdout).error?.code === "E404") continue;
+			throw error;
 		}
 		out[pkg.name] = { tarball: packed.size, unpacked: packed.unpackedSize };
 		published.push(pkg.name);
@@ -117,7 +117,7 @@ async function measurePublished(root) {
 				dependencies: Object.fromEntries(published.map((n) => [n, "latest"])),
 			}),
 		);
-		execFileSync("npm", ["install", "--no-audit", "--no-fund"], {
+		execFileSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"], {
 			cwd: tmp,
 			stdio: ["ignore", "ignore", "inherit"],
 		});

--- a/scripts/package-size-report.test.ts
+++ b/scripts/package-size-report.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testRoot = join(tmpdir(), `package-size-report-${process.pid}`);
+const fixtureRoot = join(testRoot, "fixture");
+const fakeBin = join(testRoot, "bin");
+const installArgs = join(testRoot, "install-args.json");
+const reportScript = join(import.meta.dir, "package-size-report.mjs");
+
+beforeEach(() => {
+	rmSync(testRoot, { recursive: true, force: true });
+	mkdirSync(join(fixtureRoot, "packages", "fixture"), { recursive: true });
+	mkdirSync(fakeBin, { recursive: true });
+	writeFileSync(
+		join(fixtureRoot, "packages", "fixture", "package.json"),
+		JSON.stringify({ name: "@fixture/package", exports: {} }),
+	);
+	const npm = join(fakeBin, "npm");
+	writeFileSync(
+		npm,
+		`#!/usr/bin/env bun
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+const args = process.argv.slice(2);
+if (args[0] === "pack") {
+	if (process.env.FAKE_NPM_ERROR) {
+		console.log(JSON.stringify({ error: { code: process.env.FAKE_NPM_ERROR } }));
+		process.exit(1);
+	}
+	console.log(JSON.stringify([{ size: 1, unpackedSize: 2 }]));
+} else if (args[0] === "install") {
+	writeFileSync(process.env.NPM_ARGS_FILE, JSON.stringify(args));
+	const packageDir = join(process.cwd(), "node_modules", "@fixture", "package");
+	mkdirSync(packageDir, { recursive: true });
+	writeFileSync(join(packageDir, "package.json"), JSON.stringify({ name: "@fixture/package", exports: {} }));
+}
+`,
+	);
+	chmodSync(npm, 0o755);
+});
+
+afterAll(() => rmSync(testRoot, { recursive: true, force: true }));
+
+function run(errorCode?: string) {
+	return Bun.spawnSync({
+		cmd: [process.execPath, reportScript, "sizes-published", fixtureRoot],
+		env: {
+			...process.env,
+			PATH: `${fakeBin}:${process.env.PATH}`,
+			NPM_ARGS_FILE: installArgs,
+			...(errorCode ? { FAKE_NPM_ERROR: errorCode } : {}),
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+}
+
+describe("sizes-published", () => {
+	it("only treats npm E404 responses as unpublished", () => {
+		const notFound = run("E404");
+		expect(notFound.exitCode).toBe(0);
+		expect(JSON.parse(notFound.stdout.toString())).toEqual({});
+		expect(run("E503").exitCode).not.toBe(0);
+	});
+
+	it("disables lifecycle scripts when installing published packages", () => {
+		expect(run().exitCode).toBe(0);
+		expect(JSON.parse(readFileSync(installArgs, "utf8"))).toContain("--ignore-scripts");
+	});
+});


### PR DESCRIPTION
## Why

Two problems with size reporting on the changeset release PR:

1. The `pull_request` package-size workflow **never actually runs** there — changesets creates the PR with `GITHUB_TOKEN`, so those runs stall at `action_required` forever (GitHub recursive-trigger prevention). You can see the permanently-pending runs on past `changeset-release/main` pushes.
2. Even if it ran, base-vs-head would be **±0 by construction** — the release PR only bumps versions and changelogs; its code is identical to main.

The meaningful comparison on a release PR is **this release vs. the last published release**.

## What

- **`sizes-published` mode** in `scripts/package-size-report.mjs`: for each publishable workspace package,
  - install sizes from `npm pack --dry-run --json <pkg>@latest` against the registry
  - bundle cost by `npm install`-ing the published versions into a throwaway dir and running the same `Bun.build` measurement against real released code (published deps, peers external)
  - unpublished packages are omitted → render as `new`
- **`release.yml`**: new `release-pr-size` job, gated on `changesets/action`'s `pr-number` output (PR created/updated, nothing published). Builds `changeset-release/main`, compares against npm, posts/updates a sticky comment — from the Release workflow's own token, sidestepping the trigger problem cleanly.
- **`package-size.yml`**: skips `changeset-release/main` head refs, killing the useless `action_required` runs.

## Sample output (current main vs npm, real registry data)

```
| @crustjs/core          | 5.40 KB | 7.85 KB  | +2.46 KB (+45.5%) |
| @crustjs/core/tooling  | —       | 7.60 KB  | new               |
| @crustjs/style         | 6.25 KB | 3.67 KB  | -2.59 KB (-41.4%) |
| @crustjs/extensions    | —       | 11.79 KB | new               |
```

## Verification

- `sizes-published` run locally against the real registry: 8 published packages measured, extensions/testing correctly omitted as unpublished
- Full compare rendered (table above) with new entrypoints, new packages, and deltas
- `bun lint` / `bun format` / YAML lint clean

Note: the comment appears on the *next* release-PR update after this merges (the job lives in release.yml, which runs on push to main).