### PR TITLE
feat(prompts,progress)!: replace global theme state with instance factories

### DIFF
--- a/.changeset/drop-create-theme.md
+++ b/.changeset/drop-create-theme.md
@@ -3,4 +3,4 @@
 "@crustjs/progress": minor
 ---
 
-Remove `createTheme` from `@crustjs/prompts` and `@crustjs/progress`. It was a redundant wrapper: `setTheme` and per-call `theme` options already accept partial overrides and merge onto `defaultTheme` themselves. Replace `setTheme(createTheme({...}))` with `setTheme({...})`. To read the fully resolved theme (e.g. for custom `runPrompt` renderers), use `getTheme()` in `@crustjs/prompts`.
+Remove `createTheme` from `@crustjs/prompts` and `@crustjs/progress`. It was a redundant wrapper: partial theme overrides already merge onto `defaultTheme` themselves. Replace `createTheme({...})` with a plain partial theme passed to `createPrompts({ theme: {...} })` / `createProgress({ theme: {...} })` or a per-call `theme` option. To read the fully resolved theme (e.g. for custom `runPrompt` renderers), use the `theme` property on a `createPrompts` instance.

--- a/.changeset/instance-themes.md
+++ b/.changeset/instance-themes.md
@@ -1,0 +1,14 @@
+---
+"@crustjs/prompts": minor
+"@crustjs/progress": minor
+---
+
+Replace global theme state with explicit themed instances (breaking):
+
+- Removed `setTheme` from both packages and `getTheme` from `@crustjs/prompts`. There is no module-global theme anymore.
+- New `createPrompts({ theme })` in `@crustjs/prompts` returns all prompt functions bound to a theme, plus the resolved `theme` for custom `runPrompt` renderers. A default `prompts` instance is exported alongside the bare functions.
+- New `createProgress({ theme })` in `@crustjs/progress` returns themed `progress`/`spinner`.
+- `runPrompt`'s `theme` config is now an optional partial merged onto `defaultTheme`.
+- Resolution order everywhere: `defaultTheme` ← instance theme ← per-call `theme` option.
+
+Migration: `setTheme({...})` → `const p = createPrompts({ theme: {...} })` and call `p.input(...)` etc.; `getTheme()` → `p.theme`.

--- a/.changeset/instance-themes.md
+++ b/.changeset/instance-themes.md
@@ -6,7 +6,7 @@
 Replace global theme state with explicit themed instances (breaking):
 
 - Removed `setTheme` from both packages and `getTheme` from `@crustjs/prompts`. There is no module-global theme anymore.
-- New `createPrompts({ theme })` in `@crustjs/prompts` returns all prompt functions bound to a theme, plus the resolved `theme` for custom `runPrompt` renderers. A default `prompts` instance is exported alongside the bare functions.
+- New `createPrompts({ theme })` in `@crustjs/prompts` returns all prompt functions bound to a theme, plus the resolved `theme` for custom `runPrompt` renderers.
 - New `createProgress({ theme })` in `@crustjs/progress` returns themed `progress`/`spinner`.
 - `runPrompt`'s `theme` config is now an optional partial merged onto `defaultTheme`.
 - Resolution order everywhere: `defaultTheme` ← instance theme ← per-call `theme` option.

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -170,7 +170,7 @@ await p.spinner({
 });
 ```
 
-The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `defaultTheme` ← instance theme ← per-call `theme` option. The public theme exports are `defaultTheme` and `createProgress`.
+The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `defaultTheme` ← instance theme ← per-call `theme` option. The public theme exports are `defaultTheme` and `createProgress`, with types `CreateProgressOptions` (factory options) and `ProgressInstance` (the returned themed `progress`/`spinner` pair plus its resolved `theme`).
 
 ## Non-interactive behavior
 

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -155,23 +155,22 @@ The default theme uses these styles:
 - `success`: `green`
 - `error`: `red`
 
+There is no global theme state. Create a themed instance with `createProgress`, or pass per-call `theme` overrides:
+
 ```ts
-import { setTheme, spinner } from "@crustjs/progress";
+import { createProgress } from "@crustjs/progress";
 import { cyan, green } from "@crustjs/style";
 
 // Partial overrides; unspecified slots keep their defaults
-setTheme({
-  spinner: cyan,
-  success: green,
-});
+const p = createProgress({ theme: { spinner: cyan, success: green } });
 
-await spinner({
+await p.spinner({
   message: "Working...",
   task: async () => doWork(),
 });
 ```
 
-The public theme exports are `defaultTheme` and `setTheme`. Individual spinners resolve global and per-spinner overrides internally.
+The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `defaultTheme` ← instance theme ← per-call `theme` option. The public theme exports are `defaultTheme` and `createProgress`.
 
 ## Non-interactive behavior
 

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -295,23 +295,27 @@ All prompts share a theming system with 10 style slots. Each slot is a `StyleFn`
 
 ### Custom Themes
 
+There is no global theme state. Create a themed instance with `createPrompts` — it exposes the same prompt functions bound to your theme:
+
 ```ts
-import { setTheme, input } from "@crustjs/prompts";
+import { createPrompts } from "@crustjs/prompts";
 import { magenta, cyan, italic } from "@crustjs/style";
 
 // Partial overrides; unspecified slots keep their defaults
-setTheme({ prefix: magenta, success: cyan });
+const p = createPrompts({ theme: { prefix: magenta, success: cyan } });
 
-const name = await input({
+const name = await p.input({
   message: "Name?",
   theme: { message: italic },
 });
 ```
 
+The bare exports (`input`, `select`, …) and the `prompts` singleton use `defaultTheme`.
+
 Theme resolution order, from lowest to highest priority:
 
 1. `defaultTheme`
-2. Global overrides from `setTheme()`
+2. Instance theme from `createPrompts()`
 3. Per-prompt overrides from the `theme` option
 
 ## Non-Interactive Environments
@@ -345,7 +349,6 @@ The low-level `runPrompt(config, io?)` API lets you build custom interactive pro
 ```ts
 import { runPrompt, submit } from "@crustjs/prompts";
 import type { KeypressEvent } from "@crustjs/prompts";
-import { getTheme } from "@crustjs/prompts";
 
 interface CounterState {
   count: number;
@@ -353,7 +356,8 @@ interface CounterState {
 
 const result = await runPrompt<CounterState, number>({
   initialState: { count: 0 },
-  theme: getTheme(),
+  // theme is optional: partial overrides merge onto defaultTheme.
+  // Pass an instance theme (createPrompts().theme) to match themed prompts.
   render: (state, theme) => `${theme.prefix("○")} Count: ${state.count}`,
   handleKey: (key, state) => {
     if (key.name === "return") return submit(state.count);
@@ -399,11 +403,11 @@ Only one prompt can be active per input or output stream. Prompts on fully disti
 
 ### Theme
 
-| Export         | Description                                                                                          |
-| -------------- | ---------------------------------------------------------------------------------------------------- |
-| `defaultTheme` | Default prompt theme                                                                                 |
-| `setTheme`     | Set the global theme for all prompts                                                                 |
-| `getTheme`     | Get the current resolved global theme (equivalent to prompt resolution without per-prompt overrides) |
+| Export          | Description                                                      |
+| --------------- | ---------------------------------------------------------------- |
+| `defaultTheme`  | Default prompt theme                                             |
+| `createPrompts` | Create a themed instance exposing all prompt functions           |
+| `prompts`       | Default instance using `defaultTheme` (mirrors the bare exports) |
 
 ### Renderer
 

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -310,7 +310,7 @@ const name = await p.input({
 });
 ```
 
-The bare exports (`input`, `select`, …) and the `prompts` singleton use `defaultTheme`.
+The bare exports (`input`, `select`, …) use `defaultTheme`.
 
 Theme resolution order, from lowest to highest priority:
 
@@ -403,11 +403,10 @@ Only one prompt can be active per input or output stream. Prompts on fully disti
 
 ### Theme
 
-| Export          | Description                                                      |
-| --------------- | ---------------------------------------------------------------- |
-| `defaultTheme`  | Default prompt theme                                             |
-| `createPrompts` | Create a themed instance exposing all prompt functions           |
-| `prompts`       | Default instance using `defaultTheme` (mirrors the bare exports) |
+| Export          | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `defaultTheme`  | Default prompt theme                                   |
+| `createPrompts` | Create a themed instance exposing all prompt functions |
 
 ### Renderer
 
@@ -451,6 +450,8 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 | `PromptOutput`            | Output stream contract composing `PromptIO`                                         |
 | `PromptTheme`             | Complete theme with all style slots                                                 |
 | `PartialPromptTheme`      | Partial theme for overrides                                                         |
+| `CreatePromptsOptions`    | Options for `createPrompts()`                                                       |
+| `PromptsInstance`         | Themed prompt functions returned by `createPrompts()`                               |
 | `Choice<T>`               | Choice item: string or `{ label, value, hint? }`                                    |
 | `ValidateFn<T>`           | Validation function type — `(value: T) => void \| Promise<void>`, throws on failure |
 | `KeypressEvent`           | Structured keypress event                                                           |

--- a/packages/progress/src/create-progress.ts
+++ b/packages/progress/src/create-progress.ts
@@ -44,7 +44,9 @@ export interface ProgressInstance {
  * ```
  */
 export function createProgress(options: CreateProgressOptions = {}): ProgressInstance {
-	const overrides = options.theme;
+	// Snapshot so later mutation of the caller's object can't diverge
+	// rendering from the exposed `theme`.
+	const overrides = { ...options.theme };
 	const themed = <O extends { readonly theme?: PartialProgressTheme }>(opts: O): O => ({
 		...opts,
 		theme: { ...overrides, ...opts.theme },

--- a/packages/progress/src/create-progress.ts
+++ b/packages/progress/src/create-progress.ts
@@ -1,0 +1,59 @@
+// ────────────────────────────────────────────────────────────────────────────
+// createProgress — themed indicator instance factory for @crustjs/progress
+// ────────────────────────────────────────────────────────────────────────────
+
+import { type ProgressHandle, type ProgressOptions, progress } from "./progress.ts";
+import { type SpinnerHandleOptions, spinner } from "./spinner.ts";
+import { defaultTheme } from "./theme.ts";
+import type { PartialProgressTheme, ProgressTheme } from "./types.ts";
+
+/** Configuration for {@link createProgress}. */
+export interface CreateProgressOptions {
+	/**
+	 * Partial theme applied to every indicator from this instance.
+	 * Per-call `theme` options layer on top; unspecified slots
+	 * fall back to `defaultTheme`.
+	 */
+	readonly theme?: PartialProgressTheme;
+}
+
+/**
+ * Progress indicators bound to a theme. Same signatures as the bare
+ * `progress`/`spinner` exports; the only difference is the theme
+ * resolution order: `defaultTheme` ← instance theme ← per-call `theme`.
+ */
+export interface ProgressInstance {
+	/** The fully resolved instance theme. */
+	readonly theme: ProgressTheme;
+	readonly progress: typeof progress;
+	readonly spinner: typeof spinner;
+}
+
+/**
+ * Create a {@link ProgressInstance} with a theme applied to every
+ * indicator. There is no global theme state: theming is explicit,
+ * owned by whoever holds the instance.
+ *
+ * @example
+ * ```ts
+ * import { createProgress } from "@crustjs/progress";
+ * import { cyan, green } from "@crustjs/style";
+ *
+ * const p = createProgress({ theme: { spinner: cyan, success: green } });
+ * await p.spinner({ message: "Working...", task: async () => doWork() });
+ * ```
+ */
+export function createProgress(options: CreateProgressOptions = {}): ProgressInstance {
+	const overrides = options.theme;
+	const themed = <O extends { readonly theme?: PartialProgressTheme }>(opts: O): O => ({
+		...opts,
+		theme: { ...overrides, ...opts.theme },
+	});
+	return {
+		theme: { ...defaultTheme, ...overrides },
+		progress: (opts: ProgressOptions): ProgressHandle => progress(themed(opts)),
+		// Double cast: the wrapper can't express spinner's task/handle overloads.
+		spinner: ((opts: SpinnerHandleOptions) =>
+			spinner(themed(opts) as never)) as unknown as typeof spinner,
+	};
+}

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -14,5 +14,7 @@ export type {
 	SpinnerType,
 } from "./spinner.ts";
 export { spinner } from "./spinner.ts";
-export { defaultTheme, setTheme } from "./theme.ts";
+export type { CreateProgressOptions, ProgressInstance } from "./create-progress.ts";
+export { createProgress } from "./create-progress.ts";
+export { defaultTheme } from "./theme.ts";
 export type { PartialProgressTheme, ProgressTheme } from "./types.ts";

--- a/packages/progress/src/theme.test.ts
+++ b/packages/progress/src/theme.test.ts
@@ -2,8 +2,36 @@ import { describe, expect, it } from "bun:test";
 
 import { bold, cyan, green, magenta, red, yellow } from "@crustjs/style";
 
-import { createProgress } from "./create-progress.ts";
+import {
+	type CreateProgressOptions,
+	createProgress,
+	type ProgressInstance,
+} from "./create-progress.ts";
+import type { SpinnerHandle } from "./spinner.ts";
 import { defaultTheme, resolveTheme } from "./theme.ts";
+
+// Indicators write to process.stderr; capture it like spinner.test.ts does.
+const captureStderr = (fn: () => void): string => {
+	const originalWrite = process.stderr.write;
+	let output = "";
+	process.stderr.write = (chunk: string | Uint8Array) => {
+		if (typeof chunk === "string") output += chunk;
+		return true;
+	};
+	try {
+		fn();
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	return output;
+};
+
+const runProgress = (p: ProgressInstance, message: string): void => {
+	const handle = p.progress({ message, total: 1 });
+	handle.start();
+	handle.advance(1);
+	handle.stop();
+};
 
 describe("defaultTheme", () => {
 	it("uses expected default colors", () => {
@@ -39,23 +67,68 @@ describe("createProgress", () => {
 		expect(createProgress().theme).toEqual(defaultTheme);
 	});
 
-	it("instance theme reaches indicator output", () => {
-		// Indicators write to process.stderr; capture it like spinner.test.ts does.
-		const originalWrite = process.stderr.write;
-		let output = "";
-		process.stderr.write = (chunk: string | Uint8Array) => {
-			if (typeof chunk === "string") output += chunk;
-			return true;
-		};
-		try {
-			const p = createProgress({ theme: { success: (t) => `<OK ${t}>` } });
-			const handle = p.progress({ message: "work", total: 2 });
+	it("instances are isolated from each other", () => {
+		// The `message` slot wraps the message text, e.g. `✓ <A a-work (1/1)>`.
+		const captured = captureStderr(() => {
+			const a = createProgress({ theme: { message: (t) => `<A ${t}>` } });
+			const b = createProgress({ theme: { message: (t) => `<B ${t}>` } });
+			runProgress(a, "a-work");
+			runProgress(b, "b-work");
+			runProgress(a, "a-again");
+		});
+		expect(captured).toContain("<A a-work");
+		expect(captured).toContain("<B b-work");
+		expect(captured).toContain("<A a-again");
+		expect(captured).not.toContain("<B a-work");
+		expect(captured).not.toContain("<A b-work");
+	});
+
+	it("merges default ← instance ← per-call, keeping instance-only slots", () => {
+		const p = createProgress({
+			theme: { success: (t) => `<INST ${t}>`, message: (t) => `[MSG ${t}]` },
+		});
+		const captured = captureStderr(() => {
+			const handle = p.progress({
+				message: "work",
+				total: 1,
+				theme: { success: (t) => `<CALL ${t}>` },
+			});
 			handle.start();
-			handle.advance(2);
+			handle.advance(1);
 			handle.stop();
-		} finally {
-			process.stderr.write = originalWrite;
-		}
+		});
+		expect(captured).toContain("<CALL"); // per-call wins the conflicting slot
+		expect(captured).toContain("[MSG work"); // instance-only slot survives
+		expect(captured).not.toContain("<INST");
+	});
+
+	it("snapshots overrides at creation; later mutation has no effect", () => {
+		const overrides = { success: (t: string) => `<ORIG ${t}>` };
+		const p = createProgress({ theme: overrides });
+		overrides.success = (t: string) => `<MUTATED ${t}>`;
+		const captured = captureStderr(() => runProgress(p, "work"));
+		// `success` styles the ✓ glyph on the final line.
+		expect(captured).toContain("<ORIG");
+		expect(captured).not.toContain("<MUTATED");
+		expect(p.theme.success("x")).toBe("<ORIG x>");
+	});
+
+	it("instance theme reaches indicator output", () => {
+		const p = createProgress({ theme: { success: (t) => `<OK ${t}>` } });
+		const output = captureStderr(() => runProgress(p, "work"));
 		expect(output).toContain("<OK");
+	});
+
+	it("bound spinner preserves the task/handle overloads (compile-time)", () => {
+		// Never executed — these arrows only need to type-check. They guard the
+		// casts in create-progress.ts against drifting from spinner's overloads.
+		const _opts: CreateProgressOptions = { theme: {} };
+		const p = null as unknown as ProgressInstance;
+		const assertTask = (): Promise<number> => p.spinner({ message: "m", task: async () => 42 });
+		const assertHandle = (): SpinnerHandle => p.spinner({ message: "m" });
+		void _opts;
+		void assertTask;
+		void assertHandle;
+		expect(true).toBe(true);
 	});
 });

--- a/packages/progress/src/theme.test.ts
+++ b/packages/progress/src/theme.test.ts
@@ -1,12 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { bold, cyan, green, magenta, red, yellow } from "@crustjs/style";
 
-import { defaultTheme, resolveTheme, setTheme } from "./theme.ts";
-
-afterEach(() => {
-	setTheme();
-});
+import { createProgress } from "./create-progress.ts";
+import { defaultTheme, resolveTheme } from "./theme.ts";
 
 describe("defaultTheme", () => {
 	it("uses expected default colors", () => {
@@ -22,19 +19,43 @@ describe("resolveTheme", () => {
 		expect(resolveTheme()).toBe(defaultTheme);
 	});
 
-	it("applies global overrides", () => {
-		setTheme({ spinner: cyan, success: yellow });
-		const theme = resolveTheme();
-		expect(theme.spinner).toBe(cyan);
-		expect(theme.success).toBe(yellow);
-		expect(theme.message).toBe(bold);
-	});
-
-	it("layers global and per-call overrides", () => {
-		setTheme({ spinner: cyan });
-		const theme = resolveTheme({ error: yellow });
+	it("merges partial overrides onto default theme", () => {
+		const theme = resolveTheme({ spinner: cyan, error: yellow });
 		expect(theme.spinner).toBe(cyan);
 		expect(theme.error).toBe(yellow);
 		expect(theme.message).toBe(bold);
+		expect(theme.success).toBe(green);
+	});
+});
+
+describe("createProgress", () => {
+	it("resolves instance theme over defaults", () => {
+		const p = createProgress({ theme: { spinner: cyan } });
+		expect(p.theme.spinner).toBe(cyan);
+		expect(p.theme.message).toBe(bold); // default preserved
+	});
+
+	it("with no options mirrors defaultTheme", () => {
+		expect(createProgress().theme).toEqual(defaultTheme);
+	});
+
+	it("instance theme reaches indicator output", () => {
+		// Indicators write to process.stderr; capture it like spinner.test.ts does.
+		const originalWrite = process.stderr.write;
+		let output = "";
+		process.stderr.write = (chunk: string | Uint8Array) => {
+			if (typeof chunk === "string") output += chunk;
+			return true;
+		};
+		try {
+			const p = createProgress({ theme: { success: (t) => `<OK ${t}>` } });
+			const handle = p.progress({ message: "work", total: 2 });
+			handle.start();
+			handle.advance(2);
+			handle.stop();
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+		expect(output).toContain("<OK");
 	});
 });

--- a/packages/progress/src/theme.ts
+++ b/packages/progress/src/theme.ts
@@ -13,17 +13,14 @@ export const defaultTheme: ProgressTheme = {
 	error: red,
 };
 
-let globalOverrides: PartialProgressTheme | undefined;
-
-export function setTheme(theme?: PartialProgressTheme): void {
-	globalOverrides = theme;
-}
-
+/**
+ * Resolve a complete theme by merging partial overrides onto
+ * {@link defaultTheme}. Instance themes from `createProgress` are
+ * pre-merged into the per-call overrides before this runs.
+ *
+ * @internal — Indicator implementations call this; users do not need to.
+ */
 export function resolveTheme(progressTheme?: PartialProgressTheme): ProgressTheme {
-	if (!globalOverrides && !progressTheme) return defaultTheme;
-	return {
-		...defaultTheme,
-		...globalOverrides,
-		...progressTheme,
-	};
+	if (!progressTheme) return defaultTheme;
+	return { ...defaultTheme, ...progressTheme };
 }

--- a/packages/progress/src/theme.ts
+++ b/packages/progress/src/theme.ts
@@ -1,5 +1,5 @@
 // ────────────────────────────────────────────────────────────────────────────
-// Theme — Default theme, global state, and resolution for @crustjs/progress
+// Theme — Default theme and resolution for @crustjs/progress
 // ────────────────────────────────────────────────────────────────────────────
 
 import { bold, green, magenta, red } from "@crustjs/style";

--- a/packages/prompts/src/core/renderer.test.ts
+++ b/packages/prompts/src/core/renderer.test.ts
@@ -226,6 +226,81 @@ describe("runPrompt", () => {
 		expect(output).toContain("prompt");
 	});
 
+	it("resolves an omitted theme to defaultTheme", async () => {
+		const input = new PassThrough() as PassThrough & {
+			isTTY: boolean;
+			isRaw: boolean;
+			setRawMode: (mode: boolean) => PassThrough;
+		};
+		input.isTTY = true;
+		input.isRaw = false;
+		input.setRawMode = (mode) => {
+			input.isRaw = mode;
+			return input;
+		};
+		const stream = new Writable({
+			write(_chunk, _encoding, callback) {
+				callback();
+			},
+		}) as Writable & { columns: number };
+		stream.columns = 80;
+
+		let seenTheme: unknown;
+		const answer = runPrompt<{ value: string }, string>(
+			{
+				render: (state, theme) => {
+					seenTheme = theme;
+					return state.value;
+				},
+				handleKey: () => submit("done"),
+				initialState: { value: "prompt" },
+			},
+			{ input, output: stream },
+		);
+		input.write("x");
+		expect(await answer).toBe("done");
+		expect(seenTheme).toEqual(defaultTheme);
+	});
+
+	it("merges a partial theme onto defaultTheme", async () => {
+		const input = new PassThrough() as PassThrough & {
+			isTTY: boolean;
+			isRaw: boolean;
+			setRawMode: (mode: boolean) => PassThrough;
+		};
+		input.isTTY = true;
+		input.isRaw = false;
+		input.setRawMode = (mode) => {
+			input.isRaw = mode;
+			return input;
+		};
+		const stream = new Writable({
+			write(_chunk, _encoding, callback) {
+				callback();
+			},
+		}) as Writable & { columns: number };
+		stream.columns = 80;
+
+		const prefix = (t: string) => `<P ${t}>`;
+		let seenTheme: { prefix: typeof prefix; message: unknown } | undefined;
+		const answer = runPrompt<{ value: string }, string>(
+			{
+				render: (state, theme) => {
+					seenTheme = theme;
+					return state.value;
+				},
+				handleKey: () => submit("done"),
+				initialState: { value: "prompt" },
+				theme: { prefix },
+			},
+			{ input, output: stream },
+		);
+		input.write("x");
+		expect(await answer).toBe("done");
+		expect(seenTheme?.prefix).toBe(prefix); // override applied
+		expect(seenTheme?.message).toBe(defaultTheme.message); // default preserved
+	});
+
 	it("disables raw mode on a fake input without isRaw", async () => {
 		const input = new PassThrough() as PassThrough & {
 			isTTY: boolean;

--- a/packages/prompts/src/core/renderer.ts
+++ b/packages/prompts/src/core/renderer.ts
@@ -6,7 +6,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as readline from "node:readline";
 import type { Readable, Writable } from "node:stream";
 
-import type { PromptTheme } from "./types.ts";
+import { resolveTheme } from "./theme.ts";
+import type { PartialPromptTheme, PromptTheme } from "./types.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -113,8 +114,8 @@ export interface PromptConfig<S, T> {
 	) => HandleKeyResult<S, T> | Promise<HandleKeyResult<S, T>>;
 	/** Initial state for the prompt */
 	readonly initialState: S;
-	/** Resolved theme for this prompt */
-	readonly theme: PromptTheme;
+	/** Optional partial theme; merged onto `defaultTheme`. */
+	readonly theme?: PartialPromptTheme;
 	/**
 	 * Optional: render the final submitted state.
 	 * Called after submit with the final state and submitted value.
@@ -223,7 +224,6 @@ function isSubmit<S, T>(result: HandleKeyResult<S, T>): result is SubmitResult<T
  * ```ts
  * const value = await runPrompt({
  *   initialState: { value: "", submitted: false },
- *   theme: resolveTheme(),
  *   render: (state, theme) => `${theme.prefix("?")} Enter value: ${state.value}`,
  *   handleKey: (key, state) => {
  *     if (key.name === "return") return { submit: state.value };
@@ -233,7 +233,8 @@ function isSubmit<S, T>(result: HandleKeyResult<S, T>): result is SubmitResult<T
  * ```
  */
 export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Promise<T> {
-	const { render, handleKey, initialState, theme, renderSubmitted } = config;
+	const { render, handleKey, initialState, renderSubmitted } = config;
+	const theme = resolveTheme(config.theme);
 	const { input: stdin, output } = resolvePromptIO(io);
 
 	return new Promise<T>((resolve, reject) => {

--- a/packages/prompts/src/core/theme.test.ts
+++ b/packages/prompts/src/core/theme.test.ts
@@ -1,13 +1,8 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { bold, cyan, dim, green, magenta, red, yellow } from "@crustjs/style";
 
-import { defaultTheme, getTheme, resolveTheme, setTheme } from "./theme.ts";
-
-// Reset global theme after each test to prevent state leakage
-afterEach(() => {
-	setTheme();
-});
+import { defaultTheme, resolveTheme } from "./theme.ts";
 
 describe("defaultTheme", () => {
 	it("uses expected default colors", () => {
@@ -34,101 +29,23 @@ describe("defaultTheme", () => {
 	});
 });
 
-describe("setTheme / getTheme", () => {
-	it("getTheme returns defaultTheme when no global theme is set", () => {
-		const theme = getTheme();
-		expect(theme).toBe(defaultTheme);
+describe("resolveTheme", () => {
+	it("returns defaultTheme when no overrides", () => {
+		expect(resolveTheme()).toBe(defaultTheme);
 	});
 
-	it("setTheme applies global overrides", () => {
-		setTheme({ prefix: magenta });
-		const theme = getTheme();
-		expect(theme.prefix).toBe(magenta);
-		expect(theme.message).toBe(bold); // default preserved
-	});
-
-	it("setTheme with multiple slots", () => {
-		setTheme({ prefix: magenta, error: yellow, success: cyan });
-		const theme = getTheme();
+	it("merges partial overrides onto default theme", () => {
+		const theme = resolveTheme({ prefix: magenta, error: yellow });
 		expect(theme.prefix).toBe(magenta);
 		expect(theme.error).toBe(yellow);
-		expect(theme.success).toBe(cyan);
+		// Untouched slots remain default
 		expect(theme.message).toBe(bold);
+		expect(theme.success).toBe(green);
 	});
 
 	it("accepts custom style functions", () => {
 		const customStyle = (text: string) => `[${text}]`;
-		setTheme({ prefix: customStyle });
-		expect(getTheme().prefix("test")).toBe("[test]");
-	});
-
-	it("setTheme with no arguments clears the global theme", () => {
-		setTheme({ prefix: magenta });
-		expect(getTheme().prefix).toBe(magenta);
-
-		setTheme();
-		expect(getTheme()).toBe(defaultTheme);
-	});
-
-	it("setTheme with undefined clears the global theme", () => {
-		setTheme({ prefix: magenta });
-		setTheme(undefined);
-		expect(getTheme()).toBe(defaultTheme);
-	});
-
-	it("later setTheme calls replace previous global theme", () => {
-		setTheme({ prefix: magenta });
-		setTheme({ prefix: red, error: yellow });
-		const theme = getTheme();
-		expect(theme.prefix).toBe(red);
-		expect(theme.error).toBe(yellow);
-		// magenta prefix is gone — replaced, not merged
-		expect(theme.filterMatch).toBe(cyan); // default
-	});
-});
-
-describe("resolveTheme", () => {
-	it("returns defaultTheme when no global or prompt overrides", () => {
-		const theme = resolveTheme();
-		expect(theme).toBe(defaultTheme);
-	});
-
-	it("applies global theme overrides", () => {
-		setTheme({ prefix: magenta });
-		const theme = resolveTheme();
-		expect(theme.prefix).toBe(magenta);
-		expect(theme.message).toBe(bold);
-	});
-
-	it("applies per-prompt overrides", () => {
-		const theme = resolveTheme({ error: yellow });
-		expect(theme.error).toBe(yellow);
-		expect(theme.message).toBe(bold);
-	});
-
-	it("per-prompt overrides take priority over global overrides", () => {
-		setTheme({ prefix: magenta, error: yellow });
-		const theme = resolveTheme({ prefix: green });
-		// Per-prompt wins for prefix
-		expect(theme.prefix).toBe(green);
-		// Global wins for error (no per-prompt override)
-		expect(theme.error).toBe(yellow);
-		// Default for everything else
-		expect(theme.message).toBe(bold);
-	});
-
-	it("layers all three levels correctly", () => {
-		setTheme({ prefix: magenta, cursor: red });
-		const theme = resolveTheme({ cursor: green, success: yellow });
-
-		// Global override (no prompt override for this slot)
-		expect(theme.prefix).toBe(magenta);
-		// Per-prompt override wins over global
-		expect(theme.cursor).toBe(green);
-		// Per-prompt override (no global for this slot)
-		expect(theme.success).toBe(yellow);
-		// Default (no overrides)
-		expect(theme.message).toBe(bold);
-		expect(theme.error).toBe(red);
+		const theme = resolveTheme({ prefix: customStyle });
+		expect(theme.prefix("test")).toBe("[test]");
 	});
 });

--- a/packages/prompts/src/core/theme.ts
+++ b/packages/prompts/src/core/theme.ts
@@ -30,80 +30,20 @@ export const defaultTheme: PromptTheme = {
 };
 
 // ────────────────────────────────────────────────────────────────────────────
-// Global Theme State
-// ────────────────────────────────────────────────────────────────────────────
-
-/** Module-level global theme overrides, applied to all prompts. */
-let globalOverrides: PartialPromptTheme | undefined;
-
-/**
- * Set the global theme applied to all prompts.
- *
- * Accepts a `PartialPromptTheme` with only the slots you want to override.
- * Unspecified slots fall back to {@link defaultTheme}.
- *
- * Call with no arguments or `undefined` to clear the global theme.
- *
- * @param theme - Theme or partial overrides to apply globally.
- *
- * @example
- * ```ts
- * import { setTheme } from "@crustjs/prompts";
- * import { magenta, cyan } from "@crustjs/style";
- *
- * // Set once at app bootstrap
- * setTheme({ prefix: magenta, success: cyan });
- *
- * // Clear the global theme
- * setTheme();
- * ```
- */
-export function setTheme(theme?: PartialPromptTheme): void {
-	globalOverrides = theme;
-}
-
-/**
- * Get the current global theme with all slots resolved.
- *
- * Returns {@link defaultTheme} if no global theme has been set.
- *
- * @returns The complete resolved global `PromptTheme`.
- *
- * @example
- * ```ts
- * import { getTheme, setTheme } from "@crustjs/prompts";
- *
- * setTheme({ prefix: magenta });
- * const theme = getTheme();
- * // theme.prefix === magenta
- * // theme.message === bold (default)
- * ```
- */
-export const getTheme = (): PromptTheme => resolveTheme();
-
-// ────────────────────────────────────────────────────────────────────────────
 // Theme Resolution (internal)
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Resolve the effective theme for a single prompt by layering global
- * and per-prompt overrides.
- *
- * Resolution order (later wins):
- * 1. {@link defaultTheme} (base)
- * 2. Global overrides (set via {@link setTheme})
- * 3. Per-prompt overrides (passed to individual prompt options)
+ * Resolve a complete theme by merging partial overrides onto
+ * {@link defaultTheme}. Instance themes from `createPrompts` are
+ * pre-merged into the per-prompt overrides before this runs.
  *
  * @internal — Prompt implementations call this; users do not need to.
  *
- * @param promptTheme - Per-prompt theme overrides (highest priority)
+ * @param promptTheme - Partial theme overrides
  * @returns A complete `PromptTheme` with all slots defined.
  */
 export function resolveTheme(promptTheme?: PartialPromptTheme): PromptTheme {
-	if (!globalOverrides && !promptTheme) return defaultTheme;
-	return {
-		...defaultTheme,
-		...globalOverrides,
-		...promptTheme,
-	};
+	if (!promptTheme) return defaultTheme;
+	return { ...defaultTheme, ...promptTheme };
 }

--- a/packages/prompts/src/core/theme.ts
+++ b/packages/prompts/src/core/theme.ts
@@ -1,5 +1,5 @@
 // ────────────────────────────────────────────────────────────────────────────
-// Theme — Default theme, global state, and resolution for @crustjs/prompts
+// Theme — Default theme and resolution for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
 import { bold, cyan, dim, green, red } from "@crustjs/style";

--- a/packages/prompts/src/create-prompts.test.ts
+++ b/packages/prompts/src/create-prompts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+
+import { bold, magenta } from "@crustjs/style";
+
+import { defaultTheme } from "./core/theme.ts";
+import { createPrompts, prompts } from "./create-prompts.ts";
+import type { ConfirmOptions } from "./prompts/confirm.ts";
+import { renderPrompt } from "./testing.ts";
+
+const tick = (ms = 10) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("createPrompts", () => {
+	it("resolves instance theme over defaults", () => {
+		const p = createPrompts({ theme: { prefix: magenta } });
+		expect(p.theme.prefix).toBe(magenta);
+		expect(p.theme.message).toBe(bold); // default preserved
+	});
+
+	it("with no options mirrors defaultTheme", () => {
+		const p = createPrompts();
+		expect(p.theme).toEqual(defaultTheme);
+	});
+
+	it("instance theme reaches prompt rendering", async () => {
+		const p = createPrompts({ theme: { success: (t) => `<${t}>` } });
+		// Non-TTY short-circuit still resolves; theme merge must not throw
+		const result = await p.input({ message: "Name?", initial: "Alice" });
+		expect(result).toBe("Alice");
+	});
+
+	it("instance theme styles rendered output", async () => {
+		const p = createPrompts({ theme: { prefix: () => "[INST]" } });
+		const prompt = renderPrompt<ConfirmOptions, boolean>(p.confirm, { message: "Continue?" });
+		await tick();
+		expect(prompt.screen()).toContain("[INST]");
+		prompt.keys("return");
+		await prompt.answer;
+	});
+
+	it("per-call theme overrides instance theme", async () => {
+		const p = createPrompts({ theme: { prefix: () => "[INST]" } });
+		const prompt = renderPrompt<ConfirmOptions, boolean>(p.confirm, {
+			message: "Continue?",
+			theme: { prefix: () => "[CALL]" },
+		});
+		await tick();
+		expect(prompt.screen()).toContain("[CALL]");
+		expect(prompt.screen()).not.toContain("[INST]");
+		prompt.keys("return");
+		await prompt.answer;
+	});
+
+	it("default prompts singleton uses defaultTheme", () => {
+		expect(prompts.theme).toEqual(defaultTheme);
+	});
+
+	it("singleton prompt functions short-circuit like bare exports", async () => {
+		const result = await prompts.confirm({ message: "Sure?", initial: true });
+		expect(result).toBe(true);
+	});
+});

--- a/packages/prompts/src/create-prompts.test.ts
+++ b/packages/prompts/src/create-prompts.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { bold, magenta } from "@crustjs/style";
 
 import { defaultTheme } from "./core/theme.ts";
-import { createPrompts, prompts } from "./create-prompts.ts";
+import { createPrompts } from "./create-prompts.ts";
 import type { ConfirmOptions } from "./prompts/confirm.ts";
 import { renderPrompt } from "./testing.ts";
 
@@ -37,6 +37,59 @@ describe("createPrompts", () => {
 		await prompt.answer;
 	});
 
+	it("instances are isolated from each other", async () => {
+		const a = createPrompts({ theme: { prefix: () => "[A]" } });
+		const b = createPrompts({ theme: { prefix: () => "[B]" } });
+
+		const first = renderPrompt<ConfirmOptions, boolean>(a.confirm, { message: "One?" });
+		await tick();
+		expect(first.screen()).toContain("[A]");
+		expect(first.screen()).not.toContain("[B]");
+		first.keys("return");
+		await first.answer;
+
+		const second = renderPrompt<ConfirmOptions, boolean>(b.confirm, { message: "Two?" });
+		await tick();
+		expect(second.screen()).toContain("[B]");
+		expect(second.screen()).not.toContain("[A]");
+		second.keys("return");
+		await second.answer;
+
+		// First instance is unaffected by the second's overrides
+		const third = renderPrompt<ConfirmOptions, boolean>(a.confirm, { message: "Three?" });
+		await tick();
+		expect(third.screen()).toContain("[A]");
+		third.keys("return");
+		await third.answer;
+	});
+
+	it("keeps instance-only slots when a different slot is overridden per call", async () => {
+		const p = createPrompts({
+			theme: { prefix: () => "[INST]", message: (t) => `«${t}»` },
+		});
+		const prompt = renderPrompt<ConfirmOptions, boolean>(p.confirm, {
+			message: "Continue?",
+			theme: { prefix: () => "[CALL]" },
+		});
+		await tick();
+		expect(prompt.screen()).toContain("[CALL]"); // per-call wins the conflicting slot
+		expect(prompt.screen()).toContain("«Continue?»"); // instance-only slot survives
+		prompt.keys("return");
+		await prompt.answer;
+	});
+
+	it("snapshots overrides at creation; later mutation has no effect", async () => {
+		const overrides = { prefix: () => "[ORIG]" };
+		const p = createPrompts({ theme: overrides });
+		overrides.prefix = () => "[MUTATED]";
+		const prompt = renderPrompt<ConfirmOptions, boolean>(p.confirm, { message: "Continue?" });
+		await tick();
+		expect(prompt.screen()).toContain("[ORIG]");
+		expect(p.theme.prefix("")).toBe("[ORIG]");
+		prompt.keys("return");
+		await prompt.answer;
+	});
+
 	it("per-call theme overrides instance theme", async () => {
 		const p = createPrompts({ theme: { prefix: () => "[INST]" } });
 		const prompt = renderPrompt<ConfirmOptions, boolean>(p.confirm, {
@@ -48,14 +101,5 @@ describe("createPrompts", () => {
 		expect(prompt.screen()).not.toContain("[INST]");
 		prompt.keys("return");
 		await prompt.answer;
-	});
-
-	it("default prompts singleton uses defaultTheme", () => {
-		expect(prompts.theme).toEqual(defaultTheme);
-	});
-
-	it("singleton prompt functions short-circuit like bare exports", async () => {
-		const result = await prompts.confirm({ message: "Sure?", initial: true });
-		expect(result).toBe(true);
 	});
 });

--- a/packages/prompts/src/create-prompts.ts
+++ b/packages/prompts/src/create-prompts.ts
@@ -1,0 +1,86 @@
+// ────────────────────────────────────────────────────────────────────────────
+// createPrompts — themed prompt instance factory for @crustjs/prompts
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { PromptIO } from "./core/renderer.ts";
+import { defaultTheme } from "./core/theme.ts";
+import type { PartialPromptTheme, PromptTheme } from "./core/types.ts";
+import { type ConfirmOptions, confirm } from "./prompts/confirm.ts";
+import { type FilterOptions, filter } from "./prompts/filter.ts";
+import { type InputOptions, input } from "./prompts/input.ts";
+import { type MultifilterOptions, multifilter } from "./prompts/multifilter.ts";
+import { type MultiselectOptions, multiselect } from "./prompts/multiselect.ts";
+import { type PasswordOptions, password } from "./prompts/password.ts";
+import { type SelectOptions, select } from "./prompts/select.ts";
+
+/** Configuration for {@link createPrompts}. */
+export interface CreatePromptsOptions {
+	/**
+	 * Partial theme applied to every prompt from this instance.
+	 * Per-call `theme` options layer on top; unspecified slots
+	 * fall back to `defaultTheme`.
+	 */
+	readonly theme?: PartialPromptTheme;
+}
+
+/**
+ * A set of prompt functions bound to a theme.
+ *
+ * Same signatures as the bare exports (`input`, `select`, …); the only
+ * difference is the theme resolution order: `defaultTheme` ← instance
+ * theme ← per-call `theme` option.
+ */
+export interface PromptsInstance {
+	/**
+	 * The fully resolved instance theme. Pass to custom `runPrompt`
+	 * renderers to match this instance's styling.
+	 */
+	readonly theme: PromptTheme;
+	readonly input: typeof input;
+	readonly password: typeof password;
+	readonly confirm: typeof confirm;
+	readonly select: typeof select;
+	readonly multiselect: typeof multiselect;
+	readonly filter: typeof filter;
+	readonly multifilter: typeof multifilter;
+}
+
+/**
+ * Create a {@link PromptsInstance} with a theme applied to every prompt.
+ *
+ * There is no global theme state: theming is explicit, owned by whoever
+ * holds the instance.
+ *
+ * @example
+ * ```ts
+ * import { createPrompts } from "@crustjs/prompts";
+ * import { magenta, cyan } from "@crustjs/style";
+ *
+ * const p = createPrompts({ theme: { prefix: magenta, success: cyan } });
+ * const name = await p.input({ message: "Name?" });
+ * ```
+ */
+export function createPrompts(options: CreatePromptsOptions = {}): PromptsInstance {
+	const overrides = options.theme;
+	// Layer instance overrides under per-call overrides; each prompt merges
+	// the combined partial onto defaultTheme itself.
+	const themed = <O extends { readonly theme?: PartialPromptTheme }>(opts: O): O => ({
+		...opts,
+		theme: { ...overrides, ...opts.theme },
+	});
+	return {
+		theme: { ...defaultTheme, ...overrides },
+		input: ((opts?: InputOptions<unknown>, io?: PromptIO) =>
+			input(themed(opts ?? {}) as never, io)) as typeof input,
+		password: ((opts?: PasswordOptions<unknown>, io?: PromptIO) =>
+			password(themed(opts ?? {}) as never, io)) as typeof password,
+		confirm: (opts: ConfirmOptions, io?: PromptIO) => confirm(themed(opts), io),
+		select: <T>(opts: SelectOptions<T>, io?: PromptIO) => select(themed(opts), io),
+		multiselect: <T>(opts: MultiselectOptions<T>, io?: PromptIO) => multiselect(themed(opts), io),
+		filter: <T>(opts: FilterOptions<T>, io?: PromptIO) => filter(themed(opts), io),
+		multifilter: <T>(opts: MultifilterOptions<T>, io?: PromptIO) => multifilter(themed(opts), io),
+	};
+}
+
+/** Default prompts instance using `defaultTheme`, mirroring the bare exports. */
+export const prompts: PromptsInstance = createPrompts();

--- a/packages/prompts/src/create-prompts.ts
+++ b/packages/prompts/src/create-prompts.ts
@@ -61,7 +61,9 @@ export interface PromptsInstance {
  * ```
  */
 export function createPrompts(options: CreatePromptsOptions = {}): PromptsInstance {
-	const overrides = options.theme;
+	// Snapshot so later mutation of the caller's object can't diverge
+	// rendering from the exposed `theme`.
+	const overrides = { ...options.theme };
 	// Layer instance overrides under per-call overrides; each prompt merges
 	// the combined partial onto defaultTheme itself.
 	const themed = <O extends { readonly theme?: PartialPromptTheme }>(opts: O): O => ({
@@ -81,6 +83,3 @@ export function createPrompts(options: CreatePromptsOptions = {}): PromptsInstan
 		multifilter: <T>(opts: MultifilterOptions<T>, io?: PromptIO) => multifilter(themed(opts), io),
 	};
 }
-
-/** Default prompts instance using `defaultTheme`, mirroring the bare exports. */
-export const prompts: PromptsInstance = createPrompts();

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -14,7 +14,9 @@ export type { NormalizedChoice } from "./core/utils.ts";
 // Theme
 // ────────────────────────────────────────────────────────────────────────────
 
-export { defaultTheme, getTheme, setTheme } from "./core/theme.ts";
+export { defaultTheme } from "./core/theme.ts";
+export type { CreatePromptsOptions, PromptsInstance } from "./create-prompts.ts";
+export { createPrompts, prompts } from "./create-prompts.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Renderer

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -16,7 +16,7 @@ export type { NormalizedChoice } from "./core/utils.ts";
 
 export { defaultTheme } from "./core/theme.ts";
 export type { CreatePromptsOptions, PromptsInstance } from "./create-prompts.ts";
-export { createPrompts, prompts } from "./create-prompts.ts";
+export { createPrompts } from "./create-prompts.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Renderer

--- a/packages/prompts/tests/integration.test.ts
+++ b/packages/prompts/tests/integration.test.ts
@@ -21,17 +21,17 @@ import {
 	NonInteractiveError,
 	normalizeChoices,
 	password,
-	prompts,
 	select,
 } from "../src/index.ts";
+import { renderPrompt } from "../src/testing.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Theme integration
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("theme integration", () => {
-	it("prompts singleton exposes a valid theme with all slots defined", () => {
-		const theme = prompts.theme;
+	it("createPrompts exposes a valid theme with all slots defined", () => {
+		const theme = createPrompts().theme;
 
 		const requiredSlots: (keyof PromptTheme)[] = [
 			"prefix",
@@ -53,7 +53,7 @@ describe("theme integration", () => {
 	});
 
 	it("every theme slot produces a string", () => {
-		const theme = prompts.theme;
+		const theme = createPrompts().theme;
 
 		for (const key of Object.keys(theme)) {
 			const fn = theme[key as keyof PromptTheme];
@@ -70,6 +70,15 @@ describe("theme integration", () => {
 		// Other slots retain defaults
 		expect(p.theme.message).toBe(defaultTheme.message);
 		expect(p.theme.cursor).toBe(defaultTheme.cursor);
+	});
+
+	it("bound prompt functions render with the instance theme", async () => {
+		const p = createPrompts({ theme: { prefix: () => "[INST]" } });
+		const prompt = renderPrompt(p.confirm, { message: "Continue?" });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(prompt.screen()).toContain("[INST]");
+		prompt.keys("return");
+		await prompt.answer;
 	});
 });
 
@@ -210,9 +219,12 @@ describe("NonInteractiveError", () => {
 // and resolve correctly. If any type is removed from the barrel, this file
 // will fail to compile.
 
+import type { StandardSchema } from "@crustjs/utils/schema";
+
 import type {
 	Choice,
 	ConfirmOptions,
+	CreatePromptsOptions,
 	FilterOptions,
 	FuzzyFilterResult,
 	FuzzyMatchResult,
@@ -225,6 +237,7 @@ import type {
 	PartialPromptTheme,
 	PasswordOptions,
 	PromptConfig,
+	PromptsInstance,
 	SelectOptions,
 	ValidateFn,
 } from "../src/index.ts";
@@ -305,6 +318,17 @@ describe("type exports", () => {
 		// accept type parameters
 		type _HKR = HandleKeyResult<{ value: string }, string>;
 		type _PC = PromptConfig<{ value: string }, string>;
+
+		// Factory types resolve, and bound prompts preserve the bare-export
+		// overloads: schema-aware input infers the schema output type.
+		const _createOpts: CreatePromptsOptions = { theme: {} };
+		const p: PromptsInstance = null as unknown as PromptsInstance;
+		const numberSchema = null as unknown as StandardSchema<unknown, number>;
+		const assertInput = (): Promise<number> => p.input({ message: "m", schema: numberSchema });
+		const assertInputPlain = (): Promise<string> => p.input({ message: "m" });
+		void assertInput;
+		void assertInputPlain;
+		void _createOpts;
 
 		// All type annotations above compiled successfully
 		expect(true).toBe(true);

--- a/packages/prompts/tests/integration.test.ts
+++ b/packages/prompts/tests/integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 // ────────────────────────────────────────────────────────────────────────────
 // Integration tests — exercise @crustjs/prompts through its public barrel
 // ────────────────────────────────────────────────────────────────────────────
@@ -8,12 +8,12 @@ import {
 	// Prompts
 	confirm,
 	// Theme
+	createPrompts,
 	defaultTheme,
 	filter,
 	// Utilities
 	fuzzyFilter,
 	fuzzyMatch,
-	getTheme,
 	input,
 	multifilter,
 	multiselect,
@@ -21,8 +21,8 @@ import {
 	NonInteractiveError,
 	normalizeChoices,
 	password,
+	prompts,
 	select,
-	setTheme,
 } from "../src/index.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -30,8 +30,8 @@ import {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("theme integration", () => {
-	it("getTheme returns a valid theme with all slots defined", () => {
-		const theme = getTheme();
+	it("prompts singleton exposes a valid theme with all slots defined", () => {
+		const theme = prompts.theme;
 
 		const requiredSlots: (keyof PromptTheme)[] = [
 			"prefix",
@@ -53,7 +53,7 @@ describe("theme integration", () => {
 	});
 
 	it("every theme slot produces a string", () => {
-		const theme = getTheme();
+		const theme = prompts.theme;
 
 		for (const key of Object.keys(theme)) {
 			const fn = theme[key as keyof PromptTheme];
@@ -62,20 +62,14 @@ describe("theme integration", () => {
 		}
 	});
 
-	afterEach(() => {
-		setTheme();
-	});
+	it("createPrompts applies instance overrides through the barrel", () => {
+		const instanceFn = (text: string) => `(${text})`;
+		const p = createPrompts({ theme: { prefix: instanceFn } });
 
-	it("setTheme applies global overrides via getTheme", () => {
-		const globalFn = (text: string) => `(${text})`;
-		setTheme({ prefix: globalFn });
-
-		const theme = getTheme();
-
-		expect(theme.prefix("x")).toBe("(x)");
+		expect(p.theme.prefix("x")).toBe("(x)");
 		// Other slots retain defaults
-		expect(theme.message).toBe(defaultTheme.message);
-		expect(theme.cursor).toBe(defaultTheme.cursor);
+		expect(p.theme.message).toBe(defaultTheme.message);
+		expect(p.theme.cursor).toBe(defaultTheme.cursor);
 	});
 });
 


### PR DESCRIPTION
> **Stacked on #169** — merge that first, then rebase this onto `main`.

## Summary

Replaces the module-global theme state in `@crustjs/prompts` and `@crustjs/progress` with explicit themed instances. No hidden state: theming is owned by whoever holds the instance. Breaking; no compat shims (revamp).

### Removed
- `setTheme` (both packages), `getTheme` (prompts) — the mutable module-global theme is gone entirely.

### Added
- **prompts**: `createPrompts({ theme })` → `PromptsInstance` with all 7 prompt functions bound to the theme, plus the resolved `theme` for custom `runPrompt` renderers. Default `prompts` singleton exported, mirroring the `createStyle`/`style` convention. Bare exports (`input`, `select`, …) remain as the `defaultTheme` path.
- **progress**: `createProgress({ theme })` → themed `progress`/`spinner`. No singleton — `progress` the name is already taken by the bare function, and the bare exports *are* the default instance.

### Changed
- `runPrompt`'s `theme` config is now an **optional partial** merged onto `defaultTheme` — custom prompts get the identical resolution as built-ins instead of manually threading `getTheme()`.
- Resolution order everywhere: `defaultTheme` ← instance theme ← per-call `theme` option.

### Migration
```ts
// before
setTheme({ prefix: magenta });
await input({ message: "Name?" });

// after
const p = createPrompts({ theme: { prefix: magenta } });
await p.input({ message: "Name?" });
```
`getTheme()` → `p.theme`.

## Tests
- New `create-prompts.test.ts`: instance layering verified through real rendered output (fake-IO harness), per-call override wins, singleton parity.
- `createProgress`: instance theme verified through captured stderr indicator output.
- Theme unit/integration tests rewritten for pure resolution.

## Checks
- `bun run check:types` 21/21 ✓
- `bun test` 2229 tests, 0 fail ✓
- lint/format ✓
- Docs (`prompts.mdx`, `progress.mdx`) updated; changeset added (minor ×2)
