### PR TITLE
refactor!: remove deprecated tooling bridge and short --target aliases

### DIFF
--- a/.changeset/canonical-build-targets.md
+++ b/.changeset/canonical-build-targets.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/crust": minor
+---
+
+`crust build --target` now accepts canonical Bun target names only. Replace short target names such as `linux-x64` and `darwin-arm64` with `bun-linux-x64-baseline` and `bun-darwin-arm64`.

--- a/.changeset/supported-command-snapshots.md
+++ b/.changeset/supported-command-snapshots.md
@@ -1,0 +1,10 @@
+---
+"@crustjs/core": minor
+"@crustjs/man": minor
+---
+
+Add `Crust.snapshot()` as the supported API for preparing a frozen, validated Command Snapshot with Extension contributions and command definitions materialized without calling Command Handlers.
+
+Remove `prepareCommandSnapshot` from `@crustjs/core/tooling`. Tooling consumers should call `app.snapshot()` instead; the tooling subpath now exports the `CommandSnapshot` type for structural consumers.
+
+Update `writeManPage()` so its `app` option requires a structural `snapshot()` method instead of access to Crust's internal `_node` field.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -304,7 +304,7 @@ A definition can mount other definitions. Nested requirements are checked agains
 snapshot(): Promise<CommandSnapshot>
 ```
 
-Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Handlers.
+Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Handlers. Rejects with a [`CrustError`](/docs/api/errors) of code `DEFINITION` when materialization or validation fails.
 
 ```ts
 import type { CommandSnapshot } from "@crustjs/core/tooling";

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -298,6 +298,22 @@ A definition can mount other definitions. Nested requirements are checked agains
   do not backfill an existing mount.
 </Callout>
 
+## `.snapshot()`
+
+```ts
+snapshot(): Promise<CommandSnapshot>
+```
+
+Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Handlers.
+
+```ts
+import type { CommandSnapshot } from "@crustjs/core/tooling";
+
+const snapshot: CommandSnapshot = await app.snapshot();
+```
+
+The `CommandSnapshot` type is exported from `@crustjs/core/tooling`; see the [core module reference](/docs/modules/core) for the tooling subpath.
+
 ## `.run(argv, io?)`
 
 ```ts

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -24,7 +24,8 @@ All exports on these pages come from `@crustjs/core`.
 See [Types](/docs/api/types) for command definitions, Command Snapshots, Command Handler contexts, Contexts, Extensions, and error detail types.
 
 <Callout type="warn">
-  `@crustjs/core/tooling` is an unsupported bridge for first-party build, man-page, and skill
-  tooling. It includes the presentation-neutral `buildCommandDocumentation()` model used by
-  first-party renderers. It is not part of the supported application-authoring API.
+  `@crustjs/core/tooling` exports the supported `CommandSnapshot` type consumed by
+  [`app.snapshot()`](/docs/api/crust#snapshot). Its remaining helpers — including the
+  presentation-neutral `buildCommandDocumentation()` model used by first-party renderers — are
+  lockstep first-party tooling, not part of the supported application-authoring API.
 </Callout>

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -49,14 +49,14 @@ crust build --env-file .env.production
 
 ## Supported Targets
 
-| Canonical Bun Target       | Platform            |
-| -------------------------- | ------------------- |
-| `bun-linux-x64-baseline`   | Linux x86_64        |
-| `bun-linux-arm64`          | Linux ARM64         |
-| `bun-darwin-x64`           | macOS Intel         |
-| `bun-darwin-arm64`         | macOS Apple Silicon |
-| `bun-windows-x64-baseline` | Windows x86_64      |
-| `bun-windows-arm64`        | Windows ARM64       |
+| Canonical Bun Target       | Platform            | Package/dir suffix |
+| -------------------------- | ------------------- | ------------------ |
+| `bun-linux-x64-baseline`   | Linux x86_64        | `linux-x64`        |
+| `bun-linux-arm64`          | Linux ARM64         | `linux-arm64`      |
+| `bun-darwin-x64`           | macOS Intel         | `darwin-x64`       |
+| `bun-darwin-arm64`         | macOS Apple Silicon | `darwin-arm64`     |
+| `bun-windows-x64-baseline` | Windows x86_64      | `windows-x64`      |
+| `bun-windows-arm64`        | Windows ARM64       | `windows-arm64`    |
 
 ## Multi-Target Build (Default)
 
@@ -285,7 +285,7 @@ The publish command reads the `manifest.json` and publishes packages in dependen
 
 ### Distribution Package Names
 
-Per-platform packages are named by appending the platform alias to your package name:
+Per-platform packages are named by appending the platform suffix (see [Supported Targets](#supported-targets)) to your package name:
 
 | Root Package    | Platform Package                                              |
 | --------------- | ------------------------------------------------------------- |

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -24,7 +24,7 @@ crust build
 crust build --entry src/main.ts
 
 # Build for a specific platform
-crust build --target darwin-arm64
+crust build --target bun-darwin-arm64
 
 # Build with explicit env files for build-time constants
 crust build --env-file .env.production
@@ -38,7 +38,7 @@ crust build --env-file .env.production
 | `--outfile`   | `-o`  | `"string"`              | —             | Output file path (single-target only)                      |
 | `--name`      | `-n`  | `"string"`              | auto-detected | Binary name                                                |
 | `--minify`    | —     | `"boolean"`             | `true`        | Minify the output                                          |
-| `--target`    | `-t`  | `"string"` (repeatable) | all platforms | Target platform(s)                                         |
+| `--target`    | `-t`  | `"string"` (repeatable) | all platforms | Canonical Bun target(s), e.g. `bun-darwin-arm64`           |
 | `--outdir`    | `-d`  | `"string"`              | `dist`        | Output directory for compiled binaries                     |
 | `--resolver`  | `-r`  | `"string"`              | `cli`         | Resolver script filename (multi-target only, no extension) |
 | `--env-file`  | —     | `"string"` (repeatable) | —             | Explicit env file(s) used for build-time constants         |
@@ -49,16 +49,14 @@ crust build --env-file .env.production
 
 ## Supported Targets
 
-| Target Alias    | Bun Target                 | Platform            |
-| --------------- | -------------------------- | ------------------- |
-| `linux-x64`     | `bun-linux-x64-baseline`   | Linux x86_64        |
-| `linux-arm64`   | `bun-linux-arm64`          | Linux ARM64         |
-| `darwin-x64`    | `bun-darwin-x64`           | macOS Intel         |
-| `darwin-arm64`  | `bun-darwin-arm64`         | macOS Apple Silicon |
-| `windows-x64`   | `bun-windows-x64-baseline` | Windows x86_64      |
-| `windows-arm64` | `bun-windows-arm64`        | Windows ARM64       |
-
-You can use either the short alias (e.g., `linux-x64`) or the full Bun target name (e.g., `bun-linux-x64-baseline`).
+| Canonical Bun Target       | Platform            |
+| -------------------------- | ------------------- |
+| `bun-linux-x64-baseline`   | Linux x86_64        |
+| `bun-linux-arm64`          | Linux ARM64         |
+| `bun-darwin-x64`           | macOS Intel         |
+| `bun-darwin-arm64`         | macOS Apple Silicon |
+| `bun-windows-x64-baseline` | Windows x86_64      |
+| `bun-windows-arm64`        | Windows ARM64       |
 
 ## Multi-Target Build (Default)
 
@@ -103,7 +101,7 @@ This is what you point to in your `package.json`'s `bin` field. No runtime (Node
 When exactly one `--target` is specified, `crust build` produces a single binary without a resolver:
 
 ```sh
-crust build --target darwin-arm64
+crust build --target bun-darwin-arm64
 ```
 
 Output:
@@ -118,7 +116,7 @@ dist/
 Use `--outfile` for single-target builds:
 
 ```sh
-crust build --target linux-x64 --outfile ./bin/my-cli
+crust build --target bun-linux-x64-baseline --outfile ./bin/my-cli
 ```
 
 <Callout type="warn">
@@ -207,7 +205,7 @@ For distributing your CLI via npm with platform-specific packages, use the `--pa
 crust build --package
 
 # Build for specific platforms only
-crust build --package --target linux-x64 --target darwin-arm64
+crust build --package --target bun-linux-x64-baseline --target bun-darwin-arm64
 
 # Use a custom staging directory
 crust build --package --stage-dir ./npm-packages

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -52,15 +52,15 @@ Downstream commands and Contexts list `api` in their `requires` array and consum
 
 ## Runtime exports
 
-| Export                                | Description                                                                                                                    |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, programmatic `.run()`, and terminal `.execute()` |
-| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                              |
-| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                       |
-| `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                              |
-| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                       |
-| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                        |
-| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                      |
+| Export                                | Description                                                                                                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.mount()`, `.handle()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
+| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                                                     |
+| `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                                              |
+| `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                     |
+| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                              |
+| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                               |
+| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                             |
 
 ## Definition types
 
@@ -129,6 +129,8 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Tooling subpath
 
-`@crustjs/core/tooling` exposes `prepareCommandSnapshot`, `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), visible children, argument tokens, and every accepted flag spelling. This subpath is explicitly unsupported and has no compatibility guarantee. Application code should use the root exports above.
+Call `app.snapshot()` to prepare a frozen, validated Command Snapshot for man-page, skill, and build generators. It materializes Extension contributions and command definitions without calling Command Handlers.
+
+`@crustjs/core/tooling` exports the `CommandSnapshot` type plus `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), visible children, argument tokens, and every accepted flag spelling. Except for the `CommandSnapshot` type consumed by `app.snapshot()`, helpers on this subpath are intended for first-party tooling that moves in lockstep with core.
 
 Use [`@crustjs/extensions`](/docs/modules/extensions) for the official Extensions and [`@crustjs/crust`](/docs/modules/crust) as a development dependency for build tooling.

--- a/apps/docs/content/docs/modules/crust.mdx
+++ b/apps/docs/content/docs/modules/crust.mdx
@@ -34,6 +34,6 @@ The default `crust build` output is a raw binary and resolver script. Use it for
 
 ## Generated man pages
 
-`crust build --man` loads the exported root `Crust` builder, prepares its Command Snapshot through the unsupported tooling bridge, and writes `<outdir>/man/<name>.1`. See [`@crustjs/man`](/docs/modules/man).
+`crust build --man` loads the exported root `Crust` builder, prepares its Command Snapshot through `app.snapshot()`, and writes `<outdir>/man/<name>.1`. See [`@crustjs/man`](/docs/modules/man).
 
 Install this package only as a development dependency; generated applications do not need it at runtime.

--- a/apps/docs/content/docs/modules/crust.mdx
+++ b/apps/docs/content/docs/modules/crust.mdx
@@ -18,7 +18,7 @@ bun add -d @crustjs/crust
 | [`crust build`](/docs/guide/build)                                 | Validate and compile a CLI to standalone executables           |
 | [`crust publish`](/docs/guide/build#publishing-with-crust-publish) | Publish staged npm packages created by `crust build --package` |
 
-`crust build` imports the entry point in a validation subprocess before compiling it. The build-validation protocol uses `VALIDATION_MODE_ENV` and `VALIDATION_FORCE_EXIT_ENV` from the explicitly unsupported `@crustjs/core/tooling` subpath. Application code should not set these internal environment variables.
+`crust build` imports the entry point in a validation subprocess before compiling it. The build-validation protocol uses `VALIDATION_MODE_ENV` and `VALIDATION_FORCE_EXIT_ENV`, lockstep first-party tooling constants from the `@crustjs/core/tooling` subpath. Application code should not set these internal environment variables.
 
 The build command can embed `PUBLIC_*` constants from Bun's current-directory environment or explicit `--env-file` inputs. See [Environment variables](/docs/guide/environment).
 

--- a/apps/docs/content/docs/modules/man.mdx
+++ b/apps/docs/content/docs/modules/man.mdx
@@ -64,7 +64,7 @@ const source = renderManPageMdoc({
 
 The renderer uses semantic mdoc(7) flag and argument macros. It intentionally summarizes only the root command's immediate visible subcommands; nested commands remain available in the shared full-tree documentation model.
 
-The package uses the explicitly unsupported `prepareCommandSnapshot()` and `buildCommandDocumentation()` bridge from `@crustjs/core/tooling` internally. That bridge is for lockstep first-party tooling, not application code.
+The package prepares the command tree through the supported `app.snapshot()` method. It uses `buildCommandDocumentation()` from `@crustjs/core/tooling` internally for its lockstep first-party rendering model.
 
 ## Package script
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -3,7 +3,7 @@ title: "Skills"
 description: Agent skill generation for AI coding assistants.
 ---
 
-The `@crustjs/skills` package generates and installs agent skills from your CLI's readonly Command Snapshot. Skills provide structured documentation that AI coding assistants use to understand your CLI. Generated skills include the full visible command tree and omit commands marked `meta.hidden`. Snapshot preparation and documentation modeling use the explicitly unsupported `@crustjs/core/tooling` bridge internally; application code registers only the `skill()` Extension.
+The `@crustjs/skills` package generates and installs agent skills from your CLI's readonly Command Snapshot. Skills provide structured documentation that AI coding assistants use to understand your CLI. Generated skills include the full visible command tree and omit commands marked `meta.hidden`. Snapshots are prepared through `app.snapshot()`, and documentation modeling uses the lockstep first-party helpers from `@crustjs/core/tooling` internally; application code registers only the `skill()` Extension.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,4 +12,4 @@ bun add @crustjs/core
 
 Full docs: [crustjs.com/docs/modules/core](https://crustjs.com/docs/modules/core)
 
-First-party renderers share a presentation-neutral command model through the unsupported `@crustjs/core/tooling` subpath. Application code should use the package root.
+Tooling calls `app.snapshot()` for a frozen, validated command snapshot; the `CommandSnapshot` type comes from the `@crustjs/core/tooling` subpath. Other helpers on that subpath are intended for first-party tooling that moves in lockstep with core. Application code should use the package root.

--- a/packages/core/src/api/flags.test.ts
+++ b/packages/core/src/api/flags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { Crust, prepareCommandSnapshot } from "../command/crust.ts";
+import { Crust } from "../command/crust.ts";
 import { defineArg, defineFlag } from "./flags.ts";
 
 type Assert<T extends true> = T;
@@ -38,7 +38,7 @@ describe("defineFlag", () => {
 		type _Output = Assert<
 			IsEqual<Local["output"], { readonly type: "string"; readonly short: "o" }>
 		>;
-		expect((await prepareCommandSnapshot(app)).flags).toEqual({
+		expect((await app.snapshot()).flags).toEqual({
 			verbose: { type: "boolean" },
 			output: { type: "string", short: "o" },
 		});
@@ -89,9 +89,6 @@ describe("defineArg", () => {
 				]
 			>
 		>;
-		expect((await prepareCommandSnapshot(app)).args.map((def) => def.name)).toEqual([
-			"target",
-			"count",
-		]);
+		expect((await app.snapshot()).args.map((def) => def.name)).toEqual(["target", "count"]);
 	});
 });

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -10,7 +10,6 @@ import {
 	Crust,
 	defineCommand,
 	type CrustCommandContext,
-	prepareCommandSnapshot,
 	VALIDATION_FORCE_EXIT_ENV,
 	VALIDATION_MODE_ENV,
 } from "./crust.ts";
@@ -31,7 +30,7 @@ type Equal<A, B> =
 
 describe("Crust constructor", () => {
 	it("creates builder with string name", async () => {
-		const snapshot = await prepareCommandSnapshot(new Crust("my-cli"));
+		const snapshot = await new Crust("my-cli").snapshot();
 		expect(snapshot.meta.name).toBe("my-cli");
 	});
 
@@ -86,9 +85,9 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 
 	it.each(builderCases)("%s does not mutate the original builder", async (_name, apply) => {
 		const app = new Crust("test");
-		const before = await prepareCommandSnapshot(app);
+		const before = await app.snapshot();
 		apply(app);
-		expect(await prepareCommandSnapshot(app)).toEqual(before);
+		expect(await app.snapshot()).toEqual(before);
 	});
 });
 
@@ -104,7 +103,7 @@ describe("Crust .flags()", () => {
 			{ name: "port", type: "number", default: 3000 },
 		);
 
-		const snapshot = await prepareCommandSnapshot(withFlags);
+		const snapshot = await withFlags.snapshot();
 		expect(snapshot.flags).toEqual({
 			verbose: { type: "boolean", short: "v" },
 			port: { type: "number", default: 3000 },
@@ -118,14 +117,14 @@ describe("Crust .flags()", () => {
 
 		// Mutating the original def should not affect the builder
 		flagDef.short = "V";
-		expect((await prepareCommandSnapshot(app)).flags.verbose?.short).toBe("v");
+		expect((await app.snapshot()).flags.verbose?.short).toBe("v");
 	});
 
 	it("preserves meta from original builder", async () => {
 		const app = new Crust("my-cli").meta({ description: "desc" });
 		const withFlags = app.flags({ name: "verbose", type: "boolean" });
 
-		const snapshot = await prepareCommandSnapshot(withFlags);
+		const snapshot = await withFlags.snapshot();
 		expect(snapshot.meta.name).toBe("my-cli");
 		expect(snapshot.meta.description).toBe("desc");
 	});
@@ -161,7 +160,7 @@ describe("Crust .flags()", () => {
 			.flags({ name: "first", type: "boolean" })
 			.flags({ name: "second", type: "string" });
 
-		expect((await prepareCommandSnapshot(app)).flags).toEqual({
+		expect((await app.snapshot()).flags).toEqual({
 			second: { type: "string" },
 		});
 	});
@@ -209,7 +208,7 @@ describe("Crust .args()", () => {
 			{ name: "count", type: "number", default: 1 },
 		);
 
-		expect((await prepareCommandSnapshot(withArgs)).args).toEqual([
+		expect((await withArgs.snapshot()).args).toEqual([
 			{ name: "file", type: "string", required: true },
 			{ name: "count", type: "number", default: 1 },
 		]);
@@ -224,7 +223,7 @@ describe("Crust .args()", () => {
 		const app = new Crust("test").args(argDef);
 
 		argDef.description = "changed";
-		expect((await prepareCommandSnapshot(app)).args[0]?.description).toBe("orig");
+		expect((await app.snapshot()).args[0]?.description).toBe("orig");
 	});
 
 	it("preserves meta and flags from original builder", async () => {
@@ -233,7 +232,7 @@ describe("Crust .args()", () => {
 			.flags({ name: "verbose", type: "boolean" });
 		const withArgs = app.args({ name: "file", type: "string" });
 
-		const snapshot = await prepareCommandSnapshot(withArgs);
+		const snapshot = await withArgs.snapshot();
 		expect(snapshot.meta.name).toBe("my-cli");
 		expect(snapshot.meta.description).toBe("desc");
 		expect(snapshot.flags.verbose).toBeDefined();
@@ -253,7 +252,7 @@ describe("Crust chaining", () => {
 			)
 			.args({ name: "file", type: "string", required: true });
 
-		const snapshot = await prepareCommandSnapshot(app);
+		const snapshot = await app.snapshot();
 		expect(Object.keys(snapshot.flags)).toEqual(["verbose", "port"]);
 		expect(snapshot.args.map((arg) => arg.name)).toEqual(["file"]);
 	});
@@ -263,7 +262,7 @@ describe("Crust chaining", () => {
 			.args({ name: "file", type: "string" })
 			.flags({ name: "verbose", type: "boolean" });
 
-		const snapshot = await prepareCommandSnapshot(app);
+		const snapshot = await app.snapshot();
 		expect(snapshot.flags.verbose).toBeDefined();
 		expect(snapshot.args).toHaveLength(1);
 	});
@@ -273,12 +272,12 @@ describe("Crust chaining", () => {
 		const withFlags = base.flags({ name: "verbose", type: "boolean" });
 		const withArgs = withFlags.args({ name: "file", type: "string" });
 
-		expect(await prepareCommandSnapshot(base)).toMatchObject({ flags: {}, args: [] });
-		expect(await prepareCommandSnapshot(withFlags)).toMatchObject({
+		expect(await base.snapshot()).toMatchObject({ flags: {}, args: [] });
+		expect(await withFlags.snapshot()).toMatchObject({
 			flags: { verbose: { type: "boolean" } },
 			args: [],
 		});
-		expect(await prepareCommandSnapshot(withArgs)).toMatchObject({
+		expect(await withArgs.snapshot()).toMatchObject({
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
 		});
@@ -296,7 +295,7 @@ describe("Crust .meta()", () => {
 			.args({ name: "file", type: "string" })
 			.meta({ description: "A test command", usage: "test [options]" });
 
-		expect(await prepareCommandSnapshot(app)).toMatchObject({
+		expect(await app.snapshot()).toMatchObject({
 			meta: { name: "test", description: "A test command", usage: "test [options]" },
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
@@ -304,7 +303,7 @@ describe("Crust .meta()", () => {
 	});
 
 	it("sets only description when usage is omitted", async () => {
-		const snapshot = await prepareCommandSnapshot(new Crust("test").meta({ description: "desc" }));
+		const snapshot = await new Crust("test").meta({ description: "desc" }).snapshot();
 		expect(snapshot.meta).toEqual({ name: "test", description: "desc" });
 	});
 
@@ -315,7 +314,7 @@ describe("Crust .meta()", () => {
 			),
 		);
 
-		expect((await prepareCommandSnapshot(app)).subCommands.sub?.meta).toEqual({
+		expect((await app.snapshot()).subCommands.sub?.meta).toEqual({
 			name: "sub",
 			description: "A subcommand",
 			usage: "cli sub [options]",
@@ -413,7 +412,7 @@ describe("Crust .mount() with inline definitions", () => {
 			defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })),
 		);
 
-		const subCommand = (await prepareCommandSnapshot(app)).subCommands.sub;
+		const subCommand = (await app.snapshot()).subCommands.sub;
 		expect(subCommand?.meta.name).toBe("sub");
 	});
 
@@ -422,7 +421,7 @@ describe("Crust .mount() with inline definitions", () => {
 			defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })),
 		);
 
-		expect((await prepareCommandSnapshot(app)).subCommands.sub?.flags).toEqual({
+		expect((await app.snapshot()).subCommands.sub?.flags).toEqual({
 			output: { type: "string" },
 		});
 	});
@@ -435,7 +434,7 @@ describe("Crust .mount() with inline definitions", () => {
 			.provide(logging())
 			.mount(defineCommand("sub", (cmd) => cmd.flags({ name: "output", type: "string" })));
 
-		expect((await prepareCommandSnapshot(app)).subCommands.sub?.flags).toEqual({
+		expect((await app.snapshot()).subCommands.sub?.flags).toEqual({
 			verbose: { type: "boolean" },
 			output: { type: "string" },
 		});
@@ -489,7 +488,7 @@ describe("Crust .mount() with inline definitions", () => {
 		expect(receivedBuilder).toBeDefined();
 		expect(receivedBuilder).not.toBe(app);
 		const runtimeBuilder = receivedBuilder as unknown as Crust;
-		expect(await prepareCommandSnapshot(runtimeBuilder)).toMatchObject({
+		expect(await runtimeBuilder.snapshot()).toMatchObject({
 			meta: { name: "sub" },
 			flags: {},
 		});
@@ -519,7 +518,7 @@ describe("Crust .mount() with inline definitions", () => {
 			.mount(defineCommand("sub1", (cmd) => cmd.flags({ name: "a", type: "string" })))
 			.mount(defineCommand("sub2", (cmd) => cmd.flags({ name: "b", type: "number" })));
 
-		const subCommands = (await prepareCommandSnapshot(app)).subCommands;
+		const subCommands = (await app.snapshot()).subCommands;
 		expect(subCommands.sub1?.flags.a).toBeDefined();
 		expect(subCommands.sub2?.flags.b).toBeDefined();
 	});
@@ -530,7 +529,7 @@ describe("Crust .mount() with inline definitions", () => {
 			.args({ name: "file", type: "string" })
 			.mount(defineCommand("sub", (cmd) => cmd));
 
-		const snapshot = await prepareCommandSnapshot(app);
+		const snapshot = await app.snapshot();
 		expect(snapshot.flags.verbose).toBeDefined();
 		expect(snapshot.args.map((arg) => arg.name)).toEqual(["file"]);
 	});
@@ -599,7 +598,7 @@ describe("Crust .handle()", () => {
 			.mount(defineCommand("sub", (command) => command))
 			.handle(() => {});
 
-		expect(await prepareCommandSnapshot(app)).toMatchObject({
+		expect(await app.snapshot()).toMatchObject({
 			hasHandler: true,
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
@@ -748,7 +747,7 @@ describe("Crust .extend()", () => {
 			.handle(() => {})
 			.extend(defineExtension("test-extension"));
 
-		expect(await prepareCommandSnapshot(app)).toMatchObject({
+		expect(await app.snapshot()).toMatchObject({
 			hasHandler: true,
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
@@ -1945,7 +1944,7 @@ describe("Invocation pipeline internal seam — validation mode", () => {
 	});
 });
 
-describe("prepareCommandSnapshot (tooling)", () => {
+describe("Crust.snapshot", () => {
 	it("returns a frozen snapshot with Extension flags applied", async () => {
 		const docs = defineExtension("doc-test", {
 			flags: {
@@ -1954,7 +1953,7 @@ describe("prepareCommandSnapshot (tooling)", () => {
 		});
 
 		const app = new Crust("cli").extend(docs).meta({ description: "Test" });
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		expect(root.flags.extra).toMatchObject({
 			type: "boolean",
 			description: "Injected for docs",
@@ -1965,8 +1964,8 @@ describe("prepareCommandSnapshot (tooling)", () => {
 
 	it("can be called multiple times", async () => {
 		const app = new Crust("cli").handle(() => {});
-		const a = await prepareCommandSnapshot(app);
-		const b = await prepareCommandSnapshot(app);
+		const a = await app.snapshot();
+		const b = await app.snapshot();
 		expect(a.meta.name).toBe("cli");
 		expect(b.meta.name).toBe("cli");
 	});
@@ -1983,10 +1982,7 @@ describe("Crust .mount() aliases", () => {
 				command.meta({ aliases: ["issues", "i"] }).handle(() => {}),
 			),
 		);
-		expect((await prepareCommandSnapshot(app)).subCommands.issue?.meta.aliases).toEqual([
-			"issues",
-			"i",
-		]);
+		expect((await app.snapshot()).subCommands.issue?.meta.aliases).toEqual(["issues", "i"]);
 	});
 
 	it("registers without error when no sibling collides", () => {

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1969,6 +1969,32 @@ describe("Crust.snapshot", () => {
 		expect(a.meta.name).toBe("cli");
 		expect(b.meta.name).toBe("cli");
 	});
+
+	it("never calls Command Handlers", async () => {
+		let called = false;
+		const app = new Crust("cli").handle(() => {
+			called = true;
+		});
+		await app.snapshot();
+		expect(called).toBe(false);
+	});
+
+	it("rejects with CrustError DEFINITION on an invalid command tree", async () => {
+		const clash = defineExtension("clash", {
+			flags: { verbose: { type: "boolean", short: "v" } },
+		});
+		const app = new Crust("cli")
+			.flags({ name: "version", type: "boolean", short: "v" })
+			.extend(clash);
+
+		try {
+			await app.snapshot();
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CrustError);
+			expect((err as CrustError).code).toBe("DEFINITION");
+		}
+	});
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -694,6 +694,17 @@ export class Crust<
 	}
 
 	/**
+	 * Prepare a frozen, validated Command Snapshot for tooling such as
+	 * man-page, skill, and build generators.
+	 *
+	 * Materializes Extension contributions and command definitions, then
+	 * validates the resulting command tree. Does not call Command Handlers.
+	 */
+	async snapshot(): Promise<CommandSnapshot> {
+		return prepareInvocationSnapshot(this._node, materializeCommandDefinition);
+	}
+
+	/**
 	 * Invoke this application programmatically: resolve, parse, run the
 	 * Extension hooks and the Command Handler for `argv`.
 	 *
@@ -739,18 +750,4 @@ export class Crust<
 		// Terminal calls render failures and set process exit status instead of throwing.
 		await executeInvocation(this._node, options, materializeCommandDefinition);
 	}
-}
-
-/**
- * Prepare a frozen, validated Command Snapshot of an application with all
- * Extension contributions applied. Does not call Command Handlers.
- *
- * Explicitly unsupported tooling bridge, exposed only via
- * `@crustjs/core/tooling` for man-page/skill generators and build tooling.
- * The parameter is structural so any `Crust` builder satisfies it.
- */
-export async function prepareCommandSnapshot(app: {
-	readonly _node: CommandNode;
-}): Promise<CommandSnapshot> {
-	return prepareInvocationSnapshot(app._node, materializeCommandDefinition);
 }

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -699,6 +699,8 @@ export class Crust<
 	 *
 	 * Materializes Extension contributions and command definitions, then
 	 * validates the resulting command tree. Does not call Command Handlers.
+	 * Rejects with a `CrustError` of code `DEFINITION` when materialization
+	 * or validation fails.
 	 */
 	async snapshot(): Promise<CommandSnapshot> {
 		return prepareInvocationSnapshot(this._node, materializeCommandDefinition);

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -4,7 +4,7 @@ import { defineContext } from "../api/context.ts";
 import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import type { CommandDefinitionBuilder } from "./crust.ts";
-import { Crust, defineCommand, prepareCommandSnapshot } from "./crust.ts";
+import { Crust, defineCommand } from "./crust.ts";
 
 type Assert<T extends true> = T;
 type IsEqual<A, B> =
@@ -22,7 +22,7 @@ describe("command definitions", () => {
 		const app = new Crust("cli").mount(definition, definition.as("compile"));
 
 		expect(configured).toBe(2);
-		const snapshot = await prepareCommandSnapshot(app);
+		const snapshot = await app.snapshot();
 		expect(snapshot.subCommands.build?.meta.name).toBe("build");
 		expect(snapshot.subCommands.compile?.meta.name).toBe("compile");
 	});
@@ -109,8 +109,8 @@ describe("command definitions", () => {
 			return configured;
 		});
 
-		const first = await prepareCommandSnapshot(new Crust("first").mount(definition));
-		const second = await prepareCommandSnapshot(new Crust("second").mount(definition.as("two")));
+		const first = await new Crust("first").mount(definition).snapshot();
+		const second = await new Crust("second").mount(definition.as("two")).snapshot();
 
 		expect((first.subCommands.one as unknown as Record<symbol, unknown>)[annotation]).toBe(
 			"preserved",

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
 import { defineCommand } from "../index.ts";
-import { Crust, prepareCommandSnapshot } from "./crust.ts";
+import { Crust } from "./crust.ts";
 import { buildCommandDocumentation } from "./documentation.ts";
 
 async function docs(app: Crust) {
-	return buildCommandDocumentation(await prepareCommandSnapshot(app));
+	return buildCommandDocumentation(await app.snapshot());
 }
 
 describe("buildCommandDocumentation", () => {

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { defineContext } from "../api/context.ts";
 import { defineFlag } from "../api/flags.ts";
-import { Crust, defineCommand, prepareCommandSnapshot } from "./crust.ts";
+import { Crust, defineCommand } from "./crust.ts";
 import { createCommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
 
@@ -67,7 +67,7 @@ describe("snapshotCommand", () => {
 			.provide(auth())
 			.mount(defineCommand("deploy", (command) => command.handle(() => {})));
 
-		const snapshot = await prepareCommandSnapshot(app);
+		const snapshot = await app.snapshot();
 		expect(snapshot.flags["api-key"]).toEqual({
 			type: "string",
 			short: "k",

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -1,16 +1,11 @@
 // ────────────────────────────────────────────────────────────────────────────
-// @crustjs/core/tooling — explicitly unsupported tooling bridge
+// @crustjs/core/tooling — shared tooling models and utilities
 //
-// Limited to serializable Command Snapshot preparation and the
-// build-validation protocol. No stability guarantees: first-party tooling
-// (man pages, skills, crust build) moves in lockstep with core.
+// Crust.snapshot() is the supported Command Snapshot preparation API. This
+// subpath provides the snapshot type plus lockstep first-party tooling helpers.
 // ────────────────────────────────────────────────────────────────────────────
 
-export {
-	prepareCommandSnapshot,
-	VALIDATION_FORCE_EXIT_ENV,
-	VALIDATION_MODE_ENV,
-} from "./command/crust.ts";
+export { VALIDATION_FORCE_EXIT_ENV, VALIDATION_MODE_ENV } from "./command/crust.ts";
 export { buildCommandDocumentation } from "./command/documentation.ts";
 export type {
 	CommandDocumentation,
@@ -19,3 +14,4 @@ export type {
 	UsageSegment,
 } from "./command/documentation.ts";
 export { snapshotCommand } from "./command/snapshot.ts";
+export type { CommandSnapshot } from "./command/snapshot.ts";

--- a/packages/create-crust/tests/cli.smoke.test.ts
+++ b/packages/create-crust/tests/cli.smoke.test.ts
@@ -115,25 +115,25 @@ function resolveInstalledCrustCli(projectDir: string): string {
 }
 
 /** Host-only target avoids cross-compile downloads (flaky on Windows CI for Linux Bun artifacts). */
-function hostCrustBuildTargetAlias(): string {
+function hostCrustBuildTarget(): string {
 	const { platform, arch } = process;
 	if (platform === "win32") {
-		return arch === "arm64" ? "windows-arm64" : "windows-x64";
+		return arch === "arm64" ? "bun-windows-arm64" : "bun-windows-x64-baseline";
 	}
 	if (platform === "darwin") {
-		return arch === "arm64" ? "darwin-arm64" : "darwin-x64";
+		return arch === "arm64" ? "bun-darwin-arm64" : "bun-darwin-x64";
 	}
 	if (platform === "linux") {
-		return arch === "arm64" ? "linux-arm64" : "linux-x64";
+		return arch === "arm64" ? "bun-linux-arm64" : "bun-linux-x64-baseline";
 	}
-	return "linux-x64";
+	return "bun-linux-x64-baseline";
 }
 
 function crustBuildArgv(crustCli: string): string[] {
 	const normalized = crustCli.replaceAll("\\", "/");
 	const useBun = normalized.endsWith("dist/cli.js");
 	const runner = useBun ? process.execPath : "node";
-	return [runner, crustCli, "build", "--target", hostCrustBuildTargetAlias()];
+	return [runner, crustCli, "build", "--target", hostCrustBuildTarget()];
 }
 
 async function packLocalDependencyPackages(): Promise<Record<string, string>> {

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -9,8 +9,6 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { prepareCommandSnapshot } from "@crustjs/core/tooling";
-
 import pkg from "../package.json";
 import { crustBase } from "./app.ts";
 import { buildCommand } from "./commands/build.ts";
@@ -76,20 +74,20 @@ describe("crust CLI entry point", () => {
 	describe("root command", () => {
 		it("should have correct meta", async () => {
 			const app = makeCrustApp();
-			const root = await prepareCommandSnapshot(app);
+			const root = await app.snapshot();
 			expect(root.meta.name).toBe("crust");
 			expect(root.meta.description).toBe("CLI tooling for the Crust framework");
 		});
 
 		it("should use extensions for root behavior", async () => {
 			const app = makeCrustApp();
-			const root = await prepareCommandSnapshot(app);
+			const root = await app.snapshot();
 			expect(root.hasHandler).toBe(false);
 		});
 
 		it("should have build and publish as subcommands", async () => {
 			const app = makeCrustApp();
-			const root = await prepareCommandSnapshot(app);
+			const root = await app.snapshot();
 			expect(root.subCommands).toBeDefined();
 			expect(root.subCommands.build).toBeDefined();
 			expect(root.subCommands.publish).toBeDefined();
@@ -179,7 +177,7 @@ describe("crust CLI entry point", () => {
 	describe("self-hosting verification", () => {
 		it("should use the cli builder from @crustjs/core (dogfooding)", async () => {
 			const app = makeCrustApp();
-			const root = await prepareCommandSnapshot(app);
+			const root = await app.snapshot();
 			expect(root.meta).toBeDefined();
 			expect(root.subCommands).toBeDefined();
 		});

--- a/packages/crust/src/commands/build.integration.test.ts
+++ b/packages/crust/src/commands/build.integration.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { Crust } from "@crustjs/core";
 
 import { buildCommand } from "../../src/commands/build.ts";
+import { SUPPORTED_TARGETS, TARGET_INFO } from "../../src/utils/build-helpers.ts";
 
 function getHostTarget(): string | null {
 	if (process.platform === "darwin" && process.arch === "arm64") {
@@ -32,6 +33,11 @@ function getHostTarget(): string | null {
 	}
 
 	return null;
+}
+
+function getHostBunTarget(): string | null {
+	const hostTarget = getHostTarget();
+	return SUPPORTED_TARGETS.find((target) => TARGET_INFO[target].alias === hostTarget) ?? null;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -87,7 +93,7 @@ console.log("hello from crust build test");
 					"--outfile",
 					join(tmpDir, "dist", "test-cli"),
 					"--target",
-					"darwin-arm64",
+					"bun-darwin-arm64",
 				],
 			});
 		} finally {
@@ -149,7 +155,7 @@ console.log("hello from crust build test");
 					outPath,
 					"--no-minify",
 					"--target",
-					"darwin-arm64",
+					"bun-darwin-arm64",
 				],
 			});
 		} finally {
@@ -173,7 +179,7 @@ console.log("hello from crust build test");
 		try {
 			const app = new Crust("test").mount(buildCommand);
 			await app.execute({
-				argv: ["build", "--entry", "src/cli.ts", "--target", "darwin-arm64"],
+				argv: ["build", "--entry", "src/cli.ts", "--target", "bun-darwin-arm64"],
 			});
 		} finally {
 			console.log = originalLog;
@@ -185,10 +191,10 @@ console.log("hello from crust build test");
 		expect(logs.some((l) => l.includes(expectedOut))).toBe(true);
 	});
 
-	it.skipIf(getHostTarget() === null)(
+	it.skipIf(getHostBunTarget() === null)(
 		"applies --env-file to validation and embeds PUBLIC_ constants only",
 		async () => {
-			const hostTarget = getHostTarget();
+			const hostTarget = getHostBunTarget();
 			if (!hostTarget) return;
 
 			const prevCwd = process.cwd;
@@ -257,10 +263,10 @@ console.log(JSON.stringify({
 		},
 	);
 
-	it.skipIf(getHostTarget() === null)(
+	it.skipIf(getHostBunTarget() === null)(
 		"uses Bun auto-loaded cwd env to embed PUBLIC_ constants when --env-file is omitted",
 		async () => {
-			const hostTarget = getHostTarget();
+			const hostTarget = getHostBunTarget();
 			if (!hostTarget) return;
 
 			const autoloadDir = join(tmpDir, "autoload-workspace");

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -19,7 +19,6 @@ import {
 	resolveBunBuildRunner,
 	resolveTarget,
 	SUPPORTED_TARGETS,
-	TARGET_ALIASES,
 } from "../../src/utils/build-helpers.ts";
 
 /**
@@ -125,13 +124,18 @@ describe("buildCommand definition", () => {
 	});
 
 	it("defines --target/-t as repeatable string flag", async () => {
-		const result = await parseBuildArgs(["--target", "linux-x64", "--target", "darwin-arm64"]);
-		expect(result.flags.target).toEqual(["linux-x64", "darwin-arm64"]);
+		const result = await parseBuildArgs([
+			"--target",
+			"bun-linux-x64-baseline",
+			"--target",
+			"bun-darwin-arm64",
+		]);
+		expect(result.flags.target).toEqual(["bun-linux-x64-baseline", "bun-darwin-arm64"]);
 	});
 
 	it("supports -t alias for --target", async () => {
-		const result = await parseBuildArgs(["-t", "linux-x64"]);
-		expect(result.flags.target).toEqual(["linux-x64"]);
+		const result = await parseBuildArgs(["-t", "bun-linux-x64-baseline"]);
+		expect(result.flags.target).toEqual(["bun-linux-x64-baseline"]);
 	});
 
 	it("has a run function", () => {
@@ -199,19 +203,17 @@ describe("resolveBunBuildRunner", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("resolveTarget", () => {
-	it("resolves short alias to full Bun target", () => {
-		expect(resolveTarget("linux-x64")).toBe("bun-linux-x64-baseline");
-		expect(resolveTarget("linux-arm64")).toBe("bun-linux-arm64");
-		expect(resolveTarget("darwin-x64")).toBe("bun-darwin-x64");
-		expect(resolveTarget("darwin-arm64")).toBe("bun-darwin-arm64");
-		expect(resolveTarget("windows-x64")).toBe("bun-windows-x64-baseline");
-		expect(resolveTarget("windows-arm64")).toBe("bun-windows-arm64");
-	});
-
 	it("accepts full Bun target names directly", () => {
 		for (const target of SUPPORTED_TARGETS) {
 			expect(resolveTarget(target)).toBe(target);
 		}
+	});
+
+	it("rejects short target names with canonical-name guidance", () => {
+		expect(() => resolveTarget("linux-x64")).toThrow(
+			'Unknown target "linux-x64". Targets must use canonical Bun names.',
+		);
+		expect(() => resolveTarget("linux-x64")).toThrow(/Valid targets: bun-linux-x64-baseline/);
 	});
 
 	it("throws on unknown target", () => {
@@ -220,13 +222,6 @@ describe("resolveTarget", () => {
 
 	it("error message includes valid targets", () => {
 		expect(() => resolveTarget("nope")).toThrow(/Valid targets/);
-	});
-
-	it("all aliases map to supported targets", () => {
-		for (const [alias, target] of Object.entries(TARGET_ALIASES)) {
-			expect(SUPPORTED_TARGETS).toContain(target);
-			expect(resolveTarget(alias)).toBe(target);
-		}
 	});
 });
 
@@ -578,7 +573,7 @@ describe("buildCommand error handling", () => {
 			const app = new Crust("test").mount(buildCommand);
 
 			await app.execute({
-				argv: ["build", "--entry", "nonexistent.ts", "--target", "linux-x64"],
+				argv: ["build", "--entry", "nonexistent.ts", "--target", "bun-linux-x64-baseline"],
 			});
 
 			expect(process.exitCode).toBe(1);

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -19,6 +19,7 @@ import {
 	resolveBunBuildRunner,
 	resolveTarget,
 	SUPPORTED_TARGETS,
+	TARGET_INFO,
 } from "../../src/utils/build-helpers.ts";
 
 /**
@@ -209,11 +210,14 @@ describe("resolveTarget", () => {
 		}
 	});
 
-	it("rejects short target names with canonical-name guidance", () => {
-		expect(() => resolveTarget("linux-x64")).toThrow(
-			'Unknown target "linux-x64". Targets must use canonical Bun names.',
-		);
-		expect(() => resolveTarget("linux-x64")).toThrow(/Valid targets: bun-linux-x64-baseline/);
+	it("rejects every short alias with canonical-name guidance and a did-you-mean hint", () => {
+		for (const target of SUPPORTED_TARGETS) {
+			const alias = TARGET_INFO[target].alias;
+			expect(() => resolveTarget(alias)).toThrow(
+				`Unknown target "${alias}". Targets must use canonical Bun names. Did you mean "${target}"?`,
+			);
+			expect(() => resolveTarget(alias)).toThrow(/Valid targets: bun-linux-x64-baseline/);
+		}
 	});
 
 	it("throws on unknown target", () => {

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -262,9 +262,9 @@ export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined)
  * crust build --entry src/main.ts             # Custom entry point
  * crust build --name my-tool                  # Output as dist/my-tool-*
  * crust build --no-minify                     # Disable minification
- * crust build --target linux-x64              # Build only for Linux x64
- * crust build --target linux-x64 --target darwin-arm64  # Specific platforms only
- * crust build --target linux-x64 --outfile ./my-cli     # Single target with custom output
+ * crust build --target bun-linux-x64-baseline              # Build only for Linux x64
+ * crust build --target bun-linux-x64-baseline --target bun-darwin-arm64  # Specific platforms only
+ * crust build --target bun-linux-x64-baseline --outfile ./my-cli     # Single target with custom output
  * crust build --outdir out                              # Output binaries to out/ directory
  * ```
  */
@@ -302,7 +302,7 @@ export const buildCommand = defineCommand("build", (command) =>
 				type: "string",
 				multiple: true,
 				description:
-					"Target platform(s) to compile for (e.g. linux-x64, darwin-arm64). Omit to build all.",
+					"Canonical Bun target(s) to compile for (e.g. bun-linux-x64-baseline, bun-darwin-arm64). Omit to build all.",
 				short: "t",
 			},
 			{

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -88,43 +88,21 @@ export const TARGET_INFO = {
 } as const satisfies Record<BunTarget, TargetInfo>;
 
 /**
- * Human-friendly target aliases that map to Bun compile targets.
+ * Resolve a canonical Bun target string to a supported compile target.
  *
- * Users can pass either the full Bun target string or these short aliases.
- *
- * @example
- * ```sh
- * crust build --target linux-x64    # same as --target bun-linux-x64-baseline
- * crust build --target darwin-arm64 # same as --target bun-darwin-arm64
- * ```
- */
-export const TARGET_ALIASES: Record<string, BunTarget> = Object.fromEntries(
-	SUPPORTED_TARGETS.map((t) => [TARGET_INFO[t].alias, t]),
-);
-
-/**
- * Resolve a user-provided target string to a valid Bun compile target.
- *
- * Accepts both full Bun target names and short aliases.
- *
- * @param input - User-provided target string (e.g. "linux-x64" or "bun-linux-x64-baseline")
+ * @param input - User-provided canonical Bun target string
  * @returns The resolved Bun compile target
  * @throws {Error} If the target is not recognized
  */
 export function resolveTarget(input: string): BunTarget {
-	// Direct match against supported targets
 	if ((SUPPORTED_TARGETS as readonly string[]).includes(input)) {
 		return input as BunTarget;
 	}
 
-	// Try alias lookup
-	const aliased = TARGET_ALIASES[input];
-	if (aliased) {
-		return aliased;
-	}
-
-	const validTargets = [...Object.keys(TARGET_ALIASES), ...SUPPORTED_TARGETS].join(", ");
-	throw new Error(`Unknown target "${input}"\n  Valid targets: ${validTargets}`);
+	const validTargets = SUPPORTED_TARGETS.join(", ");
+	throw new Error(
+		`Unknown target "${input}". Targets must use canonical Bun names.\n  Valid targets: ${validTargets}`,
+	);
 }
 
 /**

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -99,9 +99,11 @@ export function resolveTarget(input: string): BunTarget {
 		return input as BunTarget;
 	}
 
+	const canonical = SUPPORTED_TARGETS.find((target) => TARGET_INFO[target].alias === input);
+	const hint = canonical ? ` Did you mean "${canonical}"?` : "";
 	const validTargets = SUPPORTED_TARGETS.join(", ");
 	throw new Error(
-		`Unknown target "${input}". Targets must use canonical Bun names.\n  Valid targets: ${validTargets}`,
+		`Unknown target "${input}". Targets must use canonical Bun names.${hint}\n  Valid targets: ${validTargets}`,
 	);
 }
 

--- a/packages/crust/src/utils/distribute.test.ts
+++ b/packages/crust/src/utils/distribute.test.ts
@@ -211,7 +211,7 @@ describe("runDistributeBuild", () => {
 		await runDistributeBuild({
 			entry: "src/cli.ts",
 			minify: true,
-			target: ["darwin-arm64"],
+			target: ["bun-darwin-arm64"],
 			stageDir: ".stage",
 			validate: false,
 		});
@@ -270,7 +270,7 @@ export const app = new Crust("x").handle(() => {});
 		await runDistributeBuild({
 			entry: "src/cli.ts",
 			minify: true,
-			target: ["darwin-arm64"],
+			target: ["bun-darwin-arm64"],
 			stageDir: ".stage-man",
 			validate: false,
 			man: true,

--- a/packages/crust/src/utils/generate-man.test.ts
+++ b/packages/crust/src/utils/generate-man.test.ts
@@ -1,0 +1,26 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { generateManPageFromEntry } from "./generate-man.ts";
+
+describe("generateManPageFromEntry", () => {
+	const tmpDir = join(import.meta.dir, ".tmp-generate-man");
+
+	afterAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("rejects an entry whose app export lacks snapshot()", async () => {
+		mkdirSync(tmpDir, { recursive: true });
+		writeFileSync(join(tmpDir, "not-crust.ts"), "export const app = {};\n");
+
+		await expect(
+			generateManPageFromEntry({
+				cwd: tmpDir,
+				entry: "not-crust.ts",
+				outfile: join(tmpDir, "out.1"),
+			}),
+		).rejects.toThrow("Man generation requires a Crust app exported as `app` or default export");
+	});
+});

--- a/packages/crust/src/utils/generate-man.ts
+++ b/packages/crust/src/utils/generate-man.ts
@@ -37,7 +37,7 @@ export async function generateManPageFromEntry(
 		typeof (raw as { snapshot?: unknown }).snapshot !== "function"
 	) {
 		throw new Error(
-			`Man generation requires a Crust app exported as \`app\` or default export from ${options.entry}.`,
+			`Man generation requires a Crust app exported as \`app\` or default export from ${options.entry} (requires @crustjs/core with .snapshot()).`,
 		);
 	}
 	const app = raw as WriteManPageOptions["app"];

--- a/packages/crust/src/utils/generate-man.ts
+++ b/packages/crust/src/utils/generate-man.ts
@@ -34,8 +34,7 @@ export async function generateManPageFromEntry(
 	if (
 		typeof raw !== "object" ||
 		raw === null ||
-		(raw as { _node?: unknown })._node === null ||
-		typeof (raw as { _node?: unknown })._node !== "object"
+		typeof (raw as { snapshot?: unknown }).snapshot !== "function"
 	) {
 		throw new Error(
 			`Man generation requires a Crust app exported as \`app\` or default export from ${options.entry}.`,

--- a/packages/crust/tests/package-manager.smoke.test.ts
+++ b/packages/crust/tests/package-manager.smoke.test.ts
@@ -16,22 +16,22 @@ const packDir = join(testRoot, "packs");
 
 function resolveHostTarget(): string {
 	if (process.platform === "darwin" && process.arch === "arm64") {
-		return "darwin-arm64";
+		return "bun-darwin-arm64";
 	}
 	if (process.platform === "darwin" && process.arch === "x64") {
-		return "darwin-x64";
+		return "bun-darwin-x64";
 	}
 	if (process.platform === "linux" && process.arch === "arm64") {
-		return "linux-arm64";
+		return "bun-linux-arm64";
 	}
 	if (process.platform === "linux" && process.arch === "x64") {
-		return "linux-x64";
+		return "bun-linux-x64-baseline";
 	}
 	if (process.platform === "win32" && process.arch === "arm64") {
-		return "windows-arm64";
+		return "bun-windows-arm64";
 	}
 	if (process.platform === "win32" && process.arch === "x64") {
-		return "windows-x64";
+		return "bun-windows-x64-baseline";
 	}
 
 	throw new Error(`Unsupported smoke-test host: ${process.platform}-${process.arch}`);

--- a/packages/crust/tests/package.integration.test.ts
+++ b/packages/crust/tests/package.integration.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { Crust } from "@crustjs/core";
 
 import { buildCommand } from "../src/commands/build.ts";
+import { SUPPORTED_TARGETS, TARGET_INFO } from "../src/utils/build-helpers.ts";
 
 const tmpDir = join(import.meta.dir, ".tmp-stage");
 const originalCwd = process.cwd;
@@ -77,9 +78,9 @@ describe("crust build --package integration", () => {
 		await runBuild([
 			"--package",
 			"--target",
-			"linux-x64",
+			"bun-linux-x64-baseline",
 			"--target",
-			"darwin-arm64",
+			"bun-darwin-arm64",
 			"--stage-dir",
 			".stage",
 			"--no-validate",
@@ -110,7 +111,7 @@ describe("crust build --package integration", () => {
 		await runBuild([
 			"--package",
 			"--target",
-			"linux-x64",
+			"bun-linux-x64-baseline",
 			"--stage-dir",
 			".subset",
 			"--no-validate",
@@ -125,13 +126,16 @@ describe("crust build --package integration", () => {
 		"executes the staged JS resolver through Node on the host platform",
 		async () => {
 			const hostTarget = getHostTarget();
+			const hostBunTarget = SUPPORTED_TARGETS.find(
+				(target) => TARGET_INFO[target].alias === hostTarget,
+			);
 			const nodePath = Bun.which("node");
-			if (!hostTarget || !nodePath) return;
+			if (!hostTarget || !hostBunTarget || !nodePath) return;
 
 			await runBuild([
 				"--package",
 				"--target",
-				hostTarget,
+				hostBunTarget,
 				"--stage-dir",
 				".host",
 				"--no-validate",

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Crust, defineCommand } from "@crustjs/core";
-import { prepareCommandSnapshot } from "@crustjs/core/tooling";
 
 import { completionExtension } from "./index.ts";
 
@@ -91,7 +90,7 @@ function buildCli() {
 describe("completionExtension", () => {
 	it("registers a `completion` subcommand on the root command (after setup)", async () => {
 		const app = buildCli();
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		expect(Object.keys(root.subCommands)).toContain("completion");
 		const completionNode = root.subCommands.completion;
 		expect(completionNode?.meta.description).toBe("Generate shell tab-completion scripts");
@@ -101,7 +100,7 @@ describe("completionExtension", () => {
 		const app = new Crust("mycli")
 			.extend(completionExtension({ command: "shell-completion" }))
 			.handle(() => {});
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		expect(Object.keys(root.subCommands)).toContain("shell-completion");
 	});
 

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
 import { Crust, defineCommand } from "@crustjs/core";
-import { prepareCommandSnapshot } from "@crustjs/core/tooling";
 import { help } from "@crustjs/extensions";
 
 import { renderManPageMdoc } from "./mdoc.ts";
@@ -14,7 +13,7 @@ describe("renderManPageMdoc", () => {
 			.flags({ name: "verbose", type: "boolean", short: "v", description: "Verbose" })
 			.mount(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).handle(() => {})));
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).toContain(".Sh NAME");
@@ -33,7 +32,7 @@ describe("renderManPageMdoc", () => {
 			.meta({ description: ".config is read automatically." })
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "x", section: 1 });
 
 		expect(mdoc).toMatch(/\.Nd .*\\&\.config is read automatically\./);
@@ -42,7 +41,7 @@ describe("renderManPageMdoc", () => {
 
 	it("uses explicit date for .Dd", async () => {
 		const app = new Crust("x").handle(() => {});
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({
 			root,
 			name: "x",
@@ -56,7 +55,7 @@ describe("renderManPageMdoc", () => {
 		process.env.SOURCE_DATE_EPOCH = "86400";
 		try {
 			const app = new Crust("x").handle(() => {});
-			const root = await prepareCommandSnapshot(app);
+			const root = await app.snapshot();
 			const mdoc = renderManPageMdoc({ root, name: "x" });
 			expect(mdoc.startsWith(".Dd January 2, 1970\n")).toBe(true);
 		} finally {
@@ -82,7 +81,7 @@ describe("renderManPageMdoc", () => {
 				),
 			);
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).toContain(".Sh SUBCOMMANDS");
@@ -117,7 +116,7 @@ describe("renderManPageMdoc", () => {
 				),
 			);
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).toContain(".It Nm build");
@@ -133,7 +132,7 @@ describe("renderManPageMdoc", () => {
 			)
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).not.toContain(".Sh SUBCOMMANDS");
@@ -151,7 +150,7 @@ describe("renderManPageMdoc", () => {
 			})
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		// Convention audit M1: use semantic mdoc flag macros.
@@ -171,7 +170,7 @@ describe("renderManPageMdoc", () => {
 			})
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		expect(mdoc).toContain(".Sh ARGUMENTS");
@@ -191,7 +190,7 @@ describe("renderManPageMdoc", () => {
 			})
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		// Both the canonical `--output` and the alias `--out` appear in the
@@ -209,7 +208,7 @@ describe("renderManPageMdoc", () => {
 			})
 			.handle(() => {});
 
-		const root = await prepareCommandSnapshot(app);
+		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
 
 		// Canonical + alias + both negations, in declaration order.

--- a/packages/man/src/write-man-page.ts
+++ b/packages/man/src/write-man-page.ts
@@ -1,10 +1,10 @@
-import { prepareCommandSnapshot } from "@crustjs/core/tooling";
+import type { CommandSnapshot } from "@crustjs/core/tooling";
 
 import { renderManPageMdoc } from "./mdoc.ts";
 
 export interface WriteManPageOptions {
-	/** Root Crust builder for your CLI. */
-	app: Parameters<typeof prepareCommandSnapshot>[0];
+	/** Root Crust builder for your CLI, typed structurally across bundled entry points. */
+	app: { snapshot(): Promise<CommandSnapshot> };
 	/** Name for `.Nm` / `man <name>` (usually the installed binary name). */
 	name: string;
 	/** Output path (e.g. `man/mycli.1`). Parent directories are created. */
@@ -26,7 +26,7 @@ export interface WriteManPageOptions {
 export async function writeManPage(options: WriteManPageOptions): Promise<void> {
 	const { app, name, outfile, section = 1, date } = options;
 
-	const root = await prepareCommandSnapshot(app);
+	const root = await app.snapshot();
 
 	const mdoc = renderManPageMdoc({ root, name, section, date });
 	await Bun.write(outfile, mdoc);


### PR DESCRIPTION
## Summary

Consolidates the backward-compat cleanup from a full subagent audit of the codebase. Two breaking pre-1.0 changes, each with its own changeset:

### 1. `prepareCommandSnapshot` bridge → supported `Crust.snapshot()` (`@crustjs/core`, `@crustjs/man`)

The `@crustjs/core/tooling` subpath exposed `prepareCommandSnapshot`, an explicitly unsupported structural bridge reaching through the builder's internal `_node`.

- New public `Crust.snapshot(): Promise<CommandSnapshot>` — same preparation path (materializes extensions/definitions, validates, never calls handlers)
- Bridge deleted; zero `_node` reach-through remains in runtime code outside core (the `skills/annotations.ts` structural check stays — module-identity workaround, not compat)
- `writeManPage` now takes `app: { snapshot(): Promise<CommandSnapshot> }`; `crust` man generation duck-checks `snapshot`
- Docs: `.snapshot()` added to the API reference, module docs, and core README

### 2. Canonical Bun names only for `--target` (`crust`)

- Short aliases (`linux-x64`, `darwin-arm64`, …) no longer accepted as input; unknown targets fail with canonical-name guidance
- Output/package naming unchanged (`TARGET_INFO` / `TargetInfo.alias` still drive distribution suffixes and staging dirs); `distribute.ts` has zero diff

### Deliberately kept (audited, decided against removal)

- Store string→number/boolean coercion (intentional contract)
- Bun-issue workarounds (#22161, #14155, #28327) — tracked, removable when upstream fixes land

## Validation

- `bun run check:types` ✓ · `bun run test` ✓ (2,230 pass / 0 fail / 8 env-skips) · `bun run lint` ✓ · `bun run format` ✓
- Implemented and independently reviewed via subagent workflow (no findings on final pass)

## Stack

Base of the stack: #173 (`.mount()` → `.add()` rename) is stacked on this PR. Merge this one first.
