### PR TITLE
refactor!: consolidate public naming conventions, drop redundant createTheme

### DIFF
--- a/.changeset/drop-create-theme.md
+++ b/.changeset/drop-create-theme.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/prompts": minor
+"@crustjs/progress": minor
+---
+
+Remove `createTheme` from `@crustjs/prompts` and `@crustjs/progress`. It was a redundant wrapper: `setTheme` and per-call `theme` options already accept partial overrides and merge onto `defaultTheme` themselves. Replace `setTheme(createTheme({...}))` with `setTheme({...})`. To read the fully resolved theme (e.g. for custom `runPrompt` renderers), use `getTheme()` in `@crustjs/prompts`.

--- a/.changeset/naming-consolidation.md
+++ b/.changeset/naming-consolidation.md
@@ -1,0 +1,11 @@
+---
+"@crustjs/extensions": minor
+"@crustjs/skills": minor
+"@crustjs/testing": minor
+---
+
+Consolidate public naming conventions (breaking renames):
+
+- `@crustjs/extensions`: `VersionExtensionOptions` → `VersionOptions` (matches `CompletionOptions`, `DidYouMeanOptions`, `UpdateNotifierOptions`).
+- `@crustjs/skills`: `skillStatus()` → `getSkillStatus()`; type renames `GenerateOptions`/`GenerateResult` → `GenerateSkillOptions`/`GenerateSkillResult`, `UninstallOptions`/`UninstallResult` → `UninstallSkillOptions`/`UninstallSkillResult`, `StatusOptions`/`StatusResult` → `SkillStatusOptions`/`SkillStatusResult` (domain-qualified, collision-safe names).
+- `@crustjs/testing`: `interactiveRun()` → `runInteractive()` (verb-first, consistent with `captureRun`/`captureExecute`).

--- a/.changeset/naming-consolidation.md
+++ b/.changeset/naming-consolidation.md
@@ -4,8 +4,8 @@
 "@crustjs/testing": minor
 ---
 
-Consolidate public naming conventions (breaking renames):
+Consolidate public naming conventions:
 
-- `@crustjs/extensions`: `VersionExtensionOptions` → `VersionOptions` (matches `CompletionOptions`, `DidYouMeanOptions`, `UpdateNotifierOptions`).
-- `@crustjs/skills`: `skillStatus()` → `getSkillStatus()`; type renames `GenerateOptions`/`GenerateResult` → `GenerateSkillOptions`/`GenerateSkillResult`, `UninstallOptions`/`UninstallResult` → `UninstallSkillOptions`/`UninstallSkillResult`, `StatusOptions`/`StatusResult` → `SkillStatusOptions`/`SkillStatusResult` (domain-qualified, collision-safe names).
-- `@crustjs/testing`: `interactiveRun()` → `runInteractive()` (verb-first, consistent with `captureRun`/`captureExecute`).
+- `@crustjs/extensions`: Name the version extension options `VersionOptions` (matching `CompletionOptions`, `DidYouMeanOptions`, and `UpdateNotifierOptions`).
+- `@crustjs/skills`: Rename `skillStatus()` to `getSkillStatus()`; rename `GenerateOptions`/`GenerateResult` to `GenerateSkillOptions`/`GenerateSkillResult`, `UninstallOptions`/`UninstallResult` to `UninstallSkillOptions`/`UninstallSkillResult`, and `StatusOptions`/`StatusResult` to `SkillStatusOptions`/`SkillStatusResult` (domain-qualified, collision-safe names).
+- `@crustjs/testing`: Name the interactive runner `runInteractive()` (verb-first, consistent with `captureRun` and `captureExecute`).

--- a/.changeset/testing-runnable-app.md
+++ b/.changeset/testing-runnable-app.md
@@ -2,6 +2,6 @@
 "@crustjs/testing": patch
 ---
 
-Export the structural `RunnableApp` contract and accept any application with its `run(argv, io)` shape in `captureRun` and `interactiveRun`.
+Export the structural `RunnableApp` contract and accept any application with its `run(argv, io)` shape in `captureRun` and `runInteractive`.
 
 Inert command definitions are not directly runnable; mount them into an application before passing them to either helper.

--- a/apps/docs/content/docs/guide/development.mdx
+++ b/apps/docs/content/docs/guide/development.mdx
@@ -18,7 +18,7 @@ await app.execute();
 
 ## Test programmatically
 
-Use the [Testing guide](/docs/guide/testing) for `captureRun()` and `interactiveRun()` helpers. It also explains when custom prompt authors should use `@crustjs/prompts/testing` directly.
+Use the [Testing guide](/docs/guide/testing) for `captureRun()` and `runInteractive()` helpers. It also explains when custom prompt authors should use `@crustjs/prompts/testing` directly.
 
 ## Validate definitions
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -47,16 +47,16 @@ See [Contexts](/docs/guide/contexts#test-doubles-with-of).
 
 ## Test interactive commands
 
-Use `interactiveRun()` when a handler renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
+Use `runInteractive()` when a handler renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
 
 ```ts
 import { expect, test } from "bun:test";
-import { interactiveRun } from "@crustjs/testing";
+import { runInteractive } from "@crustjs/testing";
 
 import { app } from "./cli.ts";
 
 test("collects a name", async () => {
-  const run = interactiveRun(app, []);
+  const run = runInteractive(app, []);
   await run.waitFor(/Name\?/);
 
   run.type("Ada");

--- a/apps/docs/content/docs/modules/extensions/version.mdx
+++ b/apps/docs/content/docs/modules/extensions/version.mdx
@@ -25,11 +25,11 @@ my-cli v1.2.3
 ```ts
 type VersionValue = string | (() => string);
 
-interface VersionExtensionOptions {
+interface VersionOptions {
   format?: "plain" | ((version: string, context: ExtensionContext) => string);
 }
 
-function version(value?: VersionValue, options?: VersionExtensionOptions): Extension;
+function version(value?: VersionValue, options?: VersionOptions): Extension;
 ```
 
 The default value is `"0.0.0"`. Pass a function to resolve the version only when the flag is handled:

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -156,15 +156,14 @@ The default theme uses these styles:
 - `error`: `red`
 
 ```ts
-import { createTheme, setTheme, spinner } from "@crustjs/progress";
+import { setTheme, spinner } from "@crustjs/progress";
 import { cyan, green } from "@crustjs/style";
 
-setTheme(
-  createTheme({
-    spinner: cyan,
-    success: green,
-  }),
-);
+// Partial overrides; unspecified slots keep their defaults
+setTheme({
+  spinner: cyan,
+  success: green,
+});
 
 await spinner({
   message: "Working...",
@@ -172,7 +171,7 @@ await spinner({
 });
 ```
 
-The public theme exports are `defaultTheme`, `createTheme`, and `setTheme`. Individual spinners resolve global and per-spinner overrides internally.
+The public theme exports are `defaultTheme` and `setTheme`. Individual spinners resolve global and per-spinner overrides internally.
 
 ## Non-interactive behavior
 

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -296,13 +296,11 @@ All prompts share a theming system with 10 style slots. Each slot is a `StyleFn`
 ### Custom Themes
 
 ```ts
-import { setTheme, createTheme, input } from "@crustjs/prompts";
+import { setTheme, input } from "@crustjs/prompts";
 import { magenta, cyan, italic } from "@crustjs/style";
 
+// Partial overrides; unspecified slots keep their defaults
 setTheme({ prefix: magenta, success: cyan });
-
-const myTheme = createTheme({ prefix: magenta, success: cyan });
-setTheme(myTheme);
 
 const name = await input({
   message: "Name?",
@@ -404,7 +402,6 @@ Only one prompt can be active per input or output stream. Prompts on fully disti
 | Export         | Description                                                                                          |
 | -------------- | ---------------------------------------------------------------------------------------------------- |
 | `defaultTheme` | Default prompt theme                                                                                 |
-| `createTheme`  | Create a theme with partial overrides                                                                |
 | `setTheme`     | Set the global theme for all prompts                                                                 |
 | `getTheme`     | Get the current resolved global theme (equivalent to prompt resolution without per-prompt overrides) |
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -285,26 +285,26 @@ For custom workflows, the package also exports lower-level functions.
 
 ### `generateSkill()` options
 
-<auto-type-table path="../../../../../packages/skills/src/types.ts" name="GenerateOptions" />
+<auto-type-table path="../../../../../packages/skills/src/types.ts" name="GenerateSkillOptions" />
 
 ### Default targets — omit `agents` for the common case
 
-`generateSkill`, `uninstallSkill`, and `skillStatus` accept an optional
+`generateSkill`, `uninstallSkill`, and `getSkillStatus` accept an optional
 `agents` field. The default differs by entrypoint so install behavior tracks
 what is actually on the current machine, while uninstall and status sweep
 every known path:
 
-| Entrypoint                      | Default when `agents` is omitted                            | `PATH` I/O? |
-| ------------------------------- | ----------------------------------------------------------- | ----------- |
-| `generateSkill`                 | Universal agents + additional agents detected on `PATH`     | Yes         |
-| `uninstallSkill`, `skillStatus` | Every supported agent (exhaustive sweep of all known paths) | No          |
+| Entrypoint                         | Default when `agents` is omitted                            | `PATH` I/O? |
+| ---------------------------------- | ----------------------------------------------------------- | ----------- |
+| `generateSkill`                    | Universal agents + additional agents detected on `PATH`     | Yes         |
+| `uninstallSkill`, `getSkillStatus` | Every supported agent (exhaustive sweep of all known paths) | No          |
 
 In all three, passing `agents: []` is treated as a no-op (no install,
 uninstall, or status entries). An explicit array always overrides the
 default.
 
 ```ts
-import { generateSkill, skillStatus, uninstallSkill } from "@crustjs/skills";
+import { generateSkill, getSkillStatus, uninstallSkill } from "@crustjs/skills";
 
 // Install — universal + agents whose CLI is on PATH.
 const result = await generateSkill({
@@ -315,7 +315,7 @@ const result = await generateSkill({
 
 // Status — reports an entry for every supported agent. Most read
 // `installed: false` on a typical machine; that is expected.
-const status = await skillStatus({ name: "my-cli" });
+const status = await getSkillStatus({ name: "my-cli" });
 
 // Uninstall — sweeps every known agent path and removes any Crust-managed
 // install regardless of whether its CLI is currently on PATH.
@@ -521,10 +521,10 @@ throws `SkillConflictError` unless `force: true` is set.
 
 <auto-type-table path="../../../../../packages/skills/src/types.ts" name="AgentResult" />
 
-<auto-type-table path="../../../../../packages/skills/src/types.ts" name="GenerateResult" />
+<auto-type-table path="../../../../../packages/skills/src/types.ts" name="GenerateSkillResult" />
 
 ### Status and uninstall options
 
-<auto-type-table path="../../../../../packages/skills/src/types.ts" name="StatusOptions" />
+<auto-type-table path="../../../../../packages/skills/src/types.ts" name="SkillStatusOptions" />
 
-<auto-type-table path="../../../../../packages/skills/src/types.ts" name="UninstallOptions" />
+<auto-type-table path="../../../../../packages/skills/src/types.ts" name="UninstallSkillOptions" />

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -55,16 +55,16 @@ expect(result.exitCode).toBe(1);
 expect(result.stderr).toContain("Unknown flag");
 ```
 
-## `interactiveRun(app, argv)`
+## `runInteractive(app, argv)`
 
 Run an application against a fake TTY. Use `waitFor()` before sending input with `type()` or `keys()`, then await `done`.
 
 `waitFor(pattern, timeoutMs?)` polls the terminal (default timeout 5000ms). It fails fast instead of hanging: if the application throws before the pattern matches, `waitFor()` rethrows that error; if the application completes without matching, or the timeout elapses, it throws with the current screen contents.
 
 ```ts
-import { interactiveRun } from "@crustjs/testing";
+import { runInteractive } from "@crustjs/testing";
 
-const run = interactiveRun(app, []);
+const run = runInteractive(app, []);
 await run.waitFor(/Project name/);
 run.type("my-app");
 run.keys("return");

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -13,4 +13,4 @@ export type {
 	UpdateNotifierOptions,
 } from "./update-notifier.ts";
 export { versionExtension as version } from "./version.ts";
-export type { VersionExtensionOptions, VersionValue } from "./version.ts";
+export type { VersionOptions, VersionValue } from "./version.ts";

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -2,7 +2,7 @@ import { type Extension, type ExtensionContext, defineExtension } from "@crustjs
 
 export type VersionValue = string | (() => string);
 
-export interface VersionExtensionOptions {
+export interface VersionOptions {
 	/**
 	 * Output format. `"plain"` prints the bare version (script-friendly:
 	 * `$(cli --version)`); a function receives the resolved version and the
@@ -15,7 +15,7 @@ export interface VersionExtensionOptions {
 
 export function versionExtension(
 	versionValue: VersionValue = "0.0.0",
-	options: VersionExtensionOptions = {},
+	options: VersionOptions = {},
 ): Extension {
 	const { format } = options;
 

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -14,5 +14,5 @@ export type {
 	SpinnerType,
 } from "./spinner.ts";
 export { spinner } from "./spinner.ts";
-export { createTheme, defaultTheme, setTheme } from "./theme.ts";
+export { defaultTheme, setTheme } from "./theme.ts";
 export type { PartialProgressTheme, ProgressTheme } from "./types.ts";

--- a/packages/progress/src/theme.test.ts
+++ b/packages/progress/src/theme.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 
 import { bold, cyan, green, magenta, red, yellow } from "@crustjs/style";
 
-import { createTheme, defaultTheme, resolveTheme, setTheme } from "./theme.ts";
+import { defaultTheme, resolveTheme, setTheme } from "./theme.ts";
 
 afterEach(() => {
 	setTheme();
@@ -14,20 +14,6 @@ describe("defaultTheme", () => {
 		expect(defaultTheme.message).toBe(bold);
 		expect(defaultTheme.success).toBe(green);
 		expect(defaultTheme.error).toBe(red);
-	});
-});
-
-describe("createTheme", () => {
-	it("returns defaultTheme when called with no arguments", () => {
-		expect(createTheme()).toBe(defaultTheme);
-	});
-
-	it("merges partial overrides onto default theme", () => {
-		const theme = createTheme({ spinner: cyan, error: yellow });
-		expect(theme.spinner).toBe(cyan);
-		expect(theme.error).toBe(yellow);
-		expect(theme.message).toBe(bold);
-		expect(theme.success).toBe(green);
 	});
 });
 

--- a/packages/progress/src/theme.ts
+++ b/packages/progress/src/theme.ts
@@ -13,11 +13,6 @@ export const defaultTheme: ProgressTheme = {
 	error: red,
 };
 
-export function createTheme(overrides?: PartialProgressTheme): ProgressTheme {
-	if (!overrides) return defaultTheme;
-	return { ...defaultTheme, ...overrides };
-}
-
 let globalOverrides: PartialProgressTheme | undefined;
 
 export function setTheme(theme?: PartialProgressTheme): void {

--- a/packages/prompts/src/core/theme.test.ts
+++ b/packages/prompts/src/core/theme.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 
 import { bold, cyan, dim, green, magenta, red, yellow } from "@crustjs/style";
 
-import { createTheme, defaultTheme, getTheme, resolveTheme, setTheme } from "./theme.ts";
+import { defaultTheme, getTheme, resolveTheme, setTheme } from "./theme.ts";
 
 // Reset global theme after each test to prevent state leakage
 afterEach(() => {
@@ -34,47 +34,6 @@ describe("defaultTheme", () => {
 	});
 });
 
-describe("createTheme", () => {
-	it("returns defaultTheme when called with no arguments", () => {
-		const theme = createTheme();
-		expect(theme).toBe(defaultTheme);
-	});
-
-	it("returns defaultTheme when called with undefined", () => {
-		const theme = createTheme(undefined);
-		expect(theme).toBe(defaultTheme);
-	});
-
-	it("merges partial overrides onto default theme", () => {
-		const theme = createTheme({ prefix: magenta });
-		expect(theme.prefix).toBe(magenta);
-		// Other slots retain defaults
-		expect(theme.message).toBe(bold);
-		expect(theme.error).toBe(red);
-		expect(theme.success).toBe(green);
-	});
-
-	it("overrides multiple slots at once", () => {
-		const theme = createTheme({
-			prefix: magenta,
-			success: cyan,
-			error: yellow,
-		});
-		expect(theme.prefix).toBe(magenta);
-		expect(theme.success).toBe(cyan);
-		expect(theme.error).toBe(yellow);
-		// Untouched slots remain default
-		expect(theme.message).toBe(bold);
-		expect(theme.cursor).toBe(cyan);
-	});
-
-	it("accepts custom style functions", () => {
-		const customStyle = (text: string) => `[${text}]`;
-		const theme = createTheme({ prefix: customStyle });
-		expect(theme.prefix("test")).toBe("[test]");
-	});
-});
-
 describe("setTheme / getTheme", () => {
 	it("getTheme returns defaultTheme when no global theme is set", () => {
 		const theme = getTheme();
@@ -97,13 +56,10 @@ describe("setTheme / getTheme", () => {
 		expect(theme.message).toBe(bold);
 	});
 
-	it("setTheme accepts a full PromptTheme from createTheme", () => {
-		const custom = createTheme({ prefix: magenta, cursor: red });
-		setTheme(custom);
-		const theme = getTheme();
-		expect(theme.prefix).toBe(magenta);
-		expect(theme.cursor).toBe(red);
-		expect(theme.message).toBe(bold);
+	it("accepts custom style functions", () => {
+		const customStyle = (text: string) => `[${text}]`;
+		setTheme({ prefix: customStyle });
+		expect(getTheme().prefix("test")).toBe("[test]");
 	});
 
 	it("setTheme with no arguments clears the global theme", () => {

--- a/packages/prompts/src/core/theme.ts
+++ b/packages/prompts/src/core/theme.ts
@@ -30,39 +30,6 @@ export const defaultTheme: PromptTheme = {
 };
 
 // ────────────────────────────────────────────────────────────────────────────
-// Theme Creation
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Create a complete theme by merging partial overrides onto the default theme.
- *
- * Use this to build a reusable theme object, then apply it globally
- * with {@link setTheme}.
- *
- * @param overrides - Partial theme slots to override. Only specified slots
- *   are replaced; all others retain their default values.
- * @returns A complete `PromptTheme` with all slots defined.
- *
- * @example
- * ```ts
- * import { createTheme, setTheme } from "@crustjs/prompts";
- * import { magenta, cyan } from "@crustjs/style";
- *
- * const myTheme = createTheme({
- *   prefix: magenta,
- *   success: cyan,
- * });
- *
- * // Apply globally so all prompts use it
- * setTheme(myTheme);
- * ```
- */
-export function createTheme(overrides?: PartialPromptTheme): PromptTheme {
-	if (!overrides) return defaultTheme;
-	return { ...defaultTheme, ...overrides };
-}
-
-// ────────────────────────────────────────────────────────────────────────────
 // Global Theme State
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -72,8 +39,7 @@ let globalOverrides: PartialPromptTheme | undefined;
 /**
  * Set the global theme applied to all prompts.
  *
- * Accepts either a complete `PromptTheme` (e.g., from {@link createTheme})
- * or a `PartialPromptTheme` with only the slots you want to override.
+ * Accepts a `PartialPromptTheme` with only the slots you want to override.
  * Unspecified slots fall back to {@link defaultTheme}.
  *
  * Call with no arguments or `undefined` to clear the global theme.

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -14,7 +14,7 @@ export type { NormalizedChoice } from "./core/utils.ts";
 // Theme
 // ────────────────────────────────────────────────────────────────────────────
 
-export { createTheme, defaultTheme, getTheme, setTheme } from "./core/theme.ts";
+export { defaultTheme, getTheme, setTheme } from "./core/theme.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Renderer

--- a/packages/prompts/tests/integration.test.ts
+++ b/packages/prompts/tests/integration.test.ts
@@ -8,7 +8,6 @@ import {
 	// Prompts
 	confirm,
 	// Theme
-	createTheme,
 	defaultTheme,
 	filter,
 	// Utilities
@@ -30,9 +29,9 @@ import {
 // Theme integration
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("createTheme integration", () => {
-	it("returns a valid theme with all slots defined", () => {
-		const theme = createTheme();
+describe("theme integration", () => {
+	it("getTheme returns a valid theme with all slots defined", () => {
+		const theme = getTheme();
 
 		const requiredSlots: (keyof PromptTheme)[] = [
 			"prefix",
@@ -53,8 +52,8 @@ describe("createTheme integration", () => {
 		}
 	});
 
-	it("returns a theme where every slot produces a string", () => {
-		const theme = createTheme();
+	it("every theme slot produces a string", () => {
+		const theme = getTheme();
 
 		for (const key of Object.keys(theme)) {
 			const fn = theme[key as keyof PromptTheme];

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -10,8 +10,8 @@ type CommandNode = Parameters<typeof snapshotCommand>[0];
 
 import { ALL_AGENTS, getUniversalAgents } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
-import { generateSkill, isValidSkillName, skillStatus, uninstallSkill } from "./generate.ts";
-import type { AgentResult, UninstallResult } from "./types.ts";
+import { generateSkill, isValidSkillName, getSkillStatus, uninstallSkill } from "./generate.ts";
+import type { AgentResult, UninstallSkillResult } from "./types.ts";
 import { CRUST_MANIFEST } from "./version.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1671,7 +1671,7 @@ describe("uninstallSkill", () => {
 			}),
 		);
 
-		const agentResult = result.agents[0] as UninstallResult["agents"][number];
+		const agentResult = result.agents[0] as UninstallSkillResult["agents"][number];
 		expect(agentResult.status).toBe("removed");
 
 		// Verify directory is gone
@@ -1692,16 +1692,16 @@ describe("uninstallSkill", () => {
 			}),
 		);
 
-		const agentResult = result.agents[0] as UninstallResult["agents"][number];
+		const agentResult = result.agents[0] as UninstallSkillResult["agents"][number];
 		expect(agentResult.status).toBe("not-found");
 	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// skillStatus
+// getSkillStatus
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("skillStatus", () => {
+describe("getSkillStatus", () => {
 	it("reports installed with version for existing skill", async () => {
 		await withCwd(tmpDir, () =>
 			generateSkill({
@@ -1713,7 +1713,7 @@ describe("skillStatus", () => {
 		);
 
 		const status = await withCwd(tmpDir, () =>
-			skillStatus({
+			getSkillStatus({
 				name: "my-cli",
 				agents: ["claude-code"],
 				scope: "project",
@@ -1726,7 +1726,7 @@ describe("skillStatus", () => {
 
 	it("reports not installed for missing skill", async () => {
 		const status = await withCwd(tmpDir, () =>
-			skillStatus({
+			getSkillStatus({
 				name: "nonexistent",
 				agents: ["claude-code"],
 				scope: "project",
@@ -1749,7 +1749,7 @@ describe("skillStatus", () => {
 		);
 
 		const status = await withCwd(tmpDir, () =>
-			skillStatus({
+			getSkillStatus({
 				name: "my-cli",
 				agents: ["claude-code", "opencode"],
 				scope: "project",
@@ -1946,7 +1946,7 @@ describe("default agent resolution", () => {
 		});
 	});
 
-	describe("skillStatus", () => {
+	describe("getSkillStatus", () => {
 		it("defaults to all supported agents when `agents` is omitted", async () => {
 			await withCwd(tmpDir, () =>
 				generateSkill({
@@ -1962,7 +1962,7 @@ describe("default agent resolution", () => {
 			);
 
 			const status = await withCwd(tmpDir, () =>
-				skillStatus({
+				getSkillStatus({
 					name: "my-cli",
 					scope: "project",
 				}),
@@ -1984,7 +1984,7 @@ describe("default agent resolution", () => {
 
 		it("treats `agents: []` as no-op (does not trigger default)", async () => {
 			const status = await withCwd(tmpDir, () =>
-				skillStatus({
+				getSkillStatus({
 					name: "my-cli",
 					agents: [],
 					scope: "project",

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -19,18 +19,18 @@ import { renderSkill } from "./render.ts";
 import type {
 	AgentResult,
 	AgentTarget,
-	GenerateOptions,
-	GenerateResult,
+	GenerateSkillOptions,
+	GenerateSkillResult,
 	InstallStatus,
 	RenderedFile,
 	Scope,
 	SkillInstallMode,
 	SkillKind,
 	SkillMeta,
-	StatusOptions,
-	StatusResult,
-	UninstallOptions,
-	UninstallResult,
+	SkillStatusOptions,
+	SkillStatusResult,
+	UninstallSkillOptions,
+	UninstallSkillResult,
 } from "./types.ts";
 import {
 	CRUST_MANIFEST,
@@ -112,7 +112,7 @@ export function isValidSkillName(name: string): boolean {
  * }
  * ```
  */
-export async function generateSkill(options: GenerateOptions): Promise<GenerateResult> {
+export async function generateSkill(options: GenerateSkillOptions): Promise<GenerateSkillResult> {
 	const {
 		command,
 		meta,
@@ -193,7 +193,9 @@ interface InstallRenderedSkillOptions {
  * The function does **not** validate the meta name — callers must do that
  * before invoking the core.
  */
-async function installRenderedSkill(options: InstallRenderedSkillOptions): Promise<GenerateResult> {
+async function installRenderedSkill(
+	options: InstallRenderedSkillOptions,
+): Promise<GenerateSkillResult> {
 	const { files, meta, agents, scope, clean, force, installMode, kind } = options;
 
 	const primaryAgent = agents[0];
@@ -347,11 +349,13 @@ export { installRenderedSkill };
  * @param options - Uninstall options specifying name, agents, and scope
  * @returns Per-agent uninstall results
  */
-export async function uninstallSkill(options: UninstallOptions): Promise<UninstallResult> {
+export async function uninstallSkill(
+	options: UninstallSkillOptions,
+): Promise<UninstallSkillResult> {
 	const { name, scope = "global" } = options;
 	const agents = options.agents ?? [...ALL_AGENTS];
 	const canonicalOutputDir = resolveCanonicalSkillPath(scope, name);
-	const results: UninstallResult["agents"] = [];
+	const results: UninstallSkillResult["agents"] = [];
 	const groups = groupAgentsByOutputDir(agents, scope, name);
 
 	for (const [outputDir, groupedAgents] of groups) {
@@ -376,7 +380,7 @@ export async function uninstallSkill(options: UninstallOptions): Promise<Uninsta
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Public API — skillStatus
+// Public API — getSkillStatus
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -385,10 +389,10 @@ export async function uninstallSkill(options: UninstallOptions): Promise<Uninsta
  * @param options - Status options specifying name, agents, and scope
  * @returns Per-agent status results
  */
-export async function skillStatus(options: StatusOptions): Promise<StatusResult> {
+export async function getSkillStatus(options: SkillStatusOptions): Promise<SkillStatusResult> {
 	const { name, scope = "global" } = options;
 	const agents = options.agents ?? [...ALL_AGENTS];
-	const results: StatusResult["agents"] = [];
+	const results: SkillStatusResult["agents"] = [];
 	const groups = groupAgentsByOutputDir(agents, scope, name);
 
 	for (const [outputDir, groupedAgents] of groups) {

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -24,7 +24,7 @@ export type { SkillConflictDetails, SkillKindMismatch, SkillManifestMalformed } 
 export { SkillConflictError } from "./errors.ts";
 
 // Primitives
-export { generateSkill, isValidSkillName, skillStatus, uninstallSkill } from "./generate.ts";
+export { generateSkill, isValidSkillName, getSkillStatus, uninstallSkill } from "./generate.ts";
 
 // Extension
 export function skill(options: SkillOptions): Extension {
@@ -37,8 +37,8 @@ export type {
 	AgentResult,
 	AgentTarget,
 	CustomSkillConfig,
-	GenerateOptions,
-	GenerateResult,
+	GenerateSkillOptions,
+	GenerateSkillResult,
 	InstallSkillBundleOptions,
 	InstallSkillBundleResult,
 	InstallStatus,
@@ -47,9 +47,9 @@ export type {
 	SkillKind,
 	SkillMeta,
 	SkillOptions,
-	StatusOptions,
-	StatusResult,
-	UninstallOptions,
-	UninstallResult,
+	SkillStatusOptions,
+	SkillStatusResult,
+	UninstallSkillOptions,
+	UninstallSkillResult,
 	UninstallStatus,
 } from "./types.ts";

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -22,11 +22,11 @@ import {
 } from "./agents.ts";
 import { installSkillBundle } from "./bundle.ts";
 import { SkillConflictError } from "./errors.ts";
-import { generateSkill, isValidSkillName, skillStatus, uninstallSkill } from "./generate.ts";
+import { generateSkill, isValidSkillName, getSkillStatus, uninstallSkill } from "./generate.ts";
 import type {
 	AgentTarget,
 	CustomSkillConfig,
-	GenerateResult,
+	GenerateSkillResult,
 	Scope,
 	SkillMeta,
 	SkillOptions,
@@ -190,7 +190,7 @@ function resolveCustomSkillScopes(entry: CustomSkillConfig, options: SkillOption
 
 /**
  * Reconciles a single hand-authored bundle entry for `autoUpdateSkills` and
- * `skill update`. Mirrors the main-skill loop body: per-scope `skillStatus`,
+ * `skill update`. Mirrors the main-skill loop body: per-scope `getSkillStatus`,
  * version diff, then a single `installSkillBundle` call for outdated agents.
  *
  * Per-scope `SkillConflictError`s are logged (including `kindMismatch`) and
@@ -213,7 +213,7 @@ async function autoUpdateCustomSkill(
 
 	for (const scope of scopes) {
 		const effectiveScope = resolveEffectiveScope(scope);
-		const status = await skillStatus({ name: entry.name, scope });
+		const status = await getSkillStatus({ name: entry.name, scope });
 		const needsUpdate = status.agents.filter((agent) => {
 			if (!agent.installed) return false;
 			const expectedOutputDir = resolveAgentPath(agent.agent, scope, entry.name);
@@ -291,7 +291,7 @@ async function updateGeneratedSkill(
 ): Promise<void> {
 	const effectiveScope = resolveEffectiveScope(scope);
 	const meta = deriveSkillMeta(rootCmd, options);
-	const status = await skillStatus({ name: meta.name, scope });
+	const status = await getSkillStatus({ name: meta.name, scope });
 	const needsUpdate = status.agents.filter((entry) => needsSkillReconciliation(meta, entry));
 
 	if (needsUpdate.length === 0) {
@@ -421,7 +421,7 @@ async function autoUpdateCustomSkillsLoop(
  *
  * For first-time installation, use the interactive command or build custom
  * auto-install logic with the exported primitives (`detectInstalledAgents`,
- * `skillStatus`, `generateSkill`).
+ * `getSkillStatus`, `generateSkill`).
  *
  * @param options - Plugin configuration with version and defaults
  * @returns The internal plugin behind the `skill()` Extension
@@ -473,14 +473,14 @@ async function reconcileSkillInteractively(opts: {
 	isInteractive: boolean;
 	labelSuffix: string;
 	installNoun: "skill" | "bundle";
-	install: (agents: AgentTarget[], force?: boolean) => Promise<GenerateResult>;
+	install: (agents: AgentTarget[], force?: boolean) => Promise<GenerateSkillResult>;
 }): Promise<void> {
 	const { name, version, scope, installAll, isInteractive, labelSuffix, installNoun, install } =
 		opts;
 	const detectedAgents = await detectInstalledAgents();
 	const universalAgents = getUniversalAgents();
 	const allAdditionalAgents = getAdditionalAgents();
-	const status = await skillStatus({ name, scope });
+	const status = await getSkillStatus({ name, scope });
 
 	const installedAgentSet = new Set<AgentTarget>(
 		status.agents.filter((entry) => entry.installed).map((entry) => entry.agent),

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -28,7 +28,7 @@ export interface SkillMeta {
 	/**
 	 * Skill name — the user-facing CLI name (e.g. `"my-cli"`).
 	 *
-	 * `generateSkill()`, `uninstallSkill()`, and `skillStatus()` treat this as
+	 * `generateSkill()`, `uninstallSkill()`, and `getSkillStatus()` treat this as
 	 * the canonical raw skill name for output directory paths, SKILL.md
 	 * frontmatter, and crust.json metadata. For example, `name: "my-cli"`
 	 * produces output under `my-cli/`.
@@ -292,7 +292,7 @@ export interface RenderedFile {
  * });
  * ```
  */
-export interface GenerateOptions {
+export interface GenerateSkillOptions {
 	/** Root command to generate the skill from */
 	command: CommandSnapshot;
 	/** Skill metadata for the generated bundle */
@@ -353,7 +353,7 @@ export interface GenerateOptions {
 /**
  * Top-level options for installing a hand-authored skill bundle.
  *
- * Unlike {@link GenerateOptions}, the bundle entrypoint does not render
+ * Unlike {@link GenerateSkillOptions}, the bundle entrypoint does not render
  * `SKILL.md` from a command tree — it copies a directory the caller has
  * already authored. The bundle's `SKILL.md` frontmatter is the source of
  * truth for `name` and `description`; Crust reads them but does not rewrite
@@ -400,7 +400,7 @@ export interface InstallSkillBundleOptions {
 	/**
 	 * Agent targets to install the bundle for.
 	 *
-	 * Required — unlike {@link GenerateOptions.agents}, the bundle entrypoint
+	 * Required — unlike {@link GenerateSkillOptions.agents}, the bundle entrypoint
 	 * does not auto-detect agents. Pass `[]` for a validated no-op: no install
 	 * is performed, but `sourceDir`, `SKILL.md`, bundle paths, frontmatter, and
 	 * skill name are still validated.
@@ -455,9 +455,9 @@ export interface InstallSkillBundleOptions {
 /**
  * Result returned by `installSkillBundle` after writing files to disk.
  *
- * Type alias of {@link GenerateResult} — the per-agent shape is identical.
+ * Type alias of {@link GenerateSkillResult} — the per-agent shape is identical.
  */
-export type InstallSkillBundleResult = GenerateResult;
+export type InstallSkillBundleResult = GenerateSkillResult;
 
 // ────────────────────────────────────────────────────────────────────────────
 // Generation result — returned from generateSkill
@@ -486,7 +486,7 @@ export interface AgentResult {
 /**
  * Result returned by `generateSkill` after writing files to disk.
  */
-export interface GenerateResult {
+export interface GenerateSkillResult {
 	/** Per-agent installation results */
 	agents: AgentResult[];
 }
@@ -496,7 +496,7 @@ export interface GenerateResult {
 // ────────────────────────────────────────────────────────────────────────────
 
 /** Options for removing installed skills. */
-export interface UninstallOptions {
+export interface UninstallSkillOptions {
 	/** Skill name to uninstall */
 	name: string;
 	/**
@@ -521,7 +521,7 @@ export interface UninstallOptions {
 }
 
 /** Result returned by `uninstallSkill`. */
-export interface UninstallResult {
+export interface UninstallSkillResult {
 	/** Per-agent uninstall results */
 	agents: Array<{
 		agent: AgentTarget;
@@ -535,7 +535,7 @@ export interface UninstallResult {
 // ────────────────────────────────────────────────────────────────────────────
 
 /** Options for checking installed skill status. */
-export interface StatusOptions {
+export interface SkillStatusOptions {
 	/** Skill name to check */
 	name: string;
 	/**
@@ -559,8 +559,8 @@ export interface StatusOptions {
 	scope?: Scope;
 }
 
-/** Result returned by `skillStatus`. */
-export interface StatusResult {
+/** Result returned by `getSkillStatus`. */
+export interface SkillStatusResult {
 	/** Per-agent status results */
 	agents: Array<{
 		agent: AgentTarget;
@@ -679,7 +679,7 @@ export interface CustomSkillConfig extends Pick<
  *
  * For first-time installation, use the interactive `skill` subcommand or
  * build custom auto-install logic with the exported primitives
- * (`detectInstalledAgents`, `skillStatus`, `generateSkill`).
+ * (`detectInstalledAgents`, `getSkillStatus`, `generateSkill`).
  *
  * **Interactive command** (default): registers a `skill` subcommand (or the
  * custom `command` name) that

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { Crust, defineExtension } from "@crustjs/core";
 import { input } from "@crustjs/prompts";
 
-import { captureExecute, captureRun, interactiveRun, type RunnableApp } from "./index.ts";
+import { captureExecute, captureRun, runInteractive, type RunnableApp } from "./index.ts";
 
 describe("captureRun", () => {
 	it("captures output from a structural runnable as lines", async () => {
@@ -38,7 +38,7 @@ describe("captureRun", () => {
 	});
 });
 
-describe("interactiveRun", () => {
+describe("runInteractive", () => {
 	it("drives prompts from a structural runnable and merges stderr with prompt frames", async () => {
 		const app: RunnableApp = {
 			async run(_argv, io) {
@@ -48,7 +48,7 @@ describe("interactiveRun", () => {
 			},
 		};
 
-		const run = interactiveRun(app, []);
+		const run = runInteractive(app, []);
 		await run.waitFor(/Name\?/);
 		run.type("Ada");
 		run.keys("return");
@@ -66,7 +66,7 @@ describe("interactiveRun", () => {
 			},
 		};
 
-		const run = interactiveRun(app, []);
+		const run = runInteractive(app, []);
 		await expect(run.waitFor(/never rendered/)).rejects.toBe(error);
 	});
 
@@ -77,7 +77,7 @@ describe("interactiveRun", () => {
 			},
 		};
 
-		const run = interactiveRun(app, []);
+		const run = runInteractive(app, []);
 		await expect(run.waitFor(/never rendered/)).rejects.toThrow("already completed");
 		await run.done;
 	});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -122,7 +122,7 @@ export interface InteractiveRun {
 }
 
 /** Run an application with fake terminal streams for its prompts and stderr output. */
-export function interactiveRun(app: RunnableApp, argv: readonly string[]): InteractiveRun {
+export function runInteractive(app: RunnableApp, argv: readonly string[]): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output!;
 	const done = withPromptIO(harness.io, () =>


### PR DESCRIPTION
## Summary

Naming-convention audit across all packages surfaced a coherent implicit rule (`define*` = declarative definition, `create*` = configured instance, bare noun = ready-made default) with a handful of outliers. This PR fixes the outliers and removes one redundant API. Breaking; no compat shims (revamp).

### Renames
- **extensions**: `VersionExtensionOptions` → `VersionOptions` (matches `CompletionOptions`, `DidYouMeanOptions`, `UpdateNotifierOptions`)
- **skills**: `skillStatus()` → `getSkillStatus()`; `Generate/Uninstall/Status{Options,Result}` → `GenerateSkill/UninstallSkill/SkillStatus{Options,Result}` (domain-qualified, collision-safe)
- **testing**: `interactiveRun()` → `runInteractive()` (verb-first, consistent with `captureRun`/`captureExecute`)

### Removed
- **prompts/progress**: `createTheme` — `setTheme` and per-call `theme` options already accept partial overrides and merge onto `defaultTheme`; `createTheme` was a no-op wrapper. Migration: `setTheme(createTheme({...}))` → `setTheme({...})`.

### Verified non-issues
`ValueType`, `DefinitionErrorDetails`/`ValidationErrorDetails`, and the two `createTheme`s are parallel per-package types sharing `@crustjs/utils` as a single base — not duplicates.

## Checks
- `bun run check:types` 21/21 ✓
- `bun test` all green ✓
- lint/format ✓
- Docs updated in same change; changesets added (minor ×5)
