### PR TITLE
refactor(core)!: rename subcommand attachment from .mount() to .add()

### DIFF
--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -5,7 +5,7 @@
 
 Add inert reusable command definitions with `defineCommand(name, requirements?, recipe)` and checked attachment with the variadic `.add(...definitions)`.
 
-A definition carries its own name and lists the Context capabilities it needs from its attach site in a plain `requires` array. Every requirement is checked at the `.add()` call — compile-time for missing or incompatible Context values, and at runtime for required Context names missing from the parent path. Every `.add()` materializes a fresh command under the definition's carried name; use `.as(newName)` to add one definition under multiple names or parents, and definitions can `.add()` other definitions.
+A definition carries its own name and lists the Context capabilities it needs from its parent in a plain `requires` array. Every requirement is checked at the `.add()` call — compile-time for missing or incompatible Context values, and at runtime for required Context names missing from the parent path. Every `.add()` materializes a fresh command under the definition's carried name; use `.as(newName)` to add one definition under multiple names or parents, and definitions can `.add()` other definitions.
 
 Remove `.sub()`, `.command(name, callback)`, `.command(builder)`, and the exported `ChildCrust` type. One-off inline commands are `.add(defineCommand("up", (command) => ...))`.
 

--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -3,11 +3,11 @@
 "@crustjs/crust": patch
 ---
 
-Add inert reusable command definitions with `defineCommand(name, requirements?, recipe)` and checked mounting with the variadic `.mount(...definitions)`.
+Add inert reusable command definitions with `defineCommand(name, requirements?, recipe)` and checked attachment with the variadic `.add(...definitions)`.
 
-A definition carries its own name and lists the Context capabilities it needs from its mount site in a plain `requires` array. Every requirement is checked at the `.mount()` call — compile-time for missing or incompatible Context values, and at runtime for required Context names missing from the parent path. Every mount materializes a fresh command under the definition's carried name; use `.as(newName)` to mount one definition under multiple names or parents, and definitions can `.mount()` other definitions.
+A definition carries its own name and lists the Context capabilities it needs from its attach site in a plain `requires` array. Every requirement is checked at the `.add()` call — compile-time for missing or incompatible Context values, and at runtime for required Context names missing from the parent path. Every `.add()` materializes a fresh command under the definition's carried name; use `.as(newName)` to add one definition under multiple names or parents, and definitions can `.add()` other definitions.
 
-Remove `.sub()`, `.command(name, callback)`, `.command(builder)`, and the exported `ChildCrust` type. One-off inline commands are `.mount(defineCommand("up", (command) => ...))`.
+Remove `.sub()`, `.command(name, callback)`, `.command(builder)`, and the exported `ChildCrust` type. One-off inline commands are `.add(defineCommand("up", (command) => ...))`.
 
 Migration:
 
@@ -25,8 +25,8 @@ const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) 
 	command.handle(({ ctx }) => {}),
 );
 
-const app = parent.provide(logging(), auth()).mount(deploy);
-const shipToo = parent.mount(deploy.as("ship"));
+const app = parent.provide(logging(), auth()).add(deploy);
+const shipToo = parent.add(deploy.as("ship"));
 ```
 
-Provide required Context capabilities with `.provide()` on the parent builder before `.mount()`. Extension-contributed commands are unchanged.
+Provide required Context capabilities with `.provide()` on the parent builder before `.add()`. Extension-contributed commands are unchanged.

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -2,7 +2,7 @@
 "@crustjs/core": minor
 ---
 
-Add Context-owned flags with `defineContext(name, { flags }, setup)`. Calling `.provide()` installs each owned flag as a propagating effective flag on that command and descendants mounted afterward, refines the builder's flag types, and passes the validated values to Context setup:
+Add Context-owned flags with `defineContext(name, { flags }, setup)`. Calling `.provide()` installs each owned flag as a propagating effective flag on that command and descendants added afterward, refines the builder's flag types, and passes the validated values to Context setup:
 
 ```ts
 const apiKey = defineFlag("api-key", { type: "string" });
@@ -10,7 +10,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) =>
   createClient({ apiKey: flags["api-key"] }),
 );
 
-const app = new Crust("cli").provide(api()).mount(deploy);
+const app = new Crust("cli").provide(api()).add(deploy);
 ```
 
 Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
@@ -25,6 +25,6 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
 
 Owned flag names, short forms, and aliases cannot collide with application, other Context, or Extension flags; collisions throw `CrustError("DEFINITION", ...)` in either fluent registration order. Extension flag collisions now use `details.reason: "flag-collision"` instead of `"extension-flag-collision"`, with updated message wording.
 
-`.of(value)` test doubles retain owned flags so test and production command grammars match. `.provide()` does not backfill descendants mounted on an earlier builder.
+`.of(value)` test doubles retain owned flags so test and production command grammars match. `.provide()` does not backfill descendants added on an earlier builder.
 
 The generic slots on `ContextInstance`, `ContextFactory`, `ContextSetup`, `Crust`, and `CommandDefinitionBuilder` now carry Context-owned flags instead of required or inherited flags. Pre-1.0 consumers that specify these generic parameters positionally must update their type arguments.

--- a/.changeset/remove-flag-inherit.md
+++ b/.changeset/remove-flag-inherit.md
@@ -9,7 +9,7 @@ The public `FlagSnapshot.inherit` field and the internal `InheritableFlags` and 
 
 | Previous usage | Migration |
 | --- | --- |
-| `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before mounting descendants. Handlers should require the derived Context capability. |
+| `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before adding descendants. Handlers should require the derived Context capability. |
 | Each command reads the raw flag directly | Define the descriptor once with `defineFlag()` and attach it with `.flags()` to each command that parses it. |
 
 Cross-command dependencies are capability-only: list Context factories in `requires` and consume their derived values through `ctx`. Raw flag requirements are removed.

--- a/.changeset/testing-runnable-app.md
+++ b/.changeset/testing-runnable-app.md
@@ -4,4 +4,4 @@
 
 Export the structural `RunnableApp` contract and accept any application with its `run(argv, io)` shape in `captureRun` and `runInteractive`.
 
-Inert command definitions are not directly runnable; mount them into an application before passing them to either helper.
+Inert command definitions are not directly runnable; add them to an application before passing them to either helper.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -18,7 +18,7 @@ import {
 } from "@crustjs/core";
 ```
 
-`Crust` builds an executable application root. `defineCommand()` builds inert reusable definitions that become commands only when mounted. Every fluent method returns a new builder; the original is unchanged.
+`Crust` builds an executable application root. `defineCommand()` builds inert reusable definitions that become commands only when added. Every fluent method returns a new builder; the original is unchanged.
 
 ## Reusable command definitions
 
@@ -32,7 +32,7 @@ interface CommandRequirements {
 type ContextRequirements = readonly AnyContextFactory[];
 ```
 
-`requires` lists Context factories whose capabilities the mount path must provide. It types the recipe builder's `ctx` and is checked at every `.mount()`: compile-time for missing or incompatible values, plus a runtime check for missing Context names.
+`requires` lists Context factories whose capabilities the parent path must provide. It types the recipe builder's `ctx` and is checked at every `.add()` call: compile-time for missing or incompatible values, plus a runtime check for missing Context names.
 
 `defineContext()` accepts `ContextConfig`, where top-level `flags` are owned and activated by `.provide()`, while `requires` is the same plain capability array. The grammar is: `flags` means definitions this unit owns or parses; `requires` means capabilities supplied by the command path.
 
@@ -44,7 +44,7 @@ interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx> {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
-  mount(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
+  add(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
   handle(
     handler: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
   ): CommandDefinitionBuilder;
@@ -62,7 +62,7 @@ interface CommandDefinition<R extends CommandRequirements = {}> {
 }
 ```
 
-A `CommandDefinition<R>` is a frozen value carrying its name and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be mounted twice. It has no command node or execution methods.
+A `CommandDefinition<R>` is a frozen value carrying its name and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. It has no command node or execution methods.
 
 ### `defineCommand(name, requirements?, recipe)`
 
@@ -97,7 +97,7 @@ const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) 
 );
 ```
 
-The recipe does not execute when the definition is created. It executes once for each `.mount()`, so keep configuration side-effect-free. An empty name or a missing recipe throws `DEFINITION`.
+The recipe does not execute when the definition is created. It executes once for each `.add()`, so keep configuration side-effect-free. An empty name or a missing recipe throws `DEFINITION`.
 
 ## Constructor
 
@@ -117,7 +117,7 @@ const app = new Crust("my-cli");
 meta(meta: Omit<CommandMeta, "name">): Crust
 ```
 
-Sets `description`, `usage`, `aliases`, or `hidden`. The constructor or the mounted definition supplies the name.
+Sets `description`, `usage`, `aliases`, or `hidden`. The constructor or the added definition supplies the name.
 
 ```ts
 const app = new Crust("issue").meta({
@@ -216,7 +216,7 @@ const app = new Crust("my-cli")
 
 Provide order is free: at invocation time, the instances on the resolved path are constructed topologically by their declared capability requirements, with registration order preserved among independent Contexts. A missing capability dependency or a dependency cycle throws `DEFINITION` at dispatch (and during `crust build` validation).
 
-A Context's top-level `flags` are installed as propagating flags on this builder and later-mounted descendants, without mutating the original definitions. Its `requires` capabilities are resolved topologically at invocation.
+A Context's top-level `flags` are installed as propagating flags on this builder and later-added descendants, without mutating the original definitions. Its `requires` capabilities are resolved topologically at invocation.
 
 Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in reverse construction order after success or failure. A duplicate Context name, passing a factory instead of an instance, or a Context-owned flag spelling collision throws `DEFINITION`.
 
@@ -234,7 +234,7 @@ import { help, version } from "@crustjs/extensions";
 const app = new Crust("my-cli").extend(help(), version("1.2.3"));
 ```
 
-Mounted definitions become ordinary command nodes before root Extensions prepare the application, so root Extensions apply to them. Extension-contributed definitions are materialized when the application prepares.
+Added definitions become ordinary command nodes before root Extensions prepare the application, so root Extensions apply to them. Extension-contributed definitions are materialized when the application prepares.
 
 Extension-owned command or flag name and alias collisions throw `DEFINITION` when the application is prepared.
 
@@ -260,29 +260,29 @@ const app = new Crust("greet")
 
 The context contains typed `args`, typed effective `flags`, typed Context values in `ctx`, `rawArgs` after `--`, the resolved `command` and application `rootCommand` snapshots, and injectable `stdout(text)` and `stderr(text)` callbacks from `InvocationIO`. `CrustCommandContext` extends `InvocationIO`; Context setups receive those same callbacks for the invocation.
 
-## `.mount(...definitions)`
+## `.add(...definitions)`
 
 ```ts
-mount<const Ds extends readonly CommandDefinition<any>[]>(
-  ...definitions: MountChecks<Ctx, Ds>,
+add<const Ds extends readonly CommandDefinition<any>[]>(
+  ...definitions: AddChecks<Ctx, Ds>,
 ): Crust
 ```
 
 Materializes inert definitions as fresh child commands, each under its carried name. `.as(name)` renames a definition, so the same definition can route under different names:
 
 ```ts
-const app = new Crust("git").provide(logging()).provide(auth()).mount(deploy, deploy.as("ship"));
+const app = new Crust("git").provide(logging()).provide(auth()).add(deploy, deploy.as("ship"));
 ```
 
-Inline one-off commands are mounted the same way:
+Inline one-off commands are added the same way:
 
 ```ts
-const app = new Crust("my-cli").mount(
+const app = new Crust("my-cli").add(
   defineCommand("up", (command) => command.handle(({ stdout }) => stdout("up"))),
 );
 ```
 
-`MountChecks` is internal declaration machinery that checks each definition's requirements against the parent builder. On failure, TypeScript reports one or more readable structural properties at the `.mount()` call:
+`AddChecks` is internal declaration machinery that checks each definition's requirements against the parent builder. On failure, TypeScript reports one or more readable structural properties at the `.add()` call:
 
 - `"missing Contexts"`
 - `"incompatible Contexts"`
@@ -291,11 +291,11 @@ Compatibility compares provided and required Context value types in the provided
 
 At runtime, empty names, duplicate sibling names, alias collisions, duplicate provided Context names, required Context names not provided on the parent path, unrelated recipe returns, values that are not `defineCommand()` definitions, and Extensions registered inside definitions throw `CrustError` code `DEFINITION`.
 
-A definition can mount other definitions. Nested requirements are checked against the enclosing definition builder at that exact point.
+A definition can add other definitions. Nested requirements are checked against the enclosing definition builder at that exact point.
 
 <Callout type="info">
-  Finalize Contexts on the builder used for `.mount()`. Later fluent calls create a new builder and
-  do not backfill an existing mount.
+  Finalize Contexts on the builder used for `.add()`. Later fluent calls create a new builder and do
+  not backfill a definition that was already added.
 </Callout>
 
 ## `.snapshot()`

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -9,15 +9,15 @@ All exports on these pages come from `@crustjs/core`.
 
 ## Runtime API
 
-| Export                                                    | Description                                                      |
-| --------------------------------------------------------- | ---------------------------------------------------------------- |
-| [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary     |
-| [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.mount()` |
-| `defineContext(name, config?, setup)`                     | Define a named command dependency factory                        |
-| `defineExtension(name, config)`                           | Define an application-wide Extension                             |
-| `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition         |
-| `defineArg(name, definition)`                             | Define one named positional argument                             |
-| [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes         |
+| Export                                                    | Description                                                    |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary   |
+| [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.add()` |
+| `defineContext(name, config?, setup)`                     | Define a named command dependency factory                      |
+| `defineExtension(name, config)`                           | Define an application-wide Extension                           |
+| `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition       |
+| `defineArg(name, definition)`                             | Define one named positional argument                           |
+| [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes       |
 
 ## Types
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -30,7 +30,7 @@ const app = new Crust("app").provide(clock());
 
 ## Owned flags
 
-A Context can own the flags used to construct its value. Declare each flag once in its top-level `flags`; attaching the Context installs those flags on the provider command and its later-mounted descendants:
+A Context can own the flags used to construct its value. Declare each flag once in its top-level `flags`; attaching the Context installs those flags on the provider command and its later-added descendants:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -48,7 +48,7 @@ const deploy = defineCommand("deploy", { requires: [api] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
 );
 
-const app = new Crust("app").provide(api()).mount(deploy);
+const app = new Crust("app").provide(api()).add(deploy);
 ```
 
 Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores a cloned definition in the Context-owned propagation channel; the original `apiKey` value is not mutated.
@@ -59,7 +59,7 @@ The child requires `ctx.api`, not the raw flag. If a handler also needs the raw 
 
 Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
 
-Contexts are inherited by descendant commands. A mounted command lists the factories it depends on in `requires`, which types `ctx` in its handler:
+Contexts are inherited by descendant commands. An added command lists the factories it depends on in `requires`, which types `ctx` in its handler:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
@@ -68,7 +68,7 @@ const status = defineCommand("status", { requires: [database] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
-const app = new Crust("app").provide(database({ url: process.env.DATABASE_URL! })).mount(status);
+const app = new Crust("app").provide(database({ url: process.env.DATABASE_URL! })).add(status);
 ```
 
 Setups may be synchronous or asynchronous.
@@ -155,33 +155,33 @@ const invoices = defineCommand("invoices", { requires: [user] }, (child) =>
 );
 
 const billing = defineCommand("billing", { requires: [session] }, (command) =>
-  command.provide(user()).mount(invoices),
+  command.provide(user()).add(invoices),
 );
 
-const app = new Crust("app").provide(session()).mount(billing);
+const app = new Crust("app").provide(session()).add(billing);
 ```
 
 A throwing setup aborts the invocation before the Command Handler and disposes the values already constructed.
 
 ## Context requirements in definitions
 
-A reusable command declares the Context factories it needs, and every `.mount()` checks them — compile-time against the parent's provided value types, and at runtime by name:
+A reusable command declares the Context factories it needs, and every `.add()` checks them — compile-time against the parent's provided value types, and at runtime by name:
 
 ```ts
 const status = defineCommand("status", { requires: [database] }, (command) =>
   command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
-const app = new Crust("app").provide(logging(), config(), database()).mount(status);
+const app = new Crust("app").provide(logging(), config(), database()).add(status);
 ```
 
-Call `.provide()` before `.mount()`: a missing requirement name is a `DEFINITION` error at the mount. Contexts and their owned flags do not backfill children mounted on an earlier builder. The general mount-checking and finalize-before-mounting rules live in [Subcommands](/docs/guide/subcommands).
+Call `.provide()` before `.add()`: a missing requirement name is a `DEFINITION` error at the `.add()` call. Contexts and their owned flags do not backfill children added on an earlier builder. The general add-time checks and finalize-before-adding rules live in [Subcommands](/docs/guide/subcommands).
 
 ## Name and flag collisions
 
 Providing two Context values with the same name on one command path is a `DEFINITION` error at the `.provide()` call. This includes a descendant re-providing a name it inherited.
 
-Mounted definitions use the same rule. Because materialization starts with the parent's Context path, a definition or nested descendant that provides the same name is rejected during `.mount()`.
+Added definitions use the same rule. Because materialization starts with the parent's Context path, a definition or nested descendant that provides the same name is rejected during `.add()`.
 
 Owned flag names, short forms, and aliases must be unique across application flags, other Contexts, and Extensions. Application and Context collisions fail while building; Extension collisions fail when `run()`, `execute()`, or `crust build` prepares the complete graph. Every case uses `CrustError` code `DEFINITION` rather than shadowing a definition.
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -20,7 +20,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 
 Two consequences of the root-only model:
 
-- Added definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to added and inline commands alike.
+- Added definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to every added command, inline or file-split.
 - Extension-owned flags are runtime parser inputs, not typed command capabilities. Use a Context-owned flag when downstream handlers need a typed value.
 
 ## Author an Extension

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -20,7 +20,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 
 Two consequences of the root-only model:
 
-- Mounted definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to mounted and inline commands alike.
+- Added definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to added and inline commands alike.
 - Extension-owned flags are runtime parser inputs, not typed command capabilities. Use a Context-owned flag when downstream handlers need a typed value.
 
 ## Author an Extension

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -74,7 +74,7 @@ const format = defineFlag("format", { type: "string", default: "json" });
 const print = defineCommand("print", (command) => command.flags(format));
 const inspect = defineCommand("inspect", (command) => command.flags(format));
 
-const app = new Crust("app").mount(print, inspect);
+const app = new Crust("app").add(print, inspect);
 ```
 
 This keeps one source of truth without adding the flag to commands that do not use it.
@@ -97,14 +97,14 @@ const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
   command.handle(({ ctx }) => ctx.logging.debug("deploying")),
 );
 
-const app = new Crust("app").provide(logging()).mount(deploy);
+const app = new Crust("app").provide(logging()).add(deploy);
 ```
 
 The Context declares, parses, and consumes `--verbose`, then wraps the invocation's injected `stderr` as behavior. Handlers call the logging capability without re-checking the flag. Renaming the flag or deriving log levels later changes the Context rather than every handler.
 
-Context-owned flags are parsed and shown in help at the provider and later-mounted descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
+Context-owned flags are parsed and shown in help at the provider and later-added descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
-If a handler needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into a mounted handler's types.
+If a handler needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into an added handler's types.
 
 ## Standard Schemas
 

--- a/apps/docs/content/docs/guide/split-files.mdx
+++ b/apps/docs/content/docs/guide/split-files.mdx
@@ -3,7 +3,7 @@ title: Split Commands Across Files
 description: Declare command requirements without coupling command files to the application root.
 ---
 
-For a small application, mount definitions inline at the root. When a command becomes large or reusable, export an inert definition from its own file and mount it at the composition root.
+For a small application, add definitions inline at the root. When a command becomes large or reusable, export an inert definition from its own file and add it at the composition root.
 
 ## Shared definitions
 
@@ -33,7 +33,7 @@ Define the root and its application-wide Extensions independently:
   ../../../examples/split-files/app.ts
 </include>
 
-## Mount and execute
+## Add and execute
 
 The composition root imports both sides:
 
@@ -41,8 +41,8 @@ The composition root imports both sides:
   ../../../examples/split-files/cli.ts
 </include>
 
-`.mount()` checks that `app` provides a compatible `logger` Context and reports a missing or incompatible requirement at this line. Because `.provide(logger())` precedes the mount, its owned `--verbose` flag is also available to the command. [How mount checking and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-mounting rule — is covered in Subcommands.
+`.add()` checks that `app` provides a compatible `logger` Context and reports a missing or incompatible requirement at this line. Because `.provide(logger())` precedes `.add()`, its owned `--verbose` flag is also available to the command. [How add-time checks and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-adding rule — is covered in Subcommands.
 
 ## Inline or split?
 
-Mount `defineCommand(name, recipe)` inline when the implementation is short and local. Move the definition to its own file, with a `requires` config when needed, when a separate file improves readability or when the same command should be mounted more than once.
+Add `defineCommand(name, recipe)` inline when the implementation is short and local. Move the definition to its own file, with a `requires` config when needed, when a separate file improves readability or when the same command should be added more than once.

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -3,14 +3,14 @@ title: Subcommands
 description: Compose nested command trees from named command definitions.
 ---
 
-## Mounting commands
+## Adding commands
 
-`defineCommand(name, recipe)` creates an inert definition that carries its name; `.mount(...definitions)` materializes definitions as child commands:
+`defineCommand(name, recipe)` creates an inert definition that carries its name; `.add(...definitions)` materializes definitions as child commands:
 
 ```ts
 import { Crust, defineCommand } from "@crustjs/core";
 
-const app = new Crust("git").mount(
+const app = new Crust("git").add(
   defineCommand("clone", (command) =>
     command
       .args({ name: "url", type: "url", required: true })
@@ -19,7 +19,7 @@ const app = new Crust("git").mount(
 );
 ```
 
-Routing consumes command names before parsing the resolved command's arguments and flags. Metadata aliases can route to the same command. Nest `.mount()` calls inside definitions to any depth.
+Routing consumes command names before parsing the resolved command's arguments and flags. Metadata aliases can route to the same command. Nest `.add()` calls inside definitions to any depth.
 
 ## Requirements
 
@@ -45,23 +45,20 @@ const clone = defineCommand("clone", { requires: [logging, repository] }, (comma
   }),
 );
 
-const app = new Crust("git").provide(logging(), repository()).mount(clone);
+const app = new Crust("git").provide(logging(), repository()).add(clone);
 ```
 
-`.mount()` checks the requirements at each call and creates a fresh command node. Use `.as(name)` to mount one definition under different names:
+`.add()` checks the requirements at each call and creates a fresh command node. Use `.as(name)` to add one definition under different names:
 
 ```ts
-const git = new Crust("git")
-  .provide(logging())
-  .provide(repository())
-  .mount(clone, clone.as("copy"));
+const git = new Crust("git").provide(logging()).provide(repository()).add(clone, clone.as("copy"));
 ```
 
-Missing or incompatible Context capabilities are TypeScript errors on `.mount()`; missing capabilities are also runtime `DEFINITION` errors.
+Missing or incompatible Context capabilities are TypeScript errors on `.add()`; missing capabilities are also runtime `DEFINITION` errors.
 
 ## Nested definitions
 
-Definitions can mount other definitions. Nested requirements must be available at the exact nested `.mount()` call:
+Definitions can add other definitions. Nested requirements must be available at the exact nested `.add()` call:
 
 ```ts
 const environment = defineFlag("environment", { type: "string" });
@@ -74,17 +71,17 @@ const status = defineCommand("status", { requires: [logging, deployment] }, (com
 );
 
 const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-  command.provide(deployment()).mount(status),
+  command.provide(deployment()).add(status),
 );
 
-const app = new Crust("app").provide(logging()).mount(deploy);
+const app = new Crust("app").provide(logging()).add(deploy);
 ```
 
 ## Context inheritance
 
-Mounting materializes a fresh command scope seeded with the parent's current Context path. The mounted handler and all nested descendants receive those Context values at runtime; list factories in `requires` to see them in the handler's types.
+Adding materializes a fresh command scope seeded with the parent's current Context path. The added handler and all nested descendants receive those Context values at runtime; list factories in `requires` to see them in the handler's types.
 
-Finalize `.provide()` calls on the parent builder before `.mount()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into later-mounted descendants. Later fluent calls return a new builder and do not backfill an earlier mount.
+Finalize `.provide()` calls on the parent builder before `.add()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into descendants added later. Later fluent calls return a new builder and do not backfill a definition that was already added.
 
 ## Unknown commands
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -35,7 +35,7 @@ await app.execute();
 
 ## Context-owned flags
 
-Use top-level `ContextConfig.flags` when a flag exists to construct a dependency. The Context defines and consumes the flag once; `.provide()` installs it on the current command and later-mounted descendants:
+Use top-level `ContextConfig.flags` when a flag exists to construct a dependency. The Context defines and consumes the flag once; `.provide()` installs it on the current command and later-added descendants:
 
 ```ts
 import { Crust, defineContext, defineFlag } from "@crustjs/core";
@@ -52,15 +52,15 @@ Downstream commands and Contexts list `api` in their `requires` array and consum
 
 ## Runtime exports
 
-| Export                                | Description                                                                                                                                           |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
-| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                                                     |
-| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                                              |
-| `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                     |
-| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                              |
-| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                               |
-| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                             |
+| Export                                | Description                                                                                                                                         |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.add()`, `.handle()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
+| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                                                   |
+| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                                            |
+| `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                   |
+| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                            |
+| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                             |
+| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                           |
 
 ## Definition types
 
@@ -71,7 +71,7 @@ Downstream commands and Contexts list `api` in their `requires` array and consum
 | [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                                      |
 | [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                               |
 | `CommandMeta`                                 | Name, description, usage, aliases, and visibility                                |
-| [`CommandRequirements`](/docs/api/crust)      | Context capability requirements checked at mount time                            |
+| [`CommandRequirements`](/docs/api/crust)      | Context capability requirements checked at add time                              |
 | `FlagDef`                                     | Core-value or Standard Schema flag definition                                    |
 | `FlagsDef`                                    | Flag-name-to-definition record                                                   |
 | `NamedFlagDef`                                | Flag definition carrying its `name` (the `.flags()` input shape)                 |

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -14,7 +14,7 @@ import pkg from "../package.json";
 
 const app = new Crust("my-cli")
   .extend(completion({ version: pkg.version }))
-  .mount(
+  .add(
     defineCommand("build", (command) =>
       command
         .flags({ name: "target", type: "string", choices: ["browser", "bun", "node"] })

--- a/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
+++ b/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
@@ -11,7 +11,7 @@ import { didYouMean } from "@crustjs/extensions";
 
 const app = new Crust("my-cli")
   .extend(didYouMean())
-  .mount(defineCommand("deploy", (command) => command.handle(() => {})));
+  .add(defineCommand("deploy", (command) => command.handle(() => {})));
 
 await app.execute();
 ```

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -263,7 +263,7 @@ const deploy = defineCommand("deploy", (command) =>
   }),
 );
 
-const app = new Crust("my-cli").mount(deploy);
+const app = new Crust("my-cli").add(deploy);
 ```
 
 ## Name Validation

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -27,7 +27,7 @@ interface RunnableApp {
 }
 ```
 
-Any application that implements this `run()` shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` does not implement `run()` and must first be mounted into a runnable application.
+Any application that implements this `run()` shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` does not implement `run()` and must first be added into a runnable application.
 
 ## `captureRun(app, argv)`
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -27,7 +27,7 @@ interface RunnableApp {
 }
 ```
 
-Any application that implements this `run()` shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` does not implement `run()` and must first be added into a runnable application.
+Any application that implements this `run()` shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` does not implement `run()` and must first be added to a runnable application.
 
 ## `captureRun(app, argv)`
 

--- a/apps/docs/examples/quick-start/subcommand.ts
+++ b/apps/docs/examples/quick-start/subcommand.ts
@@ -3,7 +3,7 @@ import { help } from "@crustjs/extensions";
 
 export const app = new Crust("my-cli")
   .extend(help())
-  .mount(
+  .add(
     defineCommand("build", (command) =>
       command
         .flags({ name: "minify", type: "boolean" })

--- a/apps/docs/examples/split-files/cli.ts
+++ b/apps/docs/examples/split-files/cli.ts
@@ -1,4 +1,4 @@
 import { app } from "./app.ts";
 import { greetCommand } from "./commands/greet.ts";
 
-await app.mount(greetCommand).execute();
+await app.add(greetCommand).execute();

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -7,7 +7,7 @@ type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 describe("public beta API", () => {
-	it("passes typed command context into mounted definitions with requirements", async () => {
+	it("passes typed command context into added definitions with requirements", async () => {
 		const calls: string[] = [];
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const db = defineContext("db", ({ options }: { options: { url: string } }) => ({
@@ -37,14 +37,14 @@ describe("public beta API", () => {
 		const app = new Crust("my-cli")
 			.provide(logging())
 			.provide(db({ url: "memory://test" }))
-			.mount(deploy);
+			.add(deploy);
 
 		await app.execute({ argv: ["deploy", "api", "--verbose"] });
 
 		expect(calls).toEqual(["memory://test:api:prod:true"]);
 	});
 
-	it("mounts one definition twice via .as()", async () => {
+	it("adds one definition twice via .as()", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", () => ({ user: "chenxin" }));
 		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
@@ -54,7 +54,7 @@ describe("public beta API", () => {
 				seen.push(`${ctx.auth.user}:${args.target}`);
 			}),
 		);
-		const app = new Crust("my-cli").provide(auth()).mount(deploy, deploy.as("ship"));
+		const app = new Crust("my-cli").provide(auth()).add(deploy, deploy.as("ship"));
 
 		await app.execute({ argv: ["deploy", "api"] });
 		await app.execute({ argv: ["ship", "web"] });

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -116,25 +116,25 @@ describe("Crust .provide()", () => {
 		expect(() =>
 			new Crust("cli")
 				.provide(parentDb())
-				.mount(defineCommand("sub", (cmd) => cmd.provide(childDb()).handle(() => {}))),
+				.add(defineCommand("sub", (cmd) => cmd.provide(childDb()).handle(() => {}))),
 		).toThrow(CrustError);
 	});
 
-	it("throws DEFINITION when a mounted subtree re-provides a path name", () => {
+	it("throws DEFINITION when an added subtree re-provides a path name", () => {
 		const parentDb = defineContext("db", () => "parent");
 		const nestedDb = defineContext("db", () => "nested");
 		const sub = defineCommand("sub", { requires: [parentDb] }, (command) =>
-			command.mount(defineCommand("g", (child) => child.provide(nestedDb()).handle(() => {}))),
+			command.add(defineCommand("g", (child) => child.provide(nestedDb()).handle(() => {}))),
 		);
 
-		expect(() => new Crust("cli").provide(parentDb()).mount(sub)).toThrow(CrustError);
+		expect(() => new Crust("cli").provide(parentDb()).add(sub)).toThrow(CrustError);
 	});
 
-	it("seeds mounted descendants with the parent Context path", async () => {
+	it("seeds added descendants with the parent Context path", async () => {
 		const seen: string[] = [];
 		const db = defineContext("db", () => "root-db");
 		const sub = defineCommand("sub", { requires: [db] }, (command) =>
-			command.mount(
+			command.add(
 				defineCommand("g", { requires: [db] }, (child) =>
 					child.handle(({ ctx }) => {
 						seen.push(ctx.db);
@@ -142,7 +142,7 @@ describe("Crust .provide()", () => {
 				),
 			),
 		);
-		const root = new Crust("cli").provide(db()).mount(sub);
+		const root = new Crust("cli").provide(db()).add(sub);
 
 		await root.run(["sub", "g"]);
 
@@ -158,22 +158,22 @@ describe("Crust .provide()", () => {
 
 		const app = new Crust("cli")
 			.provide(lazy())
-			.mount(defineCommand("a", (cmd) => cmd.handle(() => {})))
-			.mount(defineCommand("b", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("a", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("b", (cmd) => cmd.handle(() => {})));
 
 		// Resolving "a" builds the inherited context once; "b" not executed
 		await app.run(["a"]);
 		expect(built).toBe(1);
 	});
 
-	it("does not backfill mounted children with later parent provides", async () => {
+	it("does not backfill added children with later parent provides", async () => {
 		let lateProvided = false;
 		const late = defineContext("late", () => {
 			lateProvided = true;
 			return "late";
 		});
 		const app = new Crust("cli")
-			.mount(defineCommand("status", (command) => command.handle(() => {})))
+			.add(defineCommand("status", (command) => command.handle(() => {})))
 			.provide(late());
 
 		await app.run(["status"]);
@@ -277,7 +277,7 @@ describe("Context-owned flags", () => {
 		expect(messages).toEqual(["debug"]);
 	});
 
-	it("exposes a provided capability to later mounted commands", async () => {
+	it("exposes a provided capability to later added commands", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
@@ -288,7 +288,7 @@ describe("Context-owned flags", () => {
 			}),
 		);
 
-		await new Crust("cli").provide(auth()).mount(deploy).run(["--api-key", "secret", "deploy"]);
+		await new Crust("cli").provide(auth()).add(deploy).run(["--api-key", "secret", "deploy"]);
 		expect(seen).toEqual(["secret"]);
 	});
 
@@ -331,7 +331,7 @@ describe("Context-owned flags", () => {
 					seen.push(`${name}:${ctx.auth.apiKey}`);
 				}),
 			);
-		const app = new Crust("cli").mount(branch("first"), branch("second"));
+		const app = new Crust("cli").add(branch("first"), branch("second"));
 
 		await app.run(["first", "--api-key", "one"]);
 		await app.run(["second", "--api-key", "two"]);
@@ -496,7 +496,7 @@ describe("Context capability requirements (topological construction)", () => {
 		});
 	});
 
-	it("satisfies a mounted definition's Context requirement before its dependents construct", async () => {
+	it("satisfies an added definition's Context requirement before its dependents construct", async () => {
 		const session = defineContext("session", () => ({ userId: "yan" }));
 		const user = defineContext("user", { requires: [session] }, ({ ctx }) => ({
 			id: ctx.session.userId,
@@ -508,7 +508,7 @@ describe("Context capability requirements (topological construction)", () => {
 			}),
 		);
 
-		await new Crust("cli").provide(session()).mount(account).run(["account"]);
+		await new Crust("cli").provide(session()).add(account).run(["account"]);
 	});
 });
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -74,7 +74,7 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 				) as Crust,
 		],
 		[".meta()", (app) => app.meta({ description: "desc" }) as Crust],
-		[".mount()", (app) => app.mount(defineCommand("sub", (command) => command)) as Crust],
+		[".add()", (app) => app.add(defineCommand("sub", (command) => command)) as Crust],
 		[".handle()", (app) => app.handle(() => {}) as Crust],
 	];
 
@@ -308,7 +308,7 @@ describe("Crust .meta()", () => {
 	});
 
 	it("works in subcommand callbacks", async () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("sub", (command) =>
 				command.meta({ description: "A subcommand", usage: "cli sub [options]" }),
 			),
@@ -403,12 +403,12 @@ describe("Crust type-level tests", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// .mount() — Runtime tests
+// .add() — Runtime tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .mount() with inline definitions", () => {
+describe("Crust .add() with inline definitions", () => {
 	it("registers a subcommand in the public snapshot", async () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })),
 		);
 
@@ -417,7 +417,7 @@ describe("Crust .mount() with inline definitions", () => {
 	});
 
 	it("subcommand exposes its flags", async () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })),
 		);
 
@@ -432,7 +432,7 @@ describe("Crust .mount() with inline definitions", () => {
 		const app = new Crust("cli")
 			.flags({ name: "port", type: "number" })
 			.provide(logging())
-			.mount(defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })));
+			.add(defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })));
 
 		expect((await app.snapshot()).subCommands.sub?.flags).toEqual({
 			verbose: { type: "boolean" },
@@ -443,7 +443,7 @@ describe("Crust .mount() with inline definitions", () => {
 	it("throws CrustError DEFINITION on empty subcommand name", () => {
 		const app = new Crust("cli");
 		try {
-			app.mount(defineCommand("", (cmd) => cmd));
+			app.add(defineCommand("", (cmd) => cmd));
 			expect.unreachable("should have thrown");
 		} catch (err) {
 			expect(err).toBeInstanceOf(CrustError);
@@ -455,7 +455,7 @@ describe("Crust .mount() with inline definitions", () => {
 	it("throws CrustError DEFINITION on whitespace-only subcommand name", () => {
 		const app = new Crust("cli");
 		try {
-			app.mount(defineCommand("   ", (cmd) => cmd));
+			app.add(defineCommand("   ", (cmd) => cmd));
 			expect.unreachable("should have thrown");
 		} catch (err) {
 			expect(err).toBeInstanceOf(CrustError);
@@ -464,9 +464,9 @@ describe("Crust .mount() with inline definitions", () => {
 	});
 
 	it("throws CrustError DEFINITION on duplicate subcommand name", () => {
-		const app = new Crust("cli").mount(defineCommand("sub", (cmd) => cmd));
+		const app = new Crust("cli").add(defineCommand("sub", (cmd) => cmd));
 		try {
-			app.mount(defineCommand("sub", (cmd) => cmd));
+			app.add(defineCommand("sub", (cmd) => cmd));
 			expect.unreachable("should have thrown");
 		} catch (err) {
 			expect(err).toBeInstanceOf(CrustError);
@@ -478,7 +478,7 @@ describe("Crust .mount() with inline definitions", () => {
 	it("callback receives a fresh child builder (not the parent)", async () => {
 		let receivedBuilder: CommandDefinitionBuilder | undefined;
 
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).mount(
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).add(
 			defineCommand("sub", (cmd) => {
 				receivedBuilder = cmd;
 				return cmd;
@@ -502,7 +502,7 @@ describe("Crust .mount() with inline definitions", () => {
 		new Crust("cli")
 			.flags({ name: "port", type: "number" })
 			.provide(logging())
-			.mount(
+			.add(
 				defineCommand("sub", (cmd) => {
 					childOwned = (cmd as unknown as Crust)._ancestorOwnedFlags;
 					return cmd;
@@ -515,8 +515,8 @@ describe("Crust .mount() with inline definitions", () => {
 
 	it("multiple subcommands can be registered", async () => {
 		const app = new Crust("cli")
-			.mount(defineCommand("sub1", (cmd) => cmd.flags({ name: "a", type: "string" })))
-			.mount(defineCommand("sub2", (cmd) => cmd.flags({ name: "b", type: "number" })));
+			.add(defineCommand("sub1", (cmd) => cmd.flags({ name: "a", type: "string" })))
+			.add(defineCommand("sub2", (cmd) => cmd.flags({ name: "b", type: "number" })));
 
 		const subCommands = (await app.snapshot()).subCommands;
 		expect(subCommands.sub1?.flags.a).toBeDefined();
@@ -527,7 +527,7 @@ describe("Crust .mount() with inline definitions", () => {
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
-			.mount(defineCommand("sub", (cmd) => cmd));
+			.add(defineCommand("sub", (cmd) => cmd));
 
 		const snapshot = await app.snapshot();
 		expect(snapshot.flags.verbose).toBeDefined();
@@ -536,10 +536,10 @@ describe("Crust .mount() with inline definitions", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// .mount() — Type-level tests
+// .add() — Type-level tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .mount() type-level tests", () => {
+describe("Crust .add() type-level tests", () => {
 	it("types required capabilities and local values in handlers", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
@@ -548,9 +548,9 @@ describe("Crust .mount() type-level tests", () => {
 		new Crust("cli")
 			.flags({ name: "rootOnly", type: "string" })
 			.provide(logging())
-			.mount(
+			.add(
 				defineCommand("level1", { requires: [logging] }, (command) =>
-					command.mount(
+					command.add(
 						defineCommand("level2", { requires: [logging] }, (child) =>
 							child
 								.args({ name: "target", type: "string", required: true })
@@ -591,11 +591,11 @@ describe("Crust .handle()", () => {
 		});
 	});
 
-	it("preserves the definition and can follow .mount()", async () => {
+	it("preserves the definition and can follow .add()", async () => {
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
-			.mount(defineCommand("sub", (command) => command))
+			.add(defineCommand("sub", (command) => command))
 			.handle(() => {});
 
 		expect(await app.snapshot()).toMatchObject({
@@ -630,7 +630,7 @@ describe("Crust .handle() type-level tests", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose === true,
 		}));
-		new Crust("cli").provide(logging()).mount(
+		new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
 				cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
 					type _checkOutput = Expect<Equal<typeof _ctx.flags.output, string>>;
@@ -743,7 +743,7 @@ describe("Crust .extend()", () => {
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
-			.mount(defineCommand("sub", (command) => command))
+			.add(defineCommand("sub", (command) => command))
 			.handle(() => {})
 			.extend(defineExtension("test-extension"));
 
@@ -783,7 +783,7 @@ describe("Extension application at prepare time", () => {
 			flags: { debug: { type: "boolean" } },
 		});
 
-		const app = new Crust("cli").extend(debug).mount(
+		const app = new Crust("cli").extend(debug).add(
 			defineCommand("sub", (cmd) =>
 				cmd.handle(({ flags }) => {
 					seen.push(flags);
@@ -803,7 +803,7 @@ describe("Extension application at prepare time", () => {
 
 		const app = new Crust("cli")
 			.extend(version)
-			.mount(defineCommand("sub", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("sub", (cmd) => cmd.handle(() => {})));
 
 		// --version is unknown on the subcommand → PARSE error
 		await expect(app.run(["sub", "--version"])).rejects.toMatchObject({ code: "PARSE" });
@@ -888,7 +888,7 @@ describe("Extension application at prepare time", () => {
 			commands: [defineCommand("sub", (command) => command.handle(() => {}))],
 		});
 		const app = new Crust("cli")
-			.mount(defineCommand("sub", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("sub", (cmd) => cmd.handle(() => {})))
 			.extend(clash);
 
 		await expect(app.run(["sub"])).rejects.toMatchObject({ code: "DEFINITION" });
@@ -1076,7 +1076,7 @@ describe("Extension named hooks", () => {
 		});
 		const app = new Crust("cli")
 			.extend(probe)
-			.mount(defineCommand("known", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("known", (cmd) => cmd.handle(() => {})));
 
 		await app.run(["known"], { stdout: (line) => lines.push(line) });
 		expect(lines).toEqual(["probe:known"]);
@@ -1391,7 +1391,7 @@ describe("Crust .execute()", () => {
 			.handle(() => {
 				handlerRan = "root";
 			})
-			.mount(
+			.add(
 				defineCommand("sub", (cmd) =>
 					cmd.handle(() => {
 						handlerRan = "sub";
@@ -1412,7 +1412,7 @@ describe("Crust .execute()", () => {
 		const app = new Crust("cli")
 			.flags({ name: "port", type: "number", default: 3000 })
 			.provide(logging())
-			.mount(
+			.add(
 				defineCommand("sub", (cmd) =>
 					cmd.handle((ctx) => {
 						subFlags = ctx.flags;
@@ -1579,7 +1579,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("command not found error with no run on parent", async () => {
-		const app = new Crust("cli").mount(defineCommand("sub", (cmd) => cmd.handle(() => {})));
+		const app = new Crust("cli").add(defineCommand("sub", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["unknown-sub"] });
 
@@ -1621,7 +1621,7 @@ describe("Crust .execute()", () => {
 		const skillLike = defineExtension("inject-subcommand", {
 			commands: [
 				defineCommand("skill", (command) =>
-					command.mount(
+					command.add(
 						defineCommand("update", (cmd) =>
 							cmd.handle((runCtx) => {
 								receivedFlags = runCtx.flags as Record<string, unknown>;
@@ -1645,11 +1645,11 @@ describe("Crust .execute()", () => {
 	it("deeply nested subcommand routing works", async () => {
 		let handlerRan = "";
 
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).mount(
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).add(
 			defineCommand("level1", (cmd) =>
-				cmd.mount(
+				cmd.add(
 					defineCommand("level2", (cmd2) =>
-						cmd2.mount(
+						cmd2.add(
 							defineCommand("level3", (cmd3) =>
 								cmd3.handle(() => {
 									handlerRan = "level3";
@@ -1693,7 +1693,7 @@ describe("Crust .execute()", () => {
 
 		const app = new Crust("cli")
 			.extend(inspect)
-			.mount(
+			.add(
 				defineCommand("sub", (cmd) =>
 					cmd.flags({ name: "output", type: "string", default: "stdout" }).handle(() => {}),
 				),
@@ -1729,7 +1729,7 @@ describe("Crust .execute()", () => {
 				receivedVerbose = ctx.logging.verbose;
 			}),
 		);
-		const app = new Crust("cli").provide(logging()).mount(sub);
+		const app = new Crust("cli").provide(logging()).add(sub);
 
 		await app.execute({ argv: ["sub", "--verbose"] });
 
@@ -1743,7 +1743,7 @@ describe("Crust .execute()", () => {
 		const ports = defineContext("ports", { flags: [port] }, ({ flags }) => ({
 			port: flags.port,
 		}));
-		const app = new Crust("cli").provide(ports()).mount(
+		const app = new Crust("cli").provide(ports()).add(
 			defineCommand("sub", { requires: [ports] }, (cmd) =>
 				cmd.handle(({ ctx }) => {
 					receivedPort = ctx.ports.port;
@@ -1763,7 +1763,7 @@ describe("Crust .execute()", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose,
 		}));
-		const app = new Crust("cli").provide(logging()).mount(
+		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
 				cmd.handle(({ ctx }) => {
 					receivedVerbose = ctx.logging.verbose;
@@ -1998,12 +1998,12 @@ describe("Crust.snapshot", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-// .mount() aliases
+// .add() aliases
 // ──────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .mount() aliases", () => {
+describe("Crust .add() aliases", () => {
 	it("plumbs aliases from meta() into the registered subcommand snapshot", async () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("issue", (command) =>
 				command.meta({ aliases: ["issues", "i"] }).handle(() => {}),
 			),
@@ -2014,44 +2014,42 @@ describe("Crust .mount() aliases", () => {
 	it("registers without error when no sibling collides", () => {
 		expect(() =>
 			new Crust("cli")
-				.mount(
+				.add(
 					defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
 				)
-				.mount(defineCommand("version", (cmd) => cmd.handle(() => {}))),
+				.add(defineCommand("version", (cmd) => cmd.handle(() => {}))),
 		).not.toThrow();
 	});
 
 	it("throws DEFINITION when an alias collides with a sibling's canonical name", () => {
-		const app = new Crust("cli").mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+		const app = new Crust("cli").add(defineCommand("build", (cmd) => cmd.handle(() => {})));
 		expect(() =>
-			app.mount(
-				defineCommand("compile", (cmd) => cmd.meta({ aliases: ["build"] }).handle(() => {})),
-			),
+			app.add(defineCommand("compile", (cmd) => cmd.meta({ aliases: ["build"] }).handle(() => {}))),
 		).toThrow(/collides with sibling canonical name "build"/);
 	});
 
 	it("throws DEFINITION when an alias collides with another sibling's alias", () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})),
 		);
 		expect(() =>
-			app.mount(defineCommand("info", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {}))),
+			app.add(defineCommand("info", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {}))),
 		).toThrow(/collides with alias of sibling "issue"/);
 	});
 
 	it("throws DEFINITION on the reverse-order case (new canonical equals an existing alias)", () => {
-		const app = new Crust("cli").mount(
+		const app = new Crust("cli").add(
 			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})),
 		);
 		// Now try to register a *new* command whose canonical name == existing alias.
-		expect(() => app.mount(defineCommand("i", (cmd) => cmd.handle(() => {})))).toThrow(
+		expect(() => app.add(defineCommand("i", (cmd) => cmd.handle(() => {})))).toThrow(
 			/canonical name "i" collides with alias of sibling "issue"/,
 		);
 	});
 
 	it("throws DEFINITION on duplicate aliases within one subcommand's own list", () => {
 		expect(() =>
-			new Crust("cli").mount(
+			new Crust("cli").add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i", "i"] }).handle(() => {})),
 			),
 		).toThrow(/lists alias "i" more than once/);
@@ -2059,7 +2057,7 @@ describe("Crust .mount() aliases", () => {
 
 	it("throws DEFINITION on an alias equal to its own canonical name", () => {
 		expect(() =>
-			new Crust("cli").mount(
+			new Crust("cli").add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issue"] }).handle(() => {})),
 			),
 		).toThrow(/must not equal its own canonical name/);
@@ -2067,7 +2065,7 @@ describe("Crust .mount() aliases", () => {
 
 	it("throws DEFINITION on an empty alias", () => {
 		expect(() =>
-			new Crust("cli").mount(
+			new Crust("cli").add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: [""] }).handle(() => {})),
 			),
 		).toThrow(/must be a non-empty string/);
@@ -2075,7 +2073,7 @@ describe("Crust .mount() aliases", () => {
 
 	it("throws DEFINITION on an alias containing whitespace", () => {
 		expect(() =>
-			new Crust("cli").mount(
+			new Crust("cli").add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["my issue"] }).handle(() => {})),
 			),
 		).toThrow(/must not contain whitespace/);
@@ -2083,22 +2081,22 @@ describe("Crust .mount() aliases", () => {
 
 	it("throws DEFINITION on an alias starting with '-'", () => {
 		expect(() =>
-			new Crust("cli").mount(
+			new Crust("cli").add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["-i"] }).handle(() => {})),
 			),
 		).toThrow(/must not start with "-"/);
 	});
 
-	it("applies the same checks on the .mount() path", () => {
+	it("applies the same checks on the .add() path", () => {
 		const issue = defineCommand("issue", (command) =>
 			command.meta({ aliases: ["i"] }).handle(() => {}),
 		);
 		const conflicting = defineCommand("info", (command) =>
 			command.meta({ aliases: ["i"] }).handle(() => {}),
 		);
-		const app = new Crust("cli").mount(issue);
+		const app = new Crust("cli").add(issue);
 
-		expect(() => app.mount(conflicting)).toThrow(/collides with alias of sibling "issue"/);
+		expect(() => app.add(conflicting)).toThrow(/collides with alias of sibling "issue"/);
 	});
 
 	it("Extension command with a colliding alias is a DEFINITION error (no silent shadowing)", async () => {
@@ -2112,7 +2110,7 @@ describe("Crust .mount() aliases", () => {
 
 		const app = new Crust("cli")
 			.extend(rogue)
-			.mount(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})));
 
 		await expect(app.run(["i"])).rejects.toMatchObject({ code: "DEFINITION" });
 	});

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -99,7 +99,7 @@ function validateSchemaExclusivity(
 // Reusable command definitions
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Context capabilities a command definition requires from its mount path. */
+/** Context capabilities a command definition requires from its parent path. */
 export interface CommandRequirements {
 	readonly requires?: readonly AnyContextFactory[];
 }
@@ -116,18 +116,18 @@ const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefini
 
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
-	/** Requirement names, runtime-checked at each mount site */
+	/** Requirement names, runtime-checked when the definition is added */
 	readonly requiredCtxNames: readonly string[];
 }
 
 export interface CommandDefinition<R extends CommandRequirements = {}> {
-	/** The subcommand name this definition mounts under */
+	/** The subcommand name this definition is added under */
 	readonly name: string;
-	/** The same definition under a different name (mount one definition twice) */
+	/** The same definition under a different name (add one definition twice) */
 	as(name: string): CommandDefinition<R>;
 	/** @internal */
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
-	/** @internal — phantom carrying the requirements for mount-site checks */
+	/** @internal — phantom carrying the requirements for add-time checks */
 	readonly _requirements?: R;
 }
 
@@ -151,7 +151,7 @@ function materializeCommandDefinition(
 		}
 		throw new CrustError(
 			"DEFINITION",
-			"mount() requires a command definition created by defineCommand()",
+			"add() requires a command definition created by defineCommand()",
 		);
 	}
 
@@ -172,7 +172,7 @@ function materializeCommandDefinition(
 		if (!providedNames.has(ctxName)) {
 			const message = extensionName
 				? `Extension "${extensionName}" command "${name}" requires Context "${ctxName}", which is not provided on application root "${parent.meta.name}"`
-				: `Command "${name}" requires Context "${ctxName}", which is not provided on "${parent.meta.name}" — call .provide() before .mount()`;
+				: `Command "${name}" requires Context "${ctxName}", which is not provided on "${parent.meta.name}" — call .provide() before .add()`;
 			throw new CrustError("DEFINITION", message, {
 				subject: "context",
 				name: ctxName,
@@ -260,8 +260,8 @@ type ContextRequirementErrors<Ctx extends ContextMap, Required extends ContextMa
 
 type DefinitionRequirements<D> = D extends CommandDefinition<infer R> ? R : never;
 
-/** Per-definition mount checks (compile-time counterpart of the runtime attach checks). */
-type MountChecks<Ctx extends ContextMap, Ds extends readonly CommandDefinition<any>[]> = {
+/** Per-definition add-time checks (compile-time counterpart of the runtime attach checks). */
+type AddChecks<Ctx extends ContextMap, Ds extends readonly CommandDefinition<any>[]> = {
 	[I in keyof Ds]: Ds[I] &
 		ContextRequirementErrors<Ctx, RequirementContext<DefinitionRequirements<Ds[I]>>>;
 };
@@ -299,8 +299,8 @@ export interface CommandDefinitionBuilder<
 		MergeContext<Ctx, ContextsOutput<Cs>>
 	>;
 
-	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<Ctx, Ds>
+	add<const Ds extends readonly CommandDefinition<any>[]>(
+		...definitions: AddChecks<Ctx, Ds>
 	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 
 	handle(
@@ -311,10 +311,10 @@ export interface CommandDefinitionBuilder<
 /**
  * Define a reusable, inert command under a required name.
  *
- * The recipe runs once per `.mount()`, receiving a fresh builder typed by
- * the declared Context capabilities, which must be provided on the mount path.
+ * The recipe runs once per `.add()`, receiving a fresh builder typed by
+ * the declared Context capabilities, which must be provided on the parent path.
  *
- * Use `.as(name)` to mount one definition under a different name.
+ * Use `.as(name)` to add one definition under a different name.
  */
 export function defineCommand(name: string, recipe: CommandRecipe<{}>): CommandDefinition;
 export function defineCommand<const R extends CommandRequirements>(
@@ -442,7 +442,7 @@ export class Crust<
 	/**
 	 * Set metadata (description, usage) for this command.
 	 *
-	 * The command name is already set by the constructor or mount call.
+	 * The command name is already set by the constructor or add call.
 	 * Provide `description`, `usage`, and/or `aliases` here.
 	 *
 	 * Returns a new builder with updated metadata. The original builder
@@ -673,19 +673,19 @@ export class Crust<
 	 * under its own carried name (use `.as(name)` to rename).
 	 *
 	 * Each definition's Context requirement names must already be provided
-	 * on this builder's path — call `.provide()` before `.mount()`.
+	 * on this builder's path — call `.provide()` before `.add()`.
 	 */
-	mount<const Ds extends readonly CommandDefinition<any>[]>(
-		...definitions: MountChecks<Ctx, Ds>
+	add<const Ds extends readonly CommandDefinition<any>[]>(
+		...definitions: AddChecks<Ctx, Ds>
 	): Crust<Local, Owned, A, Eff, Ctx> {
 		let result = this as Crust<Local, Owned, A, Eff, Ctx>;
 		for (const definition of definitions) {
-			result = result._mountDefinition(definition as CommandDefinition);
+			result = result._addDefinition(definition as CommandDefinition);
 		}
 		return result;
 	}
 
-	private _mountDefinition(definition: CommandDefinition): Crust<Local, Owned, A, Eff, Ctx> {
+	private _addDefinition(definition: CommandDefinition): Crust<Local, Owned, A, Eff, Ctx> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -11,7 +11,7 @@ type IsEqual<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 describe("command definitions", () => {
-	it("stays inert and materializes each mount", async () => {
+	it("stays inert and materializes each time it is added", async () => {
 		let configured = 0;
 		const definition = defineCommand("build", (command) => {
 			configured++;
@@ -19,7 +19,7 @@ describe("command definitions", () => {
 		});
 
 		expect(configured).toBe(0);
-		const app = new Crust("cli").mount(definition, definition.as("compile"));
+		const app = new Crust("cli").add(definition, definition.as("compile"));
 
 		expect(configured).toBe(2);
 		const snapshot = await app.snapshot();
@@ -47,14 +47,14 @@ describe("command definitions", () => {
 	it("does not backfill nested definitions with later inheritable flags", async () => {
 		const nested = defineCommand("nested", (command) => command.handle(() => {}));
 		const outer = defineCommand("outer", (command) =>
-			command.mount(nested).flags({ name: "late", type: "boolean" }),
+			command.add(nested).flags({ name: "late", type: "boolean" }),
 		);
-		const app = new Crust("cli").mount(outer);
+		const app = new Crust("cli").add(outer);
 
 		await expect(app.run(["outer", "nested", "--late"])).rejects.toThrow(/Unknown flag/);
 	});
 
-	it("propagates Context-owned flags only to definitions mounted after provide()", async () => {
+	it("propagates Context-owned flags only to definitions added after provide()", async () => {
 		const calls: string[] = [];
 		const apiKey = defineFlag("api-key", { type: "string" });
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
@@ -67,9 +67,9 @@ describe("command definitions", () => {
 			}),
 		);
 		const outer = defineCommand("outer", (command) =>
-			command.mount(before).provide(auth()).mount(after),
+			command.add(before).provide(auth()).add(after),
 		);
-		const app = new Crust("cli").mount(outer);
+		const app = new Crust("cli").add(outer);
 
 		await expect(app.run(["outer", "before", "--api-key", "secret"])).rejects.toThrow(
 			/Unknown flag/,
@@ -91,16 +91,16 @@ describe("command definitions", () => {
 			}),
 		);
 		const deploy = defineCommand("deploy", { requires: [logging, db] }, (command) =>
-			command.mount(status),
+			command.add(status),
 		);
-		const app = new Crust("cli").provide(logging(), db()).mount(deploy);
+		const app = new Crust("cli").provide(logging(), db()).add(deploy);
 
 		await app.run(["deploy", "status", "--verbose"]);
 
 		expect(calls).toEqual(["database:true"]);
 	});
 
-	it("clones annotations and isolates mounts across parents", async () => {
+	it("clones annotations and isolates materializations across parents", async () => {
 		const annotation = Symbol("annotation");
 		const definition = defineCommand("one", (command) => {
 			const configured = command.meta({ description: "Reusable" });
@@ -109,8 +109,8 @@ describe("command definitions", () => {
 			return configured;
 		});
 
-		const first = await new Crust("first").mount(definition).snapshot();
-		const second = await new Crust("second").mount(definition.as("two")).snapshot();
+		const first = await new Crust("first").add(definition).snapshot();
+		const second = await new Crust("second").add(definition.as("two")).snapshot();
 
 		expect((first.subCommands.one as unknown as Record<symbol, unknown>)[annotation]).toBe(
 			"preserved",
@@ -124,26 +124,26 @@ describe("command definitions", () => {
 		const db = defineContext("db", () => "database");
 		const definition = defineCommand("users", (command) => command.provide(db()));
 
-		expect(() => new Crust("cli").provide(db()).mount(definition)).toThrow(
+		expect(() => new Crust("cli").provide(db()).add(definition)).toThrow(
 			/Context "db" is already provided/,
 		);
 	});
 
-	it("excludes parent local flags from mounted commands", async () => {
+	it("excludes parent local flags from added commands", async () => {
 		const definition = defineCommand("users", (command) => command.handle(() => {}));
-		const app = new Crust("cli").flags({ name: "secret", type: "string" }).mount(definition);
+		const app = new Crust("cli").flags({ name: "secret", type: "string" }).add(definition);
 
 		await expect(app.run(["users", "--secret", "value"])).rejects.toThrow(/Unknown flag/);
 	});
 
-	it("runs mounted definitions through run and execute", async () => {
+	it("runs added definitions through run and execute", async () => {
 		let calls = 0;
 		const definition = defineCommand("build", (command) =>
 			command.handle(() => {
 				calls++;
 			}),
 		);
-		const app = new Crust("cli").mount(definition);
+		const app = new Crust("cli").add(definition);
 
 		await app.run(["build"]);
 		await app.execute({ argv: ["build"] });
@@ -151,7 +151,7 @@ describe("command definitions", () => {
 		expect(calls).toBe(2);
 	});
 
-	it("mounts multiple definitions in one variadic call", async () => {
+	it("adds multiple definitions in one variadic call", async () => {
 		const ran: string[] = [];
 		const build = defineCommand("build", (command) =>
 			command.handle(() => {
@@ -163,7 +163,7 @@ describe("command definitions", () => {
 				ran.push("publish");
 			}),
 		);
-		const app = new Crust("cli").mount(build, publish);
+		const app = new Crust("cli").add(build, publish);
 
 		await app.run(["build"]);
 		await app.run(["publish"]);
@@ -173,41 +173,41 @@ describe("command definitions", () => {
 
 	it("uses the same lineage checks for inline definitions", () => {
 		expect(() =>
-			new Crust("cli").mount(defineCommand("bad", () => new Crust("foreign") as never)),
+			new Crust("cli").add(defineCommand("bad", () => new Crust("foreign") as never)),
 		).toThrow(/same command builder/);
 	});
 
-	it("validates canonical names and aliases on every mount", () => {
+	it("validates canonical names and aliases on every add", () => {
 		const definition = defineCommand("build", (command) =>
 			command.meta({ aliases: ["b"] }).handle(() => {}),
 		);
-		const app = new Crust("cli").mount(definition);
+		const app = new Crust("cli").add(definition);
 
-		expect(() => app.mount(definition)).toThrow(/already registered/);
-		expect(() => app.mount(defineCommand("b", (command) => command))).toThrow(
+		expect(() => app.add(definition)).toThrow(/already registered/);
+		expect(() => app.add(defineCommand("b", (command) => command))).toThrow(
 			/collides with alias of sibling "build"/,
 		);
 		expect(() =>
-			new Crust("cli").mount(defineCommand("b", (command) => command)).mount(definition),
+			new Crust("cli").add(defineCommand("b", (command) => command)).add(definition),
 		).toThrow(/collides with sibling canonical name "b"/);
 	});
 
 	it("rejects unrelated returned builders and nested Extensions", () => {
 		const unrelated = defineCommand("bad", () => new Crust("other") as never);
-		expect(() => new Crust("cli").mount(unrelated)).toThrow(/same command builder/);
+		expect(() => new Crust("cli").add(unrelated)).toThrow(/same command builder/);
 
 		const nestedExtension = defineCommand(
 			"bad",
 			(command) => (command as unknown as Crust).extend(defineExtension("nested")) as never,
 		);
-		expect(() => new Crust("cli").mount(nestedExtension)).toThrow(
+		expect(() => new Crust("cli").add(nestedExtension)).toThrow(
 			/Extensions cannot be registered inside command definitions/,
 		);
 	});
 
 	it("rejects values that are not command definitions", () => {
 		for (const bad of [{}, null, undefined, "definition"]) {
-			expect(() => new Crust("cli").mount(bad as never)).toThrow(
+			expect(() => new Crust("cli").add(bad as never)).toThrow(
 				/requires a command definition created by defineCommand/,
 			);
 		}
@@ -219,14 +219,14 @@ describe("command definitions", () => {
 		);
 	});
 
-	it("checks Context requirement names at the mount call at runtime", () => {
+	it("checks Context requirement names at runtime when added", () => {
 		const db = defineContext("db", () => "database");
 		const definition = defineCommand("users", { requires: [db] }, (command) =>
 			command.handle(() => {}),
 		);
 
-		expect(() => new Crust("cli").provide(db()).mount(definition)).not.toThrow();
-		expect(() => new Crust("cli").mount(definition as never)).toThrow(
+		expect(() => new Crust("cli").provide(db()).add(definition)).not.toThrow();
+		expect(() => new Crust("cli").add(definition as never)).toThrow(
 			/Command "users" requires Context "db"/,
 		);
 	});
@@ -247,15 +247,15 @@ describe("command definitions", () => {
 				}),
 		);
 
-		new Crust("cli").provide(auth()).mount(definition);
+		new Crust("cli").provide(auth()).add(definition);
 		expect(() =>
 			// @ts-expect-error -- missing Contexts: auth
-			new Crust("cli").mount(definition),
+			new Crust("cli").add(definition),
 		).toThrow(/requires Context "auth"/);
 		new Crust("cli")
 			.provide(defineContext("auth", () => "wrong")())
 			// @ts-expect-error -- incompatible Contexts: auth
-			.mount(definition);
+			.add(definition);
 	});
 
 	it("keeps root-only methods off the definition builder", () => {
@@ -283,14 +283,14 @@ describe("command definitions", () => {
 		});
 	});
 
-	it("checks nested requirements at the enclosing mount point", () => {
+	it("checks nested requirements at the enclosing add point", () => {
 		const auth = defineContext("auth", () => ({ user: "yan" }));
 		const nested = defineCommand("nested", { requires: [auth] }, (command) => command);
 
-		defineCommand("outer", { requires: [auth] }, (command) => command.mount(nested));
+		defineCommand("outer", { requires: [auth] }, (command) => command.add(nested));
 		defineCommand("outer", (command) => {
 			// @ts-expect-error -- missing Contexts: auth
-			return command.mount(nested);
+			return command.add(nested);
 		});
 	});
 });

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -35,14 +35,12 @@ describe("buildCommandDocumentation", () => {
 	it("omits hidden commands while traversing the full visible tree", async () => {
 		const model = await docs(
 			new Crust("app")
-				.mount(
+				.add(
 					defineCommand("visible", (command) =>
-						command.mount(defineCommand("nested", (child) => child.handle(() => {}))),
+						command.add(defineCommand("nested", (child) => child.handle(() => {}))),
 					),
 				)
-				.mount(
-					defineCommand("hidden", (command) => command.meta({ hidden: true }).handle(() => {})),
-				),
+				.add(defineCommand("hidden", (command) => command.meta({ hidden: true }).handle(() => {}))),
 		);
 		expect(model.children.map((child) => child.name)).toEqual(["visible"]);
 		expect(model.children[0]?.children[0]?.path).toEqual(["app", "visible", "nested"]);

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -65,7 +65,7 @@ describe("snapshotCommand", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
-			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.handle(() => {})));
 
 		const snapshot = await app.snapshot();
 		expect(snapshot.flags["api-key"]).toEqual({

--- a/packages/core/src/parsing/validation.test.ts
+++ b/packages/core/src/parsing/validation.test.ts
@@ -335,7 +335,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 // ──────────────────────────────────────────────────────────────────────────────
 // validateCommandTree — alias collisions
 //
-// Catches plugin-installed subcommands that bypass `.mount()` (where
+// Catches plugin-installed subcommands that bypass `.add()` (where
 // collision detection runs eagerly).
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/parsing/validation.ts
+++ b/packages/core/src/parsing/validation.ts
@@ -11,7 +11,7 @@ import { parseArgs, validateParsed } from "./parser.ts";
 // Both registration time (`crust.ts`) and tree-walk validation
 // (`validateCommandTree`) reuse these helpers so the policy lives in one
 // place and surfaces as the same `DEFINITION` error shape regardless of
-// how a subcommand was installed (`.mount()` vs. plugin-installed via
+// how a subcommand was installed (`.add()` vs. plugin-installed via
 // the `addCommand` action / direct `node.subCommands` mutation).
 // ──────────────────────────────────────────────────────────────────────────────
 
@@ -237,7 +237,7 @@ export function validateCommandTree(root: CommandNode): void {
 		}
 
 		// Detect alias collisions among children. Catches plugin-installed
-		// subcommands that bypassed `.mount()` (where collision detection
+		// subcommands that bypassed `.add()` (where collision detection
 		// already runs eagerly). We re-run the full check by walking the
 		// children and validating each one against the children registered
 		// before it in iteration order.

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -44,8 +44,8 @@ export const deploy = defineCommand("deploy", { requires: [auth] }, (cmd) =>
 export const app = new Crust("consumer-cli")
 	.flags(...flags)
 	.provide(auth())
-	.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
-	.mount(deploy);
+	.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+	.add(deploy);
 `;
 
 let fixtureDir: string;

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -41,7 +41,7 @@ const serveCmd = defineCommand("serve", (command) =>
 		}),
 );
 
-const rootCmd = rootBase.mount(serveCmd).handle(({ flags }) => {
+const rootCmd = rootBase.add(serveCmd).handle(({ flags }) => {
 	if (flags.help) {
 		console.log("help");
 	}
@@ -127,7 +127,7 @@ describe("integration: .execute() full pipeline with argv override", () => {
 		const env = defineFlag("env", { type: "string", default: "staging" });
 		const dryRun = defineFlag("dryRun", { type: "boolean" });
 		const deployment = defineContext("deployment", { flags: [env, dryRun] }, ({ flags }) => flags);
-		const app = new Crust("deploy").provide(deployment()).mount(
+		const app = new Crust("deploy").provide(deployment()).add(
 			defineCommand("service", { requires: [deployment] }, (cmd) =>
 				cmd.args(defineArg("name", { type: "string", required: true })).handle(({ args, ctx }) => {
 					console.log(
@@ -170,7 +170,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 				console.log(`${typeof ctx.auth.credential}:${ctx.auth.credential}`);
 			}),
 		);
-		const app = new Crust("cli").provide(auth()).mount(deploy);
+		const app = new Crust("cli").provide(auth()).add(deploy);
 
 		const result = await executeCrust(app, ["--token=42", "deploy"]);
 		expect(result.stdout).toContain("number:42");
@@ -185,9 +185,9 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const app = new Crust("cli")
 			.flags({ name: "root-only", type: "boolean" })
 			.provide(logging())
-			.mount(
+			.add(
 				defineCommand("group", { requires: [logging] }, (group) =>
-					group.mount(
+					group.add(
 						defineCommand("deploy", { requires: [logging] }, (deploy) =>
 							deploy.handle(({ ctx }) => console.log(`verbose=${ctx.logging.verbose}`)),
 						),
@@ -208,7 +208,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const auth = defineContext("auth", { flags: [token] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
-			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.handle(() => {})));
 
 		const result = await executeCrust(app, ["deploy"]);
 		expect(result.exitCode).toBe(1);
@@ -220,7 +220,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const outputConfig = defineContext("output-config", { flags: [output] }, ({ flags }) => flags);
 		const app = new Crust("cli")
 			.provide(outputConfig())
-			.mount(
+			.add(
 				defineCommand("render", { requires: [outputConfig] }, (command) =>
 					command.handle(({ ctx }) => console.log(`output=${ctx["output-config"].output}`)),
 				),
@@ -269,7 +269,7 @@ describe("integration: Extension adds flag visible to subcommand handler", () =>
 				},
 			},
 		});
-		const app = new Crust("cli").extend(logging).mount(
+		const app = new Crust("cli").extend(logging).add(
 			defineCommand("sub", (cmd) =>
 				cmd.handle(() => {
 					order.push("sub:run");
@@ -282,7 +282,7 @@ describe("integration: Extension adds flag visible to subcommand handler", () =>
 	});
 });
 
-describe("integration: nested mounted definitions end-to-end", () => {
+describe("integration: nested added definitions end-to-end", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
@@ -292,9 +292,9 @@ describe("integration: nested mounted definitions end-to-end", () => {
 		const timeout = defineFlag("timeout", { type: "number", default: 30 });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const remoteConfig = defineContext("remote-config", { flags: [timeout] }, ({ flags }) => flags);
-		const app = new Crust("git").provide(logging()).mount(
+		const app = new Crust("git").provide(logging()).add(
 			defineCommand("remote", { requires: [logging] }, (cmd) =>
-				cmd.provide(remoteConfig()).mount(
+				cmd.provide(remoteConfig()).add(
 					defineCommand("add", { requires: [logging, remoteConfig] }, (cmd2) =>
 						cmd2.args({ name: "name", type: "string", required: true }).handle(({ args, ctx }) => {
 							console.log(
@@ -324,7 +324,7 @@ describe("integration: nested mounted definitions end-to-end", () => {
 			.handle((ctx) => {
 				console.log(`root input=${ctx.args.input}`);
 			})
-			.mount(
+			.add(
 				defineCommand("sub", (cmd) =>
 					cmd.handle(() => {
 						console.log("sub ran");
@@ -366,7 +366,7 @@ describe("integration: split-file definitions end-to-end", () => {
 	);
 
 	it("runs standalone definitions through the full pipeline", async () => {
-		const app = new Crust("kubectl").provide(logging()).mount(listCommand, getCommand);
+		const app = new Crust("kubectl").provide(logging()).add(listCommand, getCommand);
 
 		const listResult = await executeCrust(app, ["list", "pods", "--verbose", "--format", "json"]);
 		expect(listResult.stdout).toContain("list pods format=json verbose=true");
@@ -378,27 +378,27 @@ describe("integration: split-file definitions end-to-end", () => {
 	});
 
 	it("reuses a definition across satisfying parents, renamed via .as()", async () => {
-		const first = new Crust("first").provide(logging()).mount(listCommand);
+		const first = new Crust("first").provide(logging()).add(listCommand);
 		const defaultLogging = defineContext(
 			"logging",
 			{ flags: [{ ...verbose, default: true }] },
 			({ flags }) => flags,
 		);
-		const second = new Crust("second").provide(defaultLogging()).mount(listCommand.as("show"));
+		const second = new Crust("second").provide(defaultLogging()).add(listCommand.as("show"));
 
 		expect((await executeCrust(first, ["list", "pods"])).stdout).toContain("verbose=undefined");
 		expect((await executeCrust(second, ["show", "pods"])).stdout).toContain("verbose=true");
 	});
 });
 
-describe("integration: mounted definitions", () => {
+describe("integration: added definitions", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
 	const verbose = defineFlag("verbose", { type: "boolean" });
 
-	it("mounts nested definitions end-to-end", async () => {
+	it("adds nested definitions end-to-end", async () => {
 		const env = defineFlag("env", { type: "string" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const deployment = defineContext("deployment", { flags: [env] }, ({ flags }) => flags);
@@ -408,25 +408,25 @@ describe("integration: mounted definitions", () => {
 			}),
 		);
 		const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-			command.provide(deployment()).mount(status),
+			command.provide(deployment()).add(status),
 		);
-		const app = new Crust("cli").provide(logging()).mount(deploy);
+		const app = new Crust("cli").provide(logging()).add(deploy);
 
 		const result = await executeCrust(app, ["deploy", "status", "--verbose", "--env", "staging"]);
 		expect(result.stdout).toContain("verbose=true env=staging");
 		expect(result.exitCode).toBe(0);
 	});
 
-	it("excludes parent-local flags from mounted commands", async () => {
+	it("excludes parent-local flags from added commands", async () => {
 		const sub = defineCommand("sub", (command) => command.handle(() => console.log("sub ran")));
-		const app = new Crust("cli").flags({ name: "rootOnly", type: "string" }).mount(sub);
+		const app = new Crust("cli").flags({ name: "rootOnly", type: "string" }).add(sub);
 
 		const result = await executeCrust(app, ["sub", "--rootOnly", "val"]);
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain("Unknown flag");
 	});
 
-	it("mounts multiple definitions in one call", async () => {
+	it("adds multiple definitions in one call", async () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
 			command.handle(({ ctx }) => console.log(`deploy verbose=${ctx.logging.verbose}`)),
@@ -434,7 +434,7 @@ describe("integration: mounted definitions", () => {
 		const status = defineCommand("status", { requires: [logging] }, (command) =>
 			command.handle(({ ctx }) => console.log(`status verbose=${ctx.logging.verbose}`)),
 		);
-		const app = new Crust("cli").provide(logging()).mount(status, deploy);
+		const app = new Crust("cli").provide(logging()).add(status, deploy);
 
 		expect((await executeCrust(app, ["deploy", "--verbose"])).stdout).toContain(
 			"deploy verbose=true",
@@ -453,7 +453,7 @@ describe("integration: Context-owned boolean flag negation", () => {
 	it("--no-verbose negates a Context-owned boolean flag on a subcommand", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean", default: true });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
-		const app = new Crust("cli").provide(logging()).mount(
+		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
 				cmd.handle(({ ctx }) => {
 					console.log(`verbose=${ctx.logging.verbose}`);
@@ -479,7 +479,7 @@ describe("integration: Context-owned multiple-value flag", () => {
 	it("Context-owned multiple-value flag collects values on a subcommand", async () => {
 		const tag = defineFlag("tag", { type: "string", multiple: true });
 		const tags = defineContext("tags", { flags: [tag] }, ({ flags }) => flags);
-		const app = new Crust("cli").provide(tags()).mount(
+		const app = new Crust("cli").provide(tags()).add(
 			defineCommand("sub", { requires: [tags] }, (cmd) =>
 				cmd.handle(({ ctx }) => {
 					console.log(`tags=${JSON.stringify(ctx.tags.tag)}`);
@@ -505,7 +505,7 @@ describe("integration: separator (--) with subcommand and Context-owned flags", 
 	it("rawArgs captured correctly on a subcommand with Context-owned flags", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
-		const app = new Crust("cli").provide(logging()).mount(
+		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
 				cmd.handle(({ ctx, rawArgs }) => {
 					console.log(`verbose=${ctx.logging.verbose}`);
@@ -548,7 +548,7 @@ describe("integration: complex real-world CLI scenario", () => {
 		const app = new Crust("myctl")
 			.provide(settings())
 			.extend(auditExtension)
-			.mount(
+			.add(
 				defineCommand("deploy", { requires: [settings] }, (cmd) =>
 					cmd.flags({ name: "env", type: "string", required: true }).handle(({ flags, ctx }) => {
 						order.push("deploy:run");

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -63,7 +63,7 @@ const expectedVersion = pkg.version;
 
 /** Build a fresh app from the production root builder for each test. */
 function makeCrustApp() {
-	return crustBase.mount(buildCommand, publishCommand);
+	return crustBase.add(buildCommand, publishCommand);
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/crust/src/cli.ts
+++ b/packages/crust/src/cli.ts
@@ -14,6 +14,6 @@ import { publishCommand } from "./commands/publish.ts";
  * - `crust build` - Compile your CLI to a standalone Bun executable
  * - `crust publish` - Publish staged npm packages in manifest order
  */
-export const crustApp = crustBase.mount(buildCommand, publishCommand);
+export const crustApp = crustBase.add(buildCommand, publishCommand);
 
 await crustApp.execute();

--- a/packages/crust/src/commands/build.integration.test.ts
+++ b/packages/crust/src/commands/build.integration.test.ts
@@ -84,7 +84,7 @@ console.log("hello from crust build test");
 		};
 
 		try {
-			const app = new Crust("test").mount(buildCommand);
+			const app = new Crust("test").add(buildCommand);
 			await app.execute({
 				argv: [
 					"build",
@@ -145,7 +145,7 @@ console.log("hello from crust build test");
 		const outPath = join(tmpDir, "dist", "test-cli-no-minify");
 
 		try {
-			const app = new Crust("test").mount(buildCommand);
+			const app = new Crust("test").add(buildCommand);
 			await app.execute({
 				argv: [
 					"build",
@@ -177,7 +177,7 @@ console.log("hello from crust build test");
 		};
 
 		try {
-			const app = new Crust("test").mount(buildCommand);
+			const app = new Crust("test").add(buildCommand);
 			await app.execute({
 				argv: ["build", "--entry", "src/cli.ts", "--target", "bun-darwin-arm64"],
 			});
@@ -225,7 +225,7 @@ console.log(JSON.stringify({
 				);
 
 				const outPath = join(tmpDir, "dist", "env-cli");
-				const app = new Crust("test").mount(buildCommand);
+				const app = new Crust("test").add(buildCommand);
 
 				await app.execute({
 					argv: [

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -26,15 +26,15 @@ import {
  * Helper to extract the build command's internal node for definition checks.
  */
 function makeBuildNode() {
-	const buildNode = new Crust("test").mount(buildCommand)._node.subCommands.build;
+	const buildNode = new Crust("test").add(buildCommand)._node.subCommands.build;
 	if (!buildNode) throw new Error("build subcommand not found");
 	return buildNode;
 }
 
-/** Parse argv against the mounted build command's grammar. */
+/** Parse argv against the added build command's grammar. */
 async function parseBuildArgs(argv: string[]) {
 	let captured: { args: Record<string, unknown>; flags: Record<string, unknown> } | undefined;
-	const app = new Crust("test").mount(buildCommand);
+	const app = new Crust("test").add(buildCommand);
 	const node = app._node.subCommands.build!;
 	node.run = (ctx) => {
 		const commandContext = ctx as {
@@ -574,7 +574,7 @@ describe("buildCommand error handling", () => {
 
 		try {
 			process.exitCode = 0;
-			const app = new Crust("test").mount(buildCommand);
+			const app = new Crust("test").add(buildCommand);
 
 			await app.execute({
 				argv: ["build", "--entry", "nonexistent.ts", "--target", "bun-linux-x64-baseline"],
@@ -609,7 +609,7 @@ describe("buildCommand error handling", () => {
 
 		try {
 			process.exitCode = 0;
-			const app = new Crust("test").mount(buildCommand);
+			const app = new Crust("test").add(buildCommand);
 
 			await app.execute({
 				argv: ["build", "--outfile", "./out"],

--- a/packages/crust/src/commands/publish.test.ts
+++ b/packages/crust/src/commands/publish.test.ts
@@ -13,10 +13,10 @@ import {
 } from "../../src/commands/publish.ts";
 import type { DistributionManifest } from "../utils/distribute.ts";
 
-/** Parse argv against the mounted publish command's grammar. */
+/** Parse argv against the added publish command's grammar. */
 async function parsePublishArgs(argv: string[]) {
 	let captured: { flags: Record<string, unknown> } | undefined;
-	const app = new Crust("test").mount(publishCommand);
+	const app = new Crust("test").add(publishCommand);
 	const node = app._node.subCommands.publish!;
 	node.run = (ctx) => {
 		captured = { flags: (ctx as { flags: Record<string, unknown> }).flags };

--- a/packages/crust/tests/package-manager.smoke.test.ts
+++ b/packages/crust/tests/package-manager.smoke.test.ts
@@ -87,7 +87,7 @@ console.log(args.join(" ") || "resolver-ok");
 		),
 	);
 
-	const app = new Crust("test").mount(buildCommand);
+	const app = new Crust("test").add(buildCommand);
 	const originalCwd = process.cwd;
 	process.cwd = () => sampleDir;
 	try {

--- a/packages/crust/tests/package.integration.test.ts
+++ b/packages/crust/tests/package.integration.test.ts
@@ -43,7 +43,7 @@ function getHostTarget(): string | null {
 }
 
 async function runBuild(argv: string[]) {
-	const app = new Crust("test").mount(buildCommand);
+	const app = new Crust("test").add(buildCommand);
 	process.cwd = () => tmpDir;
 	await app.execute({ argv: ["build", ...argv] });
 }

--- a/packages/extensions/src/completion/adversarial.test.ts
+++ b/packages/extensions/src/completion/adversarial.test.ts
@@ -28,7 +28,7 @@ import { walkCommandNode } from "./walker.ts";
 describe("walker · validation", () => {
 	it("rejects command names containing whitespace", () => {
 		const cli = new Crust("bad")
-			.mount(defineCommand("two words" as string, (c) => c.handle(() => {})))
+			.add(defineCommand("two words" as string, (c) => c.handle(() => {})))
 			.handle(() => {});
 		expect(() => walkCommandNode(snapshotCommand(cli._node))).toThrow(/invalid command name/);
 	});

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -59,7 +59,7 @@ function buildCli() {
 	return new Crust("mycli")
 		.meta({ description: "Test CLI" })
 		.extend(completionExtension({ version: "1.2.3" }))
-		.mount(
+		.add(
 			defineCommand("build", (cmd) =>
 				cmd
 					.meta({ description: "Build artifact" })
@@ -69,7 +69,7 @@ function buildCli() {
 			defineCommand("deploy", (cmd) =>
 				cmd
 					.meta({ description: "Deploy", aliases: ["dep"] })
-					.mount(
+					.add(
 						defineCommand("prod", (sub) =>
 							sub
 								.meta({ description: "Production deploy" })

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -95,7 +95,7 @@ describe("walkCommandNode", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("mycli")
 			.provide(auth())
-			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.handle(() => {})));
 
 		const spec = walkCommandNode(snapshotCommand(app._node));
 		expect(spec.root.flags.map((flag) => flag.name)).toContain("api-key");

--- a/packages/extensions/src/did-you-mean.test.ts
+++ b/packages/extensions/src/did-you-mean.test.ts
@@ -34,8 +34,8 @@ describe("didYouMeanExtension", () => {
 	it("suggests the closest command on a typo (smoke test)", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.mount(defineCommand("test", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("test", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["buld"] });
 
@@ -52,10 +52,8 @@ describe("didYouMeanExtension", () => {
 	it("suggests the canonical name when the input matches an alias", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
-			)
-			.mount(defineCommand("version", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})))
+			.add(defineCommand("version", (cmd) => cmd.handle(() => {})));
 
 		// "issuess" is closest to the alias "issues" (distance 1) than to
 		// "issue" (distance 2). The plugin must report the canonical name
@@ -72,7 +70,7 @@ describe("didYouMeanExtension", () => {
 	it("suggests the canonical name unchanged when the typo is closest to the canonical", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(
+			.add(
 				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
 			);
 
@@ -88,8 +86,8 @@ describe("didYouMeanExtension", () => {
 		// because it is a prefix of the input.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})))
-			.mount(defineCommand("install", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})))
+			.add(defineCommand("install", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["insall"] });
 
@@ -101,10 +99,8 @@ describe("didYouMeanExtension", () => {
 	it("lists only canonical names under 'Available commands'", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
-			)
-			.mount(defineCommand("version", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})))
+			.add(defineCommand("version", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["completely-unknown"] });
 
@@ -116,7 +112,7 @@ describe("didYouMeanExtension", () => {
 	it("deduplicates suggestions when an alias and its canonical both match", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension({ mode: "help" }))
-			.mount(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues"] }).handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues"] }).handle(() => {})));
 
 		// Both the canonical "issue" and the alias "issues" are within
 		// Levenshtein distance 3 of "issuee". The first suggestion line
@@ -135,8 +131,8 @@ describe("didYouMeanExtension", () => {
 		// error output. A close typo of it must not produce a suggestion.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.mount(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
 
 		// Typo distance(__complet -> __complete) = 1, well within the
 		// threshold. Distance(__complet -> build) is > 3, so without the
@@ -154,8 +150,8 @@ describe("didYouMeanExtension", () => {
 		// the typo, it still must not leak.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.mount(
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd.meta({ hidden: true, aliases: ["__comp"] }).handle(() => {}),
 				),
@@ -172,9 +168,9 @@ describe("didYouMeanExtension", () => {
 	it("omits hidden commands from the 'Available commands' fallback list", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.mount(defineCommand("test", (cmd) => cmd.handle(() => {})))
-			.mount(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("test", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
 
 		// No close match — we want the "Available commands" line.
 		await app.execute({ argv: ["zzzzz"] });

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -71,7 +71,7 @@ function lateSkillExtension() {
 			defineCommand("skill", (command) =>
 				command
 					.meta({ description: "Manage agent skills" })
-					.mount(
+					.add(
 						defineCommand("update", (cmd) =>
 							cmd.meta({ description: "Update installed skills" }).handle(() => {}),
 						),
@@ -111,7 +111,7 @@ describe("built-in plugins", () => {
 				description: "Output directory",
 				default: ".",
 			})
-			.mount(defineCommand("build", (cmd) => cmd.meta({ description: "Build the project" })))._node;
+			.add(defineCommand("build", (cmd) => cmd.meta({ description: "Build the project" })))._node;
 
 		const output = renderHelp(snapshotCommand(command));
 		const plain = stripAnsi(output);
@@ -211,7 +211,7 @@ describe("built-in plugins", () => {
 	it("help plugin renders generated help for no-run command", async () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["--help"] });
 
@@ -227,9 +227,9 @@ describe("built-in plugins", () => {
 	it("help reaches nested subcommands", async () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.mount(
+			.add(
 				defineCommand("group", (group) =>
-					group.mount(defineCommand("build", (build) => build.handle(() => {}))),
+					group.add(defineCommand("build", (build) => build.handle(() => {}))),
 				),
 			);
 
@@ -256,7 +256,7 @@ describe("built-in plugins", () => {
 		});
 		const app = new Crust("app")
 			.extend(rootOnly)
-			.mount(defineCommand("build", (build) => build.handle(() => {})));
+			.add(defineCommand("build", (build) => build.handle(() => {})));
 
 		await expect(app.run(["build", "--root"])).rejects.toMatchObject({ code: "PARSE" });
 	});
@@ -265,7 +265,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())
 			.extend(helpExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["--help"] });
 
@@ -400,7 +400,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())
 			.extend(helpExtension())
-			.mount(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
 
 		await app.execute({ argv: ["build", "--help"] });
 
@@ -411,7 +411,7 @@ describe("built-in plugins", () => {
 	it("help plugin shows help instead of error when --help is used with missing required arg", async () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.mount(
+			.add(
 				defineCommand("create", (cmd) =>
 					cmd.args({ name: "name", type: "string", required: true }).handle(() => {}),
 				),
@@ -429,7 +429,7 @@ describe("built-in plugins", () => {
 	it("help plugin shows help instead of error when --help is used with missing required flag", async () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.mount(
+			.add(
 				defineCommand("deploy", (cmd) =>
 					cmd.flags({ name: "target", type: "string", required: true }).handle(() => {}),
 				),
@@ -450,7 +450,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.meta({ description: "Test app" })
 			.extend(helpExtension())
-			.mount(
+			.add(
 				defineCommand("build", (cmd) =>
 					cmd.handle((ctx) => {
 						capturedRawArgs = [...ctx.rawArgs];
@@ -473,7 +473,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.provide(auth())
 			.extend(helpExtension())
-			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.handle(() => {})));
 
 		await app.run(["--help"]);
 		const rootHelp = stripAnsi(getStdout());
@@ -560,7 +560,7 @@ describe("built-in plugins", () => {
 	it("version plugin only triggers on root command", async () => {
 		let ran = false;
 
-		const app = new Crust("app").extend(versionExtension("1.0.0")).mount(
+		const app = new Crust("app").extend(versionExtension("1.0.0")).add(
 			defineCommand("build", (cmd) =>
 				cmd.handle(() => {
 					ran = true;
@@ -625,7 +625,7 @@ describe("built-in plugins", () => {
 	// ──────────────────────────────────────────────────────────────────────────────
 
 	it("renderHelp renders aliases inline next to the canonical command name", () => {
-		const command = new Crust("app").mount(
+		const command = new Crust("app").add(
 			defineCommand("issue", (cmd) =>
 				cmd
 					.meta({
@@ -643,7 +643,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("renderHelp renders unchanged for a command without aliases", () => {
-		const command = new Crust("app").mount(
+		const command = new Crust("app").add(
 			defineCommand("build", (cmd) =>
 				cmd.meta({ description: "Build the project" }).handle(() => {}),
 			),
@@ -658,7 +658,7 @@ describe("built-in plugins", () => {
 
 	it("renderHelp keeps description column aligned when aliases overflow the column", () => {
 		const command = new Crust("app")
-			.mount(
+			.add(
 				defineCommand("issue", (cmd) =>
 					cmd
 						.meta({
@@ -668,7 +668,7 @@ describe("built-in plugins", () => {
 						.handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("build", (cmd) =>
 					cmd.meta({ description: "Build the project" }).handle(() => {}),
 				),
@@ -690,12 +690,12 @@ describe("built-in plugins", () => {
 
 	it("renderHelp omits subcommands marked meta.hidden: true", () => {
 		const command = new Crust("app")
-			.mount(
+			.add(
 				defineCommand("build", (cmd) =>
 					cmd.meta({ description: "Build the project" }).handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd
 						.meta({
@@ -715,7 +715,7 @@ describe("built-in plugins", () => {
 
 	it("renderHelp omits the COMMANDS section when every subcommand is hidden", () => {
 		const command = new Crust("app")
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
 				),
@@ -731,7 +731,7 @@ describe("built-in plugins", () => {
 		// Regression: formatUsage previously counted hidden subcommands when
 		// deciding whether to emit `<command>`, producing the incoherent
 		// `Usage: app <command>` with no COMMANDS section below it.
-		const command = new Crust("app").mount(
+		const command = new Crust("app").add(
 			defineCommand("__complete", (cmd) =>
 				cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
 			),
@@ -748,12 +748,12 @@ describe("built-in plugins", () => {
 		// A hidden subcommand with aliases should be entirely absent. A visible
 		// subcommand with aliases should still render `name (a, b)`.
 		const command = new Crust("app")
-			.mount(
+			.add(
 				defineCommand("issue", (cmd) =>
 					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd
 						.meta({
@@ -776,12 +776,12 @@ describe("built-in plugins", () => {
 		let didRun = false;
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.mount(
+			.add(
 				defineCommand("build", (cmd) =>
 					cmd.meta({ description: "Build the project" }).handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {
 						didRun = true;

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -11,7 +11,7 @@ describe("renderManPageMdoc", () => {
 			.meta({ description: "Demo CLI for tests." })
 			.extend(help())
 			.flags({ name: "verbose", type: "boolean", short: "v", description: "Verbose" })
-			.mount(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).handle(() => {})));
+			.add(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).handle(() => {})));
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -70,12 +70,12 @@ describe("renderManPageMdoc", () => {
 	it("renders subcommand aliases inline next to the canonical name", async () => {
 		const app = new Crust("demo")
 			.meta({ description: "Demo CLI for alias tests." })
-			.mount(
+			.add(
 				defineCommand("issue", (cmd) =>
 					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("version", (cmd) =>
 					cmd.meta({ description: "Show version" }).handle(() => {}),
 				),
@@ -103,12 +103,12 @@ describe("renderManPageMdoc", () => {
 		// but never appear in published man pages.
 		const app = new Crust("demo")
 			.meta({ description: "Demo." })
-			.mount(
+			.add(
 				defineCommand("build", (cmd) =>
 					cmd.meta({ description: "Build the project" }).handle(() => {}),
 				),
 			)
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd
 						.meta({ description: "Internal completion entrypoint", hidden: true })
@@ -125,7 +125,7 @@ describe("renderManPageMdoc", () => {
 
 	it("omits the SUBCOMMANDS section entirely when every subcommand is hidden", async () => {
 		const app = new Crust("demo")
-			.mount(
+			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
 				),

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -630,7 +630,7 @@ describe("buildManifest", () => {
 					"Read the environment carefully before execution.",
 				).handle(() => {}),
 			);
-			const root = new Crust("app").mount(deploy);
+			const root = new Crust("app").add(deploy);
 
 			const node = buildManifest(snapshotCommand(root._node));
 			const child = node.children[0];

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -666,7 +666,7 @@ function buildSkillCommandGrammar(
 					description: "Install for all detected agents non-interactively (universal + detected)",
 				},
 			)
-			.mount(
+			.add(
 				defineCommand("update", (cmd) =>
 					cmd
 						.meta({ description: "Update installed skills to latest version" })

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -705,7 +705,7 @@ describe("renderSkill", () => {
 			const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 			const app = new Crust("test-cli")
 				.provide(auth())
-				.mount(defineCommand("deploy", (command) => command.handle(() => {})));
+				.add(defineCommand("deploy", (command) => command.handle(() => {})));
 			const files = renderSkill(buildManifest(snapshotCommand(app._node)), baseMeta);
 			const deploy = findFile(files, "commands/deploy.md");
 


### PR DESCRIPTION
## What

Renames the unshipped subcommand-attachment API from `.mount()` to `.add()` — a clean rename, no compatibility shims.

- `.mount()` → `.add()` on both `Crust` and `CommandDefinitionBuilder`
- `MountChecks` → `AddChecks`, `_mountDefinition` → `_addDefinition` (internal `subCommands` storage unchanged)
- All call sites updated across packages, tests, and docs examples
- Docs prose reworded ("add-time checks", "added definitions")
- Pending changesets that documented `.mount()` updated so release notes describe the shipped name

## Why

`mount` is a borrowed runtime metaphor (Express routers, filesystems) for what is declarative tree structure. `.add()` matches the builder's literal verb style (`.provide`, `.handle`, `.extend`) and commander's `.addCommand()` precedent for attaching an existing command object.

## Verification

- `bun run check:types` — 21/21 tasks pass
- `bun run test` — green
- `rg -i mount` across src/tests/docs — zero API-related hits remaining

## Stack

Stacked on #174 (`chore/remove-compat-shims`) — merge #174 first, then re-target this PR to `main` (or let GitHub auto-retarget on merge). The branch was rebuilt on top of #174 to untangle an accidental commit that mixed both changes; the previous head (`bcfce014`) is superseded.
