### PR TITLE
refactor(core)!: make variadic builder methods accumulative with loud duplicate errors

### DIFF
--- a/.changeset/accumulative-builder-methods.md
+++ b/.changeset/accumulative-builder-methods.md
@@ -1,0 +1,9 @@
+---
+"@crustjs/core": minor
+---
+
+Make variadic builder methods accumulative with loud duplicate errors:
+
+- `.flags()` and `.args()` now accumulate across chained calls instead of silently replacing earlier definitions, preserving their combined runtime and inferred types. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
+- `.handle()` is set-once: calling it a second time on the same builder throws instead of replacing the handler.
+- `.extend()` rejects duplicate Extension names, both within one call and across calls.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -128,6 +128,10 @@ const app = new Crust("issue").meta({
 
 Aliases must be non-empty, contain no whitespace, not start with `-`, and not collide with sibling names or aliases.
 
+## Chaining semantics
+
+Variadic builder methods accumulate across calls: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` preserve earlier registrations and throw `DEFINITION` on duplicate names or spellings. `.meta()` shallow-merges fields. `.handle()` is set once and throws `DEFINITION` if called again.
+
 ## `.args(...defs)`
 
 ```ts
@@ -136,7 +140,7 @@ args<const NewA extends ArgsDef>(
 ): Crust
 ```
 
-Defines positional arguments; the order they are passed is the positional order. Pass values from `defineArg(name, def)` or inline literals. Only the last argument may be variadic.
+Defines positional arguments; repeated calls append in call order. Pass values from `defineArg(name, def)` or inline literals. Duplicate names throw `DEFINITION`, and only the final argument across all calls may be variadic.
 
 ```ts
 const app = new Crust("copy").args(
@@ -169,7 +173,7 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls **replace** the local flags — they do not merge; pass all definitions in one call. A duplicate name within one call throws `DEFINITION`.
+Repeated `.flags()` calls accumulate local flags. Duplicate names, short forms, or aliases across or within calls throw `DEFINITION`.
 
 Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
@@ -226,7 +230,7 @@ Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are disposed in re
 extend(...extensions: readonly Extension[]): Crust
 ```
 
-Registers application-wide Extensions. `.extend()` exists on `Crust` roots and is intentionally absent from `CommandDefinitionBuilder`.
+Registers application-wide Extensions. Repeated calls accumulate in registration order; duplicate Extension names across or within calls throw `DEFINITION`. `.extend()` exists on `Crust` roots and is intentionally absent from `CommandDefinitionBuilder`.
 
 ```ts
 import { help, version } from "@crustjs/extensions";
@@ -248,7 +252,7 @@ handle(
 ): Crust
 ```
 
-Defines the Command Handler. It runs after routing, parsing, `preRun` hooks, validation, and Context construction.
+Defines the Command Handler once. A second `.handle()` call throws `DEFINITION` instead of replacing existing behavior. The handler runs after routing, parsing, `preRun` hooks, validation, and Context construction.
 
 ```ts
 const app = new Crust("greet")

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -3,7 +3,7 @@ title: Arguments
 description: Define typed positional inputs for a command.
 ---
 
-`.args(...defs)` maps positional tokens to names in the order the definitions are passed. Pass values from `defineArg(name, def)` or inline literals:
+`.args(...defs)` maps positional tokens to names in the order the definitions are passed. Repeated `.args()` calls append in call order, and a duplicate name throws a `DEFINITION` error. Pass values from `defineArg(name, def)` or inline literals:
 
 ```ts
 import { Crust } from "@crustjs/core";

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -3,8 +3,6 @@ title: Flags
 description: Define typed named inputs, aliases, repeated values, and shared flag capabilities.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
-
 `.flags(...defs)` takes named flag definitions — values from `defineFlag(name, def)` or inline literals carrying `name`:
 
 ```ts
@@ -20,11 +18,9 @@ const command = new Crust("serve")
 
 See [`FlagDef`](/docs/api/types#flagdef) for the complete definition. A duplicate name within one call is a `DEFINITION` error.
 
-<Callout type="warn">
-  Repeated `.flags()` calls **replace** the local flags — they do not merge. `.flags(a).flags(b)`
-  leaves only `b`. Pass all definitions in a single `.flags()` call. This differs from
-  Commander/yargs `.option()`, which is additive.
-</Callout>
+Repeated `.flags()` calls accumulate: `.flags(a).flags(b)` defines both flags. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
+
+Builder chaining follows the same rule for every variadic method: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` accumulate and reject duplicates. `.meta()` shallow-merges fields, while `.handle()` is set once and throws if called again.
 
 ## Aliases and negation
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -16,7 +16,7 @@ const command = new Crust("serve")
   .handle(({ flags, stdout }) => stdout(`${flags.port} ${flags.verbose ?? false}`));
 ```
 
-See [`FlagDef`](/docs/api/types#flagdef) for the complete definition. A duplicate name within one call is a `DEFINITION` error.
+See [`FlagDef`](/docs/api/types#flagdef) for the complete definition.
 
 Repeated `.flags()` calls accumulate: `.flags(a).flags(b)` defines both flags. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -307,7 +307,7 @@ describe("Context-owned flags", () => {
 		>;
 	});
 
-	it("keeps owned flags when later .flags() calls replace local flags", async () => {
+	it("keeps owned flags when later .flags() calls accumulate local flags", async () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -155,14 +155,37 @@ describe("Crust .flags()", () => {
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
 
-	it("repeated .flags() calls replace local flags", async () => {
+	it("repeated .flags() calls accumulate runtime and handler types", async () => {
+		let received: { first: boolean | undefined; second: string | undefined } | undefined;
 		const app = new Crust("test")
 			.flags({ name: "first", type: "boolean" })
-			.flags({ name: "second", type: "string" });
+			.flags({ name: "second", type: "string" })
+			.handle(({ flags }) => {
+				type _First = Expect<Equal<typeof flags.first, boolean | undefined>>;
+				type _Second = Expect<Equal<typeof flags.second, string | undefined>>;
+				received = flags;
+			});
 
+		await app.run(["--first", "--second", "value"]);
+		expect(received).toEqual({ first: true, second: "value" });
 		expect((await app.snapshot()).flags).toEqual({
+			first: { type: "boolean" },
 			second: { type: "string" },
 		});
+	});
+
+	it("throws CrustError DEFINITION on flag collisions across .flags() calls", () => {
+		expect(() =>
+			new Crust("test")
+				.flags({ name: "verbose", type: "boolean" })
+				.flags({ name: "verbose", type: "string" }),
+		).toThrow(/Flag "--verbose" is already defined/);
+
+		expect(() =>
+			new Crust("test")
+				.flags({ name: "verbose", type: "boolean", short: "v" })
+				.flags({ name: "version", type: "boolean", short: "v" }),
+		).toThrow(/spelling "v" collides with flag "--verbose"/);
 	});
 
 	it("throws CrustError DEFINITION on duplicate names within one .flags() call", () => {
@@ -171,7 +194,7 @@ describe("Crust .flags()", () => {
 				{ name: "verbose", type: "boolean" },
 				{ name: "verbose", type: "string" },
 			),
-		).toThrow(/defined more than once/);
+		).toThrow(/already defined/);
 	});
 
 	it("throws CrustError DEFINITION on short/alias collisions within one .flags() call", () => {
@@ -236,6 +259,43 @@ describe("Crust .args()", () => {
 		expect(snapshot.meta.name).toBe("my-cli");
 		expect(snapshot.meta.description).toBe("desc");
 		expect(snapshot.flags.verbose).toBeDefined();
+	});
+
+	it("repeated .args() calls append in positional order and preserve handler types", async () => {
+		let received: { source: string; destination: string } | undefined;
+		const app = new Crust("copy")
+			.args({ name: "source", type: "string", required: true })
+			.args({ name: "destination", type: "string", required: true })
+			.handle(({ args }) => {
+				type _Source = Expect<Equal<typeof args.source, string>>;
+				type _Destination = Expect<Equal<typeof args.destination, string>>;
+				received = args;
+			});
+
+		await app.run(["from", "to"]);
+		expect(received).toEqual({ source: "from", destination: "to" });
+		expect((await app.snapshot()).args.map((arg) => arg.name)).toEqual(["source", "destination"]);
+	});
+
+	it("throws CrustError DEFINITION on duplicate arg names", () => {
+		expect(() =>
+			new Crust("test")
+				.args({ name: "file", type: "string" })
+				.args({ name: "file", type: "string" }),
+		).toThrow(/Argument "file" is already defined/);
+		expect(() =>
+			new Crust("test").args({ name: "file", type: "string" }, { name: "file", type: "string" }),
+		).toThrow(/Argument "file" is already defined/);
+	});
+
+	it("throws CrustError DEFINITION when an arg follows a variadic from an earlier call", () => {
+		const app = new Crust("test").args({ name: "files", type: "string", variadic: true });
+		expect(() =>
+			app.args(
+				// @ts-expect-error -- the variadic position is also guarded at runtime
+				{ name: "destination", type: "string" },
+			),
+		).toThrow(/only the last positional argument can be variadic/);
 	});
 });
 
@@ -591,6 +651,11 @@ describe("Crust .handle()", () => {
 		});
 	});
 
+	it("throws CrustError DEFINITION instead of replacing an existing handler", () => {
+		const app = new Crust("test").handle(() => {});
+		expect(() => app.handle(() => {})).toThrow(/Command "test" already has a handler/);
+	});
+
 	it("preserves the definition and can follow .add()", async () => {
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean" })
@@ -725,6 +790,18 @@ describe("Crust .extend()", () => {
 
 		await app.run([]);
 		expect(calls).toEqual(["one", "two", "three"]);
+	});
+
+	it("throws CrustError DEFINITION on duplicate Extension names", () => {
+		const first = defineExtension("duplicate");
+		const second = defineExtension("duplicate");
+
+		expect(() => new Crust("test").extend(first).extend(second)).toThrow(
+			/Extension "duplicate" is already registered/,
+		);
+		expect(() => new Crust("test").extend(first, second)).toThrow(
+			/Extension "duplicate" is already registered/,
+		);
 	});
 
 	it("defineExtension() returns a frozen plain config", () => {

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -277,6 +277,15 @@ describe("Crust .args()", () => {
 		expect((await app.snapshot()).args.map((arg) => arg.name)).toEqual(["source", "destination"]);
 	});
 
+	it("throws CrustError DEFINITION on an arg definition without a name", () => {
+		expect(() =>
+			new Crust("test").args(
+				// @ts-expect-error -- missing name is also guarded at runtime
+				{ type: "string" },
+			),
+		).toThrow(/Every argument definition must carry a non-empty name/);
+	});
+
 	it("throws CrustError DEFINITION on duplicate arg names", () => {
 		expect(() =>
 			new Crust("test")

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -260,6 +260,25 @@ type ContextRequirementErrors<Ctx extends ContextMap, Required extends ContextMa
 
 type DefinitionRequirements<D> = D extends CommandDefinition<infer R> ? R : never;
 
+// Bare `Crust` uses broad `ArgsDef` for structural consumers; its first concrete
+// `.args()` call establishes the tuple, while already-refined builders append.
+type AppendedArgs<A extends ArgsDef, NewA extends ArgsDef> = ArgsDef extends A
+	? NewA
+	: readonly [...A, ...NewA];
+
+type AppendArgsChecks<A extends ArgsDef, NewA extends ArgsDef> = A extends readonly [
+	...unknown[],
+	infer Last,
+]
+	? Last extends { variadic: true }
+		? {
+				[I in keyof NewA]: NewA[I] & {
+					readonly FIX_VARIADIC_POSITION: "Only the last positional argument can be variadic";
+				};
+			}
+		: ValidateVariadicArgs<NewA>
+	: ValidateVariadicArgs<NewA>;
+
 /** Per-definition add-time checks (compile-time counterpart of the runtime attach checks). */
 type AddChecks<Ctx extends ContextMap, Ds extends readonly CommandDefinition<any>[]> = {
 	[I in keyof Ds]: Ds[I] &
@@ -278,16 +297,16 @@ export interface CommandDefinitionBuilder<
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
 	): CommandDefinitionBuilder<
-		NamedFlagsRecord<Defs>,
+		MergeFlags<Local, NamedFlagsRecord<Defs>>,
 		Owned,
 		A,
-		EffectiveFlags<NamedFlagsRecord<Defs>, Owned>,
+		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx
 	>;
 
 	args<const NewA extends ArgsDef>(
-		...defs: NewA & ValidateVariadicArgs<NewA>
-	): CommandDefinitionBuilder<Local, Owned, NewA, Eff, Ctx>;
+		...defs: NewA & AppendArgsChecks<A, NewA>
+	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: Cs
@@ -468,9 +487,8 @@ export class Crust<
 	 * (created with `defineFlag(name, def)` or written inline as
 	 * `{ name: "dry-run", type: "boolean" }`).
 	 *
-	 * Repeated `.flags()` calls replace the local flags. Returns a new
-	 * builder with updated local flag types. The original builder is not
-	 * mutated.
+	 * Repeated `.flags()` calls accumulate local flags. Returns a new builder
+	 * with the combined local flag types. The original builder is not mutated.
 	 *
 	 * NOTE: Compile-time ancestor-owned/local cross-collision checks are intentionally
 	 * omitted here to reduce TypeScript type-check cost in large projects.
@@ -478,12 +496,18 @@ export class Crust<
 	 *
 	 * @param defs - Named flag definitions
 	 * @returns A new `Crust` instance with the given flags
-	 * @throws {CrustError} `DEFINITION` on duplicate names or schema-exclusivity violations
+	 * @throws {CrustError} `DEFINITION` on duplicate names or spellings, or schema-exclusivity violations
 	 */
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
-	): Crust<NamedFlagsRecord<Defs>, Owned, A, EffectiveFlags<NamedFlagsRecord<Defs>, Owned>, Ctx> {
-		const copiedFlags: FlagsDef = {};
+	): Crust<
+		MergeFlags<Local, NamedFlagsRecord<Defs>>,
+		Owned,
+		A,
+		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
+		Ctx
+	> {
+		const copiedFlags: FlagsDef = { ...this._node.localFlags };
 		for (const def of defs) {
 			// Destructuring also decouples the stored def from the caller's object
 			const { name, ...rest } = def as NamedFlagDef;
@@ -494,16 +518,15 @@ export class Crust<
 				});
 			}
 			if (name in copiedFlags) {
-				throw new CrustError(
-					"DEFINITION",
-					`Flag "--${name}" is defined more than once in one .flags() call`,
-					{ subject: "flag", name, reason: "duplicate-flag" },
-				);
+				throw new CrustError("DEFINITION", `Flag "--${name}" is already defined`, {
+					subject: "flag",
+					name,
+					reason: "duplicate-flag",
+				});
 			}
 			validateSchemaExclusivity("flag", name, rest as Record<string, unknown>);
-			// Include same-call siblings so short/alias collisions between two
-			// definitions in one .flags() call fail here (DEFINITION errors throw
-			// at the definition site), not at first run() via validateCommandTree.
+			// Include flags from earlier calls and same-call siblings so spelling
+			// collisions fail at the definition site, not at first run().
 			validateIncomingFlag(
 				{ name, def: rest as FlagDef },
 				{ ...this._node.ownedFlags, ...copiedFlags },
@@ -516,10 +539,10 @@ export class Crust<
 			localFlags: copiedFlags,
 			effectiveFlags: computeEffectiveFlags(this._node.ownedFlags, copiedFlags),
 		}) as unknown as Crust<
-			NamedFlagsRecord<Defs>,
+			MergeFlags<Local, NamedFlagsRecord<Defs>>,
 			Owned,
 			A,
-			EffectiveFlags<NamedFlagsRecord<Defs>, Owned>,
+			EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 			Ctx
 		>;
 	}
@@ -529,15 +552,16 @@ export class Crust<
 	 * order they are passed (created with `defineArg(name, def)` or written
 	 * inline).
 	 *
-	 * Returns a new builder with updated args types. The original
-	 * builder is not mutated.
+	 * Repeated `.args()` calls append in call order. Returns a new builder with
+	 * the combined args types. The original builder is not mutated.
 	 *
 	 * @param defs - Positional argument definitions, in positional order
-	 * @returns A new `Crust` instance with the given args
+	 * @returns A new `Crust` instance with the combined args
+	 * @throws {CrustError} `DEFINITION` on duplicate names, a non-final variadic arg, or schema-exclusivity violations
 	 */
 	args<const NewA extends ArgsDef>(
-		...defs: NewA & ValidateVariadicArgs<NewA>
-	): Crust<Local, Owned, NewA, Eff, Ctx> {
+		...defs: NewA & AppendArgsChecks<A, NewA>
+	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
 			validateSchemaExclusivity("arg", (def as ArgDef).name, record);
@@ -554,12 +578,30 @@ export class Crust<
 				);
 			}
 		}
-		// Deep copy arg defs to decouple from caller
-		const copiedArgs = defs.map((def) => ({ ...def })) as unknown as ArgsDef;
+		// Deep copy new defs to decouple storage from the caller.
+		const copiedArgs = [...(this._node.args ?? []), ...defs.map((def) => ({ ...def }))] as ArgsDef;
+		const names = new Set<string>();
+		for (const [index, def] of copiedArgs.entries()) {
+			if (names.has(def.name)) {
+				throw new CrustError("DEFINITION", `Argument "${def.name}" is already defined`, {
+					subject: "arg",
+					name: def.name,
+					reason: "duplicate-arg",
+				});
+			}
+			names.add(def.name);
+			if (def.variadic === true && index !== copiedArgs.length - 1) {
+				throw new CrustError(
+					"DEFINITION",
+					`Argument "${def.name}" is variadic, but only the last positional argument can be variadic`,
+					{ subject: "arg", name: def.name, reason: "variadic-position" },
+				);
+			}
+		}
 
 		return this._clone({
 			args: copiedArgs,
-		}) as unknown as Crust<Local, Owned, NewA, Eff, Ctx>;
+		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx>;
 	}
 
 	/**
@@ -642,15 +684,23 @@ export class Crust<
 	 * The handler receives a {@link CrustCommandContext} with `args` typed from
 	 * `.args()` and `flags` typed as `EffectiveFlags<Local, Owned>`.
 	 *
-	 * Returns a new builder with the handler stored. The original builder is
-	 * not mutated.
+	 * A handler is set once; calling `.handle()` again throws rather than
+	 * silently replacing command behavior. The original builder is not mutated.
 	 *
 	 * @param handler - The Command Handler function
 	 * @returns A new `Crust` instance with the handler registered
+	 * @throws {CrustError} `DEFINITION` when this command already has a handler
 	 */
 	handle(
 		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
 	): Crust<Local, Owned, A, Eff, Ctx> {
+		if (this._node.run) {
+			throw new CrustError(
+				"DEFINITION",
+				`Command "${this._node.meta.name}" already has a handler`,
+				{ subject: "command", name: this._node.meta.name, reason: "duplicate-handler" },
+			);
+		}
 		return this._clone({
 			run: handler as (ctx: unknown) => void | Promise<void>,
 		}) as Crust<Local, Owned, A, Eff, Ctx>;
@@ -660,9 +710,23 @@ export class Crust<
 	 * Register one or more CLI Extensions on the application root.
 	 *
 	 * Extensions are application-wide: they own the flags and commands they
-	 * contribute. Command definition builders do not expose this method.
+	 * contribute. Repeated calls accumulate Extensions in registration order;
+	 * duplicate names throw. Command definition builders do not expose this method.
+	 *
+	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
 	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx> {
+		const names = new Set(this._node.extensions.map((extension) => extension.name));
+		for (const extension of extensions) {
+			if (names.has(extension.name)) {
+				throw new CrustError("DEFINITION", `Extension "${extension.name}" is already registered`, {
+					subject: "extension",
+					name: extension.name,
+					reason: "duplicate-extension",
+				});
+			}
+			names.add(extension.name);
+		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
 		}) as Crust<Local, Owned, A, Eff, Ctx>;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -260,8 +260,9 @@ type ContextRequirementErrors<Ctx extends ContextMap, Required extends ContextMa
 
 type DefinitionRequirements<D> = D extends CommandDefinition<infer R> ? R : never;
 
-// Bare `Crust` uses broad `ArgsDef` for structural consumers; its first concrete
-// `.args()` call establishes the tuple, while already-refined builders append.
+// Bare `Crust` uses broad `ArgsDef` for structural consumers; a `.args()` call on
+// that broad type only reflects the new defs (runtime still appends to any args a
+// widened builder already carries), while already-refined builders append in-type.
 type AppendedArgs<A extends ArgsDef, NewA extends ArgsDef> = ArgsDef extends A
 	? NewA
 	: readonly [...A, ...NewA];
@@ -491,8 +492,10 @@ export class Crust<
 	 * with the combined local flag types. The original builder is not mutated.
 	 *
 	 * NOTE: Compile-time ancestor-owned/local cross-collision checks are intentionally
-	 * omitted here to reduce TypeScript type-check cost in large projects.
-	 * Runtime collision checks still run during parsing and command-tree validation.
+	 * omitted here to reduce TypeScript type-check cost in large projects; the same
+	 * applies to same-name flags across chained `.flags()` calls, where the type level
+	 * merges (later wins) while runtime throws. Runtime collision checks still run
+	 * during parsing and command-tree validation.
 	 *
 	 * @param defs - Named flag definitions
 	 * @returns A new `Crust` instance with the given flags
@@ -517,7 +520,7 @@ export class Crust<
 					reason: "missing-name",
 				});
 			}
-			if (name in copiedFlags) {
+			if (Object.hasOwn(copiedFlags, name)) {
 				throw new CrustError("DEFINITION", `Flag "--${name}" is already defined`, {
 					subject: "flag",
 					name,
@@ -564,7 +567,18 @@ export class Crust<
 	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
-			validateSchemaExclusivity("arg", (def as ArgDef).name, record);
+			const argName = (def as ArgDef).name;
+			if (typeof argName !== "string" || argName.length === 0) {
+				throw new CrustError(
+					"DEFINITION",
+					"Every argument definition must carry a non-empty name",
+					{
+						subject: "arg",
+						reason: "missing-name",
+					},
+				);
+			}
+			validateSchemaExclusivity("arg", argName, record);
 			// Schema args receive raw strings: a parser `type` would coerce first
 			if (record.schema !== undefined && record.type !== undefined) {
 				throw new CrustError(

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -27,6 +27,42 @@ describe("command definitions", () => {
 		expect(snapshot.subCommands.compile?.meta.name).toBe("compile");
 	});
 
+	it("accumulates chained flags and args on the definition builder", async () => {
+		let received:
+			| {
+					args: { source: string; destination: string };
+					flags: { verbose: boolean | undefined; output: string | undefined };
+			  }
+			| undefined;
+		const definition = defineCommand("copy", (command) =>
+			command
+				.flags({ name: "verbose", type: "boolean" })
+				.flags({ name: "output", type: "string" })
+				.args({ name: "source", type: "string", required: true })
+				.args({ name: "destination", type: "string", required: true })
+				.handle(({ args, flags }) => {
+					type _Source = Assert<IsEqual<typeof args.source, string>>;
+					type _Output = Assert<IsEqual<typeof flags.output, string | undefined>>;
+					received = { args, flags };
+				}),
+		);
+
+		await new Crust("cli")
+			.add(definition)
+			.run(["copy", "from", "to", "--verbose", "--output", "dist"]);
+		expect(received).toEqual({
+			args: { source: "from", destination: "to" },
+			flags: { verbose: true, output: "dist" },
+		});
+	});
+
+	it("rejects a second handler on the definition builder", () => {
+		const definition = defineCommand("duplicate", (command) =>
+			command.handle(() => {}).handle(() => {}),
+		);
+		expect(() => new Crust("cli").add(definition)).toThrow(/already has a handler/);
+	});
+
 	it(".as() renames without mutating the original definition", () => {
 		const definition = defineCommand("build", (command) => command.handle(() => {}));
 		const renamed = definition.as("compile");

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -135,8 +135,8 @@ describe("InferArgs type inference", () => {
 	});
 
 	it("turns duplicate arg names with conflicting types into never", () => {
-		// No runtime duplicate-name check exists for positional args; the
-		// intersection-produced `never` is the only conflict signal.
+		// The inferred conflict signal complements the builder's runtime
+		// duplicate-name check.
 		type Args = readonly [
 			{ name: "x"; type: "string"; required: true },
 			{ name: "x"; type: "number"; required: true },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -762,9 +762,9 @@ type InferArgValue<A extends ArgDef> = A extends {
  *
  * Deliberately recursive rather than key-remapped over `A[number]`:
  * intersection turns duplicate arg names with conflicting types into
- * `never` (a conflict signal — there is no runtime duplicate-name check
- * for positional args), and a widened non-tuple `ArgsDef` resolves to
- * `{}` instead of a string-indexed record.
+ * `never`; builder registration also rejects duplicate positional names at
+ * runtime. A widened non-tuple `ArgsDef` resolves to `{}` instead of a
+ * string-indexed record.
  */
 type InferArgsTuple<A extends readonly ArgDef[]> = A extends readonly [
 	infer Head extends ArgDef,


### PR DESCRIPTION
> **Stacked on #173** (`refactor/rename-mount-to-add`) — merge that first; this diff is only the top commit.

## What

Unifies chaining semantics across the builder (both `Crust` and `CommandDefinitionBuilder`): every variadic method now **accumulates** and rejects duplicates with a `DEFINITION` error, instead of the previous mix of silent replacement and accumulation.

| Method | Before | After |
|---|---|---|
| `.flags(...)` | second call silently replaced local flags | accumulates; cross-call name/short/alias collision throws |
| `.args(...)` | second call silently replaced the tuple | appends in call order; duplicate name or arg-after-variadic throws (checked across the combined tuple) |
| `.handle(fn)` | last handler silently won | set-once; second call throws |
| `.extend(...)` | same extension name could register twice | duplicate name throws |
| `.provide()`, `.add()`, `.meta()` | unchanged | unchanged |

Type-level accumulation matches runtime: `Local` merges via `MergeFlags<Local, NamedFlagsRecord<Defs>>` (same machinery `.provide()` uses for `Owned`), args become `[...A, ...NewA]`.

## Why

Silent replacement was the worst of both worlds — it neither errored like `.provide()`/`.add()` do on duplicates, nor composed. A second `.flags()` call is either a composition attempt or a bug; both are better served by accumulate + loud error. Resulting rule is one line: *variadic methods accumulate and reject duplicates; `.meta()` shallow-merges; `.handle()` is set-once.* API is unshipped, so no compatibility shims.

## Verification

- `bun run check:types` — pass
- `bun run test` — 552 pass / 0 fail (core), full suite green
- `bun run lint` / `format` — clean
- New tests: cross-call flag collision, args append order, arg-after-variadic, duplicate arg name, double `.handle()`, duplicate extension name