### PR TITLE
refactor(core)!: rename command handler API from .handle() to .action()

### DIFF
--- a/.changeset/accumulative-builder-methods.md
+++ b/.changeset/accumulative-builder-methods.md
@@ -5,5 +5,5 @@
 Make variadic builder methods accumulative with loud duplicate errors:
 
 - `.flags()` and `.args()` now accumulate across chained calls instead of silently replacing earlier definitions, preserving their combined runtime and inferred types. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
-- `.handle()` is set-once: calling it a second time on the same builder throws instead of replacing the handler.
+- `.action()` is set-once: calling it a second time on the same builder throws instead of replacing the action.
 - `.extend()` rejects duplicate Extension names, both within one call and across calls.

--- a/.changeset/beta-api-revamp.md
+++ b/.changeset/beta-api-revamp.md
@@ -11,8 +11,8 @@ Ship the 0.2 API revamp for the framework spine (see `docs/adr/0001`–`0009`):
 
 - Extensions replace plugins: `@crustjs/extensions` package, `defineExtension(name, config)` plain frozen configs with `intercept(ctx, next)` and `handleError` presentation chain; `.use()` removed.
 - Contexts are command dependencies: `defineContext(name, config?, setup)` always returns a factory, attached with the variadic `.provide(...)`, constructed topologically by declared `requires` dependencies (values arrive via `ctx`), and disposed via native `Symbol.dispose`/`Symbol.asyncDispose` in reverse construction order.
-- `.handle(handler)` defines the Command Handler; `.run(argv, { stdout, stderr })` throws for programmatic embedding; `.execute()` renders and sets `process.exitCode`. `preRun`/`postRun` removed.
-- `CrustError` keeps four stable codes (`DEFINITION`, `PARSE`, `VALIDATION`, `COMMAND_NOT_FOUND`); `_tag`, `CONFIG`, and `EXECUTION` removed; handler and Context errors pass through unwrapped.
+- `.action(action)` defines the Command Action; `.run(argv, { stdout, stderr })` throws for programmatic embedding; `.execute()` renders and sets `process.exitCode`. `preRun`/`postRun` removed.
+- `CrustError` keeps four stable codes (`DEFINITION`, `PARSE`, `VALIDATION`, `COMMAND_NOT_FOUND`); `_tag`, `CONFIG`, and `EXECUTION` removed; action and Context errors pass through unwrapped.
 - Standard Schema supported directly on arg/flag definitions; `@crustjs/validate` removed.
 - Public `CommandNode`/`prepareCommandTree()` removed; serializable Command Snapshots cross public boundaries; man/crust/skills consume the unsupported `@crustjs/core/tooling` subpath.
 - `create-crust` ships a single minimal template.

--- a/.changeset/child-builder-surface.md
+++ b/.changeset/child-builder-surface.md
@@ -13,7 +13,7 @@ Migration:
 
 ```ts
 // Before
-const deploy = parent.sub("deploy").handle(({ flags, ctx }) => {});
+const deploy = parent.sub("deploy").action(({ flags, ctx }) => {});
 const app = parent.command(deploy);
 
 // After
@@ -22,7 +22,7 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => fl
 const auth = defineContext("auth", () => createAuthClient());
 
 const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
-	command.handle(({ ctx }) => {}),
+	command.action(({ ctx }) => {}),
 );
 
 const app = parent.provide(logging(), auth()).add(deploy);

--- a/.changeset/context-owned-flags.md
+++ b/.changeset/context-owned-flags.md
@@ -13,9 +13,9 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) =>
 const app = new Crust("cli").provide(api()).add(deploy);
 ```
 
-Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. Required raw flags are not injected into downstream handler types; expose any needed value from its owning Context.
+Make requirements capability-only. `defineCommand(name, { requires: [logging, auth] }, recipe)` and `defineContext(name, { flags, requires: [config] }, setup)` accept a plain array of Context factories. Top-level `flags` means definitions the unit owns or parses; `requires` means Context capabilities supplied by the command path. Required raw flags are not injected into downstream action types; expose any needed value from its owning Context.
 
-Context setup now receives the invocation's injected `stdout` and `stderr` callbacks, shared with the Command Handler. Contexts can encapsulate output behavior instead of exposing flag state for every handler to interpret:
+Context setup now receives the invocation's injected `stdout` and `stderr` callbacks, shared with the Command Action. Contexts can encapsulate output behavior instead of exposing flag state for every action to interpret:
 
 ```ts
 const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr }) => ({

--- a/.changeset/define-api-names.md
+++ b/.changeset/define-api-names.md
@@ -13,5 +13,5 @@ const target = defineArg("target", { type: "string", required: true });
 const app = new Crust("my-cli")
 	.flags(verbose, { name: "dry-run", type: "boolean" })
 	.args(target)
-	.handle(({ flags, args }) => {});
+	.action(({ flags, args }) => {});
 ```

--- a/.changeset/extension-named-hooks.md
+++ b/.changeset/extension-named-hooks.md
@@ -6,4 +6,4 @@
 
 Replace Extension `intercept(ctx, next)` and `handleError(error, ctx, next)` with named `hooks`: `preRun(ctx)`, `postRun(ctx, outcome)`, and `onError(error, ctx)`. `preRun` returns `ctx.finish()` to short-circuit successfully; `postRun` runs in reverse extension order after every settled invocation; `onError` returns `true` after rendering an `execute()` failure.
 
-Command Handlers now receive `rootCommand`, including handlers for Extension-owned commands. Migrate Extension-owned routing work into real `.handle()` callbacks.
+Command Actions now receive `rootCommand`, including actions for Extension-owned commands. Migrate Extension-owned routing work into real `.action()` callbacks.

--- a/.changeset/remove-flag-inherit.md
+++ b/.changeset/remove-flag-inherit.md
@@ -9,7 +9,7 @@ The public `FlagSnapshot.inherit` field and the internal `InheritableFlags` and 
 
 | Previous usage | Migration |
 | --- | --- |
-| `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before adding descendants. Handlers should require the derived Context capability. |
+| `inherit: true` feeds behavior shared by a subtree | Move the flag into `defineContext(name, { flags: [...] }, setup)` and attach the instance with `.provide()` before adding descendants. Actions should require the derived Context capability. |
 | Each command reads the raw flag directly | Define the descriptor once with `defineFlag()` and attach it with `.flags()` to each command that parses it. |
 
 Cross-command dependencies are capability-only: list Context factories in `requires` and consume their derived values through `ctx`. Raw flag requirements are removed.

--- a/.changeset/rename-handle-to-action.md
+++ b/.changeset/rename-handle-to-action.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/core": minor
+---
+
+Rename `.handle()` to `.action()` and the Command Handler terminology to Command Action, including `CommandSnapshot.hasHandler` to `hasAction` and the duplicate-definition reason from `duplicate-handler` to `duplicate-action`.
+
+The noun-style method matches the rest of the builder and follows Commander and cac precedent. This prerelease API is replaced directly without a compatibility shim.

--- a/.changeset/router-flag-skipping.md
+++ b/.changeset/router-flag-skipping.md
@@ -2,6 +2,6 @@
 "@crustjs/core": minor
 ---
 
-Routing now skips known flags (and their values) that appear before a subcommand name, so `app --quiet translate` runs `translate` instead of silently resolving the handler-less root and exiting 0. All parser-accepted spellings are recognized during routing: long names, `--flag=value`, `--no-<name>` negation (respecting `noNegate`), short flags and inline values, long aliases, and bundled short booleans. Unknown flags and the `--` terminator still stop routing as before.
+Routing now skips known flags (and their values) that appear before a subcommand name, so `app --quiet translate` runs `translate` instead of silently resolving the root without an action and exiting 0. All parser-accepted spellings are recognized during routing: long names, `--flag=value`, `--no-<name>` negation (respecting `noNegate`), short flags and inline values, long aliases, and bundled short booleans. Unknown flags and the `--` terminator still stop routing as before.
 
 Behavior change: recursive flags placed before a subcommand now bind to the subcommand's invocation — e.g. `app --help sub` shows `sub`'s help (previously the root's), and a root-only flag before a subcommand name is now an "unknown flag" error in the subcommand (previously a silent no-op).

--- a/.changeset/supported-command-snapshots.md
+++ b/.changeset/supported-command-snapshots.md
@@ -3,7 +3,7 @@
 "@crustjs/man": minor
 ---
 
-Add `Crust.snapshot()` as the supported API for preparing a frozen, validated Command Snapshot with Extension contributions and command definitions materialized without calling Command Handlers.
+Add `Crust.snapshot()` as the supported API for preparing a frozen, validated Command Snapshot with Extension contributions and command definitions materialized without calling Command Actions.
 
 Remove `prepareCommandSnapshot` from `@crustjs/core/tooling`. Tooling consumers should call `app.snapshot()` instead; the tooling subpath now exports the `CommandSnapshot` type for structural consumers.
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -45,8 +45,8 @@ interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx> {
   args(...defs: ArgsDef): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
   add(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
-  handle(
-    handler: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
+  action(
+    action: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
   ): CommandDefinitionBuilder;
 }
 ```
@@ -91,7 +91,7 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
 const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
-  command.args({ name: "target", type: "string", required: true }).handle(({ args, ctx }) => {
+  command.args({ name: "target", type: "string", required: true }).action(({ args, ctx }) => {
     ctx.logging.debug(`${ctx.auth.user}:${args.target}`);
   }),
 );
@@ -130,7 +130,7 @@ Aliases must be non-empty, contain no whitespace, not start with `-`, and not co
 
 ## Chaining semantics
 
-Variadic builder methods accumulate across calls: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` preserve earlier registrations and throw `DEFINITION` on duplicate names or spellings. `.meta()` shallow-merges fields. `.handle()` is set once and throws `DEFINITION` if called again.
+Variadic builder methods accumulate across calls: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` preserve earlier registrations and throw `DEFINITION` on duplicate names or spellings. `.meta()` shallow-merges fields. `.action()` is set once and throws `DEFINITION` if called again.
 
 ## `.args(...defs)`
 
@@ -201,7 +201,7 @@ provide<const Cs extends readonly ContextInstance[]>(
 >
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Handler. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";
@@ -213,7 +213,7 @@ const database = defineContext("database", ({ options }: { options: { url: strin
 
 const app = new Crust("my-cli")
   .provide(database({ url: "postgres://localhost/app" }))
-  .handle(({ ctx }) => {
+  .action(({ ctx }) => {
     ctx.database.url;
   });
 ```
@@ -244,20 +244,20 @@ Extension-owned command or flag name and alias collisions throw `DEFINITION` whe
 
 See [Extensions](/docs/guide/extensions) for authoring custom Extensions.
 
-## `.handle(handler)`
+## `.action(action)`
 
 ```ts
-handle(
-  handler: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
+action(
+  action: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
 ): Crust
 ```
 
-Defines the Command Handler once. A second `.handle()` call throws `DEFINITION` instead of replacing existing behavior. The handler runs after routing, parsing, `preRun` hooks, validation, and Context construction.
+Defines the Command Action once. A second `.action()` call throws `DEFINITION` instead of replacing existing behavior. The action runs after routing, parsing, `preRun` hooks, validation, and Context construction.
 
 ```ts
 const app = new Crust("greet")
   .args({ name: "name", type: "string", required: true })
-  .handle(({ args, flags, ctx, rawArgs, command, rootCommand, stdout, stderr }) => {
+  .action(({ args, flags, ctx, rawArgs, command, rootCommand, stdout, stderr }) => {
     stdout(`Hello, ${args.name}!`);
   });
 ```
@@ -282,7 +282,7 @@ Inline one-off commands are added the same way:
 
 ```ts
 const app = new Crust("my-cli").add(
-  defineCommand("up", (command) => command.handle(({ stdout }) => stdout("up"))),
+  defineCommand("up", (command) => command.action(({ stdout }) => stdout("up"))),
 );
 ```
 
@@ -308,7 +308,7 @@ A definition can add other definitions. Nested requirements are checked against 
 snapshot(): Promise<CommandSnapshot>
 ```
 
-Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Handlers. Rejects with a [`CrustError`](/docs/api/errors) of code `DEFINITION` when materialization or validation fails.
+Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Actions. Rejects with a [`CrustError`](/docs/api/errors) of code `DEFINITION` when materialization or validation fails.
 
 ```ts
 import type { CommandSnapshot } from "@crustjs/core/tooling";
@@ -340,7 +340,7 @@ await app.run(["Ada"], {
 });
 ```
 
-`run()` resolves after successful cleanup. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Handler, and cancellation failures are thrown unchanged.
+`run()` resolves after successful cleanup. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
 
 ## `.execute(options?)`
 
@@ -363,6 +363,6 @@ await app.execute();
 `execute()` renders a failure once through Extension `onError` hooks ending in Core's renderer, sets `process.exitCode` to `1`, and resolves. A standard `AbortError` cancellation sets exit code `130` and is offered to `onError` hooks; it renders nothing when no hook claims it.
 
 <Callout type="warn">
-  Use `.handle(handler)` to define behavior. `.run(argv, io)` is only programmatic invocation;
+  Use `.action(action)` to define behavior. `.run(argv, io)` is only programmatic invocation;
   `.execute()` is the terminal entry point. Command definitions are inert and expose neither.
 </Callout>

--- a/apps/docs/content/docs/api/errors.mdx
+++ b/apps/docs/content/docs/api/errors.mdx
@@ -89,11 +89,11 @@ Standard Schema failures are aggregated into one `VALIDATION` error. Paths are n
 
 ## Propagation boundaries
 
-`.run(argv, io)` throws the original error without rendering it or changing process status. Context and Command Handler failures are not wrapped in `CrustError`.
+`.run(argv, io)` throws the original error without rendering it or changing process status. Context and Command Action failures are not wrapped in `CrustError`.
 
 ```ts
 const failure = new Error("database unavailable");
-const app = new Crust("my-cli").handle(() => {
+const app = new Crust("my-cli").action(() => {
   throw failure;
 });
 

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -21,7 +21,7 @@ All exports on these pages come from `@crustjs/core`.
 
 ## Types
 
-See [Types](/docs/api/types) for command definitions, Command Snapshots, Command Handler contexts, Contexts, Extensions, and error detail types.
+See [Types](/docs/api/types) for command definitions, Command Snapshots, Command Action contexts, Contexts, Extensions, and error detail types.
 
 <Callout type="warn">
   `@crustjs/core/tooling` exports the supported `CommandSnapshot` type consumed by

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Types"
-description: Public command definitions, snapshots, Command Handler contexts, Contexts, and Extensions.
+description: Public command definitions, snapshots, Command Action contexts, Contexts, and Extensions.
 ---
 
 All types on this page are exported from `@crustjs/core`.
@@ -47,7 +47,7 @@ A schema-backed argument has `name`, optional `description` and `variadic`, and 
 const args = [{ name: "port", schema: z.coerce.number().int().min(1) }] as const satisfies ArgsDef;
 ```
 
-The schema receives `string | undefined`, or `string[]` for a variadic argument. It exclusively owns coercion, defaults, requiredness, choices, and validation, so `type`, `required`, `default`, `choices`, and `parse` are not available in this variant. The schema's output type reaches the Command Handler.
+The schema receives `string | undefined`, or `string[]` for a variadic argument. It exclusively owns coercion, defaults, requiredness, choices, and validation, so `type`, `required`, `default`, `choices`, and `parse` are not available in this variant. The schema's output type reaches the Command Action.
 
 An argument with neither `type` nor `schema` is a raw definition and returns the raw token value.
 
@@ -109,7 +109,7 @@ const target = defineArg("target", { type: "string", required: true });
 
 ## Command Snapshots
 
-Command Snapshots are readonly, serializable descriptions. They contain no Command Handler, parser, schema, or Context functions and are deeply frozen at public boundaries.
+Command Snapshots are readonly, serializable descriptions. They contain no Command Action, parser, schema, or Context functions and are deeply frozen at public boundaries.
 
 ### `CommandSnapshot`
 
@@ -118,7 +118,7 @@ Command Snapshots are readonly, serializable descriptions. They contain no Comma
   name="CommandSnapshot"
 />
 
-`flags` contains effective local and Context-owned flags. Command Handlers, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
+`flags` contains effective local and Context-owned flags. Command Actions, Extension hooks, and `COMMAND_NOT_FOUND` details receive snapshots rather than mutable runtime internals.
 
 ### `ArgSnapshot`
 
@@ -136,9 +136,9 @@ Snapshots omit schemas and parse functions. `URL` defaults become strings, and a
 
 <auto-type-table path="../../../../../packages/core/src/types.ts" name="InvocationIO" />
 
-The same injectable callbacks are passed to the Command Handler and every Context setup constructed for that invocation.
+The same injectable callbacks are passed to the Command Action and every Context setup constructed for that invocation.
 
-## Command Handler context
+## Command Action context
 
 ### `CrustCommandContext<A, F, Ctx>`
 
@@ -231,7 +231,7 @@ An Extension owns contributed flags. `recursive` defaults to `true`; `false` con
   name="ExtensionContext"
 />
 
-`args` and `flags` are syntax-parsed values. Extension hooks do not alter application Command Handler types.
+`args` and `flags` are syntax-parsed values. Extension hooks do not alter application Command Action types.
 
 ### `ExtensionHooks`
 
@@ -255,7 +255,7 @@ An Extension owns contributed flags. `recursive` defaults to `true`; `false` con
   name="InvocationOutcome"
 />
 
-`postRun` receives `completed` after a Command Handler completes, `finished` when an Extension short-circuits with `ctx.finish()`, or `failed` with the thrown value.
+`postRun` receives `completed` after a Command Action completes, `finished` when an Extension short-circuits with `ctx.finish()`, or `failed` with the thrown value.
 
 ## Error types
 

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -13,7 +13,7 @@ const command = new Crust("serve")
     { name: "port", type: "number", default: 3000 },
     { name: "host", type: "string", default: "localhost" },
   )
-  .handle(({ args, stdout }) => stdout(`${args.host}:${args.port}`));
+  .action(({ args, stdout }) => stdout(`${args.host}:${args.port}`));
 ```
 
 ## Required, optional, and defaulted
@@ -38,7 +38,7 @@ new Crust("copy")
     { name: "destination", type: "path", required: true },
     { name: "files", type: "path", variadic: true },
   )
-  .handle(({ args }) => {
+  .action(({ args }) => {
     args.files; // string[]
   });
 ```
@@ -57,14 +57,14 @@ Invalid choices produce a `PARSE` error.
 
 ## Standard Schemas
 
-A `schema` receives the raw positional token (`string | undefined`, or `string[]` for a variadic argument) and determines the Command Handler's output type:
+A `schema` receives the raw positional token (`string | undefined`, or `string[]` for a variadic argument) and determines the Command Action's output type:
 
 ```ts
 import { z } from "zod";
 
 new Crust("serve")
   .args({ name: "port", schema: z.coerce.number().int().positive() })
-  .handle(({ args }) => {
+  .action(({ args }) => {
     args.port; // number
   });
 ```
@@ -76,5 +76,5 @@ A schema cannot be combined with core value options — see [Schema-backed defin
 Tokens after `--` bypass argument and flag parsing and appear in `rawArgs`:
 
 ```ts
-new Crust("wrap").handle(({ rawArgs, stdout }) => stdout(rawArgs.join(" ")));
+new Crust("wrap").action(({ rawArgs, stdout }) => stdout(rawArgs.join(" ")));
 ```

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -169,7 +169,7 @@ See [Environment Variables](/docs/guide/environment) for the full env model, inc
 
 Before compiling, `crust build` validates your CLI's command definitions by running your entry file in a special validation mode. This catches definition errors — such as flag alias collisions, reserved `no-` prefix misuse, and other structural issues — **before** the binary is compiled, rather than at runtime when users invoke it.
 
-The validation subprocess asks `.execute()` to prepare and validate the full command graph, including subcommands and Extension-owned flags and commands, without executing any Command Handlers. It then exits before code after `await app.execute()` can run.
+The validation subprocess asks `.execute()` to prepare and validate the full command graph, including subcommands and Extension-owned flags and commands, without executing any Command Actions. It then exits before code after `await app.execute()` can run.
 
 If you pass `--env-file`, the validation subprocess receives the same explicit env-file inputs as the build step. This keeps Extension configuration and command definitions aligned with the final compilation.
 

--- a/apps/docs/content/docs/guide/commands.mdx
+++ b/apps/docs/content/docs/guide/commands.mdx
@@ -1,11 +1,11 @@
 ---
 title: Commands
-description: Define immutable, typed commands and Command Handlers.
+description: Define immutable, typed commands and Command Actions.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-A command combines metadata, inputs, dependencies, and one Command Handler.
+A command combines metadata, inputs, dependencies, and one Command Action.
 
 ```ts
 import { Crust } from "@crustjs/core";
@@ -14,7 +14,7 @@ const app = new Crust("greet")
   .meta({ description: "Print a greeting", aliases: ["hello"] })
   .args({ name: "name", type: "string", required: true })
   .flags({ name: "loud", type: "boolean", short: "l" })
-  .handle(({ args, flags, stdout }) => {
+  .action(({ args, flags, stdout }) => {
     const text = `Hello, ${args.name}!`;
     stdout(flags.loud ? text.toUpperCase() : text);
   });
@@ -33,9 +33,9 @@ const described = base.meta({ description: "My app" });
 
 This permits safe composition and preserves input inference through the chain.
 
-## Command Handler context
+## Command Action context
 
-`.handle()` receives a typed `CrustCommandContext`:
+`.action()` receives a typed `CrustCommandContext`:
 
 <auto-type-table
   path="../../../../../packages/core/src/command/crust.ts"
@@ -43,12 +43,12 @@ This permits safe composition and preserves input inference through the chain.
 />
 
 ```ts
-const command = new Crust("inspect").handle(({ command, stdout }) => {
+const command = new Crust("inspect").action(({ command, stdout }) => {
   stdout(command.meta.name);
 });
 ```
 
-Throw ordinary errors from Command Handlers. Crust does not wrap them.
+Throw ordinary errors from Command Actions. Crust does not wrap them.
 
 ## Invocation
 
@@ -70,6 +70,6 @@ await app.run(["Ada"], {
 `run()` throws the original error. `execute()` presents errors through Extension `onError` hooks, sets `process.exitCode`, and resolves. See [Execution Model](/docs/guide/lifecycle).
 
 <Callout type="info">
-  A command without a Command Handler is valid when it owns subcommands. Invoking it directly
+  A command without a Command Action is valid when it owns subcommands. Invoking it directly
   resolves without output; register the `help()` Extension to present the container's help instead.
 </Callout>

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -18,10 +18,10 @@ const database = defineContext("db", ({ options }: { options: { url: string } })
 
 const app = new Crust("app")
   .provide(database({ url: "postgres://localhost/app" }))
-  .handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
+  .action(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
 ```
 
-The setup receives one input object. `options` is the factory argument; `stdout` and `stderr` are the same injectable callbacks passed to the Command Handler. A zero-option factory is still a factory — invoke it with no argument:
+The setup receives one input object. `options` is the factory argument; `stdout` and `stderr` are the same injectable callbacks passed to the Command Action. A zero-option factory is still a factory — invoke it with no argument:
 
 ```ts
 const clock = defineContext("clock", () => ({ now: () => Date.now() }));
@@ -45,7 +45,7 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
 }));
 
 const deploy = defineCommand("deploy", { requires: [api] }, (command) =>
-  command.handle(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
+  command.action(({ ctx, stdout }) => stdout(ctx.api.get("/deploy"))),
 );
 
 const app = new Crust("app").provide(api()).add(deploy);
@@ -53,19 +53,19 @@ const app = new Crust("app").provide(api()).add(deploy);
 
 Both `app --api-key secret deploy` and `app deploy --api-key secret` work. The owned flag appears in help and completion at the provider and descendant commands. Crust stores a cloned definition in the Context-owned propagation channel; the original `apiKey` value is not mutated.
 
-The child requires `ctx.api`, not the raw flag. If a handler also needs the raw value, expose it from `api`; the owning Context remains the single boundary between CLI input and downstream capabilities.
+The child requires `ctx.api`, not the raw flag. If an action also needs the raw value, expose it from `api`; the owning Context remains the single boundary between CLI input and downstream capabilities.
 
 ## Lazy construction and inheritance
 
 Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
 
-Contexts are inherited by descendant commands. An added command lists the factories it depends on in `requires`, which types `ctx` in its handler:
+Contexts are inherited by descendant commands. An added command lists the factories it depends on in `requires`, which types `ctx` in its action:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
 
 const status = defineCommand("status", { requires: [database] }, (command) =>
-  command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
+  command.action(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
 const app = new Crust("app").provide(database({ url: process.env.DATABASE_URL! })).add(status);
@@ -92,7 +92,7 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
   },
 }));
 const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-  command.handle(({ ctx }) => ctx.logging.debug("deploying")),
+  command.action(({ ctx }) => ctx.logging.debug("deploying")),
 );
 const config = defineContext("config", () => ({ url: "postgres://localhost/app" }));
 
@@ -108,7 +108,7 @@ The setup input carries five fields:
 - `ctx` — the constructed values from `requires`
 - `stdout` and `stderr` — the invocation's injectable output callbacks
 
-Contexts receive the exact callbacks passed to the Command Handler, so capabilities can encapsulate output behavior such as verbose logging. Tests that inject capturing callbacks through `run()` or `execute()` observe Context output through those same callbacks.
+Contexts receive the exact callbacks passed to the Command Action, so capabilities can encapsulate output behavior such as verbose logging. Tests that inject capturing callbacks through `run()` or `execute()` observe Context output through those same callbacks.
 
 ### Requirements and construction order
 
@@ -129,7 +129,7 @@ Every factory carries `.of(value)`: it produces an instance whose setup returns 
 ```ts
 const fake = database.of({ query: (sql) => `fake: ${sql}` });
 
-const app = new Crust("app").provide(fake).handle(({ ctx, stdout }) => {
+const app = new Crust("app").provide(fake).action(({ ctx, stdout }) => {
   stdout(ctx.db.query("select 1"));
 });
 ```
@@ -151,7 +151,7 @@ const user = defineContext("user", { requires: [session] }, ({ ctx }) => {
 });
 
 const invoices = defineCommand("invoices", { requires: [user] }, (child) =>
-  child.handle(({ ctx, stdout }) => stdout(`Invoices for ${ctx.user.id}`)),
+  child.action(({ ctx, stdout }) => stdout(`Invoices for ${ctx.user.id}`)),
 );
 
 const billing = defineCommand("billing", { requires: [session] }, (command) =>
@@ -161,7 +161,7 @@ const billing = defineCommand("billing", { requires: [session] }, (command) =>
 const app = new Crust("app").provide(session()).add(billing);
 ```
 
-A throwing setup aborts the invocation before the Command Handler and disposes the values already constructed.
+A throwing setup aborts the invocation before the Command Action and disposes the values already constructed.
 
 ## Context requirements in definitions
 
@@ -169,7 +169,7 @@ A reusable command declares the Context factories it needs, and every `.add()` c
 
 ```ts
 const status = defineCommand("status", { requires: [database] }, (command) =>
-  command.handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
+  command.action(({ ctx, stdout }) => stdout(ctx.db.query("select 1"))),
 );
 
 const app = new Crust("app").provide(logging(), config(), database()).add(status);

--- a/apps/docs/content/docs/guide/development.mdx
+++ b/apps/docs/content/docs/guide/development.mdx
@@ -26,11 +26,11 @@ Use the [Testing guide](/docs/guide/testing) for `captureRun()` and `runInteract
 crust build
 ```
 
-Build validation prepares the complete command graph, including Extension-owned flags and commands, before compilation. It catches collisions and malformed definitions without running Command Handlers. Use `--no-validate` only when the validation subprocess cannot run in your environment.
+Build validation prepares the complete command graph, including Extension-owned flags and commands, before compilation. It catches collisions and malformed definitions without running Command Actions. Use `--no-validate` only when the validation subprocess cannot run in your environment.
 
 ## Inspect input
 
-A Command Handler receives validated `args`, `flags`, Context values under `ctx`, forwarded `rawArgs`, a readonly `command` snapshot, and injectable writers. Extension hooks receive syntax-parsed invocation data and Command Snapshots.
+A Command Action receives validated `args`, `flags`, Context values under `ctx`, forwarded `rawArgs`, a readonly `command` snapshot, and injectable writers. Extension hooks receive syntax-parsed invocation data and Command Snapshots.
 
 ## Project structure
 

--- a/apps/docs/content/docs/guide/environment.mdx
+++ b/apps/docs/content/docs/guide/environment.mdx
@@ -10,7 +10,7 @@ Crust adds no environment-variable abstraction. Read runtime configuration from 
 ```ts
 import { Crust } from "@crustjs/core";
 
-const deploy = new Crust("deploy").handle(({ stdout }) => {
+const deploy = new Crust("deploy").action(({ stdout }) => {
   const token = process.env.API_TOKEN;
   if (!token) throw new Error("Missing API_TOKEN");
   stdout("Deploying");

--- a/apps/docs/content/docs/guide/error-handling.mdx
+++ b/apps/docs/content/docs/guide/error-handling.mdx
@@ -32,11 +32,11 @@ A `CrustError` exposes `code`, `message`, `details`, optional `cause`, `.is(code
 
 ## Application errors pass through
 
-Errors from Command Handlers and Context construction or disposal are not wrapped:
+Errors from Command Actions and Context construction or disposal are not wrapped:
 
 ```ts
 const failure = new Error("service unavailable");
-const app = new Crust("app").handle(() => {
+const app = new Crust("app").action(() => {
   throw failure;
 });
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -21,7 +21,7 @@ See the [Extensions module](/docs/modules/extensions) for each capability's opti
 Two consequences of the root-only model:
 
 - Added definitions are materialized into ordinary command nodes before root Extensions prepare the application, so Extensions apply to every added command, inline or file-split.
-- Extension-owned flags are runtime parser inputs, not typed command capabilities. Use a Context-owned flag when downstream handlers need a typed value.
+- Extension-owned flags are runtime parser inputs, not typed command capabilities. Use a Context-owned flag when downstream actions need a typed value.
 
 ## Author an Extension
 
@@ -35,7 +35,7 @@ Two consequences of the root-only model:
 
 Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. Ordinary command flags are always local; Context-owned flags are the application-level propagation mechanism.
 
-Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare Context capabilities under `requires`; a missing capability is a `DEFINITION` error when the application prepares. Their `.handle()` callbacks receive the same typed handler context as application commands, including `rootCommand`.
+Extension commands are `defineCommand()` definitions attached at the root. `new Crust()` creates only the application root; every contributed command is a definition. Definitions may declare Context capabilities under `requires`; a missing capability is a `DEFINITION` error when the application prepares. Their `.action()` callbacks receive the same typed action context as application commands, including `rootCommand`.
 
 A contributed command name or alias cannot collide with the application or another Extension. Flag names, short forms, and long aliases cannot collide with application flags, [Context-owned flags](/docs/guide/contexts#owned-flags), or other Extensions. Every collision is a `CrustError` with code `DEFINITION`; Crust never warns and skips a contribution.
 
@@ -47,7 +47,7 @@ Hooks run after routing and syntax parsing. Where each hook sits in the invocati
 
 ### `preRun`
 
-`preRun(ctx)` runs before validation, Contexts, and the Command Handler, in `.extend()` order. Return `ctx.finish()` to end the invocation successfully and skip the remaining work:
+`preRun(ctx)` runs before validation, Contexts, and the Command Action, in `.extend()` order. Return `ctx.finish()` to end the invocation successfully and skip the remaining work:
 
 <include lang="ts">../../../examples/extensions/hooks.ts#cached</include>
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -13,14 +13,14 @@ const command = new Crust("serve")
     { name: "port", type: "number", default: 3000, short: "p" },
     { name: "verbose", type: "boolean", short: "v" },
   )
-  .handle(({ flags, stdout }) => stdout(`${flags.port} ${flags.verbose ?? false}`));
+  .action(({ flags, stdout }) => stdout(`${flags.port} ${flags.verbose ?? false}`));
 ```
 
 See [`FlagDef`](/docs/api/types#flagdef) for the complete definition.
 
 Repeated `.flags()` calls accumulate: `.flags(a).flags(b)` defines both flags. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
 
-Builder chaining follows the same rule for every variadic method: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` accumulate and reject duplicates. `.meta()` shallow-merges fields, while `.handle()` is set once and throws if called again.
+Builder chaining follows the same rule for every variadic method: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` accumulate and reject duplicates. `.meta()` shallow-merges fields, while `.action()` is set once and throws if called again.
 
 ## Aliases and negation
 
@@ -41,7 +41,7 @@ Boolean flags support `--no-<spelling>` negation for the canonical name and ever
 )
 ```
 
-Both values are non-optional in the Command Handler. Other flags include `undefined` in their inferred type.
+Both values are non-optional in the Command Action. Other flags include `undefined` in their inferred type.
 
 ## Repeated values
 
@@ -77,7 +77,7 @@ This keeps one source of truth without adding the flag to commands that do not u
 
 ## Propagating flags with Contexts
 
-When one flag configures shared behavior for a command subtree, let a Context own and consume it. Handlers depend on the derived capability rather than the raw flag:
+When one flag configures shared behavior for a command subtree, let a Context own and consume it. Actions depend on the derived capability rather than the raw flag:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -90,17 +90,17 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
 }));
 
 const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-  command.handle(({ ctx }) => ctx.logging.debug("deploying")),
+  command.action(({ ctx }) => ctx.logging.debug("deploying")),
 );
 
 const app = new Crust("app").provide(logging()).add(deploy);
 ```
 
-The Context declares, parses, and consumes `--verbose`, then wraps the invocation's injected `stderr` as behavior. Handlers call the logging capability without re-checking the flag. Renaming the flag or deriving log levels later changes the Context rather than every handler.
+The Context declares, parses, and consumes `--verbose`, then wraps the invocation's injected `stderr` as behavior. Actions call the logging capability without re-checking the flag. Renaming the flag or deriving log levels later changes the Context rather than every action.
 
 Context-owned flags are parsed and shown in help at the provider and later-added descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
-If a handler needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into an added handler's types.
+If an action needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into an added action's types.
 
 ## Standard Schemas
 
@@ -111,7 +111,7 @@ import { z } from "zod";
 
 new Crust("serve")
   .flags({ name: "port", type: "string", schema: z.coerce.number().int() })
-  .handle(({ flags }) => {
+  .action(({ flags }) => {
     flags.port; // number
   });
 ```

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -29,19 +29,19 @@ It requires explicit argv, honors injected writers, throws the original error, d
 1. **Prepare definitions** — apply Extensions and reject command, flag, and alias collisions, including collisions with Context-owned flags (application and Context-only collisions are rejected earlier by `.flags()` or `.provide()`).
 2. **Route** — resolve the command path.
 3. **Parse syntax** — consume positional and flag tokens.
-4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Handler.
+4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Action.
 5. **Validate structure** — enforce required values, choices, and other core rules.
 6. **Apply schemas** — validate and transform every schema-backed input, aggregating issues.
 7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared capability requirements (registration order among independent Contexts), passing each setup only its validated owned flags.
-8. **Run the Command Handler**.
+8. **Run the Command Action**.
 9. **Dispose Contexts** — run `Symbol.dispose` or `Symbol.asyncDispose` in reverse construction order, including after failure.
 10. **Run `postRun` hooks** — invoke every Extension hook in reverse `.extend()` order with the completed, finished, or failed outcome. This is the invocation-level `finally` slot.
 
 ## Error flow
 
-Definition, routing, and parse failures occur before `preRun` and `postRun`. A failure from `preRun`, validation, schema application, Context construction or disposal, or the Command Handler still runs every `postRun` hook. The original failure wins over cleanup failures; after a successful or finished invocation, the first cleanup failure fails the invocation after remaining hooks run.
+Definition, routing, and parse failures occur before `preRun` and `postRun`. A failure from `preRun`, validation, schema application, Context construction or disposal, or the Command Action still runs every `postRun` hook. The original failure wins over cleanup failures; after a successful or finished invocation, the first cleanup failure fails the invocation after remaining hooks run.
 
-With `run()`, the original value is thrown to the caller. Handler and Context failures are never wrapped in `CrustError`.
+With `run()`, the original value is thrown to the caller. Action and Context failures are never wrapped in `CrustError`.
 
 With `execute()`, Crust first establishes a nonzero status, then invokes Extension `onError` hooks in `.extend()` order. A hook returns `true` when it rendered the failure; falsy results continue to the next hook and then Core's default renderer. `onError` is presentation only and never runs for `run()`.
 
@@ -53,6 +53,6 @@ Choose the mechanism that matches the setup's scope:
 
 - use a Context for command-specific setup and native disposal
 - use Extension `preRun` and `postRun` for app-wide behavior around an invocation
-- keep ordinary local setup in the Command Handler when it is not reusable
+- keep ordinary local setup in the Command Action when it is not reusable
 
 This keeps dependency construction lazy and guarantees reverse-order cleanup.

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -14,7 +14,7 @@ const app = new Crust("git").add(
   defineCommand("clone", (command) =>
     command
       .args({ name: "url", type: "url", required: true })
-      .handle(({ args, stdout }) => stdout(`clone ${args.url}`)),
+      .action(({ args, stdout }) => stdout(`clone ${args.url}`)),
   ),
 );
 ```
@@ -23,7 +23,7 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition lists the Context capabilities it expects from its parent in the `requires` array. The recipe builder and handler's `ctx` are typed from those factories:
+A definition lists the Context capabilities it expects from its parent in the `requires` array. The recipe builder and action's `ctx` are typed from those factories:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -39,7 +39,7 @@ const repository = defineContext("repository", () => ({
 }));
 
 const clone = defineCommand("clone", { requires: [logging, repository] }, (command) =>
-  command.args({ name: "url", type: "url", required: true }).handle(({ args, ctx, stdout }) => {
+  command.args({ name: "url", type: "url", required: true }).action(({ args, ctx, stdout }) => {
     ctx.logging.debug(`cloning ${args.url}`);
     stdout(ctx.repository.defaultBranch);
   }),
@@ -65,7 +65,7 @@ const environment = defineFlag("environment", { type: "string" });
 const deployment = defineContext("deployment", { flags: [environment] }, ({ flags }) => flags);
 
 const status = defineCommand("status", { requires: [logging, deployment] }, (command) =>
-  command.handle(({ ctx }) => {
+  command.action(({ ctx }) => {
     ctx.logging.debug(`environment: ${ctx.deployment.environment}`);
   }),
 );
@@ -79,7 +79,7 @@ const app = new Crust("app").provide(logging()).add(deploy);
 
 ## Context inheritance
 
-Adding materializes a fresh command scope seeded with the parent's current Context path. The added handler and all nested descendants receive those Context values at runtime; list factories in `requires` to see them in the handler's types.
+Adding materializes a fresh command scope seeded with the parent's current Context path. The added action and all nested descendants receive those Context values at runtime; list factories in `requires` to see them in the action's types.
 
 Finalize `.provide()` calls on the parent builder before `.add()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into descendants added later. Later fluent calls return a new builder and do not backfill a definition that was already added.
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -40,14 +40,14 @@ import { database } from "./contexts.ts";
 
 const app = new Crust("my-cli")
   .provide(database.of({ query: (sql) => `fake: ${sql}` }))
-  .handle(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
+  .action(({ ctx, stdout }) => stdout(ctx.db.query("select 1")));
 ```
 
 See [Contexts](/docs/guide/contexts#test-doubles-with-of).
 
 ## Test interactive commands
 
-Use `runInteractive()` when a handler renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
+Use `runInteractive()` when an action renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
 
 ```ts
 import { expect, test } from "bun:test";

--- a/apps/docs/content/docs/guide/types.mdx
+++ b/apps/docs/content/docs/guide/types.mdx
@@ -11,7 +11,7 @@ Arguments and flags support `string`, `number`, `boolean`, `url`, `path`, and `j
 new Crust("inspect")
   .args({ name: "file", type: "path", required: true })
   .flags({ name: "config", type: "json" })
-  .handle(({ args, flags }) => {
+  .action(({ args, flags }) => {
     args.file; // string
     flags.config; // unknown
   });
@@ -31,7 +31,7 @@ Use `parse` for a small synchronous transformation when a full schema is unneces
 })
 ```
 
-The Command Handler receives the return type. A parser must be synchronous.
+The Command Action receives the return type. A parser must be synchronous.
 
 ## Schema-backed definitions
 
@@ -48,7 +48,7 @@ const command = new Crust("serve")
     { name: "host", type: "string", schema: z.string().default("localhost") },
     { name: "secure", type: "boolean", schema: z.boolean().default(false) },
   )
-  .handle(({ args, flags }) => {
+  .action(({ args, flags }) => {
     args.port; // number
     flags.host; // string
     flags.secure; // boolean
@@ -91,7 +91,7 @@ import { z } from "zod";
 
 const Port = z.coerce.number().int().min(1).max(65535);
 
-new Crust("serve").flags({ name: "port", type: "string", schema: Port }).handle(({ flags }) => {
+new Crust("serve").flags({ name: "port", type: "string", schema: Port }).action(({ flags }) => {
   flags.port; // number
 });
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -33,7 +33,7 @@ $ greet --help
 ## Philosophy
 
 - **One way to do it.** One starter pattern. `defineCommand()` for every command; `new Crust()` appears exactly once, at the root.
-- **Inference over annotation.** Types flow from definitions to handlers. No decorators, no codegen, no manual generics.
+- **Inference over annotation.** Types flow from definitions to actions. No decorators, no codegen, no manual generics.
 - **Plain values, immutable builders.** Definitions and Extensions are frozen data; every fluent call returns a new builder.
 - **Fail loud at definition time.** Collisions and malformed definitions are `DEFINITION` errors at startup and in `crust build` — never warn-and-skip.
 - **Standards over lock-in.** Standard Schema for validation, `NO_COLOR`/`FORCE_COLOR` and OSC 8 conventions, native `Symbol.dispose` cleanup.
@@ -43,7 +43,7 @@ $ greet --help
 
 - **TypeScript-first** — Immutable, chainable builders with args and flags fully inferred from your definitions. No manual type annotations, just autocomplete that works.
 - **Compile-time validation** — Flag alias collisions and variadic arg mistakes are caught before your code runs
-- **Schema-first validation** — Place any Standard Schema on an argument or flag definition; the handler receives its output type
+- **Schema-first validation** — Place any Standard Schema on an argument or flag definition; the action receives its output type
 - **Composable, not monolithic** — Every capability ships as its own module with zero runtime dependencies in core. Install only what you need — `@crustjs/core` for the framework, `@crustjs/extensions` for official extensions, `@crustjs/crust` for build tooling.
 - **Extensions** — App-wide capabilities like help, version, completion, and update notices, attached once at the root
 - **Contexts** — Named command dependencies created lazily for the resolved command path

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -3,7 +3,7 @@ title: "Core"
 description: Supported command-authoring runtime for Crust applications and Extensions.
 ---
 
-`@crustjs/core` defines commands, routes and validates argv, constructs Contexts, applies Extensions, and runs Command Handlers.
+`@crustjs/core` defines commands, routes and validates argv, constructs Contexts, applies Extensions, and runs Command Actions.
 
 ## Install
 
@@ -26,7 +26,7 @@ const app = new Crust("deploy")
   .extend(help())
   .flags({ name: "verbose", type: "boolean", short: "v" })
   .provide(config({ environment: "production" }))
-  .handle(({ flags, ctx, stdout }) => {
+  .action(({ flags, ctx, stdout }) => {
     stdout(`${ctx.config.environment}: verbose=${flags.verbose ?? false}`);
   });
 
@@ -54,7 +54,7 @@ Downstream commands and Contexts list `api` in their `requires` array and consum
 
 | Export                                | Description                                                                                                                                         |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.add()`, `.handle()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
+| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.add()`, `.action()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
 | [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                                                   |
 | `defineContext(name, config?, setup)` | Define a named Context factory with optional requirements and owned flags; setup receives invocation I/O                                            |
 | `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                   |
@@ -85,7 +85,7 @@ See [Types](/docs/api/types) for field-level definitions.
 
 | Type                  | Description                                                          |
 | --------------------- | -------------------------------------------------------------------- |
-| `CrustCommandContext` | Typed context passed to a Command Handler, including `rootCommand`   |
+| `CrustCommandContext` | Typed context passed to a Command Action, including `rootCommand`    |
 | `InvocationIO`        | Injectable `stdout` and `stderr` callbacks shared with Context setup |
 | `CommandSnapshot`     | Readonly, serializable command description                           |
 | `ArgSnapshot`         | Serializable argument projection                                     |
@@ -101,7 +101,7 @@ See [Types](/docs/api/types) for field-level definitions.
 | `ContextRequirements` | Context capabilities required from a command path                           |
 | `ContextConfig`       | Owned flags plus capability dependencies under `requires`                   |
 | `ContextSetup`        | Typed setup input: `options`, `flags`, dependency `ctx`, and invocation I/O |
-| `ContextMap`          | Record shape used for inferred Command Handler `ctx` values                 |
+| `ContextMap`          | Record shape used for inferred Command Action `ctx` values                  |
 
 ## Extension types
 
@@ -129,7 +129,7 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Tooling subpath
 
-Call `app.snapshot()` to prepare a frozen, validated Command Snapshot for man-page, skill, and build generators. It materializes Extension contributions and command definitions without calling Command Handlers.
+Call `app.snapshot()` to prepare a frozen, validated Command Snapshot for man-page, skill, and build generators. It materializes Extension contributions and command definitions without calling Command Actions.
 
 `@crustjs/core/tooling` exports the `CommandSnapshot` type plus `snapshotCommand`, `buildCommandDocumentation`, its documentation model types, and the validation environment constants for lockstep first-party tooling. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), visible children, argument tokens, and every accepted flag spelling. Except for the `CommandSnapshot` type consumed by `app.snapshot()`, helpers on this subpath are intended for first-party tooling that moves in lockstep with core.
 

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -18,7 +18,7 @@ const app = new Crust("my-cli")
     defineCommand("build", (command) =>
       command
         .flags({ name: "target", type: "string", choices: ["browser", "bun", "node"] })
-        .handle(() => {}),
+        .action(() => {}),
     ),
   );
 

--- a/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
+++ b/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
@@ -11,7 +11,7 @@ import { didYouMean } from "@crustjs/extensions";
 
 const app = new Crust("my-cli")
   .extend(didYouMean())
-  .add(defineCommand("deploy", (command) => command.handle(() => {})));
+  .add(defineCommand("deploy", (command) => command.action(() => {})));
 
 await app.execute();
 ```

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -12,7 +12,7 @@ import { help } from "@crustjs/extensions";
 const app = new Crust("my-cli")
   .meta({ description: "My CLI" })
   .extend(help())
-  .handle(() => {});
+  .action(() => {});
 
 await app.execute();
 ```
@@ -27,7 +27,7 @@ my-cli deploy --help
 function help(): Extension;
 ```
 
-`help()` owns a recursive boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Handler also displays help.
+`help()` owns a recursive boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Action also displays help.
 
 The renderer includes usage, visible subcommands, positional arguments, effective flags, aliases, defaults, and choices. Commands with `meta.hidden: true` stay routable but are omitted from listings.
 

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -34,7 +34,7 @@ const app = new Crust("my-cli")
     completion({ version: pkg.version }),
     updateNotifier({ packageName: pkg.name, currentVersion: pkg.version }),
   )
-  .handle(({ stdout }) => stdout("Hello"));
+  .action(({ stdout }) => stdout("Hello"));
 
 await app.execute();
 ```
@@ -48,7 +48,7 @@ await app.execute();
 | [`completion(options?)`](/docs/modules/extensions/completion)         | Static bash, zsh, and fish completion command     |
 | [`didYouMean(options?)`](/docs/modules/extensions/did-you-mean)       | `COMMAND_NOT_FOUND` presentation                  |
 | [`noColor()`](/docs/modules/extensions/no-color)                      | Recursive `--color` / `--no-color` flag           |
-| [`updateNotifier(options)`](/docs/modules/extensions/update-notifier) | Post-handler npm update notice                    |
+| [`updateNotifier(options)`](/docs/modules/extensions/update-notifier) | Post-action npm update notice                     |
 
 These factories return plain `Extension` values. Contributions are application-wide. Extension-owned command, flag, short-name, or alias collisions with the application or another Extension are `DEFINITION` errors.
 

--- a/apps/docs/content/docs/modules/extensions/no-color.mdx
+++ b/apps/docs/content/docs/modules/extensions/no-color.mdx
@@ -7,7 +7,7 @@ description: Control terminal color with a recursive Extension flag.
 import { Crust } from "@crustjs/core";
 import { noColor } from "@crustjs/extensions";
 
-const app = new Crust("my-cli").extend(noColor()).handle(() => {});
+const app = new Crust("my-cli").extend(noColor()).action(() => {});
 
 await app.execute();
 ```

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -17,7 +17,7 @@ const app = new Crust("my-cli")
       currentVersion: pkg.version,
     }),
   )
-  .handle(({ stdout }) => stdout("Done"));
+  .action(({ stdout }) => stdout("Done"));
 
 await app.execute();
 ```
@@ -33,7 +33,7 @@ function updateNotifier(options: UpdateNotifierOptions): Extension;
   name="UpdateNotifierOptions"
 />
 
-The `postRun` hook checks for an update only after a Command Handler completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written through the invocation's stderr callback (process stderr under `execute()`). Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
+The `postRun` hook checks for an update only after a Command Action completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written through the invocation's stderr callback (process stderr under `execute()`). Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
 
 Without `cache`, the check occurs once per process execution. With `cache`, a fresh cached result is reused for `intervalMs` and duplicate notices for the same version are suppressed.
 

--- a/apps/docs/content/docs/modules/extensions/version.mdx
+++ b/apps/docs/content/docs/modules/extensions/version.mdx
@@ -10,7 +10,7 @@ import { Crust } from "@crustjs/core";
 import { version } from "@crustjs/extensions";
 import pkg from "../package.json";
 
-const app = new Crust("my-cli").extend(version(pkg.version)).handle(() => {});
+const app = new Crust("my-cli").extend(version(pkg.version)).action(() => {});
 
 await app.execute();
 ```
@@ -38,7 +38,7 @@ The default value is `"0.0.0"`. Pass a function to resolve the version only when
 const app = new Crust("my-cli").extend(version(() => process.env.APP_VERSION ?? "dev"));
 ```
 
-`version()` owns a root-only boolean `version` flag with short name `v`. It prints through `ctx.stdout` and short-circuits the Command Handler only for a root invocation with `--version` or `-v`; subcommands do not receive the flag.
+`version()` owns a root-only boolean `version` flag with short name `v`. It prints through `ctx.stdout` and short-circuits the Command Action only for a root invocation with `--version` or `-v`; subcommands do not receive the flag.
 
 ## Options
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -129,7 +129,7 @@ const app = new Crust("my-cli")
       ],
     }),
   )
-  .handle(() => {});
+  .action(() => {});
 ```
 
 The `CustomSkillConfig` shape is generated from the exported type:
@@ -258,7 +258,7 @@ const deploy = defineCommand("deploy", (command) =>
   annotate(command.meta({ description: "Deploy the application" }), [
     "Prefer preview modes before running destructive operations.",
     "Ask for confirmation before production changes.",
-  ]).handle(() => {
+  ]).action(() => {
     // ...
   }),
 );
@@ -397,7 +397,7 @@ import { Crust } from "@crustjs/core";
 
 export const rootCommand = new Crust("my-cli")
   .meta({ description: "My CLI tool" })
-  .handle(() => console.log("Hello from my-cli!"));
+  .action(() => console.log("Hello from my-cli!"));
 
 if (import.meta.main) await rootCommand.execute();
 ```

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -3,7 +3,7 @@ title: Testing
 description: Test Crust applications with captured output and fake interactive terminals.
 ---
 
-`@crustjs/testing` provides application-level test helpers for `@crustjs/core`. It captures ordinary command output and drives handlers that use built-in `@crustjs/prompts` prompts.
+`@crustjs/testing` provides application-level test helpers for `@crustjs/core`. It captures ordinary command output and drives actions that use built-in `@crustjs/prompts` prompts.
 
 ## Install
 

--- a/apps/docs/examples/extensions/diagnostics.ts
+++ b/apps/docs/examples/extensions/diagnostics.ts
@@ -13,7 +13,7 @@ export const diagnostics = defineExtension("diagnostics", {
     defineCommand("doctor", (command) =>
       command
         .meta({ description: "Check the installation" })
-        .handle(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
+        .action(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
     ),
   ],
   hooks: {

--- a/apps/docs/examples/landing/greet.ts
+++ b/apps/docs/examples/landing/greet.ts
@@ -5,7 +5,7 @@ const app = new Crust("greet")
   .extend(help(), version("1.0.0"))
   .args({ name: "name", type: "string", default: "world" })
   .flags({ name: "shout", type: "boolean", short: "s" })
-  .handle(({ args, flags, stdout }) => {
+  .action(({ args, flags, stdout }) => {
     // args.name: string · flags.shout: boolean | undefined
     const line = `Hello, ${args.name}!`;
     stdout(flags.shout ? line.toUpperCase() : line);

--- a/apps/docs/examples/quick-start/invoke.ts
+++ b/apps/docs/examples/quick-start/invoke.ts
@@ -3,7 +3,7 @@ import { Crust } from "@crustjs/core";
 const app = new Crust("my-cli")
   .args({ name: "name", type: "string", default: "world" })
   .flags({ name: "greet", type: "string", default: "Hello", short: "g" })
-  .handle(({ args, flags, stdout }) => stdout(`${flags.greet}, ${args.name}!`));
+  .action(({ args, flags, stdout }) => stdout(`${flags.greet}, ${args.name}!`));
 
 //#region run
 const output: string[] = [];

--- a/apps/docs/examples/quick-start/starter.ts
+++ b/apps/docs/examples/quick-start/starter.ts
@@ -19,7 +19,7 @@ const app = new Crust("my-cli")
     default: "Hello",
     short: "g",
   })
-  .handle(({ args, flags, stdout }) => {
+  .action(({ args, flags, stdout }) => {
     stdout(`${flags.greet}, ${args.name}!`);
   });
 

--- a/apps/docs/examples/quick-start/subcommand.ts
+++ b/apps/docs/examples/quick-start/subcommand.ts
@@ -7,6 +7,6 @@ export const app = new Crust("my-cli")
     defineCommand("build", (command) =>
       command
         .flags({ name: "minify", type: "boolean" })
-        .handle(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
+        .action(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
     ),
   );

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -6,7 +6,7 @@ export const greetCommand = defineCommand("greet", { requires: [logger] }, (comm
   command
     .args({ name: "name", type: "string", default: "world" })
     .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })
-    .handle(({ args, flags, ctx, stdout }) => {
+    .action(({ args, flags, ctx, stdout }) => {
       ctx.logger.write("Preparing greeting");
       stdout(`${flags.greeting}, ${args.name}!`);
     }),

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -215,7 +215,7 @@ const app = new Crust("greet")
   .extend(help())
   .args({ name: "name", type: "string" })
   .flags({ name: "shout", type: "boolean", short: "s" })
-  .handle(({ args, flags, stdout }) => {
+  .action(({ args, flags, stdout }) => {
     const msg = \`Hello, \${args.name}!\`;
     stdout(flags.shout ? msg.toUpperCase() : msg);
   });

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -24,7 +24,7 @@ describe("public beta API", () => {
 			cmd
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "env", type: "string", default: "prod" })
-				.handle(({ args, flags, ctx }) => {
+				.action(({ args, flags, ctx }) => {
 					type _target = Expect<Equal<typeof args.target, string>>;
 					type _env = Expect<Equal<typeof flags.env, string>>;
 					type _verbose = Expect<Equal<typeof ctx.logging.verbose, boolean>>;
@@ -48,7 +48,7 @@ describe("public beta API", () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", () => ({ user: "chenxin" }));
 		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
-			command.args({ name: "target", type: "string", required: true }).handle(({ args, ctx }) => {
+			command.args({ name: "target", type: "string", required: true }).action(({ args, ctx }) => {
 				type _target = Expect<Equal<typeof args.target, string>>;
 				type _user = Expect<Equal<typeof ctx.auth.user, string>>;
 				seen.push(`${ctx.auth.user}:${args.target}`);
@@ -75,7 +75,7 @@ describe("public beta API", () => {
 			},
 		});
 
-		const app = new Crust("my-cli").extend(version).handle(({ flags, ctx }) => {
+		const app = new Crust("my-cli").extend(version).action(({ flags, ctx }) => {
 			type _ctx = Expect<Equal<typeof ctx, Readonly<{}>>>;
 			expect((flags as Record<string, unknown>).version).toBe(true);
 		});
@@ -92,7 +92,7 @@ describe("public beta API", () => {
 				debug: { type: "boolean" },
 			},
 		});
-		const app = new Crust("repeat").extend(debug).handle(({ flags }) => {
+		const app = new Crust("repeat").extend(debug).action(({ flags }) => {
 			if ((flags as Record<string, unknown>).debug) {
 				runCount++;
 			}

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -52,7 +52,7 @@ describe("defineContext()", () => {
 		db.of({ wrong: true });
 
 		const seen: string[] = [];
-		const app = new Crust("cli").provide(fake).handle(({ ctx }) => {
+		const app = new Crust("cli").provide(fake).action(({ ctx }) => {
 			seen.push(ctx.db.url);
 		});
 		await app.run([]);
@@ -67,7 +67,7 @@ describe("Crust .provide()", () => {
 			url: options.url,
 		}));
 
-		const app = new Crust("cli").provide(db({ url: "memory://x" })).handle(({ ctx }) => {
+		const app = new Crust("cli").provide(db({ url: "memory://x" })).action(({ ctx }) => {
 			seen.push(ctx.db.url);
 		});
 
@@ -80,7 +80,7 @@ describe("Crust .provide()", () => {
 		const a = defineContext("a", () => "value-a");
 		const b = defineContext("b", () => "value-b");
 
-		const app = new Crust("cli").provide(a(), b()).handle(({ ctx }) => {
+		const app = new Crust("cli").provide(a(), b()).action(({ ctx }) => {
 			seen.push(`${ctx.a}:${ctx.b}`);
 			type _A = Assert<IsEqual<typeof ctx.a, string>>;
 			type _B = Assert<IsEqual<typeof ctx.b, string>>;
@@ -116,7 +116,7 @@ describe("Crust .provide()", () => {
 		expect(() =>
 			new Crust("cli")
 				.provide(parentDb())
-				.add(defineCommand("sub", (cmd) => cmd.provide(childDb()).handle(() => {}))),
+				.add(defineCommand("sub", (cmd) => cmd.provide(childDb()).action(() => {}))),
 		).toThrow(CrustError);
 	});
 
@@ -124,7 +124,7 @@ describe("Crust .provide()", () => {
 		const parentDb = defineContext("db", () => "parent");
 		const nestedDb = defineContext("db", () => "nested");
 		const sub = defineCommand("sub", { requires: [parentDb] }, (command) =>
-			command.add(defineCommand("g", (child) => child.provide(nestedDb()).handle(() => {}))),
+			command.add(defineCommand("g", (child) => child.provide(nestedDb()).action(() => {}))),
 		);
 
 		expect(() => new Crust("cli").provide(parentDb()).add(sub)).toThrow(CrustError);
@@ -136,7 +136,7 @@ describe("Crust .provide()", () => {
 		const sub = defineCommand("sub", { requires: [db] }, (command) =>
 			command.add(
 				defineCommand("g", { requires: [db] }, (child) =>
-					child.handle(({ ctx }) => {
+					child.action(({ ctx }) => {
 						seen.push(ctx.db);
 					}),
 				),
@@ -158,8 +158,8 @@ describe("Crust .provide()", () => {
 
 		const app = new Crust("cli")
 			.provide(lazy())
-			.add(defineCommand("a", (cmd) => cmd.handle(() => {})))
-			.add(defineCommand("b", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("a", (cmd) => cmd.action(() => {})))
+			.add(defineCommand("b", (cmd) => cmd.action(() => {})));
 
 		// Resolving "a" builds the inherited context once; "b" not executed
 		await app.run(["a"]);
@@ -173,7 +173,7 @@ describe("Crust .provide()", () => {
 			return "late";
 		});
 		const app = new Crust("cli")
-			.add(defineCommand("status", (command) => command.handle(() => {})))
+			.add(defineCommand("status", (command) => command.action(() => {})))
 			.provide(late());
 
 		await app.run(["status"]);
@@ -203,8 +203,8 @@ describe("Context-owned flags", () => {
 			aliases: ["token"],
 		});
 
-		const app = new Crust("cli").provide(instance).handle(({ flags, ctx }) => {
-			type _HandlerApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
+		const app = new Crust("cli").provide(instance).action(({ flags, ctx }) => {
+			type _ActionApiKey = Assert<IsEqual<(typeof flags)["api-key"], string | undefined>>;
 			seen.push(ctx.auth.apiKey);
 		});
 		await app.run(["--api-key", "secret"]);
@@ -223,7 +223,7 @@ describe("Context-owned flags", () => {
 
 		await new Crust("cli")
 			.provide(server())
-			.handle(() => {})
+			.action(() => {})
 			.run(["--port", "8080"]);
 
 		expect(seen).toEqual([8080]);
@@ -243,13 +243,13 @@ describe("Context-owned flags", () => {
 
 		await new Crust("cli")
 			.provide(auth(), location())
-			.handle(() => {})
+			.action(() => {})
 			.run(["--api-key", "secret", "--region", "us"]);
 
 		expect(seen).toEqual([["api-key"], ["region"]]);
 	});
 
-	it("builds behavior capabilities with the handler's injected io", async () => {
+	it("builds behavior capabilities with the action's injected io", async () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		let setupStdout: ((text: string) => void) | undefined;
 		let setupStderr: ((text: string) => void) | undefined;
@@ -267,7 +267,7 @@ describe("Context-owned flags", () => {
 		const messages: string[] = [];
 		const stdout = (_message: string) => {};
 		const stderr = (message: string) => messages.push(message);
-		const app = new Crust("cli").provide(logging()).handle(({ ctx, stdout, stderr }) => {
+		const app = new Crust("cli").provide(logging()).action(({ ctx, stdout, stderr }) => {
 			expect(setupStdout).toBe(stdout);
 			expect(setupStderr).toBe(stderr);
 			ctx.logging.debug("debug");
@@ -283,7 +283,7 @@ describe("Context-owned flags", () => {
 			apiKey: flags["api-key"],
 		}));
 		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				seen.push(String(ctx.auth.apiKey));
 			}),
 		);
@@ -312,7 +312,7 @@ describe("Context-owned flags", () => {
 		const app = new Crust("cli")
 			.provide(auth())
 			.flags({ name: "verbose", type: "boolean" })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				expect(flags["api-key"]).toBe("secret");
 				expect(flags.verbose).toBe(true);
 			});
@@ -327,7 +327,7 @@ describe("Context-owned flags", () => {
 		}));
 		const branch = (name: string) =>
 			defineCommand(name, (command) =>
-				command.provide(auth()).handle(({ ctx }) => {
+				command.provide(auth()).action(({ ctx }) => {
 					seen.push(`${name}:${ctx.auth.apiKey}`);
 				}),
 			);
@@ -346,7 +346,7 @@ describe("Context-owned flags", () => {
 
 		await new Crust("cli")
 			.provide(fake)
-			.handle(({ flags, ctx }) => {
+			.action(({ flags, ctx }) => {
 				expect(flags["api-key"]).toBe("fake-key");
 				expect(ctx.auth.real).toBe(false);
 			})
@@ -420,9 +420,9 @@ describe("Context capability requirements (topological construction)", () => {
 			return "crust";
 		});
 
-		const app = new Crust("cli").provide(config(), client(), workspace()).handle(({ ctx }) => {
+		const app = new Crust("cli").provide(config(), client(), workspace()).action(({ ctx }) => {
 			type _Workspace = Assert<IsEqual<typeof ctx.workspace, string>>;
-			order.push(`handler:${ctx.workspace}`);
+			order.push(`action:${ctx.workspace}`);
 		});
 
 		await app.run([]);
@@ -431,7 +431,7 @@ describe("Context capability requirements (topological construction)", () => {
 			"config",
 			"client:https://api.example.com",
 			"workspace:https://api.example.com",
-			"handler:crust",
+			"action:crust",
 		]);
 	});
 
@@ -449,12 +449,12 @@ describe("Context capability requirements (topological construction)", () => {
 		await new Crust("cli")
 			.provide(client())
 			.provide(config())
-			.handle(() => {
-				order.push("handler");
+			.action(() => {
+				order.push("action");
 			})
 			.run([]);
 
-		expect(order).toEqual(["config", "client", "handler"]);
+		expect(order).toEqual(["config", "client", "action"]);
 	});
 
 	it("types ctx in setup from the declared dependency factories", () => {
@@ -471,7 +471,7 @@ describe("Context capability requirements (topological construction)", () => {
 		const config = defineContext("config", () => ({}));
 		const client = defineContext("client", { requires: [config] }, () => ({}));
 
-		const app = new Crust("cli").provide(client()).handle(() => {});
+		const app = new Crust("cli").provide(client()).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({
 			code: "DEFINITION",
@@ -488,7 +488,7 @@ describe("Context capability requirements (topological construction)", () => {
 		(a as { requiredCtx: readonly string[] }).requiredCtx = ["b"];
 		(b as { requiredCtx: readonly string[] }).requiredCtx = ["a"];
 
-		const app = new Crust("cli").provide(a, b).handle(() => {});
+		const app = new Crust("cli").provide(a, b).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({
 			code: "DEFINITION",
@@ -502,7 +502,7 @@ describe("Context capability requirements (topological construction)", () => {
 			id: ctx.session.userId,
 		}));
 		const account = defineCommand("account", { requires: [session] }, (command) =>
-			command.provide(user()).handle(({ ctx }) => {
+			command.provide(user()).action(({ ctx }) => {
 				type _User = Assert<IsEqual<typeof ctx.user, { id: string }>>;
 				expect(ctx.user).toEqual({ id: "yan" });
 			}),
@@ -530,7 +530,7 @@ describe("Context disposal", () => {
 		const app = new Crust("cli")
 			.provide(first())
 			.provide(second())
-			.handle(() => {
+			.action(() => {
 				log.push("run");
 			});
 
@@ -555,7 +555,7 @@ describe("Context disposal", () => {
 		// derived provided first, but base constructs first — so base disposes last
 		await new Crust("cli")
 			.provide(derived(), base())
-			.handle(() => {
+			.action(() => {
 				log.push("run");
 			})
 			.run([]);
@@ -573,18 +573,18 @@ describe("Context disposal", () => {
 
 		await new Crust("cli")
 			.provide(sync())
-			.handle(() => {})
+			.action(() => {})
 			.run([]);
 
 		expect(log).toEqual(["dispose:sync"]);
 	});
 
-	it("disposes after a handler failure and rethrows the original error", async () => {
+	it("disposes after an action failure and rethrows the original error", async () => {
 		const log: string[] = [];
 		const res = disposableContext("res", log);
-		const boom = new Error("handler failed");
+		const boom = new Error("action failed");
 
-		const app = new Crust("cli").provide(res()).handle(() => {
+		const app = new Crust("cli").provide(res()).action(() => {
 			throw boom;
 		});
 
@@ -602,7 +602,7 @@ describe("Context disposal", () => {
 		const app = new Crust("cli")
 			.provide(ok())
 			.provide(bad())
-			.handle(() => {
+			.action(() => {
 				log.push("run");
 			});
 
@@ -610,7 +610,7 @@ describe("Context disposal", () => {
 		expect(log).toEqual(["dispose:ok"]);
 	});
 
-	it("disposes constructed dependencies when a dependent setup fails before the handler", async () => {
+	it("disposes constructed dependencies when a dependent setup fails before the action", async () => {
 		const events: string[] = [];
 		const resource = defineContext("resource", () => ({
 			[Symbol.dispose]() {
@@ -620,7 +620,7 @@ describe("Context disposal", () => {
 		const guard = defineContext("guard", { requires: [resource] }, () => {
 			throw new Error("Unauthenticated");
 		});
-		const app = new Crust("cli").provide(resource(), guard()).handle(() => {
+		const app = new Crust("cli").provide(resource(), guard()).action(() => {
 			events.push("handled");
 		});
 
@@ -630,7 +630,7 @@ describe("Context disposal", () => {
 
 	it("leaves non-disposable Context values alone", async () => {
 		const plain = defineContext("plain", () => ({ value: 42 }));
-		const app = new Crust("cli").provide(plain()).handle(({ ctx }) => {
+		const app = new Crust("cli").provide(plain()).action(({ ctx }) => {
 			expect(ctx.plain.value).toBe(42);
 		});
 

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -291,7 +291,7 @@ export function sortContexts(
  * values on `disposal` so they are torn down in reverse construction order.
  *
  * @param flags - The validated parsed flags of the resolved invocation
- * @param io - The invocation output callbacks also passed to the handler
+ * @param io - The invocation output callbacks also passed to the action
  */
 export async function buildContexts(
 	contexts: readonly ContextInstance[],

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -45,7 +45,7 @@ export interface ExtensionContext extends Readonly<InvocationIO> {
 	/** Syntax-parsed flag values for the resolved command */
 	readonly flags: Readonly<Record<string, unknown>>;
 	readonly rawArgs: readonly string[];
-	/** End the invocation successfully before validation, Context construction, and the handler. */
+	/** End the invocation successfully before validation, Context construction, and the action. */
 	readonly finish: () => Finished;
 }
 
@@ -53,7 +53,7 @@ export interface ExtensionHooks {
 	/**
 	 * Runs after routing and syntax parsing, before validation, in `.extend()` order.
 	 * Return `ctx.finish()` to end the invocation successfully; later pre-run hooks,
-	 * validation, schemas, Contexts, and the Command Handler do not run.
+	 * validation, schemas, Contexts, and the Command Action do not run.
 	 */
 	readonly preRun?: (ctx: ExtensionContext) => Awaitable<void | Finished>;
 	/**

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -75,7 +75,7 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 		],
 		[".meta()", (app) => app.meta({ description: "desc" }) as Crust],
 		[".add()", (app) => app.add(defineCommand("sub", (command) => command)) as Crust],
-		[".handle()", (app) => app.handle(() => {}) as Crust],
+		[".action()", (app) => app.action(() => {}) as Crust],
 	];
 
 	it.each(builderCases)("%s returns a new instance", (_name, apply) => {
@@ -155,12 +155,12 @@ describe("Crust .flags()", () => {
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
 
-	it("repeated .flags() calls accumulate runtime and handler types", async () => {
+	it("repeated .flags() calls accumulate runtime and action types", async () => {
 		let received: { first: boolean | undefined; second: string | undefined } | undefined;
 		const app = new Crust("test")
 			.flags({ name: "first", type: "boolean" })
 			.flags({ name: "second", type: "string" })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				type _First = Expect<Equal<typeof flags.first, boolean | undefined>>;
 				type _Second = Expect<Equal<typeof flags.second, string | undefined>>;
 				received = flags;
@@ -261,12 +261,12 @@ describe("Crust .args()", () => {
 		expect(snapshot.flags.verbose).toBeDefined();
 	});
 
-	it("repeated .args() calls append in positional order and preserve handler types", async () => {
+	it("repeated .args() calls append in positional order and preserve action types", async () => {
 		let received: { source: string; destination: string } | undefined;
 		const app = new Crust("copy")
 			.args({ name: "source", type: "string", required: true })
 			.args({ name: "destination", type: "string", required: true })
-			.handle(({ args }) => {
+			.action(({ args }) => {
 				type _Source = Expect<Equal<typeof args.source, string>>;
 				type _Destination = Expect<Equal<typeof args.destination, string>>;
 				received = args;
@@ -609,7 +609,7 @@ describe("Crust .add() with inline definitions", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("Crust .add() type-level tests", () => {
-	it("types required capabilities and local values in handlers", () => {
+	it("types required capabilities and local values in actions", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose === true,
@@ -623,10 +623,10 @@ describe("Crust .add() type-level tests", () => {
 						defineCommand("level2", { requires: [logging] }, (child) =>
 							child
 								.args({ name: "target", type: "string", required: true })
-								.handle(({ args, flags, ctx }) => {
+								.action(({ args, flags, ctx }) => {
 									type _target = Expect<Equal<typeof args.target, string>>;
 									type _verbose = Expect<Equal<typeof ctx.logging.verbose, boolean>>;
-									// @ts-expect-error -- ancestor-owned flags are parsed but not handler-visible
+									// @ts-expect-error -- ancestor-owned flags are parsed but not action-visible
 									void flags.verbose;
 									// @ts-expect-error -- root-local flags do not propagate
 									void flags.rootOnly;
@@ -639,16 +639,16 @@ describe("Crust .add() type-level tests", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// .handle() — Runtime tests
+// .action() — Runtime tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .handle()", () => {
-	it("runs the handler with parsed context", async () => {
+describe("Crust .action()", () => {
+	it("runs the action with parsed context", async () => {
 		let receivedCtx: CrustCommandContext | undefined;
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string", required: true })
-			.handle((context) => {
+			.action((context) => {
 				receivedCtx = context as unknown as CrustCommandContext;
 			});
 
@@ -660,9 +660,19 @@ describe("Crust .handle()", () => {
 		});
 	});
 
-	it("throws CrustError DEFINITION instead of replacing an existing handler", () => {
-		const app = new Crust("test").handle(() => {});
-		expect(() => app.handle(() => {})).toThrow(/Command "test" already has a handler/);
+	it("throws CrustError DEFINITION instead of replacing an existing action", () => {
+		const app = new Crust("test").action(() => {});
+		let error: unknown;
+		try {
+			app.action(() => {});
+		} catch (cause) {
+			error = cause;
+		}
+		expect(error).toMatchObject({
+			code: "DEFINITION",
+			message: 'Command "test" already has an action',
+			details: { subject: "command", name: "test", reason: "duplicate-action" },
+		});
 	});
 
 	it("preserves the definition and can follow .add()", async () => {
@@ -670,10 +680,10 @@ describe("Crust .handle()", () => {
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
 			.add(defineCommand("sub", (command) => command))
-			.handle(() => {});
+			.action(() => {});
 
 		expect(await app.snapshot()).toMatchObject({
-			hasHandler: true,
+			hasAction: true,
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
 			subCommands: { sub: { meta: { name: "sub" } } },
@@ -682,31 +692,31 @@ describe("Crust .handle()", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// .handle() — Type-level tests
+// .action() — Type-level tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .handle() type-level tests", () => {
-	it("run handler receives InferArgs<A> for args", () => {
+describe("Crust .action() type-level tests", () => {
+	it("action receives InferArgs<A> for args", () => {
 		new Crust("test")
 			.args(
 				{ name: "file", type: "string", required: true },
 				{ name: "count", type: "number", default: 5 },
 			)
-			.handle((_ctx) => {
+			.action((_ctx) => {
 				type CtxArgs = typeof _ctx.args;
 				type _checkFile = Expect<Equal<CtxArgs["file"], string>>;
 				type _checkCount = Expect<Equal<CtxArgs["count"], number>>;
 			});
 	});
 
-	it("run handler receives local flags and required capabilities", () => {
+	it("action receives local flags and required capabilities", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose === true,
 		}));
 		new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
-				cmd.flags({ name: "output", type: "string", required: true }).handle((_ctx) => {
+				cmd.flags({ name: "output", type: "string", required: true }).action((_ctx) => {
 					type _checkOutput = Expect<Equal<typeof _ctx.flags.output, string>>;
 					type _checkVerbose = Expect<Equal<typeof _ctx.ctx.logging.verbose, boolean>>;
 					// @ts-expect-error -- cross-command values are capabilities, not raw flags
@@ -716,61 +726,61 @@ describe("Crust .handle() type-level tests", () => {
 		);
 	});
 
-	it("handler with no flags/args gets empty types", () => {
-		new Crust("test").handle((_ctx) => {
+	it("action with no flags/args gets empty types", () => {
+		new Crust("test").action((_ctx) => {
 			// With broad FlagsDef default, flags resolve to Record<string, ...>
 			// With broad ArgsDef default, args resolve to Record<string, never>
 			type _checkRawArgs = Expect<Equal<typeof _ctx.rawArgs, string[]>>;
 		});
 	});
 
-	it("handler receives typed flags and args", () => {
+	it("action receives typed flags and args", () => {
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean", default: false })
 			.args({ name: "file", type: "string", required: true });
 
-		const withHandler = app.handle((_ctx) => {
+		const withAction = app.action((_ctx) => {
 			type CtxFlags = typeof _ctx.flags;
 			type CtxArgs = typeof _ctx.args;
 			type _checkVerbose = Expect<Equal<CtxFlags["verbose"], boolean>>;
 			type _checkFile = Expect<Equal<CtxArgs["file"], string>>;
 		});
 
-		void withHandler;
+		void withAction;
 	});
 
-	it("variadic args resolve to array type in handler", () => {
-		new Crust("test").args({ name: "files", type: "string", variadic: true }).handle((_ctx) => {
+	it("variadic args resolve to array type in action", () => {
+		new Crust("test").args({ name: "files", type: "string", variadic: true }).action((_ctx) => {
 			type CtxArgs = typeof _ctx.args;
 			type _checkFiles = Expect<Equal<CtxArgs["files"], string[]>>;
 		});
 	});
 
-	it("multiple flag resolves to array type in handler", () => {
+	it("multiple flag resolves to array type in action", () => {
 		new Crust("test")
 			.flags({ name: "tags", type: "string", multiple: true, required: true })
-			.handle((_ctx) => {
+			.action((_ctx) => {
 				type CtxFlags = typeof _ctx.flags;
 				type _checkTags = Expect<Equal<CtxFlags["tags"], string[]>>;
 			});
 	});
 
-	it("optional flag resolves to union with undefined in handler", () => {
-		new Crust("test").flags({ name: "port", type: "number" }).handle((_ctx) => {
+	it("optional flag resolves to union with undefined in action", () => {
+		new Crust("test").flags({ name: "port", type: "number" }).action((_ctx) => {
 			type CtxFlags = typeof _ctx.flags;
 			type _checkPort = Expect<Equal<CtxFlags["port"], number | undefined>>;
 		});
 	});
 
-	it("required flag resolves to non-optional type in handler", () => {
-		new Crust("test").flags({ name: "name", type: "string", required: true }).handle((_ctx) => {
+	it("required flag resolves to non-optional type in action", () => {
+		new Crust("test").flags({ name: "name", type: "string", required: true }).action((_ctx) => {
 			type CtxFlags = typeof _ctx.flags;
 			type _checkName = Expect<Equal<CtxFlags["name"], string>>;
 		});
 	});
 
-	it("flag with default resolves to non-optional type in handler", () => {
-		new Crust("test").flags({ name: "port", type: "number", default: 3000 }).handle((_ctx) => {
+	it("flag with default resolves to non-optional type in action", () => {
+		new Crust("test").flags({ name: "port", type: "number", default: 3000 }).action((_ctx) => {
 			type CtxFlags = typeof _ctx.flags;
 			type _checkPort = Expect<Equal<CtxFlags["port"], number>>;
 		});
@@ -795,7 +805,7 @@ describe("Crust .extend()", () => {
 		const app = new Crust("test")
 			.extend(extension("one"))
 			.extend(extension("two"), extension("three"))
-			.handle(() => {});
+			.action(() => {});
 
 		await app.run([]);
 		expect(calls).toEqual(["one", "two", "three"]);
@@ -830,11 +840,11 @@ describe("Crust .extend()", () => {
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
 			.add(defineCommand("sub", (command) => command))
-			.handle(() => {})
+			.action(() => {})
 			.extend(defineExtension("test-extension"));
 
 		expect(await app.snapshot()).toMatchObject({
-			hasHandler: true,
+			hasAction: true,
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
 			subCommands: { sub: { meta: { name: "sub" } } },
@@ -851,7 +861,7 @@ describe("Crust .extend()", () => {
 					},
 				},
 			});
-		const base = new Crust("test").extend(extension("one")).handle(() => {});
+		const base = new Crust("test").extend(extension("one")).action(() => {});
 		const extended = base.extend(extension("two"));
 
 		await base.run([]);
@@ -871,7 +881,7 @@ describe("Extension application at prepare time", () => {
 
 		const app = new Crust("cli").extend(debug).add(
 			defineCommand("sub", (cmd) =>
-				cmd.handle(({ flags }) => {
+				cmd.action(({ flags }) => {
 					seen.push(flags);
 				}),
 			),
@@ -889,7 +899,7 @@ describe("Extension application at prepare time", () => {
 
 		const app = new Crust("cli")
 			.extend(version)
-			.add(defineCommand("sub", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("sub", (cmd) => cmd.action(() => {})));
 
 		// --version is unknown on the subcommand → PARSE error
 		await expect(app.run(["sub", "--version"])).rejects.toMatchObject({ code: "PARSE" });
@@ -900,7 +910,7 @@ describe("Extension application at prepare time", () => {
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean" })
 			.extend(clash)
-			.handle(() => {});
+			.action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
@@ -912,7 +922,7 @@ describe("Extension application at prepare time", () => {
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean", short: "v" })
 			.extend(clash)
-			.handle(() => {});
+			.action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
@@ -920,7 +930,7 @@ describe("Extension application at prepare time", () => {
 	it("Extension flag colliding with another Extension's flag is a DEFINITION error", async () => {
 		const a = defineExtension("a", { flags: { shared: { type: "boolean" } } });
 		const b = defineExtension("b", { flags: { shared: { type: "boolean" } } });
-		const app = new Crust("cli").extend(a, b).handle(() => {});
+		const app = new Crust("cli").extend(a, b).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
@@ -932,7 +942,7 @@ describe("Extension application at prepare time", () => {
 				defineCommand("completion", (command) =>
 					command
 						.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh"] })
-						.handle(({ args, flags, rootCommand }) => {
+						.action(({ args, flags, rootCommand }) => {
 							lines.push(
 								`completion:${args.shell}:${(flags as Record<string, unknown>).verbose}:${rootCommand.meta.name}`,
 							);
@@ -944,7 +954,7 @@ describe("Extension application at prepare time", () => {
 			flags: { verbose: { type: "boolean" } },
 		});
 
-		const app = new Crust("cli").extend(completion, verbose).handle(() => {});
+		const app = new Crust("cli").extend(completion, verbose).action(() => {});
 
 		await app.run(["completion", "bash", "--verbose"]);
 		expect(lines).toEqual(["completion:bash:true:cli"]);
@@ -955,7 +965,7 @@ describe("Extension application at prepare time", () => {
 	it("Extension command requirements name the Extension and missing Context", async () => {
 		const db = defineContext("db", () => "database");
 		const databaseTools = defineExtension("database-tools", {
-			commands: [defineCommand("users", { requires: [db] }, (command) => command.handle(() => {}))],
+			commands: [defineCommand("users", { requires: [db] }, (command) => command.action(() => {}))],
 		});
 
 		try {
@@ -971,10 +981,10 @@ describe("Extension application at prepare time", () => {
 
 	it("Extension command colliding with an application command is a DEFINITION error", async () => {
 		const clash = defineExtension("clash", {
-			commands: [defineCommand("sub", (command) => command.handle(() => {}))],
+			commands: [defineCommand("sub", (command) => command.action(() => {}))],
 		});
 		const app = new Crust("cli")
-			.add(defineCommand("sub", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("sub", (cmd) => cmd.action(() => {})))
 			.extend(clash);
 
 		await expect(app.run(["sub"])).rejects.toMatchObject({ code: "DEFINITION" });
@@ -1032,7 +1042,7 @@ describe("Extension application at prepare time", () => {
 	it("does not mutate the source builder across executions", async () => {
 		let runCount = 0;
 		const debug = defineExtension("debug", { flags: { debug: { type: "boolean" } } });
-		const app = new Crust("repeat").extend(debug).handle(({ flags }) => {
+		const app = new Crust("repeat").extend(debug).action(({ flags }) => {
 			if ((flags as Record<string, unknown>).debug) runCount++;
 		});
 
@@ -1044,7 +1054,7 @@ describe("Extension application at prepare time", () => {
 });
 
 describe("Extension named hooks", () => {
-	it("runs pre-run hooks in extension order and finish skips later hooks and the handler", async () => {
+	it("runs pre-run hooks in extension order and finish skips later hooks and the action", async () => {
 		const order: string[] = [];
 		const first = defineExtension("first", {
 			hooks: {
@@ -1071,8 +1081,8 @@ describe("Extension named hooks", () => {
 		const app = new Crust("cli")
 			.args({ name: "file", type: "string", required: true })
 			.extend(first, gate, last)
-			.handle(() => {
-				order.push("handler");
+			.action(() => {
+				order.push("action");
 			});
 
 		await app.run([]);
@@ -1098,7 +1108,7 @@ describe("Extension named hooks", () => {
 
 		await new Crust("cli")
 			.extend(first, second)
-			.handle(() => {})
+			.action(() => {})
 			.run([]);
 		expect(outcomes).toEqual(["second:completed", "first:completed"]);
 
@@ -1106,7 +1116,7 @@ describe("Extension named hooks", () => {
 		await expect(
 			new Crust("cli")
 				.extend(first, second)
-				.handle(() => {
+				.action(() => {
 					throw new Error("boom");
 				})
 				.run([]),
@@ -1117,7 +1127,7 @@ describe("Extension named hooks", () => {
 		const gate = defineExtension("gate", { hooks: { preRun: (ctx) => ctx.finish() } });
 		await new Crust("cli")
 			.extend(first, gate, second)
-			.handle(() => {})
+			.action(() => {})
 			.run([]);
 		expect(outcomes).toEqual(["second:finished", "first:finished"]);
 	});
@@ -1139,7 +1149,7 @@ describe("Extension named hooks", () => {
 		await new Crust("cli")
 			.flags({ name: "port", type: "number", required: true })
 			.extend(gate)
-			.handle(() => {})
+			.action(() => {})
 			.run(["--port", "8080"]);
 
 		expect(seenPort).toBe(8080);
@@ -1162,7 +1172,7 @@ describe("Extension named hooks", () => {
 		});
 		const app = new Crust("cli")
 			.extend(probe)
-			.add(defineCommand("known", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("known", (cmd) => cmd.action(() => {})));
 
 		await app.run(["known"], { stdout: (line) => lines.push(line) });
 		expect(lines).toEqual(["probe:known"]);
@@ -1183,7 +1193,7 @@ describe("Extension named hooks", () => {
 		await expect(
 			new Crust("cli")
 				.extend(cleanup)
-				.handle(() => {
+				.action(() => {
 					throw original;
 				})
 				.run([]),
@@ -1209,24 +1219,24 @@ describe("Extension named hooks", () => {
 		await expect(
 			new Crust("cli")
 				.extend(first, second)
-				.handle(() => {})
+				.action(() => {})
 				.run([]),
 		).rejects.toThrow("second cleanup");
 		expect(calls).toEqual(["second", "first"]);
 	});
 
-	it("passes the application root snapshot to app and Extension command handlers", async () => {
+	it("passes the application root snapshot to app and Extension command actions", async () => {
 		const roots: string[] = [];
 		const extension = defineExtension("extension", {
 			commands: [
 				defineCommand("owned", (command) =>
-					command.handle(({ rootCommand }) => {
+					command.action(({ rootCommand }) => {
 						roots.push(rootCommand.meta.name);
 					}),
 				),
 			],
 		});
-		const app = new Crust("cli").extend(extension).handle(({ rootCommand }) => {
+		const app = new Crust("cli").extend(extension).action(({ rootCommand }) => {
 			roots.push(rootCommand.meta.name);
 		});
 
@@ -1264,7 +1274,7 @@ describe("Extension onError hooks", () => {
 	});
 
 	const failing = () =>
-		new Crust("cli").handle(() => {
+		new Crust("cli").action(() => {
 			throw new Error("boom");
 		});
 
@@ -1332,13 +1342,13 @@ describe("Crust .run()", () => {
 	});
 
 	it("resolves with no value on success", async () => {
-		const app = new Crust("test").handle(() => {});
+		const app = new Crust("test").action(() => {});
 		await expect(app.run([])).resolves.toBeUndefined();
 	});
 
 	it("throws the original CrustError without rendering or setting exitCode", async () => {
 		const stderrLines: string[] = [];
-		const app = new Crust("test").flags({ name: "port", type: "number" }).handle(() => {});
+		const app = new Crust("test").flags({ name: "port", type: "number" }).action(() => {});
 
 		await expect(
 			app.run(["--unknown"], { stderr: (text) => stderrLines.push(text) }),
@@ -1348,9 +1358,9 @@ describe("Crust .run()", () => {
 		expect(process.exitCode).toBe(0);
 	});
 
-	it("throws the original handler error unwrapped", async () => {
-		const boom = new Error("handler exploded");
-		const app = new Crust("test").handle(() => {
+	it("throws the original action error unwrapped", async () => {
+		const boom = new Error("action exploded");
+		const app = new Crust("test").action(() => {
 			throw boom;
 		});
 
@@ -1359,10 +1369,10 @@ describe("Crust .run()", () => {
 		expect(process.exitCode).toBe(0);
 	});
 
-	it("injected stdout/stderr callbacks reach the Command Handler", async () => {
+	it("injected stdout/stderr callbacks reach the Command Action", async () => {
 		const out: string[] = [];
 		const err: string[] = [];
-		const app = new Crust("test").handle((ctx) => {
+		const app = new Crust("test").action((ctx) => {
 			ctx.stdout("to out");
 			ctx.stderr("to err");
 		});
@@ -1378,7 +1388,7 @@ describe("Crust .run()", () => {
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean" })
 			.args({ name: "file", type: "string" })
-			.handle((ctx) => {
+			.action((ctx) => {
 				received = { args: ctx.args, flags: ctx.flags };
 			});
 
@@ -1425,12 +1435,12 @@ describe("Crust .execute()", () => {
 		process.exitCode = (originalExitCode as number) ?? 0;
 	});
 
-	it("runs root handler with parsed flags", async () => {
+	it("runs root action with parsed flags", async () => {
 		let receivedFlags: Record<string, unknown> = {};
 
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean", short: "v" })
-			.handle((ctx) => {
+			.action((ctx) => {
 				receivedFlags = ctx.flags;
 			});
 
@@ -1439,12 +1449,12 @@ describe("Crust .execute()", () => {
 		expect(receivedFlags.verbose).toBe(true);
 	});
 
-	it("runs root handler with parsed args", async () => {
+	it("runs root action with parsed args", async () => {
 		let receivedArgs: Record<string, unknown> = {};
 
 		const app = new Crust("test")
 			.args({ name: "file", type: "string", required: true })
-			.handle((ctx) => {
+			.action((ctx) => {
 				receivedArgs = ctx.args;
 			});
 
@@ -1453,13 +1463,13 @@ describe("Crust .execute()", () => {
 		expect(receivedArgs.file).toBe("hello.txt");
 	});
 
-	it("runs root handler with flags and args combined", async () => {
+	it("runs root action with flags and args combined", async () => {
 		let receivedCtx: CrustCommandContext | undefined;
 
 		const app = new Crust("test")
 			.flags({ name: "port", type: "number", default: 3000 }, { name: "verbose", type: "boolean" })
 			.args({ name: "dir", type: "string", default: "." })
-			.handle((ctx) => {
+			.action((ctx) => {
 				receivedCtx = ctx as unknown as CrustCommandContext;
 			});
 
@@ -1471,26 +1481,26 @@ describe("Crust .execute()", () => {
 	});
 
 	it("routes to subcommand", async () => {
-		let handlerRan = "";
+		let actionRan = "";
 
 		const app = new Crust("cli")
-			.handle(() => {
-				handlerRan = "root";
+			.action(() => {
+				actionRan = "root";
 			})
 			.add(
 				defineCommand("sub", (cmd) =>
-					cmd.handle(() => {
-						handlerRan = "sub";
+					cmd.action(() => {
+						actionRan = "sub";
 					}),
 				),
 			);
 
 		await app.execute({ argv: ["sub"] });
 
-		expect(handlerRan).toBe("sub");
+		expect(actionRan).toBe("sub");
 	});
 
-	it("passes Context-owned flags but not parent-local flags to subcommand handlers", async () => {
+	it("passes Context-owned flags but not parent-local flags to subcommand actions", async () => {
 		let subFlags: Record<string, unknown> = {};
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
@@ -1500,7 +1510,7 @@ describe("Crust .execute()", () => {
 			.provide(logging())
 			.add(
 				defineCommand("sub", (cmd) =>
-					cmd.handle((ctx) => {
+					cmd.action((ctx) => {
 						subFlags = ctx.flags;
 					}),
 				),
@@ -1518,7 +1528,7 @@ describe("Crust .execute()", () => {
 
 		const app = new Crust("test")
 			.args({ name: "dir", type: "string", default: "." })
-			.handle((ctx) => {
+			.action((ctx) => {
 				receivedDir = ctx.args.dir as string;
 			});
 
@@ -1527,7 +1537,7 @@ describe("Crust .execute()", () => {
 		expect(receivedDir).toBe("custom-dir");
 	});
 
-	it("runs pre-run then post-run hooks around the handler", async () => {
+	it("runs pre-run then post-run hooks around the action", async () => {
 		const order: string[] = [];
 		const wrap = defineExtension("wrap", {
 			hooks: {
@@ -1539,7 +1549,7 @@ describe("Crust .execute()", () => {
 				},
 			},
 		});
-		const app = new Crust("test").extend(wrap).handle(() => {
+		const app = new Crust("test").extend(wrap).action(() => {
 			order.push("run");
 		});
 
@@ -1548,7 +1558,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("catches errors and sets exitCode", async () => {
-		const app = new Crust("test").handle(() => {
+		const app = new Crust("test").action(() => {
 			throw new Error("execution failed");
 		});
 
@@ -1559,7 +1569,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("catches CrustError and sets exitCode", async () => {
-		const app = new Crust("test").handle(() => {
+		const app = new Crust("test").action(() => {
 			throw new CrustError("PARSE", "custom crust error");
 		});
 
@@ -1570,7 +1580,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("treats prompt cancellation as a silent user abort", async () => {
-		const app = new Crust("test").handle(() => {
+		const app = new Crust("test").action(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
 
@@ -1592,7 +1602,7 @@ describe("Crust .execute()", () => {
 			},
 		});
 
-		const app = new Crust("test").extend(cancelRenderer).handle(() => {
+		const app = new Crust("test").extend(cancelRenderer).action(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
 
@@ -1613,7 +1623,7 @@ describe("Crust .execute()", () => {
 			},
 		});
 
-		const app = new Crust("test").extend(exitCodeOverride).handle(() => {
+		const app = new Crust("test").extend(exitCodeOverride).action(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
 
@@ -1633,7 +1643,7 @@ describe("Crust .execute()", () => {
 			},
 		});
 
-		const app = new Crust("test").extend(observer).handle(() => {
+		const app = new Crust("test").extend(observer).action(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
 
@@ -1645,7 +1655,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("handles unknown flag error", async () => {
-		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).handle(() => {});
+		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).action(() => {});
 
 		await app.execute({ argv: ["--unknown"] });
 
@@ -1656,7 +1666,7 @@ describe("Crust .execute()", () => {
 	it("handles missing required flag error", async () => {
 		const app = new Crust("test")
 			.flags({ name: "name", type: "string", required: true })
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: [] });
 
@@ -1665,7 +1675,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("command not found error with no run on parent", async () => {
-		const app = new Crust("cli").add(defineCommand("sub", (cmd) => cmd.handle(() => {})));
+		const app = new Crust("cli").add(defineCommand("sub", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["unknown-sub"] });
 
@@ -1673,7 +1683,7 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks.join("\n")).toContain("Unknown command");
 	});
 
-	it("no run handler is a no-op (no error)", async () => {
+	it("no action is a no-op (no error)", async () => {
 		const app = new Crust("test").flags({ name: "verbose", type: "boolean" });
 
 		await app.execute({ argv: ["--verbose"] });
@@ -1689,7 +1699,7 @@ describe("Crust .execute()", () => {
 			flags: { version: { type: "boolean", short: "V" } },
 		});
 
-		const app = new Crust("test").extend(version).handle((ctx) => {
+		const app = new Crust("test").extend(version).action((ctx) => {
 			receivedFlags = ctx.flags;
 		});
 
@@ -1709,7 +1719,7 @@ describe("Crust .execute()", () => {
 				defineCommand("skill", (command) =>
 					command.add(
 						defineCommand("update", (cmd) =>
-							cmd.handle((runCtx) => {
+							cmd.action((runCtx) => {
 								receivedFlags = runCtx.flags as Record<string, unknown>;
 							}),
 						),
@@ -1721,7 +1731,7 @@ describe("Crust .execute()", () => {
 		const app = new Crust("test")
 			.extend(helpLike)
 			.extend(skillLike)
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["skill", "update", "--help"] });
 
@@ -1729,7 +1739,7 @@ describe("Crust .execute()", () => {
 	});
 
 	it("deeply nested subcommand routing works", async () => {
-		let handlerRan = "";
+		let actionRan = "";
 
 		const app = new Crust("cli").flags({ name: "verbose", type: "boolean" }).add(
 			defineCommand("level1", (cmd) =>
@@ -1737,8 +1747,8 @@ describe("Crust .execute()", () => {
 					defineCommand("level2", (cmd2) =>
 						cmd2.add(
 							defineCommand("level3", (cmd3) =>
-								cmd3.handle(() => {
-									handlerRan = "level3";
+								cmd3.action(() => {
+									actionRan = "level3";
 								}),
 							),
 						),
@@ -1749,13 +1759,13 @@ describe("Crust .execute()", () => {
 
 		await app.execute({ argv: ["level1", "level2", "level3"] });
 
-		expect(handlerRan).toBe("level3");
+		expect(actionRan).toBe("level3");
 	});
 
 	it("rawArgs are passed through", async () => {
 		let receivedRawArgs: string[] = [];
 
-		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).handle((ctx) => {
+		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).action((ctx) => {
 			receivedRawArgs = ctx.rawArgs;
 		});
 
@@ -1781,7 +1791,7 @@ describe("Crust .execute()", () => {
 			.extend(inspect)
 			.add(
 				defineCommand("sub", (cmd) =>
-					cmd.flags({ name: "output", type: "string", default: "stdout" }).handle(() => {}),
+					cmd.flags({ name: "output", type: "string", default: "stdout" }).action(() => {}),
 				),
 			);
 
@@ -1792,16 +1802,16 @@ describe("Crust .execute()", () => {
 	});
 
 	it("pre-run can finish execution", async () => {
-		let handlerRan = false;
+		let actionRan = false;
 		const gate = defineExtension("short-circuit", {
 			hooks: { preRun: (ctx) => ctx.finish() },
 		});
-		const app = new Crust("test").extend(gate).handle(() => {
-			handlerRan = true;
+		const app = new Crust("test").extend(gate).action(() => {
+			actionRan = true;
 		});
 
 		await app.execute({ argv: [] });
-		expect(handlerRan).toBe(false);
+		expect(actionRan).toBe(false);
 	});
 
 	it("Context capabilities work across file-boundary pattern", async () => {
@@ -1811,7 +1821,7 @@ describe("Crust .execute()", () => {
 			verbose: flags.verbose === true,
 		}));
 		const sub = defineCommand("sub", { requires: [logging] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				receivedVerbose = ctx.logging.verbose;
 			}),
 		);
@@ -1831,7 +1841,7 @@ describe("Crust .execute()", () => {
 		}));
 		const app = new Crust("cli").provide(ports()).add(
 			defineCommand("sub", { requires: [ports] }, (cmd) =>
-				cmd.handle(({ ctx }) => {
+				cmd.action(({ ctx }) => {
 					receivedPort = ctx.ports.port;
 				}),
 			),
@@ -1851,7 +1861,7 @@ describe("Crust .execute()", () => {
 		}));
 		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
-				cmd.handle(({ ctx }) => {
+				cmd.action(({ ctx }) => {
 					receivedVerbose = ctx.logging.verbose;
 				}),
 			),
@@ -1867,7 +1877,7 @@ describe("Crust .execute()", () => {
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean" })
 			.extend(clash)
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: [] });
 
@@ -1884,7 +1894,7 @@ describe("Crust .execute()", () => {
 			},
 		});
 
-		const app = new Crust("test").extend(cancel).handle(() => {});
+		const app = new Crust("test").extend(cancel).action(() => {});
 
 		await app.execute({ argv: [] });
 
@@ -1892,10 +1902,10 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks).toEqual([]);
 	});
 
-	it("async run handler works", async () => {
+	it("async action works", async () => {
 		let result = "";
 
-		const app = new Crust("test").handle(async () => {
+		const app = new Crust("test").action(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 10));
 			result = "done";
 		});
@@ -1905,8 +1915,8 @@ describe("Crust .execute()", () => {
 		expect(result).toBe("done");
 	});
 
-	it("handler context exposes stdout/stderr text callbacks", async () => {
-		const app = new Crust("test").handle((ctx) => {
+	it("action context exposes stdout/stderr text callbacks", async () => {
+		const app = new Crust("test").action((ctx) => {
 			ctx.stdout("hello out");
 			ctx.stderr("hello err");
 		});
@@ -1920,7 +1930,7 @@ describe("Crust .execute()", () => {
 	it("command context contains a serializable snapshot of the resolved command", async () => {
 		let receivedCommand: unknown;
 
-		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).handle((ctx) => {
+		const app = new Crust("test").flags({ name: "verbose", type: "boolean" }).action((ctx) => {
 			receivedCommand = ctx.command;
 		});
 
@@ -1929,11 +1939,11 @@ describe("Crust .execute()", () => {
 		expect(receivedCommand).toBeDefined();
 		const snapshot = receivedCommand as {
 			meta: { name: string };
-			hasHandler: boolean;
+			hasAction: boolean;
 			flags: Record<string, unknown>;
 		};
 		expect(snapshot.meta.name).toBe("test");
-		expect(snapshot.hasHandler).toBe(true);
+		expect(snapshot.hasAction).toBe(true);
 		expect(Object.keys(snapshot.flags)).toContain("verbose");
 		// Serializable across boundaries — no functions anywhere in the snapshot
 		expect(() => structuredClone(snapshot)).not.toThrow();
@@ -1976,16 +1986,16 @@ describe("Invocation pipeline internal seam — validation mode", () => {
 		process.env[VALIDATION_MODE_ENV] = "1";
 		delete process.env[VALIDATION_FORCE_EXIT_ENV];
 
-		let handlerRan = false;
-		const app = new Crust("in-process-validation").handle(() => {
-			handlerRan = true;
+		let actionRan = false;
+		const app = new Crust("in-process-validation").action(() => {
+			actionRan = true;
 		});
 
 		await app.execute({ argv: [] });
 
 		expect(exitCalls).toEqual([]);
-		// Validation runs *instead of* the handler.
-		expect(handlerRan).toBe(false);
+		// Validation runs *instead of* the action.
+		expect(actionRan).toBe(false);
 		// Successful validation leaves exitCode at the baseline (0).
 		expect(process.exitCode).toBe(0);
 	});
@@ -2008,7 +2018,7 @@ describe("Invocation pipeline internal seam — validation mode", () => {
 		process.env[VALIDATION_MODE_ENV] = "1";
 		process.env[VALIDATION_FORCE_EXIT_ENV] = "1";
 
-		const app = new Crust("build-subprocess").handle(() => {});
+		const app = new Crust("build-subprocess").action(() => {});
 
 		// Stubbed process.exit throws; the rejection confirms it fired.
 		await expect(app.execute({ argv: [] })).rejects.toThrow("process.exit(0) was called");
@@ -2049,16 +2059,16 @@ describe("Crust.snapshot", () => {
 	});
 
 	it("can be called multiple times", async () => {
-		const app = new Crust("cli").handle(() => {});
+		const app = new Crust("cli").action(() => {});
 		const a = await app.snapshot();
 		const b = await app.snapshot();
 		expect(a.meta.name).toBe("cli");
 		expect(b.meta.name).toBe("cli");
 	});
 
-	it("never calls Command Handlers", async () => {
+	it("never calls Command Actions", async () => {
 		let called = false;
-		const app = new Crust("cli").handle(() => {
+		const app = new Crust("cli").action(() => {
 			called = true;
 		});
 		await app.snapshot();
@@ -2091,7 +2101,7 @@ describe("Crust .add() aliases", () => {
 	it("plumbs aliases from meta() into the registered subcommand snapshot", async () => {
 		const app = new Crust("cli").add(
 			defineCommand("issue", (command) =>
-				command.meta({ aliases: ["issues", "i"] }).handle(() => {}),
+				command.meta({ aliases: ["issues", "i"] }).action(() => {}),
 			),
 		);
 		expect((await app.snapshot()).subCommands.issue?.meta.aliases).toEqual(["issues", "i"]);
@@ -2101,34 +2111,34 @@ describe("Crust .add() aliases", () => {
 		expect(() =>
 			new Crust("cli")
 				.add(
-					defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
+					defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})),
 				)
-				.add(defineCommand("version", (cmd) => cmd.handle(() => {}))),
+				.add(defineCommand("version", (cmd) => cmd.action(() => {}))),
 		).not.toThrow();
 	});
 
 	it("throws DEFINITION when an alias collides with a sibling's canonical name", () => {
-		const app = new Crust("cli").add(defineCommand("build", (cmd) => cmd.handle(() => {})));
+		const app = new Crust("cli").add(defineCommand("build", (cmd) => cmd.action(() => {})));
 		expect(() =>
-			app.add(defineCommand("compile", (cmd) => cmd.meta({ aliases: ["build"] }).handle(() => {}))),
+			app.add(defineCommand("compile", (cmd) => cmd.meta({ aliases: ["build"] }).action(() => {}))),
 		).toThrow(/collides with sibling canonical name "build"/);
 	});
 
 	it("throws DEFINITION when an alias collides with another sibling's alias", () => {
 		const app = new Crust("cli").add(
-			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})),
+			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})),
 		);
 		expect(() =>
-			app.add(defineCommand("info", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {}))),
+			app.add(defineCommand("info", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {}))),
 		).toThrow(/collides with alias of sibling "issue"/);
 	});
 
 	it("throws DEFINITION on the reverse-order case (new canonical equals an existing alias)", () => {
 		const app = new Crust("cli").add(
-			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})),
+			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})),
 		);
 		// Now try to register a *new* command whose canonical name == existing alias.
-		expect(() => app.add(defineCommand("i", (cmd) => cmd.handle(() => {})))).toThrow(
+		expect(() => app.add(defineCommand("i", (cmd) => cmd.action(() => {})))).toThrow(
 			/canonical name "i" collides with alias of sibling "issue"/,
 		);
 	});
@@ -2136,7 +2146,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on duplicate aliases within one subcommand's own list", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i", "i"] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i", "i"] }).action(() => {})),
 			),
 		).toThrow(/lists alias "i" more than once/);
 	});
@@ -2144,7 +2154,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias equal to its own canonical name", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issue"] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issue"] }).action(() => {})),
 			),
 		).toThrow(/must not equal its own canonical name/);
 	});
@@ -2152,7 +2162,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an empty alias", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: [""] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: [""] }).action(() => {})),
 			),
 		).toThrow(/must be a non-empty string/);
 	});
@@ -2160,7 +2170,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias containing whitespace", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["my issue"] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["my issue"] }).action(() => {})),
 			),
 		).toThrow(/must not contain whitespace/);
 	});
@@ -2168,17 +2178,17 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias starting with '-'", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["-i"] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["-i"] }).action(() => {})),
 			),
 		).toThrow(/must not start with "-"/);
 	});
 
 	it("applies the same checks on the .add() path", () => {
 		const issue = defineCommand("issue", (command) =>
-			command.meta({ aliases: ["i"] }).handle(() => {}),
+			command.meta({ aliases: ["i"] }).action(() => {}),
 		);
 		const conflicting = defineCommand("info", (command) =>
-			command.meta({ aliases: ["i"] }).handle(() => {}),
+			command.meta({ aliases: ["i"] }).action(() => {}),
 		);
 		const app = new Crust("cli").add(issue);
 
@@ -2190,13 +2200,13 @@ describe("Crust .add() aliases", () => {
 		// changes routing for an existing user command.
 		const rogue = defineExtension("rogue", {
 			commands: [
-				defineCommand("info", (command) => command.meta({ aliases: ["i"] }).handle(() => {})),
+				defineCommand("info", (command) => command.meta({ aliases: ["i"] }).action(() => {})),
 			],
 		});
 
 		const app = new Crust("cli")
 			.extend(rogue)
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})));
 
 		await expect(app.run(["i"])).rejects.toMatchObject({ code: "DEFINITION" });
 	});

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -46,8 +46,8 @@ export { VALIDATION_FORCE_EXIT_ENV, VALIDATION_MODE_ENV } from "./invocation.ts"
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * The runtime context object passed to the Command Handler defined with
- * `.handle()`.
+ * The runtime context object passed to the Command Action defined with
+ * `.action()`.
  *
  * Generic parameters:
  * - `A` — positional argument definitions tuple
@@ -287,8 +287,8 @@ export interface CommandDefinitionBuilder<
 		...definitions: AddChecks<Ctx, Ds>
 	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 
-	handle(
-		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
+	action(
+		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
 	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
 }
 
@@ -359,7 +359,7 @@ export function defineCommand(
  * const app = new Crust("my-cli")
  *   .flags({ name: "verbose", type: "boolean", short: "v" })
  *   .args({ name: "file", type: "string", required: true })
- *   .handle(({ args, flags }) => {
+ *   .action(({ args, flags }) => {
  *     console.log(args.file, flags.verbose);
  *   });
  * ```
@@ -437,7 +437,7 @@ export class Crust<
 	 * @example
 	 * ```ts
 	 * defineCommand("issue", (cmd) =>
-	 *   cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})
+	 *   cmd.meta({ aliases: ["issues", "i"] }).action(() => {})
 	 * )
 	 * ```
 	 */
@@ -569,7 +569,7 @@ export class Crust<
 	 *
 	 * Contexts are inherited by descendant commands, constructed
 	 * topologically (by declared capability requirements) only for the resolved
-	 * command path, and exposed to the Command Handler as `ctx`. Provide
+	 * command path, and exposed to the Command Action as `ctx`. Provide
 	 * order is free: dependencies may be provided after their dependents.
 	 * Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are
 	 * disposed in reverse construction order after success or failure.
@@ -638,31 +638,31 @@ export class Crust<
 	}
 
 	/**
-	 * Define the Command Handler — the function that implements this
+	 * Define the Command Action — the function that implements this
 	 * command's behavior after its inputs and Contexts are ready.
 	 *
-	 * The handler receives a {@link CrustCommandContext} with `args` typed from
+	 * The action receives a {@link CrustCommandContext} with `args` typed from
 	 * `.args()` and `flags` typed as `EffectiveFlags<Local, Owned>`.
 	 *
-	 * A handler is set once; calling `.handle()` again throws rather than
+	 * An action is set once; calling `.action()` again throws rather than
 	 * silently replacing command behavior. The original builder is not mutated.
 	 *
-	 * @param handler - The Command Handler function
-	 * @returns A new `Crust` instance with the handler registered
-	 * @throws {CrustError} `DEFINITION` when this command already has a handler
+	 * @param action - The Command Action function
+	 * @returns A new `Crust` instance with the action registered
+	 * @throws {CrustError} `DEFINITION` when this command already has an action
 	 */
-	handle(
-		handler: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
+	action(
+		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
 	): Crust<Local, Owned, A, Eff, Ctx> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
-				`Command "${this._node.meta.name}" already has a handler`,
-				{ subject: "command", name: this._node.meta.name, reason: "duplicate-handler" },
+				`Command "${this._node.meta.name}" already has an action`,
+				{ subject: "command", name: this._node.meta.name, reason: "duplicate-action" },
 			);
 		}
 		return this._clone({
-			run: handler as (ctx: unknown) => void | Promise<void>,
+			run: action as (ctx: unknown) => void | Promise<void>,
 		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
@@ -722,7 +722,7 @@ export class Crust<
 	 * man-page, skill, and build generators.
 	 *
 	 * Materializes Extension contributions and command definitions, then
-	 * validates the resulting command tree. Does not call Command Handlers.
+	 * validates the resulting command tree. Does not call Command Actions.
 	 * Rejects with a `CrustError` of code `DEFINITION` when materialization
 	 * or validation fails.
 	 */
@@ -732,10 +732,10 @@ export class Crust<
 
 	/**
 	 * Invoke this application programmatically: resolve, parse, run the
-	 * Extension hooks and the Command Handler for `argv`.
+	 * Extension hooks and the Command Action for `argv`.
 	 *
 	 * Unlike {@link Crust.execute}, `run()` throws the original definition,
-	 * parse, Context, or handler failure without rendering it (Extension
+	 * parse, Context, or action failure without rendering it (Extension
 	 * `onError` hooks are a terminal presentation concern and never run
 	 * here) and without changing process status. It resolves with no value
 	 * after successful cleanup. Prompt cancellation surfaces as a standard
@@ -743,7 +743,7 @@ export class Crust<
 	 *
 	 * @param argv - Arguments to parse (no `process.argv` default — pass them explicitly)
 	 * @param io - Optional `stdout(text)` / `stderr(text)` callbacks, also
-	 *             exposed to Command Handlers and Extensions
+	 *             exposed to Command Actions and Extensions
 	 */
 	async run(
 		argv: readonly string[],
@@ -758,7 +758,7 @@ export class Crust<
 
 	/**
 	 * Parse `process.argv`, resolve subcommands, run Extension hooks, and
-	 * execute the matched Command Handler.
+	 * execute the matched Command Action.
 	 *
 	 * This is the terminal CLI boundary — call it on the root builder. It
 	 * renders a failure once (through Extension `onError` hooks, ending in

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -40,7 +40,7 @@ describe("command definitions", () => {
 				.flags({ name: "output", type: "string" })
 				.args({ name: "source", type: "string", required: true })
 				.args({ name: "destination", type: "string", required: true })
-				.handle(({ args, flags }) => {
+				.action(({ args, flags }) => {
 					type _Source = Assert<IsEqual<typeof args.source, string>>;
 					type _Output = Assert<IsEqual<typeof flags.output, string | undefined>>;
 					received = { args, flags };
@@ -56,15 +56,15 @@ describe("command definitions", () => {
 		});
 	});
 
-	it("rejects a second handler on the definition builder", () => {
+	it("rejects a second action on the definition builder", () => {
 		const definition = defineCommand("duplicate", (command) =>
-			command.handle(() => {}).handle(() => {}),
+			command.action(() => {}).action(() => {}),
 		);
-		expect(() => new Crust("cli").add(definition)).toThrow(/already has a handler/);
+		expect(() => new Crust("cli").add(definition)).toThrow(/already has an action/);
 	});
 
 	it(".as() renames without mutating the original definition", () => {
-		const definition = defineCommand("build", (command) => command.handle(() => {}));
+		const definition = defineCommand("build", (command) => command.action(() => {}));
 		const renamed = definition.as("compile");
 
 		expect(definition.name).toBe("build");
@@ -81,7 +81,7 @@ describe("command definitions", () => {
 	});
 
 	it("does not backfill nested definitions with later inheritable flags", async () => {
-		const nested = defineCommand("nested", (command) => command.handle(() => {}));
+		const nested = defineCommand("nested", (command) => command.action(() => {}));
 		const outer = defineCommand("outer", (command) =>
 			command.add(nested).flags({ name: "late", type: "boolean" }),
 		);
@@ -96,9 +96,9 @@ describe("command definitions", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
-		const before = defineCommand("before", (command) => command.handle(() => {}));
+		const before = defineCommand("before", (command) => command.action(() => {}));
 		const after = defineCommand("after", { requires: [auth] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				calls.push(String(ctx.auth.apiKey));
 			}),
 		);
@@ -122,7 +122,7 @@ describe("command definitions", () => {
 		}));
 		const db = defineContext("db", () => "database");
 		const status = defineCommand("status", { requires: [logging, db] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				calls.push(`${ctx.db}:${String(ctx.logging.verbose)}`);
 			}),
 		);
@@ -166,7 +166,7 @@ describe("command definitions", () => {
 	});
 
 	it("excludes parent local flags from added commands", async () => {
-		const definition = defineCommand("users", (command) => command.handle(() => {}));
+		const definition = defineCommand("users", (command) => command.action(() => {}));
 		const app = new Crust("cli").flags({ name: "secret", type: "string" }).add(definition);
 
 		await expect(app.run(["users", "--secret", "value"])).rejects.toThrow(/Unknown flag/);
@@ -175,7 +175,7 @@ describe("command definitions", () => {
 	it("runs added definitions through run and execute", async () => {
 		let calls = 0;
 		const definition = defineCommand("build", (command) =>
-			command.handle(() => {
+			command.action(() => {
 				calls++;
 			}),
 		);
@@ -190,12 +190,12 @@ describe("command definitions", () => {
 	it("adds multiple definitions in one variadic call", async () => {
 		const ran: string[] = [];
 		const build = defineCommand("build", (command) =>
-			command.handle(() => {
+			command.action(() => {
 				ran.push("build");
 			}),
 		);
 		const publish = defineCommand("publish", (command) =>
-			command.handle(() => {
+			command.action(() => {
 				ran.push("publish");
 			}),
 		);
@@ -215,7 +215,7 @@ describe("command definitions", () => {
 
 	it("validates canonical names and aliases on every add", () => {
 		const definition = defineCommand("build", (command) =>
-			command.meta({ aliases: ["b"] }).handle(() => {}),
+			command.meta({ aliases: ["b"] }).action(() => {}),
 		);
 		const app = new Crust("cli").add(definition);
 
@@ -258,7 +258,7 @@ describe("command definitions", () => {
 	it("checks Context requirement names at runtime when added", () => {
 		const db = defineContext("db", () => "database");
 		const definition = defineCommand("users", { requires: [db] }, (command) =>
-			command.handle(() => {}),
+			command.action(() => {}),
 		);
 
 		expect(() => new Crust("cli").provide(db()).add(definition)).not.toThrow();
@@ -267,7 +267,7 @@ describe("command definitions", () => {
 		);
 	});
 
-	it("checks requirements while preserving fluent handler types", () => {
+	it("checks requirements while preserving fluent action types", () => {
 		const auth = defineContext("auth", () => ({ user: "yan" }));
 		const region = defineContext("region", () => "us-east-1");
 		const definition = defineCommand("deploy", { requires: [auth] }, (command) =>
@@ -275,7 +275,7 @@ describe("command definitions", () => {
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "force", type: "boolean", required: true })
 				.provide(region())
-				.handle(({ args, flags, ctx }) => {
+				.action(({ args, flags, ctx }) => {
 					type _Target = Assert<IsEqual<typeof args.target, string>>;
 					type _Force = Assert<IsEqual<typeof flags.force, boolean>>;
 					type _Auth = Assert<IsEqual<typeof ctx.auth, { user: string }>>;

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -14,7 +14,7 @@ describe("buildCommandDocumentation", () => {
 			new Crust("app")
 				.args({ name: "file", required: true }, { name: "rest", variadic: true })
 				.flags({ name: "verbose", type: "boolean" })
-				.handle(() => {}),
+				.action(() => {}),
 		);
 		expect(model.usage).toBe("app <file> [rest...] [options]");
 		expect(model.args.map((arg) => arg.token)).toEqual(["<file>", "[rest...]"]);
@@ -27,7 +27,7 @@ describe("buildCommandDocumentation", () => {
 	});
 
 	it("uses explicit usage unchanged", async () => {
-		const model = await docs(new Crust("app").meta({ usage: "app FILE" }).handle(() => {}));
+		const model = await docs(new Crust("app").meta({ usage: "app FILE" }).action(() => {}));
 		expect(model.usage).toBe("app FILE");
 		expect(model.usageSegments).toEqual([{ kind: "custom", text: "app FILE" }]);
 	});
@@ -37,10 +37,10 @@ describe("buildCommandDocumentation", () => {
 			new Crust("app")
 				.add(
 					defineCommand("visible", (command) =>
-						command.add(defineCommand("nested", (child) => child.handle(() => {}))),
+						command.add(defineCommand("nested", (child) => child.action(() => {}))),
 					),
 				)
-				.add(defineCommand("hidden", (command) => command.meta({ hidden: true }).handle(() => {}))),
+				.add(defineCommand("hidden", (command) => command.meta({ hidden: true }).action(() => {}))),
 		);
 		expect(model.children.map((child) => child.name)).toEqual(["visible"]);
 		expect(model.children[0]?.children[0]?.path).toEqual(["app", "visible", "nested"]);
@@ -60,7 +60,7 @@ describe("buildCommandDocumentation", () => {
 					},
 					{ name: "help", type: "boolean", noNegate: true },
 				)
-				.handle(() => {}),
+				.action(() => {}),
 		);
 		expect(model.flags[0]).toMatchObject({
 			name: "color",
@@ -74,7 +74,7 @@ describe("buildCommandDocumentation", () => {
 		const model = await docs(
 			new Crust("app")
 				.flags({ name: "target", type: "string", default: "bun", choices: ["bun", "node"] })
-				.handle(() => {}),
+				.action(() => {}),
 		);
 		expect(model.flags[0]).toMatchObject({ default: "bun", choices: ["bun", "node"] });
 	});

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -48,7 +48,7 @@ export interface CommandDocumentation {
 	/** Plain usage line: `usageSegments` texts joined with spaces. */
 	readonly usage: string;
 	readonly usageSegments: readonly UsageSegment[];
-	readonly hasHandler: boolean;
+	readonly hasAction: boolean;
 	readonly args: readonly DocumentationArg[];
 	readonly flags: readonly DocumentationFlag[];
 	/** Visible children only; hidden commands remain invocable but are not documentation. */
@@ -103,7 +103,7 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 		? [{ kind: "custom", text: command.meta.usage }]
 		: [
 				{ kind: "path", text: path.join(" ") },
-				...(children.length > 0 && !command.hasHandler
+				...(children.length > 0 && !command.hasAction
 					? [{ kind: "command", text: "<command>" } as const]
 					: []),
 				...args.map((arg) => ({ kind: "arg", text: arg.token, required: arg.required }) as const),
@@ -118,7 +118,7 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 		aliases: Object.freeze([...(command.meta.aliases ?? [])]),
 		usage,
 		usageSegments: Object.freeze(usageSegments.map((segment) => Object.freeze(segment))),
-		hasHandler: command.hasHandler,
+		hasAction: command.hasAction,
 		args: Object.freeze(args),
 		flags: Object.freeze(flags),
 		children: Object.freeze(children),

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -209,7 +209,7 @@ async function dispatch(
 		if (!resolvedNode.run) return;
 
 		// Standard Schemas on arg/flag definitions own value validation and
-		// transformation; the handler receives schema outputs.
+		// transformation; the action receives schema outputs.
 		const validated = await applySchemas(resolvedNode, parsed);
 
 		// Native resource protocol: Context values implementing
@@ -399,7 +399,7 @@ export async function executeInvocation(
 	}
 }
 
-/** Prepare a frozen, validated snapshot without invoking a command handler. */
+/** Prepare a frozen, validated snapshot without invoking a command action. */
 export async function prepareInvocationSnapshot(
 	node: CommandNode,
 	materializeCommandDefinition: MaterializeCommandDefinition,

--- a/packages/core/src/command/node.ts
+++ b/packages/core/src/command/node.ts
@@ -12,7 +12,7 @@ import type { ArgsDef, CommandMeta, FlagsDef } from "../types.ts";
  * Built by the `Crust` builder class; not part of the public API.
  * Each node carries its own local flags, the pre-computed effective
  * (Context-owned + local merged) flags, positional args, subcommands,
- * plugins, and the Command Handler.
+ * plugins, and the Command Action.
  */
 export interface CommandNode {
 	/** Command metadata (name, description, usage) */
@@ -31,7 +31,7 @@ export interface CommandNode {
 	contexts: ContextInstance[];
 	/** Extensions registered via `.extend()` (root builder only) */
 	extensions: Extension[];
-	/** The Command Handler */
+	/** The Command Action */
 	run?: (ctx: unknown) => void | Promise<void>;
 }
 
@@ -44,7 +44,7 @@ export interface CommandNode {
  *
  * @param name - The command name.
  * @returns A fresh `CommandNode` with empty flags, no args, no subcommands,
- *          no plugins, and no lifecycle handlers.
+ *          no plugins, and no action.
  */
 export function createCommandNode(name: string): CommandNode {
 	return {

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -36,7 +36,7 @@ describe("snapshotCommand", () => {
 
 		expect(snapshot.meta.name).toBe("cli");
 		expect(snapshot.meta.description).toBe("root cli");
-		expect(snapshot.hasHandler).toBe(true);
+		expect(snapshot.hasAction).toBe(true);
 		expect(snapshot.args).toEqual([{ name: "file", type: "string", required: true }]);
 		expect(snapshot.flags.verbose).toEqual({
 			type: "boolean",
@@ -45,7 +45,7 @@ describe("snapshotCommand", () => {
 		});
 		expect(snapshot.subCommands.build?.meta.aliases).toEqual(["b"]);
 		expect(snapshot.subCommands.build?.meta.hidden).toBe(true);
-		expect(snapshot.subCommands.build?.hasHandler).toBe(false);
+		expect(snapshot.subCommands.build?.hasAction).toBe(false);
 	});
 
 	it("is serializable: no functions, URL defaults become strings", () => {
@@ -65,7 +65,7 @@ describe("snapshotCommand", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
-			.add(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.action(() => {})));
 
 		const snapshot = await app.snapshot();
 		expect(snapshot.flags["api-key"]).toEqual({

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -36,7 +36,7 @@ export interface FlagSnapshot {
 
 /**
  * A readonly, serializable description of a command, exposed across public
- * API boundaries (Command Handler context, Extension hooks, and
+ * API boundaries (Command Action context, Extension hooks, and
  * `COMMAND_NOT_FOUND` error details) instead of internal command nodes.
  *
  * `flags` contains the effective (Context-owned + local merged) flags — the same
@@ -44,8 +44,8 @@ export interface FlagSnapshot {
  */
 export interface CommandSnapshot {
 	readonly meta: Readonly<CommandMeta>;
-	/** Whether the command defines a Command Handler */
-	readonly hasHandler: boolean;
+	/** Whether the command defines a Command Action */
+	readonly hasAction: boolean;
 	readonly args: readonly ArgSnapshot[];
 	readonly flags: Readonly<Record<string, FlagSnapshot>>;
 	readonly subCommands: Readonly<Record<string, CommandSnapshot>>;
@@ -150,7 +150,7 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 			aliases: node.meta.aliases ? Object.freeze([...node.meta.aliases]) : undefined,
 			hidden: node.meta.hidden,
 		}),
-		hasHandler: node.run !== undefined,
+		hasAction: node.run !== undefined,
 		args: Object.freeze((node.args ?? []).map(snapshotArg)),
 		flags: Object.freeze(flags),
 		subCommands: Object.freeze(subCommands),

--- a/packages/core/src/parsing/schema.test.ts
+++ b/packages/core/src/parsing/schema.test.ts
@@ -28,9 +28,9 @@ const port = () =>
 	});
 
 describe("Standard Schema on arg definitions", () => {
-	it("passes the raw string token to the schema and hands the output to the handler", async () => {
+	it("passes the raw string token to the schema and hands the output to the action", async () => {
 		let received: unknown;
-		const app = new Crust("cli").args({ name: "port", schema: port() }).handle(({ args }) => {
+		const app = new Crust("cli").args({ name: "port", schema: port() }).action(({ args }) => {
 			received = args.port;
 		});
 
@@ -39,7 +39,7 @@ describe("Standard Schema on arg definitions", () => {
 	});
 
 	it("schema owns requiredness: a missing arg reaches the schema as undefined", async () => {
-		const app = new Crust("cli").args({ name: "port", schema: port() }).handle(() => {});
+		const app = new Crust("cli").args({ name: "port", schema: port() }).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({
 			code: "VALIDATION",
@@ -55,7 +55,7 @@ describe("Standard Schema on arg definitions", () => {
 
 		const app = new Crust("cli")
 			.args({ name: "files", variadic: true, schema: upper })
-			.handle(({ args }) => {
+			.action(({ args }) => {
 				received = args.files;
 			});
 
@@ -76,7 +76,7 @@ describe("Standard Schema on arg definitions", () => {
 			},
 		};
 
-		const app = new Crust("cli").args({ name: "name", schema: asyncSchema }).handle(({ args }) => {
+		const app = new Crust("cli").args({ name: "name", schema: asyncSchema }).action(({ args }) => {
 			received = args.name;
 		});
 
@@ -90,7 +90,7 @@ describe("Standard Schema on flag definitions", () => {
 		let received: unknown;
 		const app = new Crust("cli")
 			.flags({ name: "port", type: "string", schema: port() })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				received = flags.port;
 			});
 
@@ -105,7 +105,7 @@ describe("Standard Schema on flag definitions", () => {
 		}));
 		const app = new Crust("cli")
 			.flags({ name: "loud", type: "boolean", schema: onOff })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				received = flags.loud;
 			});
 
@@ -120,7 +120,7 @@ describe("Standard Schema on flag definitions", () => {
 		const app = new Crust("cli")
 			.args({ name: "input", schema: port() })
 			.flags({ name: "port", type: "string", schema: port() })
-			.handle(() => {});
+			.action(() => {});
 
 		try {
 			await app.run(["oops", "--port", "nope"]);
@@ -141,7 +141,7 @@ describe("Standard Schema on flag definitions", () => {
 		const probe = schema<boolean | undefined, string>((raw) => ({ value: String(raw) }));
 		const app = new Crust("cli")
 			.flags({ name: "loud", type: "boolean", schema: probe })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				received = flags.loud;
 			});
 
@@ -156,7 +156,7 @@ describe("Standard Schema on flag definitions", () => {
 		}));
 		const app = new Crust("cli")
 			.flags({ name: "tag", type: "string", multiple: true, schema: csv })
-			.handle(({ flags }) => {
+			.action(({ flags }) => {
 				received = flags.tag;
 			});
 
@@ -166,10 +166,10 @@ describe("Standard Schema on flag definitions", () => {
 });
 
 describe("schema interaction with Extensions", () => {
-	it("pre-run hooks observe raw values while the handler sees schema outputs", async () => {
+	it("pre-run hooks observe raw values while the action sees schema outputs", async () => {
 		const { defineExtension } = await import("../api/extension.ts");
 		let preRunSaw: unknown;
-		let handlerSaw: unknown;
+		let actionSaw: unknown;
 
 		const probe = defineExtension("probe", {
 			hooks: {
@@ -182,14 +182,14 @@ describe("schema interaction with Extensions", () => {
 		const app = new Crust("cli")
 			.flags({ name: "port", type: "string", schema: port() })
 			.extend(probe)
-			.handle(({ flags }) => {
-				handlerSaw = flags.port;
+			.action(({ flags }) => {
+				actionSaw = flags.port;
 			});
 
 		await app.run(["--port", "8080"]);
 
 		expect(preRunSaw).toBe("8080"); // raw, pre-validation
-		expect(handlerSaw).toBe(8080); // schema output
+		expect(actionSaw).toBe(8080); // schema output
 	});
 
 	it("a pre-run finish skips schema validation entirely", async () => {
@@ -204,7 +204,7 @@ describe("schema interaction with Extensions", () => {
 		const app = new Crust("cli")
 			.flags({ name: "x", type: "string", schema: spy })
 			.extend(gate)
-			.handle(() => {});
+			.action(() => {});
 
 		await app.run(["--x", "whatever"]);
 		expect(validated).toBe(false);
@@ -216,11 +216,11 @@ describe("schema type inference", () => {
 	type Equal<A, B> =
 		(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
-	it("the schema output type reaches the Command Handler", () => {
+	it("the schema output type reaches the Command Action", () => {
 		new Crust("cli")
 			.args({ name: "port", schema: port() })
 			.flags({ name: "tag", type: "string", schema: port() })
-			.handle((_ctx) => {
+			.action((_ctx) => {
 				type _argOutput = Expect<Equal<(typeof _ctx.args)["port"], number>>;
 				type _flagOutput = Expect<Equal<(typeof _ctx.flags)["tag"], number>>;
 			});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,7 +173,7 @@ interface RawArgDef extends ArgDefBase {
  * The schema receives the raw string token (`string | undefined` when the
  * argument is absent; `string[]` for variadic args) and exclusively owns
  * coercion, defaults, requiredness, choices, and validation. Its inferred
- * output type reaches the Command Handler. Core value options (`type`,
+ * output type reaches the Command Action. Core value options (`type`,
  * `default`, `required`, `choices`, `parse`) cannot be mixed in.
  */
 interface SchemaArgDef {
@@ -270,7 +270,7 @@ interface StringFlagDef extends SingleFlagBase {
 	 *
 	 * Receives the raw token as it appeared on the command line (after
 	 * `choices` validation, when present) and returns the resolved value
-	 * that flows to the `run` handler. The return type is inferred and
+	 * that flows to the `run` action. The return type is inferred and
 	 * becomes the flag's runtime type.
 	 *
 	 * Constraints:
@@ -531,7 +531,7 @@ export type MergeFlags<Base extends FlagsDef, Override extends FlagsDef> = Simpl
 	Omit<Base, keyof Override> & Override
 >;
 
-/** Computes a command's handler-visible flags from local and Context-owned definitions. */
+/** Computes a command's action-visible flags from local and Context-owned definitions. */
 export type EffectiveFlags<Local extends FlagsDef, Owned extends FlagsDef = {}> =
 	MergeFlags<Local, Owned> extends infer R extends FlagsDef ? R : never;
 

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -35,7 +35,7 @@ export const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 
 // Inferred CommandDefinition<R> embeds the required ContextFactory shape
 export const deploy = defineCommand("deploy", { requires: [auth] }, (cmd) =>
-	cmd.handle(({ ctx }) => {
+	cmd.action(({ ctx }) => {
 		void ctx.auth;
 	}),
 );
@@ -44,7 +44,7 @@ export const deploy = defineCommand("deploy", { requires: [auth] }, (cmd) =>
 export const app = new Crust("consumer-cli")
 	.flags(...flags)
 	.provide(auth())
-	.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+	.add(defineCommand("build", (cmd) => cmd.action(() => {})))
 	.add(deploy);
 `;
 

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -36,12 +36,12 @@ const serveCmd = defineCommand("serve", (command) =>
 	command
 		.args({ name: "dir", type: "string", default: "." })
 		.flags({ name: "port", type: "number", default: 3000, short: "p" })
-		.handle(({ args, flags }) => {
+		.action(({ args, flags }) => {
 			console.log(`serve ${args.dir} on ${flags.port}`);
 		}),
 );
 
-const rootCmd = rootBase.add(serveCmd).handle(({ flags }) => {
+const rootCmd = rootBase.add(serveCmd).action(({ flags }) => {
 	if (flags.help) {
 		console.log("help");
 	}
@@ -63,7 +63,7 @@ describe("integration: core APIs", () => {
 	});
 
 	it("execute() catches errors and sets exit code", async () => {
-		const failCmd = new Crust("fail").handle(() => {
+		const failCmd = new Crust("fail").action(() => {
 			throw new Error("boom");
 		});
 
@@ -129,7 +129,7 @@ describe("integration: .execute() full pipeline with argv override", () => {
 		const deployment = defineContext("deployment", { flags: [env, dryRun] }, ({ flags }) => flags);
 		const app = new Crust("deploy").provide(deployment()).add(
 			defineCommand("service", { requires: [deployment] }, (cmd) =>
-				cmd.args(defineArg("name", { type: "string", required: true })).handle(({ args, ctx }) => {
+				cmd.args(defineArg("name", { type: "string", required: true })).action(({ args, ctx }) => {
 					console.log(
 						`deploy service=${args.name} env=${ctx.deployment.env} dryRun=${ctx.deployment.dryRun}`,
 					);
@@ -148,7 +148,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		process.exitCode = 0;
 	});
 
-	it("routes before the subcommand and passes schema output to setup and handler", async () => {
+	it("routes before the subcommand and passes schema output to setup and action", async () => {
 		const schema: StandardSchema<string | undefined, number> = {
 			"~standard": {
 				version: 1,
@@ -166,7 +166,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 			credential: flags["api-key"],
 		}));
 		const deploy = defineCommand("deploy", { requires: [auth] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				console.log(`${typeof ctx.auth.credential}:${ctx.auth.credential}`);
 			}),
 		);
@@ -189,7 +189,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 				defineCommand("group", { requires: [logging] }, (group) =>
 					group.add(
 						defineCommand("deploy", { requires: [logging] }, (deploy) =>
-							deploy.handle(({ ctx }) => console.log(`verbose=${ctx.logging.verbose}`)),
+							deploy.action(({ ctx }) => console.log(`verbose=${ctx.logging.verbose}`)),
 						),
 					),
 				),
@@ -208,7 +208,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const auth = defineContext("auth", { flags: [token] }, () => ({}));
 		const app = new Crust("cli")
 			.provide(auth())
-			.add(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.action(() => {})));
 
 		const result = await executeCrust(app, ["deploy"]);
 		expect(result.exitCode).toBe(1);
@@ -222,7 +222,7 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 			.provide(outputConfig())
 			.add(
 				defineCommand("render", { requires: [outputConfig] }, (command) =>
-					command.handle(({ ctx }) => console.log(`output=${ctx["output-config"].output}`)),
+					command.action(({ ctx }) => console.log(`output=${ctx["output-config"].output}`)),
 				),
 			);
 
@@ -232,19 +232,19 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 	});
 });
 
-describe("integration: Extension adds flag visible to subcommand handler", () => {
+describe("integration: Extension adds flag visible to subcommand action", () => {
 	beforeEach(() => {
 		process.exitCode = 0;
 	});
 
-	it("Extension flag on root is parsed and available to root handler", async () => {
+	it("Extension flag on root is parsed and available to root action", async () => {
 		const versionExtension = defineExtension("version-extension", {
 			flags: {
 				version: { type: "boolean", short: "V", recursive: false },
 			},
 		});
 
-		const app = new Crust("cli").extend(versionExtension).handle((ctx) => {
+		const app = new Crust("cli").extend(versionExtension).action((ctx) => {
 			if ((ctx.flags as Record<string, unknown>).version) {
 				console.log("v1.0.0");
 			} else {
@@ -271,7 +271,7 @@ describe("integration: Extension adds flag visible to subcommand handler", () =>
 		});
 		const app = new Crust("cli").extend(logging).add(
 			defineCommand("sub", (cmd) =>
-				cmd.handle(() => {
+				cmd.action(() => {
 					order.push("sub:run");
 				}),
 			),
@@ -296,7 +296,7 @@ describe("integration: nested added definitions end-to-end", () => {
 			defineCommand("remote", { requires: [logging] }, (cmd) =>
 				cmd.provide(remoteConfig()).add(
 					defineCommand("add", { requires: [logging, remoteConfig] }, (cmd2) =>
-						cmd2.args({ name: "name", type: "string", required: true }).handle(({ args, ctx }) => {
+						cmd2.args({ name: "name", type: "string", required: true }).action(({ args, ctx }) => {
 							console.log(
 								`add remote=${args.name} verbose=${ctx.logging.verbose} timeout=${ctx["remote-config"].timeout}`,
 							);
@@ -318,21 +318,21 @@ describe("integration: nested added definitions end-to-end", () => {
 		expect(result.exitCode).toBe(0);
 	});
 
-	it("parent with run handler falls back when unknown subcommand given as positional", async () => {
+	it("parent with an action falls back when unknown subcommand given as positional", async () => {
 		const app = new Crust("cli")
 			.args({ name: "input", type: "string" })
-			.handle((ctx) => {
+			.action((ctx) => {
 				console.log(`root input=${ctx.args.input}`);
 			})
 			.add(
 				defineCommand("sub", (cmd) =>
-					cmd.handle(() => {
+					cmd.action(() => {
 						console.log("sub ran");
 					}),
 				),
 			);
 
-		// "unknown" is not a subcommand, so root handler runs with it as positional
+		// "unknown" is not a subcommand, so root action runs with it as positional
 		const result = await executeCrust(app, ["unknown"]);
 		expect(result.stdout).toContain("root input=unknown");
 		expect(result.exitCode).toBe(0);
@@ -350,7 +350,7 @@ describe("integration: split-file definitions end-to-end", () => {
 		command
 			.flags({ name: "format", type: "string", default: "table" })
 			.args({ name: "resource", type: "string", required: true })
-			.handle(({ args, flags, ctx }) => {
+			.action(({ args, flags, ctx }) => {
 				console.log(`list ${args.resource} format=${flags.format} verbose=${ctx.logging.verbose}`);
 			}),
 	);
@@ -360,7 +360,7 @@ describe("integration: split-file definitions end-to-end", () => {
 				{ name: "resource", type: "string", required: true },
 				{ name: "id", type: "string", required: true },
 			)
-			.handle(({ args, ctx }) => {
+			.action(({ args, ctx }) => {
 				console.log(`get ${args.resource}/${args.id} verbose=${ctx.logging.verbose}`);
 			}),
 	);
@@ -403,7 +403,7 @@ describe("integration: added definitions", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const deployment = defineContext("deployment", { flags: [env] }, ({ flags }) => flags);
 		const status = defineCommand("status", { requires: [logging, deployment] }, (command) =>
-			command.handle(({ ctx }) => {
+			command.action(({ ctx }) => {
 				console.log(`verbose=${ctx.logging.verbose} env=${ctx.deployment.env}`);
 			}),
 		);
@@ -418,7 +418,7 @@ describe("integration: added definitions", () => {
 	});
 
 	it("excludes parent-local flags from added commands", async () => {
-		const sub = defineCommand("sub", (command) => command.handle(() => console.log("sub ran")));
+		const sub = defineCommand("sub", (command) => command.action(() => console.log("sub ran")));
 		const app = new Crust("cli").flags({ name: "rootOnly", type: "string" }).add(sub);
 
 		const result = await executeCrust(app, ["sub", "--rootOnly", "val"]);
@@ -429,10 +429,10 @@ describe("integration: added definitions", () => {
 	it("adds multiple definitions in one call", async () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const deploy = defineCommand("deploy", { requires: [logging] }, (command) =>
-			command.handle(({ ctx }) => console.log(`deploy verbose=${ctx.logging.verbose}`)),
+			command.action(({ ctx }) => console.log(`deploy verbose=${ctx.logging.verbose}`)),
 		);
 		const status = defineCommand("status", { requires: [logging] }, (command) =>
-			command.handle(({ ctx }) => console.log(`status verbose=${ctx.logging.verbose}`)),
+			command.action(({ ctx }) => console.log(`status verbose=${ctx.logging.verbose}`)),
 		);
 		const app = new Crust("cli").provide(logging()).add(status, deploy);
 
@@ -455,7 +455,7 @@ describe("integration: Context-owned boolean flag negation", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
-				cmd.handle(({ ctx }) => {
+				cmd.action(({ ctx }) => {
 					console.log(`verbose=${ctx.logging.verbose}`);
 				}),
 			),
@@ -481,7 +481,7 @@ describe("integration: Context-owned multiple-value flag", () => {
 		const tags = defineContext("tags", { flags: [tag] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(tags()).add(
 			defineCommand("sub", { requires: [tags] }, (cmd) =>
-				cmd.handle(({ ctx }) => {
+				cmd.action(({ ctx }) => {
 					console.log(`tags=${JSON.stringify(ctx.tags.tag)}`);
 				}),
 			),
@@ -507,7 +507,7 @@ describe("integration: separator (--) with subcommand and Context-owned flags", 
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(logging()).add(
 			defineCommand("sub", { requires: [logging] }, (cmd) =>
-				cmd.handle(({ ctx, rawArgs }) => {
+				cmd.action(({ ctx, rawArgs }) => {
 					console.log(`verbose=${ctx.logging.verbose}`);
 					console.log(`rawArgs=${JSON.stringify(rawArgs)}`);
 				}),
@@ -550,7 +550,7 @@ describe("integration: complex real-world CLI scenario", () => {
 			.extend(auditExtension)
 			.add(
 				defineCommand("deploy", { requires: [settings] }, (cmd) =>
-					cmd.flags({ name: "env", type: "string", required: true }).handle(({ flags, ctx }) => {
+					cmd.flags({ name: "env", type: "string", required: true }).action(({ flags, ctx }) => {
 						order.push("deploy:run");
 						console.log(
 							`deploy env=${flags.env} verbose=${ctx.settings.verbose} config=${ctx.settings.config}`,
@@ -558,7 +558,7 @@ describe("integration: complex real-world CLI scenario", () => {
 					}),
 				),
 				defineCommand("status", { requires: [settings] }, (cmd) =>
-					cmd.handle(({ ctx }) => {
+					cmd.action(({ ctx }) => {
 						order.push("status:run");
 						console.log(`status verbose=${ctx.settings.verbose} config=${ctx.settings.config}`);
 					}),

--- a/packages/create-crust/src/index.ts
+++ b/packages/create-crust/src/index.ts
@@ -67,7 +67,7 @@ const app = new Crust("create-crust")
 		type: "string",
 		description: "Project directory to scaffold into",
 	})
-	.handle(async ({ args, flags }) => {
+	.action(async ({ args, flags }) => {
 		// ── Collect all prompts before any file operations ──────────────
 		// This ensures a mid-prompt Ctrl+C won't leave partially scaffolded files.
 

--- a/packages/create-crust/templates/minimal/src/cli.ts
+++ b/packages/create-crust/templates/minimal/src/cli.ts
@@ -19,7 +19,7 @@ const app = new Crust("{{name}}")
 		default: "Hello",
 		short: "g",
 	})
-	.handle(({ args, flags, stdout }) => {
+	.action(({ args, flags, stdout }) => {
 		stdout(`${flags.greet}, ${args.name}!`);
 	});
 

--- a/packages/create-crust/tests/scaffold.test.ts
+++ b/packages/create-crust/tests/scaffold.test.ts
@@ -191,7 +191,7 @@ describe("scaffold", () => {
 		// Has a positional name argument with string literal type
 		expect(cliContent).toContain('type: "string"');
 		// Has a run function
-		expect(cliContent).toContain(".handle(");
+		expect(cliContent).toContain(".action(");
 	});
 
 	it("generates CLI file that is valid TypeScript (compile check)", async () => {
@@ -210,7 +210,7 @@ describe("scaffold", () => {
 		expect(cliContent).toContain('new Crust("compile-test-cli")');
 		expect(cliContent).toContain(".args({");
 		expect(cliContent).toContain(".flags(");
-		expect(cliContent).toContain(".handle(");
+		expect(cliContent).toContain(".action(");
 	});
 
 	it("supports the minimal template with runtime distribution", async () => {

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -82,7 +82,7 @@ describe("crust CLI entry point", () => {
 		it("should use extensions for root behavior", async () => {
 			const app = makeCrustApp();
 			const root = await app.snapshot();
-			expect(root.hasHandler).toBe(false);
+			expect(root.hasAction).toBe(false);
 		});
 
 		it("should have build and publish as subcommands", async () => {

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -44,7 +44,7 @@ async function parseBuildArgs(argv: string[]) {
 		captured = commandContext;
 	};
 	await app.run(["build", ...argv]);
-	if (!captured) throw new Error("build handler did not run");
+	if (!captured) throw new Error("build action did not run");
 	return captured;
 }
 

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -351,7 +351,7 @@ export const buildCommand = defineCommand("build", (command) =>
 				default: false,
 			},
 		)
-		.handle(async ({ flags }) => {
+		.action(async ({ flags }) => {
 			const cwd = process.cwd();
 
 			// Resolve entry file path relative to cwd

--- a/packages/crust/src/commands/publish.test.ts
+++ b/packages/crust/src/commands/publish.test.ts
@@ -22,7 +22,7 @@ async function parsePublishArgs(argv: string[]) {
 		captured = { flags: (ctx as { flags: Record<string, unknown> }).flags };
 	};
 	await app.run(["publish", ...argv]);
-	if (!captured) throw new Error("publish handler did not run");
+	if (!captured) throw new Error("publish action did not run");
 	return captured;
 }
 

--- a/packages/crust/src/commands/publish.ts
+++ b/packages/crust/src/commands/publish.ts
@@ -243,7 +243,7 @@ export const publishCommand = defineCommand("publish", (command) =>
 				description: "Override the registry passed to bun publish",
 			},
 		)
-		.handle(async ({ flags }) => {
+		.action(async ({ flags }) => {
 			const stageDir = resolve(process.cwd(), flags["stage-dir"]);
 			const manifest = readPublishManifest(stageDir);
 

--- a/packages/crust/src/utils/distribute.test.ts
+++ b/packages/crust/src/utils/distribute.test.ts
@@ -252,7 +252,7 @@ describe("runDistributeBuild with --man", () => {
 		writeFileSync(
 			join(tmpDir, "src", "cli.ts"),
 			`import { Crust } from "@crustjs/core";
-export const app = new Crust("x").handle(() => {});
+export const app = new Crust("x").action(() => {});
 `,
 		);
 		writeFileSync(

--- a/packages/extensions/src/completion/adversarial.test.ts
+++ b/packages/extensions/src/completion/adversarial.test.ts
@@ -28,13 +28,13 @@ import { walkCommandNode } from "./walker.ts";
 describe("walker · validation", () => {
 	it("rejects command names containing whitespace", () => {
 		const cli = new Crust("bad")
-			.add(defineCommand("two words" as string, (c) => c.handle(() => {})))
-			.handle(() => {});
+			.add(defineCommand("two words" as string, (c) => c.action(() => {})))
+			.action(() => {});
 		expect(() => walkCommandNode(snapshotCommand(cli._node))).toThrow(/invalid command name/);
 	});
 
 	it("rejects flag names with shell metacharacters", () => {
-		const cli = new Crust("bad").flags({ name: "a;rm", type: "boolean" } as never).handle(() => {});
+		const cli = new Crust("bad").flags({ name: "a;rm", type: "boolean" } as never).action(() => {});
 		expect(() => walkCommandNode(snapshotCommand(cli._node))).toThrow(/invalid flag name/);
 	});
 
@@ -45,21 +45,21 @@ describe("walker · validation", () => {
 				type: "string",
 				choices: ["a", "two words", "c"],
 			})
-			.handle(() => {});
+			.action(() => {});
 		expect(() => walkCommandNode(snapshotCommand(cli._node))).toThrow(/unsupported choice value/);
 	});
 
 	it("rejects choice values containing single quotes", () => {
 		const cli = new Crust("bad")
 			.flags({ name: "target", type: "string", choices: ["a", "it's", "c"] })
-			.handle(() => {});
+			.action(() => {});
 		expect(() => walkCommandNode(snapshotCommand(cli._node))).toThrow(/unsupported choice value/);
 	});
 
 	it("strips control characters from descriptions instead of throwing", () => {
 		const cli = new Crust("safe")
 			.meta({ description: "first line\nsecond line\rstill same line" })
-			.handle(() => {});
+			.action(() => {});
 		const spec = walkCommandNode(snapshotCommand(cli._node));
 		// Newlines and CR collapse to spaces during normalisation.
 		expect(spec.root.description).toBe("first line second line still same line");
@@ -251,7 +251,7 @@ describe("completionExtension · --output-dir traversal", () => {
 		try {
 			const cli = new Crust("real")
 				.extend(completionExtension({ binName: "../pwn" }))
-				.handle(() => {});
+				.action(() => {});
 			await cli.execute({ argv: ["completion", "bash"] });
 		} finally {
 			console.error = origError;
@@ -267,7 +267,7 @@ describe("completionExtension · --output-dir traversal", () => {
 		// and nothing escapes.
 		const tmp = await mkdtemp(join(tmpdir(), "tp010-traversal-"));
 		try {
-			const cli = new Crust("good").extend(completionExtension({ version: "1" })).handle(() => {});
+			const cli = new Crust("good").extend(completionExtension({ version: "1" })).action(() => {});
 			await cli.execute({
 				argv: ["completion", "bash", "--output-dir", tmp],
 			});

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -64,7 +64,7 @@ function buildCli() {
 				cmd
 					.meta({ description: "Build artifact" })
 					.flags({ name: "target", type: "string", choices: ["browser", "bun", "node"] })
-					.handle(() => {}),
+					.action(() => {}),
 			),
 			defineCommand("deploy", (cmd) =>
 				cmd
@@ -78,13 +78,13 @@ function buildCli() {
 									type: "string",
 									choices: ["dev", "staging", "prod"],
 								})
-								.handle(() => {}),
+								.action(() => {}),
 						),
 					)
-					.handle(() => {}),
+					.action(() => {}),
 			),
 		)
-		.handle(() => {});
+		.action(() => {});
 }
 
 describe("completionExtension", () => {
@@ -99,7 +99,7 @@ describe("completionExtension", () => {
 	it("exposes options: command name override", async () => {
 		const app = new Crust("mycli")
 			.extend(completionExtension({ command: "shell-completion" }))
-			.handle(() => {});
+			.action(() => {});
 		const root = await app.snapshot();
 		expect(Object.keys(root.subCommands)).toContain("shell-completion");
 	});
@@ -151,7 +151,7 @@ describe("completionExtension", () => {
 	it("rejects unsupported shell names with a clear stderr message", async () => {
 		// `choices` enforcement is wired into the parser, so the parser
 		// rejects unsupported shell names with a `CrustError("PARSE", …)`
-		// before the run handler ever sees the value. The error message names
+		// before the action ever sees the value. The error message names
 		// the offending value and the allowed set.
 		const app = buildCli();
 		await app.execute({ argv: ["completion", "powershell"] });
@@ -221,7 +221,7 @@ describe("completionExtension", () => {
 						shells: ["bash", "zsh"],
 					}),
 				)
-				.handle(() => {});
+				.action(() => {});
 			await app.execute({
 				argv: ["completion", "bash", "--output-dir", tmpDir],
 			});

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -79,7 +79,7 @@ function renderForShell(
  * Build an Extension that contributes a `completion <shell>` command
  * which emits a tab-completion script for bash, zsh, or fish.
  *
- * **Strategy: pure-static.** The handler walks the final root snapshot, so
+ * **Strategy: pure-static.** The action walks the final root snapshot, so
  * registration order is irrelevant — any commands or recursive flags added
  * by other Extensions are visible by the time we generate the script. The
  * walker projects the root snapshot to a small `CompletionSpec`; per-shell
@@ -120,7 +120,7 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 				description:
 					"Write all configured shells' scripts into this directory instead of printing to stdout",
 			})
-			.handle(async (context) => {
+			.action(async (context) => {
 				const rootCommand = context.rootCommand;
 				// Validate `binName` before emitting anything so misconfigured
 				// CLIs fail loudly. The walker also re-validates command/flag

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -95,7 +95,7 @@ describe("walkCommandNode", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const app = new Crust("mycli")
 			.provide(auth())
-			.add(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.action(() => {})));
 
 		const spec = walkCommandNode(snapshotCommand(app._node));
 		expect(spec.root.flags.map((flag) => flag.name)).toContain("api-key");

--- a/packages/extensions/src/completion/walker.ts
+++ b/packages/extensions/src/completion/walker.ts
@@ -176,7 +176,7 @@ function walkCommand(node: CommandSnapshot): CompletionCommand {
 /**
  * Build a `CompletionSpec` from a root `CommandSnapshot`.
  *
- * This is the single entry point used by the plugin's `run()` handler. It
+ * This is the single entry point used by the plugin's `run()` action. It
  * walks lazily — never at `setup()` time — so plugin order is irrelevant
  * (other plugins may add subcommands or inject flags after this plugin
  * registers; we only see the final tree when the user actually invokes the

--- a/packages/extensions/src/did-you-mean.test.ts
+++ b/packages/extensions/src/did-you-mean.test.ts
@@ -34,8 +34,8 @@ describe("didYouMeanExtension", () => {
 	it("suggests the closest command on a typo (smoke test)", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.add(defineCommand("test", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
+			.add(defineCommand("test", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["buld"] });
 
@@ -52,8 +52,8 @@ describe("didYouMeanExtension", () => {
 	it("suggests the canonical name when the input matches an alias", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})))
-			.add(defineCommand("version", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})))
+			.add(defineCommand("version", (cmd) => cmd.action(() => {})));
 
 		// "issuess" is closest to the alias "issues" (distance 1) than to
 		// "issue" (distance 2). The plugin must report the canonical name
@@ -71,7 +71,7 @@ describe("didYouMeanExtension", () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
 			.add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})),
+				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})),
 			);
 
 		await app.execute({ argv: ["isue"] });
@@ -86,8 +86,8 @@ describe("didYouMeanExtension", () => {
 		// because it is a prefix of the input.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).handle(() => {})))
-			.add(defineCommand("install", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})))
+			.add(defineCommand("install", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["insall"] });
 
@@ -99,8 +99,8 @@ describe("didYouMeanExtension", () => {
 	it("lists only canonical names under 'Available commands'", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).handle(() => {})))
-			.add(defineCommand("version", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})))
+			.add(defineCommand("version", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["completely-unknown"] });
 
@@ -112,7 +112,7 @@ describe("didYouMeanExtension", () => {
 	it("deduplicates suggestions when an alias and its canonical both match", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension({ mode: "help" }))
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues"] }).handle(() => {})));
+			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues"] }).action(() => {})));
 
 		// Both the canonical "issue" and the alias "issues" are within
 		// Levenshtein distance 3 of "issuee". The first suggestion line
@@ -131,8 +131,8 @@ describe("didYouMeanExtension", () => {
 		// error output. A close typo of it must not produce a suggestion.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
+			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).action(() => {})));
 
 		// Typo distance(__complet -> __complete) = 1, well within the
 		// threshold. Distance(__complet -> build) is > 3, so without the
@@ -150,10 +150,10 @@ describe("didYouMeanExtension", () => {
 		// the typo, it still must not leak.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
 			.add(
 				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, aliases: ["__comp"] }).handle(() => {}),
+					cmd.meta({ hidden: true, aliases: ["__comp"] }).action(() => {}),
 				),
 			);
 
@@ -168,9 +168,9 @@ describe("didYouMeanExtension", () => {
 	it("omits hidden commands from the 'Available commands' fallback list", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})))
-			.add(defineCommand("test", (cmd) => cmd.handle(() => {})))
-			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
+			.add(defineCommand("test", (cmd) => cmd.action(() => {})))
+			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).action(() => {})));
 
 		// No close match — we want the "Available commands" line.
 		await app.execute({ argv: ["zzzzz"] });

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -111,7 +111,7 @@ export function helpExtension(): Extension {
 		flags: { help: { type: "boolean", short: "h", noNegate: true, description: "Show help" } },
 		hooks: {
 			preRun(context) {
-				if (context.flags.help !== true && context.command.hasHandler) return;
+				if (context.flags.help !== true && context.command.hasAction) return;
 				context.stdout(renderHelp(context.command, context.commandPath));
 				return context.finish();
 			},

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -73,10 +73,10 @@ function lateSkillExtension() {
 					.meta({ description: "Manage agent skills" })
 					.add(
 						defineCommand("update", (cmd) =>
-							cmd.meta({ description: "Update installed skills" }).handle(() => {}),
+							cmd.meta({ description: "Update installed skills" }).action(() => {}),
 						),
 					)
-					.handle(() => {}),
+					.action(() => {}),
 			),
 		],
 	});
@@ -211,7 +211,7 @@ describe("built-in plugins", () => {
 	it("help plugin renders generated help for no-run command", async () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["--help"] });
 
@@ -229,7 +229,7 @@ describe("built-in plugins", () => {
 			.extend(helpExtension())
 			.add(
 				defineCommand("group", (group) =>
-					group.add(defineCommand("build", (build) => build.handle(() => {}))),
+					group.add(defineCommand("build", (build) => build.action(() => {}))),
 				),
 			);
 
@@ -256,7 +256,7 @@ describe("built-in plugins", () => {
 		});
 		const app = new Crust("app")
 			.extend(rootOnly)
-			.add(defineCommand("build", (build) => build.handle(() => {})));
+			.add(defineCommand("build", (build) => build.action(() => {})));
 
 		await expect(app.run(["build", "--root"])).rejects.toMatchObject({ code: "PARSE" });
 	});
@@ -265,7 +265,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())
 			.extend(helpExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["--help"] });
 
@@ -313,7 +313,7 @@ describe("built-in plugins", () => {
 		process.env.NO_COLOR = "1";
 		let seenNoColor: string | undefined = "unset";
 
-		const app = new Crust("app").extend(noColorExtension()).handle(() => {
+		const app = new Crust("app").extend(noColorExtension()).action(() => {
 			seenNoColor = process.env.NO_COLOR;
 		});
 
@@ -334,8 +334,8 @@ describe("built-in plugins", () => {
 			releaseA = resolve;
 		});
 
-		const appA = new Crust("a").extend(noColorExtension()).handle(() => blockA);
-		const appB = new Crust("b").extend(noColorExtension()).handle(() => {});
+		const appA = new Crust("a").extend(noColorExtension()).action(() => blockA);
+		const appB = new Crust("b").extend(noColorExtension()).action(() => {});
 
 		// A (--color) starts and stays pending; B (--no-color) starts and
 		// finishes while A is mid-run, then A completes.
@@ -400,7 +400,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(noColorExtension())
 			.extend(helpExtension())
-			.add(defineCommand("build", (cmd) => cmd.handle(() => {})));
+			.add(defineCommand("build", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["build", "--help"] });
 
@@ -413,7 +413,7 @@ describe("built-in plugins", () => {
 			.extend(helpExtension())
 			.add(
 				defineCommand("create", (cmd) =>
-					cmd.args({ name: "name", type: "string", required: true }).handle(() => {}),
+					cmd.args({ name: "name", type: "string", required: true }).action(() => {}),
 				),
 			);
 
@@ -431,7 +431,7 @@ describe("built-in plugins", () => {
 			.extend(helpExtension())
 			.add(
 				defineCommand("deploy", (cmd) =>
-					cmd.flags({ name: "target", type: "string", required: true }).handle(() => {}),
+					cmd.flags({ name: "target", type: "string", required: true }).action(() => {}),
 				),
 			);
 
@@ -452,7 +452,7 @@ describe("built-in plugins", () => {
 			.extend(helpExtension())
 			.add(
 				defineCommand("build", (cmd) =>
-					cmd.handle((ctx) => {
+					cmd.action((ctx) => {
 						capturedRawArgs = [...ctx.rawArgs];
 					}),
 				),
@@ -473,7 +473,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.provide(auth())
 			.extend(helpExtension())
-			.add(defineCommand("deploy", (command) => command.handle(() => {})));
+			.add(defineCommand("deploy", (command) => command.action(() => {})));
 
 		await app.run(["--help"]);
 		const rootHelp = stripAnsi(getStdout());
@@ -490,7 +490,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
 			.extend(lateSkillExtension())
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["skill", "--help"] });
 
@@ -504,7 +504,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
 			.extend(lateSkillExtension())
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["skill", "update", "--help"] });
 
@@ -518,7 +518,7 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(lateSkillExtension())
 			.extend(helpExtension())
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["skill", "--help"] });
 
@@ -529,7 +529,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin handles --version", async () => {
-		const app = new Crust("app").extend(versionExtension("1.2.3")).handle(() => {});
+		const app = new Crust("app").extend(versionExtension("1.2.3")).action(() => {});
 
 		await app.execute({ argv: ["--version"] });
 
@@ -537,7 +537,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin handles -v alias", async () => {
-		const app = new Crust("app").extend(versionExtension("2.0.0")).handle(() => {});
+		const app = new Crust("app").extend(versionExtension("2.0.0")).action(() => {});
 
 		await app.execute({ argv: ["-v"] });
 
@@ -547,7 +547,7 @@ describe("built-in plugins", () => {
 	it("version plugin ignores --version after -- separator", async () => {
 		let ran = false;
 
-		const app = new Crust("app").extend(versionExtension("1.0.0")).handle(() => {
+		const app = new Crust("app").extend(versionExtension("1.0.0")).action(() => {
 			ran = true;
 		});
 
@@ -562,7 +562,7 @@ describe("built-in plugins", () => {
 
 		const app = new Crust("app").extend(versionExtension("1.0.0")).add(
 			defineCommand("build", (cmd) =>
-				cmd.handle(() => {
+				cmd.action(() => {
 					ran = true;
 				}),
 			),
@@ -579,7 +579,7 @@ describe("built-in plugins", () => {
 			.meta({ description: "Test app" })
 			.extend(versionExtension("1.0.0"))
 			.extend(helpExtension())
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["--help"] });
 
@@ -589,7 +589,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin with function value", async () => {
-		const app = new Crust("app").extend(versionExtension(() => "3.5.0")).handle(() => {});
+		const app = new Crust("app").extend(versionExtension(() => "3.5.0")).action(() => {});
 
 		await app.execute({ argv: ["--version"] });
 
@@ -599,7 +599,7 @@ describe("built-in plugins", () => {
 	it("version plugin supports plain format", async () => {
 		const app = new Crust("app")
 			.extend(versionExtension("1.2.3", { format: "plain" }))
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["--version"] });
 
@@ -613,7 +613,7 @@ describe("built-in plugins", () => {
 					format: (version, context) => `${context.rootCommand.meta.name}/${version}`,
 				}),
 			)
-			.handle(() => {});
+			.action(() => {});
 
 		await app.execute({ argv: ["--version"] });
 
@@ -632,7 +632,7 @@ describe("built-in plugins", () => {
 						description: "Manage issues",
 						aliases: ["issues", "i"],
 					})
-					.handle(() => {}),
+					.action(() => {}),
 			),
 		)._node;
 
@@ -645,7 +645,7 @@ describe("built-in plugins", () => {
 	it("renderHelp renders unchanged for a command without aliases", () => {
 		const command = new Crust("app").add(
 			defineCommand("build", (cmd) =>
-				cmd.meta({ description: "Build the project" }).handle(() => {}),
+				cmd.meta({ description: "Build the project" }).action(() => {}),
 			),
 		)._node;
 
@@ -665,12 +665,12 @@ describe("built-in plugins", () => {
 							description: "Manage issues",
 							aliases: ["issues", "i"],
 						})
-						.handle(() => {}),
+						.action(() => {}),
 				),
 			)
 			.add(
 				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).handle(() => {}),
+					cmd.meta({ description: "Build the project" }).action(() => {}),
 				),
 			)._node;
 
@@ -692,7 +692,7 @@ describe("built-in plugins", () => {
 		const command = new Crust("app")
 			.add(
 				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).handle(() => {}),
+					cmd.meta({ description: "Build the project" }).action(() => {}),
 				),
 			)
 			.add(
@@ -702,7 +702,7 @@ describe("built-in plugins", () => {
 							description: "Internal completion entrypoint",
 							hidden: true,
 						})
-						.handle(() => {}),
+						.action(() => {}),
 				),
 			)._node;
 
@@ -717,23 +717,23 @@ describe("built-in plugins", () => {
 		const command = new Crust("app")
 			.add(
 				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
+					cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
 				),
 			)
-			.handle(() => {})._node;
+			.action(() => {})._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
 		expect(plain).not.toContain("Commands:");
 		expect(plain).not.toContain("__complete");
 	});
 
-	it("renderHelp omits the `<command>` USAGE token when every subcommand is hidden and parent has no run handler", () => {
+	it("renderHelp omits the `<command>` USAGE token when every subcommand is hidden and parent has no action", () => {
 		// Regression: formatUsage previously counted hidden subcommands when
 		// deciding whether to emit `<command>`, producing the incoherent
 		// `Usage: app <command>` with no COMMANDS section below it.
 		const command = new Crust("app").add(
 			defineCommand("__complete", (cmd) =>
-				cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
+				cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
 			),
 		)._node;
 
@@ -750,7 +750,7 @@ describe("built-in plugins", () => {
 		const command = new Crust("app")
 			.add(
 				defineCommand("issue", (cmd) =>
-					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).handle(() => {}),
+					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).action(() => {}),
 				),
 			)
 			.add(
@@ -761,7 +761,7 @@ describe("built-in plugins", () => {
 							aliases: ["__c"],
 							hidden: true,
 						})
-						.handle(() => {}),
+						.action(() => {}),
 				),
 			)._node;
 
@@ -778,12 +778,12 @@ describe("built-in plugins", () => {
 			.extend(helpExtension())
 			.add(
 				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).handle(() => {}),
+					cmd.meta({ description: "Build the project" }).action(() => {}),
 				),
 			)
 			.add(
 				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {
+					cmd.meta({ hidden: true, description: "Internal" }).action(() => {
 						didRun = true;
 					}),
 				),
@@ -806,7 +806,7 @@ describe("built-in plugins", () => {
 				choices: ["browser", "bun", "node"],
 				description: "Build target",
 			})
-			.handle(() => {})._node;
+			.action(() => {})._node;
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
 		expect(plain).toContain("--target");
 		expect(plain).toContain("Build target");
@@ -823,7 +823,7 @@ describe("built-in plugins", () => {
 				choices: ["dev", "staging", "prod"],
 				description: "Target environment",
 			})
-			.handle(() => {})._node;
+			.action(() => {})._node;
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
 		// The ARGS section heading is the marker the rest of the
 		// assertions hang off; without it the test would silently miss
@@ -842,7 +842,7 @@ describe("built-in plugins", () => {
 				default: "a",
 				description: "Build target",
 			})
-			.handle(() => {})._node;
+			.action(() => {})._node;
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
 		// Both suffixes appear on the same flag line, in this order, so the
 		// `[default: ...]` reads before `[choices: ...]`.

--- a/packages/extensions/src/update-notifier.test.ts
+++ b/packages/extensions/src/update-notifier.test.ts
@@ -326,7 +326,7 @@ describe("updateNotifierExtension post-run hook", () => {
 
 	/** Create a basic command node for testing. */
 	function makeCommandSnapshot(name = "test-cli") {
-		return snapshotCommand(new Crust(name).handle(() => {})._node);
+		return snapshotCommand(new Crust(name).action(() => {})._node);
 	}
 
 	/** Helper to invoke the extension post-run hook with a completed outcome. */
@@ -962,13 +962,13 @@ describe("updateNotifierExtension post-run hook", () => {
 	// ── Post-run ordering ─────────────────────────────────────────────────
 
 	describe("post-run ordering", () => {
-		it("runs after the command handler", async () => {
+		it("runs after the command action", async () => {
 			const pkgName = uniquePackageName("ordering");
 			mockRegistryResponse("2.0.0");
 			const executionOrder: string[] = [];
 			const app = new Crust(pkgName)
 				.extend(updateNotifierExtension({ currentVersion: "1.0.0", packageName: pkgName }))
-				.handle(() => {
+				.action(() => {
 					executionOrder.push("command");
 				});
 
@@ -988,7 +988,7 @@ describe("updateNotifierExtension post-run hook", () => {
 			});
 			const app = new Crust(pkgName)
 				.extend(updateNotifierExtension({ currentVersion: "1.0.0", packageName: pkgName }))
-				.handle(() => {
+				.action(() => {
 					throw new Error("command failed");
 				});
 
@@ -1014,7 +1014,7 @@ describe("updateNotifierExtension post-run hook", () => {
 						packageName: pkgName,
 					}),
 				)
-				.handle(() => {
+				.action(() => {
 					commandExecuted = true;
 				});
 
@@ -1043,7 +1043,7 @@ describe("updateNotifierExtension post-run hook", () => {
 						packageName: pkgName,
 					}),
 				)
-				.handle(() => {
+				.action(() => {
 					commandExecuted = true;
 				});
 
@@ -1066,7 +1066,7 @@ describe("updateNotifierExtension post-run hook", () => {
 						packageName: pkgName,
 					}),
 				)
-				.handle(() => {
+				.action(() => {
 					commandExecuted = true;
 				});
 
@@ -1089,7 +1089,7 @@ describe("updateNotifierExtension post-run hook", () => {
 						packageName: pkgName,
 					}),
 				)
-				.handle(() => {});
+				.action(() => {});
 
 			await app.run([], { stderr: (text) => stderr.push(text) });
 

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -428,7 +428,7 @@ function resolveUpdateCommand(
  * - Without `cache`, checks run once per process execution.
  * - The network check is non-blocking — it never delays command execution.
  * - All internal errors (network, cache, parsing) are silently swallowed.
- * - The update notice is emitted *after* the command handler completes.
+ * - The update notice is emitted *after* the command action completes.
  * - Duplicate notifications for the same version are suppressed.
  *
  * @param options - Plugin configuration. `currentVersion` and `packageName` are required.
@@ -442,7 +442,7 @@ function resolveUpdateCommand(
  *
  * const app = new Crust("my-cli").meta({ description: "My awesome CLI" })
  *   .extend(updateNotifier({ packageName: "my-cli", currentVersion: pkg.version }))
- *   .handle(() => {
+ *   .action(() => {
  *     console.log("Hello!");
  *   });
  *

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -11,7 +11,7 @@ describe("renderManPageMdoc", () => {
 			.meta({ description: "Demo CLI for tests." })
 			.extend(help())
 			.flags({ name: "verbose", type: "boolean", short: "v", description: "Verbose" })
-			.add(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).handle(() => {})));
+			.add(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).action(() => {})));
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -30,7 +30,7 @@ describe("renderManPageMdoc", () => {
 	it("escapes leading dots in descriptions and .Nd", async () => {
 		const app = new Crust("x")
 			.meta({ description: ".config is read automatically." })
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "x", section: 1 });
@@ -40,7 +40,7 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("uses explicit date for .Dd", async () => {
-		const app = new Crust("x").handle(() => {});
+		const app = new Crust("x").action(() => {});
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({
 			root,
@@ -54,7 +54,7 @@ describe("renderManPageMdoc", () => {
 		const prev = process.env.SOURCE_DATE_EPOCH;
 		process.env.SOURCE_DATE_EPOCH = "86400";
 		try {
-			const app = new Crust("x").handle(() => {});
+			const app = new Crust("x").action(() => {});
 			const root = await app.snapshot();
 			const mdoc = renderManPageMdoc({ root, name: "x" });
 			expect(mdoc.startsWith(".Dd January 2, 1970\n")).toBe(true);
@@ -72,12 +72,12 @@ describe("renderManPageMdoc", () => {
 			.meta({ description: "Demo CLI for alias tests." })
 			.add(
 				defineCommand("issue", (cmd) =>
-					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).handle(() => {}),
+					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).action(() => {}),
 				),
 			)
 			.add(
 				defineCommand("version", (cmd) =>
-					cmd.meta({ description: "Show version" }).handle(() => {}),
+					cmd.meta({ description: "Show version" }).action(() => {}),
 				),
 			);
 
@@ -105,14 +105,14 @@ describe("renderManPageMdoc", () => {
 			.meta({ description: "Demo." })
 			.add(
 				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).handle(() => {}),
+					cmd.meta({ description: "Build the project" }).action(() => {}),
 				),
 			)
 			.add(
 				defineCommand("__complete", (cmd) =>
 					cmd
 						.meta({ description: "Internal completion entrypoint", hidden: true })
-						.handle(() => {}),
+						.action(() => {}),
 				),
 			);
 
@@ -127,10 +127,10 @@ describe("renderManPageMdoc", () => {
 		const app = new Crust("demo")
 			.add(
 				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).handle(() => {}),
+					cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
 				),
 			)
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -148,7 +148,7 @@ describe("renderManPageMdoc", () => {
 				choices: ["browser", "bun", "node"],
 				description: "Build target",
 			})
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -168,7 +168,7 @@ describe("renderManPageMdoc", () => {
 				choices: ["dev", "staging", "prod"],
 				description: "Target environment",
 			})
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -188,7 +188,7 @@ describe("renderManPageMdoc", () => {
 				aliases: ["out"],
 				description: "Where to write",
 			})
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -206,7 +206,7 @@ describe("renderManPageMdoc", () => {
 				aliases: ["colour"],
 				description: "Use colour",
 			})
-			.handle(() => {});
+			.action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -62,7 +62,7 @@ describe("buildManifest", () => {
 			expect(node.path).toEqual(["my-cli"]);
 		});
 
-		it("sets runnable to true when command has a run handler", () => {
+		it("sets runnable to true when command has an action", () => {
 			const cmd = makeCommand({
 				meta: { name: "serve" },
 				run() {},
@@ -73,7 +73,7 @@ describe("buildManifest", () => {
 			expect(node.runnable).toBe(true);
 		});
 
-		it("sets runnable to false when command has no run handler", () => {
+		it("sets runnable to false when command has no action", () => {
 			const cmd = makeCommand({
 				meta: { name: "app" },
 			});
@@ -628,7 +628,7 @@ describe("buildManifest", () => {
 				annotate(
 					command.meta({ description: "Deploy command" }),
 					"Read the environment carefully before execution.",
-				).handle(() => {}),
+				).action(() => {}),
 			);
 			const root = new Crust("app").add(deploy);
 

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -20,7 +20,7 @@ function buildNode(model: CommandDocumentation, source: CommandSnapshot): Manife
 		description: model.description,
 		usage: model.usage,
 		instructions: annotations?.instructions,
-		runnable: model.hasHandler,
+		runnable: model.hasAction,
 		args: model.args.map(normalizeArg),
 		flags: [...model.flags].sort((a, b) => a.name.localeCompare(b.name)).map(normalizeFlag),
 		children: [...model.children]

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -77,7 +77,7 @@ describe("skill extension auto-update", () => {
 	it("does not install skills that are not yet present", async () => {
 		const app = new Crust("no-auto-install")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -95,7 +95,7 @@ describe("skill extension auto-update", () => {
 	it("renders plugin-provided top-level instructions into SKILL.md", async () => {
 		const app = new Crust("instruction-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -133,7 +133,7 @@ describe("skill extension auto-update", () => {
 	it("renders plugin-provided markdown instructions into SKILL.md", async () => {
 		const app = new Crust("markdown-instruction-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -174,7 +174,7 @@ describe("skill extension auto-update", () => {
 	it("auto-updates already-installed skills when version changes", async () => {
 		const app = new Crust("update-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -205,7 +205,7 @@ describe("skill extension auto-update", () => {
 	it("prints auto-update message with Universal label", async () => {
 		const app = new Crust("update-message-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -249,7 +249,7 @@ describe("skill extension auto-update", () => {
 		// its auto-update work happens before any later short-circuit.
 		const app = new Crust("order-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -281,7 +281,7 @@ describe("skill extension auto-update", () => {
 
 		const app = new Crust("validation-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -318,7 +318,7 @@ describe("skill extension auto-update", () => {
 	it("does not auto-update when autoUpdate is false", async () => {
 		const app = new Crust("no-update-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -352,7 +352,7 @@ describe("skill extension auto-update", () => {
 	it("prints no changes when universal skills are already installed", async () => {
 		const app = new Crust("no-change-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -401,7 +401,7 @@ describe("skill extension auto-update", () => {
 	it("runs manual skill update command", async () => {
 		const app = new Crust("manual-update-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -434,7 +434,7 @@ describe("skill extension auto-update", () => {
 	it("reports global scope when updating from the home directory", async () => {
 		const app = new Crust("manual-home-update-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -481,7 +481,7 @@ describe("skill extension auto-update", () => {
 	it("reports no updates needed with global scope from the home directory", async () => {
 		const app = new Crust("manual-home-noop-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -523,7 +523,7 @@ describe("skill extension auto-update", () => {
 	it("renders top-level instructions when running manual skill update", async () => {
 		const app = new Crust("manual-update-instructions-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -568,7 +568,7 @@ describe("skill extension auto-update", () => {
 	it("defaults to global scope in non-interactive update when defaultScope is unset", async () => {
 		const app = new Crust("fallback-scope-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -652,7 +652,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("accepts an empty array", async () => {
 		const app = new Crust("empty-custom")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -685,7 +685,7 @@ describe("skillPlugin customSkills validation", () => {
 		// fall through to the plugin-level fallback.
 		const app = new Crust("empty-version-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -709,7 +709,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("accepts a URL sourceDir", async () => {
 		const app = new Crust("url-custom")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -731,7 +731,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("accepts an absolute string sourceDir", async () => {
 		const app = new Crust("abs-custom")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -754,7 +754,7 @@ describe("skillPlugin customSkills validation", () => {
 		// Setup must not throw — resolution-time errors defer to installSkillBundle.
 		const app = new Crust("rel-custom")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -777,7 +777,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("rejects a name that collides with the main skill", async () => {
 		const app = new Crust("collide-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -801,7 +801,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("rejects duplicate names within the array", async () => {
 		const app = new Crust("dup-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -830,7 +830,7 @@ describe("skillPlugin customSkills validation", () => {
 	it("rejects an invalid skill name", async () => {
 		const app = new Crust("invalid-name-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -893,7 +893,7 @@ describe("skillPlugin customSkills name mismatch", () => {
 
 		const app = new Crust("name-mismatch-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -969,7 +969,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("bundle-update-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1010,7 +1010,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("bundle-noop-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1071,7 +1071,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("bundle-resilience-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1122,7 +1122,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("no-auto-update-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -1163,7 +1163,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("subcmd-skip-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1218,7 +1218,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		// asserts that no bundle directory is ever created.
 		const app = new Crust("identical-test")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -1267,7 +1267,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		// it should inherit and trigger a reinstall to 2.0.0.
 		const app = new Crust("inherit-version-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -1306,7 +1306,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		// bundle whose cadence is independent of the consuming CLI.
 		const app = new Crust("override-version-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -1346,7 +1346,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const app = new Crust("inherit-noop-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1384,7 +1384,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	it("--all installs main + every bundle without prompting", async () => {
 		const app = new Crust("all-flag-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1432,7 +1432,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	it("prints sequential per-skill output (heading mentions bundle name)", async () => {
 		const app = new Crust("sequential-output-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1479,7 +1479,7 @@ describe("skillPlugin customSkills interactive command", () => {
 		// Bundle should land in the global scope, not the project scope.
 		const app = new Crust("all-scope-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1525,7 +1525,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	it("--all isolates per-bundle failures and exits non-zero", async () => {
 		const app = new Crust("all-isolation-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1607,7 +1607,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 	it("updates main + every bundle in sequence", async () => {
 		const app = new Crust("update-loop-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "2.0.0",
@@ -1678,7 +1678,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 	it("reports per-skill 'No updates needed' when nothing is outdated", async () => {
 		const app = new Crust("update-noop-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",
@@ -1754,7 +1754,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 
 		const app = new Crust("update-isolation-host")
 			.meta({ description: "test" })
-			.handle(() => {})
+			.action(() => {})
 			.extend(
 				skillExtension({
 					version: "1.0.0",

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -436,7 +436,7 @@ async function autoUpdateCustomSkillsLoop(
  *     version: "1.0.0",
  *     command: "skill", // registers "my-cli skill" subcommand
  *   }))
- *   .handle(() => { /* ... *�/ });
+ *   .action(() => { /* ... *�/ });
  *
  * await app.execute();
  * ```
@@ -675,7 +675,7 @@ function buildSkillCommandGrammar(
 							type: "string",
 							description: "Update scope (project or global)",
 						})
-						.handle(async (context) => {
+						.action(async (context) => {
 							await runSkillUpdateFlow(
 								context.rootCommand,
 								options,
@@ -685,7 +685,7 @@ function buildSkillCommandGrammar(
 						}),
 				),
 			)
-			.handle(async (context) => {
+			.action(async (context) => {
 				await runSkillInstallFlow(
 					context.rootCommand,
 					options,

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -705,7 +705,7 @@ describe("renderSkill", () => {
 			const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 			const app = new Crust("test-cli")
 				.provide(auth())
-				.add(defineCommand("deploy", (command) => command.handle(() => {})));
+				.add(defineCommand("deploy", (command) => command.action(() => {})));
 			const files = renderSkill(buildManifest(snapshotCommand(app._node)), baseMeta);
 			const deploy = findFile(files, "commands/deploy.md");
 

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -238,7 +238,7 @@ export interface ManifestNode {
 	usage: string;
 	/** Agent-facing instructions rendered into the command's markdown file */
 	instructions?: string[];
-	/** Whether this command has a `run` handler (leaf vs group) */
+	/** Whether this command has a `run` action (leaf vs group) */
 	runnable: boolean;
 	/** Positional argument definitions */
 	args: ManifestArg[];

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -85,7 +85,7 @@ describe("runInteractive", () => {
 
 describe("captureExecute", () => {
 	it("captures exit code 0 and stdout on success", async () => {
-		const app = new Crust("test-cli").handle(({ stdout }) => {
+		const app = new Crust("test-cli").action(({ stdout }) => {
 			stdout("hello");
 		});
 
@@ -94,7 +94,7 @@ describe("captureExecute", () => {
 	});
 
 	it("captures exit code 1 and the rendered failure", async () => {
-		const app = new Crust("test-cli").handle(() => {
+		const app = new Crust("test-cli").action(() => {
 			throw new Error("boom");
 		});
 
@@ -104,7 +104,7 @@ describe("captureExecute", () => {
 	});
 
 	it("captures exit code 130 for AbortError cancellation", async () => {
-		const app = new Crust("test-cli").handle(() => {
+		const app = new Crust("test-cli").action(() => {
 			throw new DOMException("Prompt was cancelled.", "AbortError");
 		});
 
@@ -122,7 +122,7 @@ describe("captureExecute", () => {
 				},
 			},
 		});
-		const app = new Crust("test-cli").extend(renderer).handle(() => {
+		const app = new Crust("test-cli").extend(renderer).action(() => {
 			throw new Error("boom");
 		});
 
@@ -147,10 +147,10 @@ describe("captureExecute", () => {
 				releaseB = resolve;
 			});
 
-			const appA = new Crust("test-cli").handle(async () => {
+			const appA = new Crust("test-cli").action(async () => {
 				await gateA;
 			});
-			const appB = new Crust("test-cli").handle(async () => {
+			const appB = new Crust("test-cli").action(async () => {
 				await gateB;
 			});
 
@@ -171,7 +171,7 @@ describe("captureExecute", () => {
 
 	it("restores process.exitCode", async () => {
 		const before = process.exitCode;
-		const app = new Crust("test-cli").handle(() => {
+		const app = new Crust("test-cli").action(() => {
 			throw new Error("boom");
 		});
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -135,7 +135,7 @@ export function runInteractive(app: RunnableApp, argv: readonly string[]): Inter
 		}),
 	);
 
-	// Observe settlement so waitFor can stop polling; the handler also keeps an
+	// Observe settlement so waitFor can stop polling; the action also keeps an
 	// unawaited rejected `done` from surfacing as an unhandled rejection.
 	let settled = false;
 	let failed = false;


### PR DESCRIPTION
> [!NOTE]
> Stacked on #177 (`refactor/colocate-validation`). Merge that first, then retarget this to `main`.

## What

Renames the prerelease command-execution API and its terminology wholesale — no compat shims:

| Before | After |
|---|---|
| `.handle(fn)` | `.action(fn)` |
| `hasHandler` | `hasAction` |
| `reason: "duplicate-handler"` | `reason: "duplicate-action"` |
| "Command Handler" (domain term) | "Command Action" |

## Why

- **Ecosystem precedent** — commander and cac, the dominant chainable CLI builders, both use `.action(fn)`. `.handle()` reads like HTTP-land (Express/Hono), not CLI-land.
- **Chain consistency** — the builder is noun-shaped (`.flags()`, `.args()`, `.meta()`); `.action()` fits.
- Prerelease API, so the rename is free now and never again.

## Scope

- ~330 call sites across core, extensions, skills, testing, man, tests, docs guides/API reference, and examples (READMEs verified clean — none contained the old API)
- 9 pending changesets updated to the new name; new changeset added (`@crustjs/core` minor)
- Deliberately **not** renamed (unrelated handler vocabulary): `SpinnerHandle`, prompt keypress/submit handlers, SIGINT handlers, extension lifecycle hooks, TanStack route `.handler()`

## Verification

- `bun run check:types` — 21/21 pass
- `bun run lint`, `bun run format` — clean
- `bun run test` — all pass (2,250+ tests)
- Repo-wide grep confirms zero stale `.handle(` / `duplicate-handler` / `hasHandler` / "Command Handler" outside the changeset describing the rename
- Independently reviewed by two fresh-context review passes (code mechanics + docs/changesets); findings addressed

