### PR TITLE
refactor(core)!: move command metadata from .meta() into builder signatures

### DIFF
--- a/.changeset/command-metadata-config.md
+++ b/.changeset/command-metadata-config.md
@@ -1,0 +1,11 @@
+---
+"@crustjs/core": minor
+"@crustjs/crust": patch
+"create-crust": patch
+"@crustjs/extensions": patch
+"@crustjs/skills": patch
+---
+
+Move static command metadata into builder signatures: root commands now accept `new Crust(name, { description, usage })`, while reusable commands accept `defineCommand(name, { description, usage, aliases, hidden, requires }, recipe)`.
+
+Remove `.meta()` from `Crust` and `CommandDefinitionBuilder` without a compatibility shim. This keeps names and static metadata together, prevents repeated metadata overrides, and makes aliases available before a definition recipe materializes.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -11,10 +11,12 @@ import {
   defineCommand,
   defineContext,
   defineFlag,
+  type CommandConfig,
   type CommandDefinition,
   type CommandDefinitionBuilder,
   type CommandRequirements,
   type ContextConfig,
+  type RootCommandMeta,
 } from "@crustjs/core";
 ```
 
@@ -40,7 +42,6 @@ type ContextRequirements = readonly AnyContextFactory[];
 
 ```ts
 interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx> {
-  meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder;
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
@@ -62,9 +63,9 @@ interface CommandDefinition<R extends CommandRequirements = {}> {
 }
 ```
 
-A `CommandDefinition<R>` is a frozen value carrying its name and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. It has no command node or execution methods.
+A `CommandDefinition<R>` is a frozen value carrying its name, static config, and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. Configured aliases travel with the renamed definition and must remain unique among siblings. It has no command node or execution methods.
 
-### `defineCommand(name, requirements?, recipe)`
+### `defineCommand(name, config?, recipe)`
 
 ```ts
 defineCommand(
@@ -72,14 +73,16 @@ defineCommand(
   recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
 ): CommandDefinition;
 
-defineCommand<const R extends CommandRequirements>(
+interface CommandConfig extends Omit<CommandMeta, "name">, CommandRequirements {}
+
+defineCommand<const C extends CommandConfig>(
   name: string,
-  requirements: R,
+  config: C,
   recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
-): CommandDefinition<R>;
+): CommandDefinition;
 ```
 
-Creates an inert reusable definition under a required name. The recipe builder is typed from the requirement values:
+Creates an inert reusable definition under a required name. Static `description`, `usage`, `aliases`, `hidden`, and Context `requires` belong in `config`. The recipe builder is typed from the requirement values:
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean" });
@@ -90,10 +93,13 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
 }));
 const auth = defineContext("auth", () => ({ user: "Ada" }));
 
-const deploy = defineCommand("deploy", { requires: [logging, auth] }, (command) =>
-  command.args({ name: "target", type: "string", required: true }).action(({ args, ctx }) => {
-    ctx.logging.debug(`${ctx.auth.user}:${args.target}`);
-  }),
+const deploy = defineCommand(
+  "deploy",
+  { description: "Deploy an application", aliases: ["ship"], requires: [logging, auth] },
+  (command) =>
+    command.args({ name: "target", type: "string", required: true }).action(({ args, ctx }) => {
+      ctx.logging.debug(`${ctx.auth.user}:${args.target}`);
+    }),
 );
 ```
 
@@ -102,35 +108,25 @@ The recipe does not execute when the definition is created. It executes once for
 ## Constructor
 
 ```ts
-new Crust(name: string)
+type RootCommandMeta = Pick<CommandMeta, "description" | "usage">;
+
+new Crust(name: string, meta?: RootCommandMeta)
 ```
 
-Creates a root command builder. An empty or whitespace-only name throws a `CrustError` with code `DEFINITION`.
+Creates a root command builder. Root metadata is declared at construction because aliases and hidden state only apply to subcommands. An empty or whitespace-only name throws a `CrustError` with code `DEFINITION`.
 
 ```ts
-const app = new Crust("my-cli");
-```
-
-## `.meta(meta)`
-
-```ts
-meta(meta: Omit<CommandMeta, "name">): Crust
-```
-
-Sets `description`, `usage`, `aliases`, or `hidden`. The constructor or the added definition supplies the name.
-
-```ts
-const app = new Crust("issue").meta({
+const app = new Crust("my-cli", {
   description: "Manage issues",
-  aliases: ["issues", "i"],
+  usage: "my-cli <command>",
 });
 ```
 
-Aliases must be non-empty, contain no whitespace, not start with `-`, and not collide with sibling names or aliases.
+Definition aliases must be non-empty, contain no whitespace, not start with `-`, and not collide with sibling names or aliases.
 
 ## Chaining semantics
 
-Variadic builder methods accumulate across calls: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` preserve earlier registrations and throw `DEFINITION` on duplicate names or spellings. `.meta()` shallow-merges fields. `.action()` is set once and throws `DEFINITION` if called again.
+Variadic builder methods accumulate across calls: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` preserve earlier registrations and throw `DEFINITION` on duplicate names or spellings. `.action()` is set once and throws `DEFINITION` if called again.
 
 ## `.args(...defs)`
 

--- a/apps/docs/content/docs/guide/commands.mdx
+++ b/apps/docs/content/docs/guide/commands.mdx
@@ -10,8 +10,7 @@ A command combines metadata, inputs, dependencies, and one Command Action.
 ```ts
 import { Crust } from "@crustjs/core";
 
-const app = new Crust("greet")
-  .meta({ description: "Print a greeting", aliases: ["hello"] })
+const app = new Crust("greet", { description: "Print a greeting" })
   .args({ name: "name", type: "string", required: true })
   .flags({ name: "loud", type: "boolean", short: "l" })
   .action(({ args, flags, stdout }) => {
@@ -27,11 +26,23 @@ await app.execute();
 Every builder method returns a new `Crust` value. Keep the returned value:
 
 ```ts
-const base = new Crust("app");
-const described = base.meta({ description: "My app" });
+const base = new Crust("app", { description: "My app" });
+const withFlags = base.flags({ name: "verbose", type: "boolean" });
 ```
 
-This permits safe composition and preserves input inference through the chain.
+Static root metadata belongs in the constructor. Subcommand metadata belongs in `defineCommand()` config:
+
+```ts
+import { defineCommand } from "@crustjs/core";
+
+const greet = defineCommand(
+  "greet",
+  { description: "Print a greeting", aliases: ["hello"] },
+  (command) => command.action(() => {}),
+);
+```
+
+Fluent methods remain immutable, permitting safe composition while preserving input inference.
 
 ## Command Action context
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -20,7 +20,7 @@ See [`FlagDef`](/docs/api/types#flagdef) for the complete definition.
 
 Repeated `.flags()` calls accumulate: `.flags(a).flags(b)` defines both flags. Duplicate names, short forms, or aliases throw a `DEFINITION` error at the call that introduces the collision.
 
-Builder chaining follows the same rule for every variadic method: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` accumulate and reject duplicates. `.meta()` shallow-merges fields, while `.action()` is set once and throws if called again.
+Builder chaining follows the same rule for every variadic method: `.flags()`, `.args()`, `.provide()`, `.add()`, and root-only `.extend()` accumulate and reject duplicates. `.action()` is set once and throws if called again.
 
 ## Aliases and negation
 

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -9,10 +9,7 @@ description: Add help output to every command.
 import { Crust } from "@crustjs/core";
 import { help } from "@crustjs/extensions";
 
-const app = new Crust("my-cli")
-  .meta({ description: "My CLI" })
-  .extend(help())
-  .action(() => {});
+const app = new Crust("my-cli", { description: "My CLI" }).extend(help()).action(() => {});
 
 await app.execute();
 ```

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -19,7 +19,7 @@ Add the `skill()` extension to your CLI. It reads `name` and `description` from 
 import { Crust } from "@crustjs/core";
 import { skill } from "@crustjs/skills";
 
-const app = new Crust("my-cli").meta({ description: "My CLI tool" }).extend(
+const app = new Crust("my-cli", { description: "My CLI tool" }).extend(
   skill({
     version: "1.0.0",
     instructions: `
@@ -112,8 +112,7 @@ import { Crust } from "@crustjs/core";
 import { skill } from "@crustjs/skills";
 import pkg from "./package.json" with { type: "json" };
 
-const app = new Crust("my-cli")
-  .meta({ description: "My CLI" })
+const app = new Crust("my-cli", { description: "My CLI" })
   .extend(
     skill({
       version: pkg.version,
@@ -254,8 +253,8 @@ command without extending the public `@crustjs/core` builder API.
 import { Crust, defineCommand } from "@crustjs/core";
 import { annotate } from "@crustjs/skills";
 
-const deploy = defineCommand("deploy", (command) =>
-  annotate(command.meta({ description: "Deploy the application" }), [
+const deploy = defineCommand("deploy", { description: "Deploy the application" }, (command) =>
+  annotate(command, [
     "Prefer preview modes before running destructive operations.",
     "Ask for confirmation before production changes.",
   ]).action(() => {
@@ -395,9 +394,9 @@ Guard execution with `import.meta.main` when a command module may also be import
 ```ts
 import { Crust } from "@crustjs/core";
 
-export const rootCommand = new Crust("my-cli")
-  .meta({ description: "My CLI tool" })
-  .action(() => console.log("Hello from my-cli!"));
+export const rootCommand = new Crust("my-cli", { description: "My CLI tool" }).action(() =>
+  console.log("Hello from my-cli!"),
+);
 
 if (import.meta.main) await rootCommand.execute();
 ```

--- a/apps/docs/examples/extensions/diagnostics.ts
+++ b/apps/docs/examples/extensions/diagnostics.ts
@@ -10,10 +10,8 @@ export const diagnostics = defineExtension("diagnostics", {
     },
   },
   commands: [
-    defineCommand("doctor", (command) =>
-      command
-        .meta({ description: "Check the installation" })
-        .action(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
+    defineCommand("doctor", { description: "Check the installation" }, (command) =>
+      command.action(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),
     ),
   ],
   hooks: {

--- a/apps/docs/examples/quick-start/starter.ts
+++ b/apps/docs/examples/quick-start/starter.ts
@@ -3,8 +3,7 @@ import { help, version } from "@crustjs/extensions";
 
 import pkg from "../package.json";
 
-const app = new Crust("my-cli")
-  .meta({ description: "A CLI built with Crust" })
+const app = new Crust("my-cli", { description: "A CLI built with Crust" })
   .extend(version(pkg.version), help())
   .args({
     name: "name",

--- a/apps/docs/examples/split-files/app.ts
+++ b/apps/docs/examples/split-files/app.ts
@@ -3,7 +3,6 @@ import { help, version } from "@crustjs/extensions";
 
 import { logger } from "./shared.ts";
 
-export const app = new Crust("my-cli")
-  .meta({ description: "A split-file CLI" })
+export const app = new Crust("my-cli", { description: "A split-file CLI" })
   .extend(version("0.2.0"), help())
   .provide(logger());

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -29,9 +29,16 @@ type Equal<A, B> =
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("Crust constructor", () => {
-	it("creates builder with string name", async () => {
-		const snapshot = await new Crust("my-cli").snapshot();
-		expect(snapshot.meta.name).toBe("my-cli");
+	it("creates builder with name and optional metadata", async () => {
+		const snapshot = await new Crust("my-cli", {
+			description: "A test CLI",
+			usage: "my-cli [options]",
+		}).snapshot();
+		expect(snapshot.meta).toEqual({
+			name: "my-cli",
+			description: "A test CLI",
+			usage: "my-cli [options]",
+		});
 	});
 
 	it("throws CrustError DEFINITION on empty name", () => {
@@ -73,7 +80,6 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 					defineContext("auth", { flags: [{ name: "api-key", type: "string" }] }, () => ({}))(),
 				) as Crust,
 		],
-		[".meta()", (app) => app.meta({ description: "desc" }) as Crust],
 		[".add()", (app) => app.add(defineCommand("sub", (command) => command)) as Crust],
 		[".action()", (app) => app.action(() => {}) as Crust],
 	];
@@ -121,7 +127,7 @@ describe("Crust .flags()", () => {
 	});
 
 	it("preserves meta from original builder", async () => {
-		const app = new Crust("my-cli").meta({ description: "desc" });
+		const app = new Crust("my-cli", { description: "desc" });
 		const withFlags = app.flags({ name: "verbose", type: "boolean" });
 
 		const snapshot = await withFlags.snapshot();
@@ -250,9 +256,10 @@ describe("Crust .args()", () => {
 	});
 
 	it("preserves meta and flags from original builder", async () => {
-		const app = new Crust("my-cli")
-			.meta({ description: "desc" })
-			.flags({ name: "verbose", type: "boolean" });
+		const app = new Crust("my-cli", { description: "desc" }).flags({
+			name: "verbose",
+			type: "boolean",
+		});
 		const withArgs = app.args({ name: "file", type: "string" });
 
 		const snapshot = await withArgs.snapshot();
@@ -354,15 +361,17 @@ describe("Crust chaining", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// .meta()
+// Command metadata
 // ────────────────────────────────────────────────────────────────────────────
 
-describe("Crust .meta()", () => {
-	it("sets metadata while preserving the existing command definition", async () => {
-		const app = new Crust("test")
+describe("command metadata", () => {
+	it("preserves root metadata through builder calls", async () => {
+		const app = new Crust("test", {
+			description: "A test command",
+			usage: "test [options]",
+		})
 			.flags({ name: "verbose", type: "boolean" })
-			.args({ name: "file", type: "string" })
-			.meta({ description: "A test command", usage: "test [options]" });
+			.args({ name: "file", type: "string" });
 
 		expect(await app.snapshot()).toMatchObject({
 			meta: { name: "test", description: "A test command", usage: "test [options]" },
@@ -371,15 +380,12 @@ describe("Crust .meta()", () => {
 		});
 	});
 
-	it("sets only description when usage is omitted", async () => {
-		const snapshot = await new Crust("test").meta({ description: "desc" }).snapshot();
-		expect(snapshot.meta).toEqual({ name: "test", description: "desc" });
-	});
-
-	it("works in subcommand callbacks", async () => {
+	it("applies definition metadata from config", async () => {
 		const app = new Crust("cli").add(
-			defineCommand("sub", (command) =>
-				command.meta({ description: "A subcommand", usage: "cli sub [options]" }),
+			defineCommand(
+				"sub",
+				{ description: "A subcommand", usage: "cli sub [options]" },
+				(command) => command,
 			),
 		);
 
@@ -2048,7 +2054,7 @@ describe("Crust.snapshot", () => {
 			},
 		});
 
-		const app = new Crust("cli").extend(docs).meta({ description: "Test" });
+		const app = new Crust("cli", { description: "Test" }).extend(docs);
 		const root = await app.snapshot();
 		expect(root.flags.extra).toMatchObject({
 			type: "boolean",
@@ -2098,11 +2104,9 @@ describe("Crust.snapshot", () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe("Crust .add() aliases", () => {
-	it("plumbs aliases from meta() into the registered subcommand snapshot", async () => {
+	it("plumbs aliases from definition config into the registered subcommand snapshot", async () => {
 		const app = new Crust("cli").add(
-			defineCommand("issue", (command) =>
-				command.meta({ aliases: ["issues", "i"] }).action(() => {}),
-			),
+			defineCommand("issue", { aliases: ["issues", "i"] }, (command) => command.action(() => {})),
 		);
 		expect((await app.snapshot()).subCommands.issue?.meta.aliases).toEqual(["issues", "i"]);
 	});
@@ -2110,9 +2114,7 @@ describe("Crust .add() aliases", () => {
 	it("registers without error when no sibling collides", () => {
 		expect(() =>
 			new Crust("cli")
-				.add(
-					defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})),
-				)
+				.add(defineCommand("issue", { aliases: ["issues", "i"] }, (cmd) => cmd.action(() => {})))
 				.add(defineCommand("version", (cmd) => cmd.action(() => {}))),
 		).not.toThrow();
 	});
@@ -2120,22 +2122,22 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION when an alias collides with a sibling's canonical name", () => {
 		const app = new Crust("cli").add(defineCommand("build", (cmd) => cmd.action(() => {})));
 		expect(() =>
-			app.add(defineCommand("compile", (cmd) => cmd.meta({ aliases: ["build"] }).action(() => {}))),
+			app.add(defineCommand("compile", { aliases: ["build"] }, (cmd) => cmd.action(() => {}))),
 		).toThrow(/collides with sibling canonical name "build"/);
 	});
 
 	it("throws DEFINITION when an alias collides with another sibling's alias", () => {
 		const app = new Crust("cli").add(
-			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})),
+			defineCommand("issue", { aliases: ["i"] }, (cmd) => cmd.action(() => {})),
 		);
 		expect(() =>
-			app.add(defineCommand("info", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {}))),
+			app.add(defineCommand("info", { aliases: ["i"] }, (cmd) => cmd.action(() => {}))),
 		).toThrow(/collides with alias of sibling "issue"/);
 	});
 
 	it("throws DEFINITION on the reverse-order case (new canonical equals an existing alias)", () => {
 		const app = new Crust("cli").add(
-			defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})),
+			defineCommand("issue", { aliases: ["i"] }, (cmd) => cmd.action(() => {})),
 		);
 		// Now try to register a *new* command whose canonical name == existing alias.
 		expect(() => app.add(defineCommand("i", (cmd) => cmd.action(() => {})))).toThrow(
@@ -2146,7 +2148,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on duplicate aliases within one subcommand's own list", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i", "i"] }).action(() => {})),
+				defineCommand("issue", { aliases: ["i", "i"] }, (cmd) => cmd.action(() => {})),
 			),
 		).toThrow(/lists alias "i" more than once/);
 	});
@@ -2154,7 +2156,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias equal to its own canonical name", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issue"] }).action(() => {})),
+				defineCommand("issue", { aliases: ["issue"] }, (cmd) => cmd.action(() => {})),
 			),
 		).toThrow(/must not equal its own canonical name/);
 	});
@@ -2162,7 +2164,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an empty alias", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: [""] }).action(() => {})),
+				defineCommand("issue", { aliases: [""] }, (cmd) => cmd.action(() => {})),
 			),
 		).toThrow(/must be a non-empty string/);
 	});
@@ -2170,7 +2172,7 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias containing whitespace", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["my issue"] }).action(() => {})),
+				defineCommand("issue", { aliases: ["my issue"] }, (cmd) => cmd.action(() => {})),
 			),
 		).toThrow(/must not contain whitespace/);
 	});
@@ -2178,35 +2180,38 @@ describe("Crust .add() aliases", () => {
 	it("throws DEFINITION on an alias starting with '-'", () => {
 		expect(() =>
 			new Crust("cli").add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["-i"] }).action(() => {})),
+				defineCommand("issue", { aliases: ["-i"] }, (cmd) => cmd.action(() => {})),
 			),
 		).toThrow(/must not start with "-"/);
 	});
 
 	it("applies the same checks on the .add() path", () => {
-		const issue = defineCommand("issue", (command) =>
-			command.meta({ aliases: ["i"] }).action(() => {}),
-		);
-		const conflicting = defineCommand("info", (command) =>
-			command.meta({ aliases: ["i"] }).action(() => {}),
+		const issue = defineCommand("issue", { aliases: ["i"] }, (command) => command.action(() => {}));
+		const conflicting = defineCommand("info", { aliases: ["i"] }, (command) =>
+			command.action(() => {}),
 		);
 		const app = new Crust("cli").add(issue);
 
 		expect(() => app.add(conflicting)).toThrow(/collides with alias of sibling "issue"/);
 	});
 
+	it("keeps configured aliases when a definition is renamed with .as()", () => {
+		const issue = defineCommand("issue", { aliases: ["i"] }, (command) => command.action(() => {}));
+		const app = new Crust("cli").add(issue);
+
+		expect(() => app.add(issue.as("ticket"))).toThrow(/collides with alias of sibling "issue"/);
+	});
+
 	it("Extension command with a colliding alias is a DEFINITION error (no silent shadowing)", async () => {
 		// Without this guard, an Extension could attach an alias that silently
 		// changes routing for an existing user command.
 		const rogue = defineExtension("rogue", {
-			commands: [
-				defineCommand("info", (command) => command.meta({ aliases: ["i"] }).action(() => {})),
-			],
+			commands: [defineCommand("info", { aliases: ["i"] }, (command) => command.action(() => {}))],
 		});
 
 		const app = new Crust("cli")
 			.extend(rogue)
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})));
+			.add(defineCommand("issue", { aliases: ["i"] }, (cmd) => cmd.action(() => {})));
 
 		await expect(app.run(["i"])).rejects.toMatchObject({ code: "DEFINITION" });
 	});

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -41,6 +41,14 @@ describe("Crust constructor", () => {
 		});
 	});
 
+	it("does not carry sibling-only metadata onto the root", async () => {
+		const snapshot = await new Crust("my-cli", {
+			// @ts-expect-error -- aliases belong to defineCommand() config
+			aliases: ["cli"],
+		}).snapshot();
+		expect(snapshot.meta.aliases).toBeUndefined();
+	});
+
 	it("throws CrustError DEFINITION on empty name", () => {
 		try {
 			new Crust("");
@@ -2104,10 +2112,18 @@ describe("Crust.snapshot", () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe("Crust .add() aliases", () => {
-	it("plumbs aliases from definition config into the registered subcommand snapshot", async () => {
+	it("routes aliases from definition config and includes them in the snapshot", async () => {
+		let calls = 0;
 		const app = new Crust("cli").add(
-			defineCommand("issue", { aliases: ["issues", "i"] }, (command) => command.action(() => {})),
+			defineCommand("issue", { aliases: ["issues", "i"] }, (command) =>
+				command.action(() => {
+					calls++;
+				}),
+			),
 		);
+
+		await app.run(["issues"]);
+		expect(calls).toBe(1);
 		expect((await app.snapshot()).subCommands.issue?.meta.aliases).toEqual(["issues", "i"]);
 	});
 

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -412,7 +412,8 @@ export class Crust<
 			throw new CrustError("DEFINITION", "meta.name must be a non-empty string");
 		}
 		this._node = createCommandNode(name);
-		this._node.meta = { name, ...meta };
+		if (meta.description !== undefined) this._node.meta.description = meta.description;
+		if (meta.usage !== undefined) this._node.meta.usage = meta.usage;
 		this._ancestorOwnedFlags = {};
 	}
 

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -81,7 +81,19 @@ export interface CommandRequirements {
 	readonly requires?: readonly AnyContextFactory[];
 }
 
+/** Static configuration for a reusable command definition. */
+export interface CommandConfig extends Omit<CommandMeta, "name">, CommandRequirements {}
+
+/** Static metadata accepted by the root command constructor. */
+export type RootCommandMeta = Pick<CommandMeta, "description" | "usage">;
+
 type RequirementContext<R extends CommandRequirements> = RequirementCtxOf<R>;
+
+type ConfigRequirements<C extends CommandConfig> = C extends {
+	readonly requires: infer R extends readonly AnyContextFactory[];
+}
+	? { readonly requires: R }
+	: {};
 
 type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any>;
 
@@ -93,6 +105,7 @@ const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefini
 
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
+	readonly meta: Omit<CommandMeta, "name">;
 	/** Requirement names, runtime-checked when the definition is added */
 	readonly requiredCtxNames: readonly string[];
 }
@@ -100,7 +113,7 @@ interface CommandDefinitionInternal {
 export interface CommandDefinition<R extends CommandRequirements = {}> {
 	/** The subcommand name this definition is added under */
 	readonly name: string;
-	/** The same definition under a different name (add one definition twice) */
+	/** The same definition under a different name; configured aliases travel with it. */
 	as(name: string): CommandDefinition<R>;
 	/** @internal */
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
@@ -158,6 +171,12 @@ function materializeCommandDefinition(
 		}
 	}
 
+	validateIncomingAliases(
+		{ canonicalName: name, aliases: internal.meta.aliases },
+		parent.subCommands,
+		name,
+	);
+
 	const child = new Crust(name);
 	(child as { _ancestorOwnedFlags: FlagsDef })._ancestorOwnedFlags = parent.ownedFlags;
 	child._node.ownedFlags = { ...parent.ownedFlags };
@@ -202,14 +221,8 @@ function materializeCommandDefinition(
 		);
 	}
 
-	validateIncomingAliases(
-		{ canonicalName: name, aliases: configured._node.meta.aliases },
-		parent.subCommands,
-		name,
-	);
-
 	const childNode = cloneCommandNode(configured._node);
-	childNode.meta.name = name;
+	childNode.meta = { name, ...internal.meta };
 	return childNode;
 }
 
@@ -257,8 +270,6 @@ export interface CommandDefinitionBuilder<
 	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
 > {
-	meta(meta: Omit<CommandMeta, "name">): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx>;
-
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs>
 	): CommandDefinitionBuilder<
@@ -298,21 +309,22 @@ export interface CommandDefinitionBuilder<
  * The recipe runs once per `.add()`, receiving a fresh builder typed by
  * the declared Context capabilities, which must be provided on the parent path.
  *
- * Use `.as(name)` to add one definition under a different name.
+ * Static metadata and Context requirements belong in `config`. Use `.as(name)`
+ * to add one definition under a different name; configured aliases travel with it.
  */
 export function defineCommand(name: string, recipe: CommandRecipe<{}>): CommandDefinition;
-export function defineCommand<const R extends CommandRequirements>(
+export function defineCommand<const C extends CommandConfig>(
 	name: string,
-	config: R,
-	recipe: CommandRecipe<R>,
-): CommandDefinition<R>;
+	config: C,
+	recipe: CommandRecipe<ConfigRequirements<C>>,
+): CommandDefinition<ConfigRequirements<C>>;
 export function defineCommand(
 	name: string,
-	configOrRecipe: CommandRequirements | CommandRecipe<CommandRequirements>,
+	configOrRecipe: CommandConfig | CommandRecipe<CommandRequirements>,
 	maybeRecipe?: CommandRecipe<CommandRequirements>,
 ): CommandDefinition<CommandRequirements> {
 	const hasConfig = typeof configOrRecipe !== "function";
-	const config = hasConfig ? configOrRecipe : {};
+	const config: CommandConfig = hasConfig ? configOrRecipe : {};
 	const recipe = hasConfig ? maybeRecipe : configOrRecipe;
 	if (typeof recipe !== "function") {
 		throw new CrustError("DEFINITION", `Command definition "${name}" requires a recipe function`, {
@@ -321,9 +333,11 @@ export function defineCommand(
 			reason: "missing-recipe",
 		});
 	}
+	const { requires, ...meta } = config;
 	const internal: CommandDefinitionInternal = {
 		recipe: recipe as CommandDefinitionInternal["recipe"],
-		requiredCtxNames: (config.requires ?? []).map((dep) => dep.contextName),
+		meta: meta.aliases ? { ...meta, aliases: [...meta.aliases] } : meta,
+		requiredCtxNames: (requires ?? []).map((dep) => dep.contextName),
 	};
 	const named = (defName: string): CommandDefinition<CommandRequirements> => {
 		if (!defName.trim()) {
@@ -390,13 +404,15 @@ export class Crust<
 	 * Create a new root command builder.
 	 *
 	 * @param name - The command name.
+	 * @param meta - Optional root description and usage.
 	 * @throws {CrustError} `DEFINITION` if name is empty or whitespace-only
 	 */
-	constructor(name: string) {
+	constructor(name: string, meta: RootCommandMeta = {}) {
 		if (!name.trim()) {
 			throw new CrustError("DEFINITION", "meta.name must be a non-empty string");
 		}
 		this._node = createCommandNode(name);
+		this._node.meta = { name, ...meta };
 		this._ancestorOwnedFlags = {};
 	}
 
@@ -421,30 +437,6 @@ export class Crust<
 		(cloned as { _node: CommandNode })._node = newNode;
 		(cloned as { _ancestorOwnedFlags: FlagsDef })._ancestorOwnedFlags = this._ancestorOwnedFlags;
 		return cloned;
-	}
-
-	/**
-	 * Set metadata (description, usage) for this command.
-	 *
-	 * The command name is already set by the constructor or add call.
-	 * Provide `description`, `usage`, and/or `aliases` here.
-	 *
-	 * Returns a new builder with updated metadata. The original builder
-	 * is not mutated.
-	 *
-	 * @param meta - Metadata fields to set (description, usage, aliases)
-	 * @returns A new `Crust` instance with updated metadata
-	 * @example
-	 * ```ts
-	 * defineCommand("issue", (cmd) =>
-	 *   cmd.meta({ aliases: ["issues", "i"] }).action(() => {})
-	 * )
-	 * ```
-	 */
-	meta(meta: Omit<CommandMeta, "name">): Crust<Local, Owned, A, Eff, Ctx> {
-		return this._clone({
-			meta: { ...this._node.meta, ...meta },
-		}) as Crust<Local, Owned, A, Eff, Ctx>;
 	}
 
 	/**

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -138,11 +138,10 @@ describe("command definitions", () => {
 
 	it("clones annotations and isolates materializations across parents", async () => {
 		const annotation = Symbol("annotation");
-		const definition = defineCommand("one", (command) => {
-			const configured = command.meta({ description: "Reusable" });
-			((configured as unknown as Crust)._node as unknown as Record<symbol, unknown>)[annotation] =
+		const definition = defineCommand("one", { description: "Reusable" }, (command) => {
+			((command as unknown as Crust)._node as unknown as Record<symbol, unknown>)[annotation] =
 				"preserved";
-			return configured;
+			return command;
 		});
 
 		const first = await new Crust("first").add(definition).snapshot();
@@ -214,8 +213,8 @@ describe("command definitions", () => {
 	});
 
 	it("validates canonical names and aliases on every add", () => {
-		const definition = defineCommand("build", (command) =>
-			command.meta({ aliases: ["b"] }).action(() => {}),
+		const definition = defineCommand("build", { aliases: ["b"] }, (command) =>
+			command.action(() => {}),
 		);
 		const app = new Crust("cli").add(definition);
 

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -27,7 +27,7 @@ describe("buildCommandDocumentation", () => {
 	});
 
 	it("uses explicit usage unchanged", async () => {
-		const model = await docs(new Crust("app").meta({ usage: "app FILE" }).action(() => {}));
+		const model = await docs(new Crust("app", { usage: "app FILE" }).action(() => {}));
 		expect(model.usage).toBe("app FILE");
 		expect(model.usageSegments).toEqual([{ kind: "custom", text: "app FILE" }]);
 	});
@@ -40,7 +40,7 @@ describe("buildCommandDocumentation", () => {
 						command.add(defineCommand("nested", (child) => child.action(() => {}))),
 					),
 				)
-				.add(defineCommand("hidden", (command) => command.meta({ hidden: true }).action(() => {}))),
+				.add(defineCommand("hidden", { hidden: true }, (command) => command.action(() => {}))),
 		);
 		expect(model.children.map((child) => child.name)).toEqual(["visible"]);
 		expect(model.children[0]?.children[0]?.path).toEqual(["app", "visible", "nested"]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,10 +27,12 @@ export type { UnnamedArgDef } from "./api/flags.ts";
 export type { ArgSnapshot, CommandSnapshot, FlagSnapshot } from "./command/snapshot.ts";
 // Command definitions and context
 export type {
+	CommandConfig,
 	CommandDefinition,
 	CommandDefinitionBuilder,
 	CommandRequirements,
 	CrustCommandContext,
+	RootCommandMeta,
 } from "./command/crust.ts";
 export { Crust, defineCommand } from "./command/crust.ts";
 // Errors

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -670,8 +670,8 @@ export interface CommandMeta {
 	 * Alternative names that resolve to the same command.
 	 *
 	 * Each entry is a sibling-level alternative for `name`. For example,
-	 * `meta: { name: "issue", aliases: ["issues", "i"] }` makes `cli issue`,
-	 * `cli issues`, and `cli i` all route to the same command node.
+	 * `defineCommand("issue", { aliases: ["issues", "i"] }, recipe)` makes
+	 * `cli issue`, `cli issues`, and `cli i` all route to the same command node.
 	 *
 	 * **Conflict policy.** Alias strings must not collide with this command's
 	 * own canonical `name`, with any sibling's `name`, or with any sibling's
@@ -686,7 +686,7 @@ export interface CommandMeta {
 	 * `didYouMeanPlugin` — it does not depend on which alias the user typed.
 	 *
 	 * @example
-	 * meta: { name: "issue", aliases: ["issues", "i"] }
+	 * defineCommand("issue", { aliases: ["issues", "i"] }, recipe)
 	 */
 	aliases?: readonly string[];
 	/**

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -28,9 +28,11 @@ import { executeCrust } from "./helpers";
 // Shared fixtures
 // ────────────────────────────────────────────────────────────────────────────
 
-const rootBase = new Crust("myapp")
-	.meta({ description: "Integration test app" })
-	.flags({ name: "help", type: "boolean", short: "h" });
+const rootBase = new Crust("myapp", { description: "Integration test app" }).flags({
+	name: "help",
+	type: "boolean",
+	short: "h",
+});
 
 const serveCmd = defineCommand("serve", (command) =>
 	command

--- a/packages/create-crust/src/index.ts
+++ b/packages/create-crust/src/index.ts
@@ -38,8 +38,7 @@ function parseDistributionMode(value: string | undefined): DistributionMode | un
 // Command definition
 // ────────────────────────────────────────────────────────────────────────────
 
-const app = new Crust("create-crust")
-	.meta({ description: "Scaffold a new Crust CLI project" })
+const app = new Crust("create-crust", { description: "Scaffold a new Crust CLI project" })
 	.flags(
 		{
 			name: "distribution",

--- a/packages/create-crust/templates/minimal/src/cli.ts
+++ b/packages/create-crust/templates/minimal/src/cli.ts
@@ -3,8 +3,7 @@ import { help, version } from "@crustjs/extensions";
 
 import pkg from "../package.json";
 
-const app = new Crust("{{name}}")
-	.meta({ description: "A CLI built with Crust" })
+const app = new Crust("{{name}}", { description: "A CLI built with Crust" })
 	.extend(version(pkg.version), help())
 	.args({
 		name: "name",

--- a/packages/create-crust/tests/scaffold.test.ts
+++ b/packages/create-crust/tests/scaffold.test.ts
@@ -207,7 +207,7 @@ describe("scaffold", () => {
 		expect(cliContent).toContain("version(");
 		expect(cliContent).toContain("help()");
 		// Has proper structure: name, args, flags, run
-		expect(cliContent).toContain('new Crust("compile-test-cli")');
+		expect(cliContent).toContain('new Crust("compile-test-cli", {');
 		expect(cliContent).toContain(".args({");
 		expect(cliContent).toContain(".flags(");
 		expect(cliContent).toContain(".action(");

--- a/packages/crust/src/app.ts
+++ b/packages/crust/src/app.ts
@@ -4,7 +4,7 @@ import { didYouMean, help, updateNotifier, version } from "@crustjs/extensions";
 import pkg from "../package.json";
 
 /** The completed root builder and Extensions for the `crust` CLI. */
-export const crustBase = new Crust("crust").meta({ description: pkg.description }).extend(
+export const crustBase = new Crust("crust", { description: pkg.description }).extend(
 	version(pkg.version),
 	updateNotifier({
 		currentVersion: pkg.version,

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -268,184 +268,193 @@ export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined)
  * crust build --outdir out                              # Output binaries to out/ directory
  * ```
  */
-export const buildCommand = defineCommand("build", (command) =>
-	command
-		.meta({ description: "Compile your CLI to a standalone executable" })
-		.flags(
-			{
-				name: "entry",
-				type: "string",
-				description: "Entry file path",
-				default: "src/cli.ts",
-				short: "e",
-			},
-			{
-				name: "outfile",
-				type: "string",
-				description: "Output file path (single-target builds only)",
-				short: "o",
-			},
-			{
-				name: "name",
-				type: "string",
-				description: "Binary name (defaults to package.json name or entry filename)",
-				short: "n",
-			},
-			{
-				name: "minify",
-				type: "boolean",
-				description: "Minify the output",
-				default: true,
-			},
-			{
-				name: "target",
-				type: "string",
-				multiple: true,
-				description:
-					"Canonical Bun target(s) to compile for (e.g. bun-linux-x64-baseline, bun-darwin-arm64). Omit to build all.",
-				short: "t",
-			},
-			{
-				name: "outdir",
-				type: "string",
-				description: "Output directory for compiled binaries",
-				default: "dist",
-				short: "d",
-			},
-			{
-				name: "resolver",
-				type: "string",
-				description: "Filename for the resolver script (multi-target builds, no extension)",
-				default: "cli",
-				short: "r",
-			},
-			{
-				name: "validate",
-				type: "boolean",
-				description: "Validate command runtime rules before compiling (disable with --no-validate)",
-				default: true,
-			},
-			{
-				name: "env-file",
-				type: "string",
-				multiple: true,
-				description: "Explicit env file(s) used for build-time constants; repeatable",
-			},
-			{
-				name: "package",
-				type: "boolean",
-				description: "Stage npm packages in dist/npm instead of raw binaries",
-				default: false,
-			},
-			{
-				name: "stage-dir",
-				type: "string",
-				description: "Directory to stage npm packages into when using --package",
-				default: "dist/npm",
-			},
-			{
-				name: "man",
-				type: "boolean",
-				description:
-					"Write an mdoc(7) page to <outdir>/man/<name>.1 (entry must export a Crust as `app` or default)",
-				default: false,
-			},
-		)
-		.action(async ({ flags }) => {
-			const cwd = process.cwd();
+export const buildCommand = defineCommand(
+	"build",
+	{ description: "Compile your CLI to a standalone executable" },
+	(command) =>
+		command
+			.flags(
+				{
+					name: "entry",
+					type: "string",
+					description: "Entry file path",
+					default: "src/cli.ts",
+					short: "e",
+				},
+				{
+					name: "outfile",
+					type: "string",
+					description: "Output file path (single-target builds only)",
+					short: "o",
+				},
+				{
+					name: "name",
+					type: "string",
+					description: "Binary name (defaults to package.json name or entry filename)",
+					short: "n",
+				},
+				{
+					name: "minify",
+					type: "boolean",
+					description: "Minify the output",
+					default: true,
+				},
+				{
+					name: "target",
+					type: "string",
+					multiple: true,
+					description:
+						"Canonical Bun target(s) to compile for (e.g. bun-linux-x64-baseline, bun-darwin-arm64). Omit to build all.",
+					short: "t",
+				},
+				{
+					name: "outdir",
+					type: "string",
+					description: "Output directory for compiled binaries",
+					default: "dist",
+					short: "d",
+				},
+				{
+					name: "resolver",
+					type: "string",
+					description: "Filename for the resolver script (multi-target builds, no extension)",
+					default: "cli",
+					short: "r",
+				},
+				{
+					name: "validate",
+					type: "boolean",
+					description:
+						"Validate command runtime rules before compiling (disable with --no-validate)",
+					default: true,
+				},
+				{
+					name: "env-file",
+					type: "string",
+					multiple: true,
+					description: "Explicit env file(s) used for build-time constants; repeatable",
+				},
+				{
+					name: "package",
+					type: "boolean",
+					description: "Stage npm packages in dist/npm instead of raw binaries",
+					default: false,
+				},
+				{
+					name: "stage-dir",
+					type: "string",
+					description: "Directory to stage npm packages into when using --package",
+					default: "dist/npm",
+				},
+				{
+					name: "man",
+					type: "boolean",
+					description:
+						"Write an mdoc(7) page to <outdir>/man/<name>.1 (entry must export a Crust as `app` or default)",
+					default: false,
+				},
+			)
+			.action(async ({ flags }) => {
+				const cwd = process.cwd();
 
-			// Resolve entry file path relative to cwd
-			const entryPath = resolve(cwd, flags.entry);
-			const envFiles = resolveEnvFilePaths(cwd, flags["env-file"]);
+				// Resolve entry file path relative to cwd
+				const entryPath = resolve(cwd, flags.entry);
+				const envFiles = resolveEnvFilePaths(cwd, flags["env-file"]);
 
-			// Verify entry file exists
-			if (!existsSync(entryPath)) {
-				throw new Error(
-					`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
-				);
-			}
-
-			if (flags.validate) {
-				await validateEntrypoint(entryPath, envFiles);
-			}
-
-			if (flags.package) {
-				if (flags.outfile) {
+				// Verify entry file exists
+				if (!existsSync(entryPath)) {
 					throw new Error(
-						"--outfile cannot be used with --package.\n  Use --stage-dir to control the staged npm output directory.",
+						`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
 					);
 				}
 
-				const { runDistributeBuild } = await import("../utils/distribute.ts");
-				await runDistributeBuild({
-					cwd,
-					entry: flags.entry,
-					name: flags.name,
-					minify: flags.minify,
-					target: flags.target,
-					stageDir: flags["stage-dir"],
-					envFiles,
-					validate: false,
-					man: flags.man,
-					outdir: flags.outdir,
-				});
-				return;
-			}
-
-			if (flags.man) {
-				const baseName = resolveBaseName(flags.name, entryPath, cwd);
-				const manPath = resolve(cwd, flags.outdir, "man", `${baseName}.1`);
-				console.log(`Writing man page ${dim(manPath)}...`);
-				await generateManPageFromEntry({
-					cwd,
-					entry: flags.entry,
-					name: flags.name,
-					outfile: manPath,
-				});
-				console.log(`${green("✓")} Man page: ${manPath}`);
-			}
-
-			// Resolve targets: default is all platforms, --target narrows to specific ones
-			const targets = resolveTargets(flags.target);
-
-			// --outfile is only allowed with exactly one target
-			if (flags.outfile && targets.length > 1) {
-				throw new Error(
-					"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
-				);
-			}
-
-			if (targets.length === 1) {
-				// Single-target build: one binary, no resolver
-				const outfilePath = resolveOutfile(flags.outfile, flags.name, entryPath, cwd, flags.outdir);
-
-				console.log(`Building ${dim(entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
-				await execBuild(entryPath, outfilePath, flags.minify, targets[0], envFiles);
-				console.log(`${green("✓")} Built successfully: ${outfilePath}`);
-			} else {
-				// Multi-target build: multiple binaries + shell/CMD resolvers
-				const baseName = resolveBaseName(flags.name, entryPath, cwd);
-
-				console.log(`Building ${dim(entryPath)} for ${bold(`${targets.length}`)} target(s)...`);
-
-				const results: string[] = [];
-				for (const target of targets) {
-					const targetOutfile = resolveTargetOutfile(baseName, target, cwd, flags.outdir);
-
-					console.log(`  ${cyan("→")} ${bold(target)}: ${dim(targetOutfile)}`);
-					await execBuild(entryPath, targetOutfile, flags.minify, target, envFiles);
-					results.push(targetOutfile);
+				if (flags.validate) {
+					await validateEntrypoint(entryPath, envFiles);
 				}
 
-				// Generate resolver scripts
-				const resolverPath = resolve(cwd, flags.outdir, flags.resolver);
-				writeResolver(resolverPath, baseName, targets);
+				if (flags.package) {
+					if (flags.outfile) {
+						throw new Error(
+							"--outfile cannot be used with --package.\n  Use --stage-dir to control the staged npm output directory.",
+						);
+					}
 
-				console.log(`\n${green("✓")} Built ${bold(`${results.length}`)} target(s) successfully:`);
-				for (const r of results) {
-					console.log(`  ${r}`);
+					const { runDistributeBuild } = await import("../utils/distribute.ts");
+					await runDistributeBuild({
+						cwd,
+						entry: flags.entry,
+						name: flags.name,
+						minify: flags.minify,
+						target: flags.target,
+						stageDir: flags["stage-dir"],
+						envFiles,
+						validate: false,
+						man: flags.man,
+						outdir: flags.outdir,
+					});
+					return;
 				}
-				console.log(`\n${dim("Resolver:")} ${resolverPath} ${dim(`(+ ${resolverPath}.cmd)`)}`);
-			}
-		}),
+
+				if (flags.man) {
+					const baseName = resolveBaseName(flags.name, entryPath, cwd);
+					const manPath = resolve(cwd, flags.outdir, "man", `${baseName}.1`);
+					console.log(`Writing man page ${dim(manPath)}...`);
+					await generateManPageFromEntry({
+						cwd,
+						entry: flags.entry,
+						name: flags.name,
+						outfile: manPath,
+					});
+					console.log(`${green("✓")} Man page: ${manPath}`);
+				}
+
+				// Resolve targets: default is all platforms, --target narrows to specific ones
+				const targets = resolveTargets(flags.target);
+
+				// --outfile is only allowed with exactly one target
+				if (flags.outfile && targets.length > 1) {
+					throw new Error(
+						"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
+					);
+				}
+
+				if (targets.length === 1) {
+					// Single-target build: one binary, no resolver
+					const outfilePath = resolveOutfile(
+						flags.outfile,
+						flags.name,
+						entryPath,
+						cwd,
+						flags.outdir,
+					);
+
+					console.log(`Building ${dim(entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
+					await execBuild(entryPath, outfilePath, flags.minify, targets[0], envFiles);
+					console.log(`${green("✓")} Built successfully: ${outfilePath}`);
+				} else {
+					// Multi-target build: multiple binaries + shell/CMD resolvers
+					const baseName = resolveBaseName(flags.name, entryPath, cwd);
+
+					console.log(`Building ${dim(entryPath)} for ${bold(`${targets.length}`)} target(s)...`);
+
+					const results: string[] = [];
+					for (const target of targets) {
+						const targetOutfile = resolveTargetOutfile(baseName, target, cwd, flags.outdir);
+
+						console.log(`  ${cyan("→")} ${bold(target)}: ${dim(targetOutfile)}`);
+						await execBuild(entryPath, targetOutfile, flags.minify, target, envFiles);
+						results.push(targetOutfile);
+					}
+
+					// Generate resolver scripts
+					const resolverPath = resolve(cwd, flags.outdir, flags.resolver);
+					writeResolver(resolverPath, baseName, targets);
+
+					console.log(`\n${green("✓")} Built ${bold(`${results.length}`)} target(s) successfully:`);
+					for (const r of results) {
+						console.log(`  ${r}`);
+					}
+					console.log(`\n${dim("Resolver:")} ${resolverPath} ${dim(`(+ ${resolverPath}.cmd)`)}`);
+				}
+			}),
 );

--- a/packages/crust/src/commands/publish.ts
+++ b/packages/crust/src/commands/publish.ts
@@ -202,58 +202,58 @@ export async function publishStagedPackages(
 	);
 }
 
-export const publishCommand = defineCommand("publish", (command) =>
-	command
-		.meta({
-			description: "Publish staged npm packages created by crust build --package",
-		})
-		.flags(
-			{
-				name: "stage-dir",
-				type: "string",
-				description: "Directory containing a staged manifest.json",
-				default: "dist/npm",
-			},
-			{
-				name: "tag",
-				type: "string",
-				description: "Override the npm dist-tag passed to bun publish",
-			},
-			{
-				name: "access",
-				type: "string",
-				description: "npm access level passed to bun publish",
-				default: "public",
-			},
-			{
-				name: "dry-run",
-				type: "boolean",
-				description: "Print publish order and commands without publishing",
-				default: false,
-			},
-			{
-				name: "verify",
-				type: "boolean",
-				description: "Verify staged directories and metadata before publishing",
-				default: true,
-			},
-			{
-				name: "registry",
-				type: "string",
-				description: "Override the registry passed to bun publish",
-			},
-		)
-		.action(async ({ flags }) => {
-			const stageDir = resolve(process.cwd(), flags["stage-dir"]);
-			const manifest = readPublishManifest(stageDir);
+export const publishCommand = defineCommand(
+	"publish",
+	{ description: "Publish staged npm packages created by crust build --package" },
+	(command) =>
+		command
+			.flags(
+				{
+					name: "stage-dir",
+					type: "string",
+					description: "Directory containing a staged manifest.json",
+					default: "dist/npm",
+				},
+				{
+					name: "tag",
+					type: "string",
+					description: "Override the npm dist-tag passed to bun publish",
+				},
+				{
+					name: "access",
+					type: "string",
+					description: "npm access level passed to bun publish",
+					default: "public",
+				},
+				{
+					name: "dry-run",
+					type: "boolean",
+					description: "Print publish order and commands without publishing",
+					default: false,
+				},
+				{
+					name: "verify",
+					type: "boolean",
+					description: "Verify staged directories and metadata before publishing",
+					default: true,
+				},
+				{
+					name: "registry",
+					type: "string",
+					description: "Override the registry passed to bun publish",
+				},
+			)
+			.action(async ({ flags }) => {
+				const stageDir = resolve(process.cwd(), flags["stage-dir"]);
+				const manifest = readPublishManifest(stageDir);
 
-			await publishStagedPackages(manifest, {
-				stageDir,
-				access: flags.access,
-				tag: flags.tag,
-				registry: flags.registry,
-				dryRun: flags["dry-run"],
-				verify: flags.verify,
-			});
-		}),
+				await publishStagedPackages(manifest, {
+					stageDir,
+					access: flags.access,
+					tag: flags.tag,
+					registry: flags.registry,
+					dryRun: flags["dry-run"],
+					verify: flags.verify,
+				});
+			}),
 );

--- a/packages/extensions/src/completion/adversarial.test.ts
+++ b/packages/extensions/src/completion/adversarial.test.ts
@@ -57,9 +57,9 @@ describe("walker · validation", () => {
 	});
 
 	it("strips control characters from descriptions instead of throwing", () => {
-		const cli = new Crust("safe")
-			.meta({ description: "first line\nsecond line\rstill same line" })
-			.action(() => {});
+		const cli = new Crust("safe", {
+			description: "first line\nsecond line\rstill same line",
+		}).action(() => {});
 		const spec = walkCommandNode(snapshotCommand(cli._node));
 		// Newlines and CR collapse to spaces during normalisation.
 		expect(spec.root.description).toBe("first line second line still same line");

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -56,23 +56,19 @@ function getProcessStdout(): string {
 }
 
 function buildCli() {
-	return new Crust("mycli")
-		.meta({ description: "Test CLI" })
+	return new Crust("mycli", { description: "Test CLI" })
 		.extend(completionExtension({ version: "1.2.3" }))
 		.add(
-			defineCommand("build", (cmd) =>
+			defineCommand("build", { description: "Build artifact" }, (cmd) =>
 				cmd
-					.meta({ description: "Build artifact" })
 					.flags({ name: "target", type: "string", choices: ["browser", "bun", "node"] })
 					.action(() => {}),
 			),
-			defineCommand("deploy", (cmd) =>
+			defineCommand("deploy", { description: "Deploy", aliases: ["dep"] }, (cmd) =>
 				cmd
-					.meta({ description: "Deploy", aliases: ["dep"] })
 					.add(
-						defineCommand("prod", (sub) =>
+						defineCommand("prod", { description: "Production deploy" }, (sub) =>
 							sub
-								.meta({ description: "Production deploy" })
 								.flags({
 									name: "env",
 									type: "string",

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -102,72 +102,72 @@ export function completionExtension(options: CompletionOptions = {}): Extension 
 	const shells = options.shells ?? SUPPORTED_SHELLS;
 	const version = options.version ?? "0.0.0";
 
-	const completionCommand = defineCommand(subcommandName, (cmd) =>
-		cmd
-			.meta({
-				description: "Generate shell tab-completion scripts",
-			})
-			.args({
-				name: "shell",
-				type: "string",
-				required: true,
-				description: "Shell to generate completion for",
-				choices: SUPPORTED_SHELLS,
-			})
-			.flags({
-				name: "output-dir",
-				type: "string",
-				description:
-					"Write all configured shells' scripts into this directory instead of printing to stdout",
-			})
-			.action(async (context) => {
-				const rootCommand = context.rootCommand;
-				// Validate `binName` before emitting anything so misconfigured
-				// CLIs fail loudly. The walker also re-validates command/flag
-				// identifiers when it builds the spec.
-				const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
-				// `version` flows into header comments only; sanitise to drop
-				// control characters (newlines especially) so they cannot break
-				// out of the comment line in the emitted script.
-				const safeVersion = sanitizeFreeText(version);
+	const completionCommand = defineCommand(
+		subcommandName,
+		{ description: "Generate shell tab-completion scripts" },
+		(cmd) =>
+			cmd
+				.args({
+					name: "shell",
+					type: "string",
+					required: true,
+					description: "Shell to generate completion for",
+					choices: SUPPORTED_SHELLS,
+				})
+				.flags({
+					name: "output-dir",
+					type: "string",
+					description:
+						"Write all configured shells' scripts into this directory instead of printing to stdout",
+				})
+				.action(async (context) => {
+					const rootCommand = context.rootCommand;
+					// Validate `binName` before emitting anything so misconfigured
+					// CLIs fail loudly. The walker also re-validates command/flag
+					// identifiers when it builds the spec.
+					const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
+					// `version` flows into header comments only; sanitise to drop
+					// control characters (newlines especially) so they cannot break
+					// out of the comment line in the emitted script.
+					const safeVersion = sanitizeFreeText(version);
 
-				const { shell: requestedShell } = context.args;
-				const spec = walkCommandNode(rootCommand);
-				const outputDir = context.flags["output-dir"];
+					const { shell: requestedShell } = context.args;
+					const spec = walkCommandNode(rootCommand);
+					const outputDir = context.flags["output-dir"];
 
-				if (outputDir === undefined) {
-					const script = renderForShell(requestedShell, spec, binName, safeVersion);
-					context.stdout(script);
-					return;
-				}
-
-				// File path: write **all** configured shells. This matches
-				// the packaging-time use case — distributors generate every
-				// supported file in one invocation regardless of which
-				// shell they nominally requested.
-				const targetDir = resolvePath(outputDir);
-				await mkdir(targetDir, { recursive: true });
-				for (const shell of shells) {
-					const filename = filenameForShell(shell, binName);
-					const script = renderForShell(shell, spec, binName, safeVersion);
-					const targetPath = resolvePath(targetDir, filename);
-					// Defence-in-depth: even though `binName` is validated
-					// upstream (rejects path separators / `..`), verify the
-					// resolved path stays inside `targetDir`. This catches
-					// future regressions in the validator and platform-
-					// specific edge cases (e.g. Windows drive letters).
-					if (
-						targetPath !== targetDir &&
-						!targetPath.startsWith(`${targetDir}/`) &&
-						!targetPath.startsWith(`${targetDir}\\`)
-					) {
-						throw new Error(
-							`completion extension: refusing to write outside output dir (${targetPath})`,
-						);
+					if (outputDir === undefined) {
+						const script = renderForShell(requestedShell, spec, binName, safeVersion);
+						context.stdout(script);
+						return;
 					}
-					await writeFile(targetPath, script, "utf8");
-				}
-			}),
+
+					// File path: write **all** configured shells. This matches
+					// the packaging-time use case — distributors generate every
+					// supported file in one invocation regardless of which
+					// shell they nominally requested.
+					const targetDir = resolvePath(outputDir);
+					await mkdir(targetDir, { recursive: true });
+					for (const shell of shells) {
+						const filename = filenameForShell(shell, binName);
+						const script = renderForShell(shell, spec, binName, safeVersion);
+						const targetPath = resolvePath(targetDir, filename);
+						// Defence-in-depth: even though `binName` is validated
+						// upstream (rejects path separators / `..`), verify the
+						// resolved path stays inside `targetDir`. This catches
+						// future regressions in the validator and platform-
+						// specific edge cases (e.g. Windows drive letters).
+						if (
+							targetPath !== targetDir &&
+							!targetPath.startsWith(`${targetDir}/`) &&
+							!targetPath.startsWith(`${targetDir}\\`)
+						) {
+							throw new Error(
+								`completion extension: refusing to write outside output dir (${targetPath})`,
+							);
+						}
+						await writeFile(targetPath, script, "utf8");
+					}
+				}),
 	);
 
 	return defineExtension("completion", { commands: [completionCommand] });

--- a/packages/extensions/src/did-you-mean.test.ts
+++ b/packages/extensions/src/did-you-mean.test.ts
@@ -52,7 +52,7 @@ describe("didYouMeanExtension", () => {
 	it("suggests the canonical name when the input matches an alias", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})))
+			.add(defineCommand("issue", { aliases: ["issues", "i"] }, (cmd) => cmd.action(() => {})))
 			.add(defineCommand("version", (cmd) => cmd.action(() => {})));
 
 		// "issuess" is closest to the alias "issues" (distance 1) than to
@@ -70,9 +70,7 @@ describe("didYouMeanExtension", () => {
 	it("suggests the canonical name unchanged when the typo is closest to the canonical", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(
-				defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})),
-			);
+			.add(defineCommand("issue", { aliases: ["issues", "i"] }, (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["isue"] });
 
@@ -86,7 +84,7 @@ describe("didYouMeanExtension", () => {
 		// because it is a prefix of the input.
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["i"] }).action(() => {})))
+			.add(defineCommand("issue", { aliases: ["i"] }, (cmd) => cmd.action(() => {})))
 			.add(defineCommand("install", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["insall"] });
@@ -99,7 +97,7 @@ describe("didYouMeanExtension", () => {
 	it("lists only canonical names under 'Available commands'", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues", "i"] }).action(() => {})))
+			.add(defineCommand("issue", { aliases: ["issues", "i"] }, (cmd) => cmd.action(() => {})))
 			.add(defineCommand("version", (cmd) => cmd.action(() => {})));
 
 		await app.execute({ argv: ["completely-unknown"] });
@@ -112,7 +110,7 @@ describe("didYouMeanExtension", () => {
 	it("deduplicates suggestions when an alias and its canonical both match", async () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension({ mode: "help" }))
-			.add(defineCommand("issue", (cmd) => cmd.meta({ aliases: ["issues"] }).action(() => {})));
+			.add(defineCommand("issue", { aliases: ["issues"] }, (cmd) => cmd.action(() => {})));
 
 		// Both the canonical "issue" and the alias "issues" are within
 		// Levenshtein distance 3 of "issuee". The first suggestion line
@@ -132,7 +130,7 @@ describe("didYouMeanExtension", () => {
 		const app = new Crust("app")
 			.extend(didYouMeanExtension())
 			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
-			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).action(() => {})));
+			.add(defineCommand("__complete", { hidden: true }, (cmd) => cmd.action(() => {})));
 
 		// Typo distance(__complet -> __complete) = 1, well within the
 		// threshold. Distance(__complet -> build) is > 3, so without the
@@ -152,8 +150,8 @@ describe("didYouMeanExtension", () => {
 			.extend(didYouMeanExtension())
 			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, aliases: ["__comp"] }).action(() => {}),
+				defineCommand("__complete", { hidden: true, aliases: ["__comp"] }, (cmd) =>
+					cmd.action(() => {}),
 				),
 			);
 
@@ -170,7 +168,7 @@ describe("didYouMeanExtension", () => {
 			.extend(didYouMeanExtension())
 			.add(defineCommand("build", (cmd) => cmd.action(() => {})))
 			.add(defineCommand("test", (cmd) => cmd.action(() => {})))
-			.add(defineCommand("__complete", (cmd) => cmd.meta({ hidden: true }).action(() => {})));
+			.add(defineCommand("__complete", { hidden: true }, (cmd) => cmd.action(() => {})));
 
 		// No close match — we want the "Available commands" line.
 		await app.execute({ argv: ["zzzzz"] });

--- a/packages/extensions/src/plugins.test.ts
+++ b/packages/extensions/src/plugins.test.ts
@@ -68,12 +68,11 @@ const stripAnsi = stripVTControlCharacters;
 function lateSkillExtension() {
 	return defineExtension("late-skill", {
 		commands: [
-			defineCommand("skill", (command) =>
+			defineCommand("skill", { description: "Manage agent skills" }, (command) =>
 				command
-					.meta({ description: "Manage agent skills" })
 					.add(
-						defineCommand("update", (cmd) =>
-							cmd.meta({ description: "Update installed skills" }).action(() => {}),
+						defineCommand("update", { description: "Update installed skills" }, (cmd) =>
+							cmd.action(() => {}),
 						),
 					)
 					.action(() => {}),
@@ -88,8 +87,7 @@ describe("built-in plugins", () => {
 		// test environments (e.g. CI). Reset via afterEach.
 		process.env.FORCE_COLOR = "3";
 
-		const command = new Crust("app")
-			.meta({ description: "Test app" })
+		const command = new Crust("app", { description: "Test app" })
 			.flags(
 				{
 					name: "verbose",
@@ -111,7 +109,7 @@ describe("built-in plugins", () => {
 				description: "Output directory",
 				default: ".",
 			})
-			.add(defineCommand("build", (cmd) => cmd.meta({ description: "Build the project" })))._node;
+			.add(defineCommand("build", { description: "Build the project" }, (cmd) => cmd))._node;
 
 		const output = renderHelp(snapshotCommand(command));
 		const plain = stripAnsi(output);
@@ -447,16 +445,13 @@ describe("built-in plugins", () => {
 	it("help plugin ignores help-like args after --", async () => {
 		let capturedRawArgs: string[] = [];
 
-		const app = new Crust("app")
-			.meta({ description: "Test app" })
-			.extend(helpExtension())
-			.add(
-				defineCommand("build", (cmd) =>
-					cmd.action((ctx) => {
-						capturedRawArgs = [...ctx.rawArgs];
-					}),
-				),
-			);
+		const app = new Crust("app", { description: "Test app" }).extend(helpExtension()).add(
+			defineCommand("build", (cmd) =>
+				cmd.action((ctx) => {
+					capturedRawArgs = [...ctx.rawArgs];
+				}),
+			),
+		);
 
 		await app.execute({ argv: ["build", "--", "--help"] });
 
@@ -575,8 +570,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("version plugin flag appears in help output", async () => {
-		const app = new Crust("app")
-			.meta({ description: "Test app" })
+		const app = new Crust("app", { description: "Test app" })
 			.extend(versionExtension("1.0.0"))
 			.extend(helpExtension())
 			.action(() => {});
@@ -626,13 +620,13 @@ describe("built-in plugins", () => {
 
 	it("renderHelp renders aliases inline next to the canonical command name", () => {
 		const command = new Crust("app").add(
-			defineCommand("issue", (cmd) =>
-				cmd
-					.meta({
-						description: "Manage issues",
-						aliases: ["issues", "i"],
-					})
-					.action(() => {}),
+			defineCommand(
+				"issue",
+				{
+					description: "Manage issues",
+					aliases: ["issues", "i"],
+				},
+				(cmd) => cmd.action(() => {}),
 			),
 		)._node;
 
@@ -644,9 +638,7 @@ describe("built-in plugins", () => {
 
 	it("renderHelp renders unchanged for a command without aliases", () => {
 		const command = new Crust("app").add(
-			defineCommand("build", (cmd) =>
-				cmd.meta({ description: "Build the project" }).action(() => {}),
-			),
+			defineCommand("build", { description: "Build the project" }, (cmd) => cmd.action(() => {})),
 		)._node;
 
 		const plain = stripAnsi(renderHelp(snapshotCommand(command)));
@@ -659,19 +651,17 @@ describe("built-in plugins", () => {
 	it("renderHelp keeps description column aligned when aliases overflow the column", () => {
 		const command = new Crust("app")
 			.add(
-				defineCommand("issue", (cmd) =>
-					cmd
-						.meta({
-							description: "Manage issues",
-							aliases: ["issues", "i"],
-						})
-						.action(() => {}),
+				defineCommand(
+					"issue",
+					{
+						description: "Manage issues",
+						aliases: ["issues", "i"],
+					},
+					(cmd) => cmd.action(() => {}),
 				),
 			)
 			.add(
-				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).action(() => {}),
-				),
+				defineCommand("build", { description: "Build the project" }, (cmd) => cmd.action(() => {})),
 			)._node;
 
 		const lines = stripAnsi(renderHelp(snapshotCommand(command))).split("\n");
@@ -691,18 +681,16 @@ describe("built-in plugins", () => {
 	it("renderHelp omits subcommands marked meta.hidden: true", () => {
 		const command = new Crust("app")
 			.add(
-				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).action(() => {}),
-				),
+				defineCommand("build", { description: "Build the project" }, (cmd) => cmd.action(() => {})),
 			)
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd
-						.meta({
-							description: "Internal completion entrypoint",
-							hidden: true,
-						})
-						.action(() => {}),
+				defineCommand(
+					"__complete",
+					{
+						description: "Internal completion entrypoint",
+						hidden: true,
+					},
+					(cmd) => cmd.action(() => {}),
 				),
 			)._node;
 
@@ -716,8 +704,8 @@ describe("built-in plugins", () => {
 	it("renderHelp omits the COMMANDS section when every subcommand is hidden", () => {
 		const command = new Crust("app")
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
+				defineCommand("__complete", { hidden: true, description: "Internal" }, (cmd) =>
+					cmd.action(() => {}),
 				),
 			)
 			.action(() => {})._node;
@@ -732,8 +720,8 @@ describe("built-in plugins", () => {
 		// deciding whether to emit `<command>`, producing the incoherent
 		// `Usage: app <command>` with no COMMANDS section below it.
 		const command = new Crust("app").add(
-			defineCommand("__complete", (cmd) =>
-				cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
+			defineCommand("__complete", { hidden: true, description: "Internal" }, (cmd) =>
+				cmd.action(() => {}),
 			),
 		)._node;
 
@@ -749,19 +737,19 @@ describe("built-in plugins", () => {
 		// subcommand with aliases should still render `name (a, b)`.
 		const command = new Crust("app")
 			.add(
-				defineCommand("issue", (cmd) =>
-					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).action(() => {}),
+				defineCommand("issue", { description: "Manage issues", aliases: ["issues", "i"] }, (cmd) =>
+					cmd.action(() => {}),
 				),
 			)
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd
-						.meta({
-							description: "Internal",
-							aliases: ["__c"],
-							hidden: true,
-						})
-						.action(() => {}),
+				defineCommand(
+					"__complete",
+					{
+						description: "Internal",
+						aliases: ["__c"],
+						hidden: true,
+					},
+					(cmd) => cmd.action(() => {}),
 				),
 			)._node;
 
@@ -777,13 +765,11 @@ describe("built-in plugins", () => {
 		const app = new Crust("app")
 			.extend(helpExtension())
 			.add(
-				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).action(() => {}),
-				),
+				defineCommand("build", { description: "Build the project" }, (cmd) => cmd.action(() => {})),
 			)
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).action(() => {
+				defineCommand("__complete", { hidden: true, description: "Internal" }, (cmd) =>
+					cmd.action(() => {
 						didRun = true;
 					}),
 				),
@@ -798,8 +784,7 @@ describe("built-in plugins", () => {
 		// `helpExtension` must surface it so users can discover the valid
 		// values from `--help` without resorting to shell completion or
 		// reading the source.
-		const command = new Crust("app")
-			.meta({ description: "Build artifact" })
+		const command = new Crust("app", { description: "Build artifact" })
 			.flags({
 				name: "target",
 				type: "string",
@@ -814,8 +799,7 @@ describe("built-in plugins", () => {
 	});
 
 	it("renderHelp surfaces positional-arg `choices` in the ARGS section", () => {
-		const command = new Crust("app")
-			.meta({ description: "Deploy to an env" })
+		const command = new Crust("app", { description: "Deploy to an env" })
 			.args({
 				name: "env",
 				type: "string",

--- a/packages/extensions/src/update-notifier.test.ts
+++ b/packages/extensions/src/update-notifier.test.ts
@@ -1006,8 +1006,7 @@ describe("updateNotifierExtension post-run hook", () => {
 			mockRegistryResponse("5.0.0");
 
 			let commandExecuted = false;
-			const app = new Crust(pkgName)
-				.meta({ description: "Test" })
+			const app = new Crust(pkgName, { description: "Test" })
 				.extend(
 					updateNotifierExtension({
 						currentVersion: "1.0.0",
@@ -1034,8 +1033,7 @@ describe("updateNotifierExtension post-run hook", () => {
 			// Combine with a custom no-op extension
 			const otherPlugin = defineExtension("test-other");
 
-			const app = new Crust(pkgName)
-				.meta({ description: "Test" })
+			const app = new Crust(pkgName, { description: "Test" })
 				.extend(otherPlugin)
 				.extend(
 					updateNotifierExtension({
@@ -1058,8 +1056,7 @@ describe("updateNotifierExtension post-run hook", () => {
 			mockRegistryFailure();
 
 			let commandExecuted = false;
-			const app = new Crust(pkgName)
-				.meta({ description: "Test" })
+			const app = new Crust(pkgName, { description: "Test" })
 				.extend(
 					updateNotifierExtension({
 						currentVersion: "1.0.0",

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -440,7 +440,7 @@ function resolveUpdateCommand(
  * import { updateNotifier } from "@crustjs/extensions";
  * import pkg from "../package.json";
  *
- * const app = new Crust("my-cli").meta({ description: "My awesome CLI" })
+ * const app = new Crust("my-cli", { description: "My awesome CLI" })
  *   .extend(updateNotifier({ packageName: "my-cli", currentVersion: pkg.version }))
  *   .action(() => {
  *     console.log("Hello!");

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -7,11 +7,10 @@ import { renderManPageMdoc } from "./mdoc.ts";
 
 describe("renderManPageMdoc", () => {
 	it("includes NAME SYNOPSIS SUBCOMMANDS OPTIONS", async () => {
-		const app = new Crust("demo")
-			.meta({ description: "Demo CLI for tests." })
+		const app = new Crust("demo", { description: "Demo CLI for tests." })
 			.extend(help())
 			.flags({ name: "verbose", type: "boolean", short: "v", description: "Verbose" })
-			.add(defineCommand("ping", (cmd) => cmd.meta({ description: "Ping" }).action(() => {})));
+			.add(defineCommand("ping", { description: "Ping" }, (cmd) => cmd.action(() => {})));
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "demo", section: 1 });
@@ -28,9 +27,7 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("escapes leading dots in descriptions and .Nd", async () => {
-		const app = new Crust("x")
-			.meta({ description: ".config is read automatically." })
-			.action(() => {});
+		const app = new Crust("x", { description: ".config is read automatically." }).action(() => {});
 
 		const root = await app.snapshot();
 		const mdoc = renderManPageMdoc({ root, name: "x", section: 1 });
@@ -68,17 +65,14 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("renders subcommand aliases inline next to the canonical name", async () => {
-		const app = new Crust("demo")
-			.meta({ description: "Demo CLI for alias tests." })
+		const app = new Crust("demo", { description: "Demo CLI for alias tests." })
 			.add(
-				defineCommand("issue", (cmd) =>
-					cmd.meta({ description: "Manage issues", aliases: ["issues", "i"] }).action(() => {}),
+				defineCommand("issue", { description: "Manage issues", aliases: ["issues", "i"] }, (cmd) =>
+					cmd.action(() => {}),
 				),
 			)
 			.add(
-				defineCommand("version", (cmd) =>
-					cmd.meta({ description: "Show version" }).action(() => {}),
-				),
+				defineCommand("version", { description: "Show version" }, (cmd) => cmd.action(() => {})),
 			);
 
 		const root = await app.snapshot();
@@ -101,18 +95,15 @@ describe("renderManPageMdoc", () => {
 	it("omits `meta.hidden: true` subcommands from the SUBCOMMANDS section", async () => {
 		// Mirrors the helpPlugin contract: hidden commands stay invocable
 		// but never appear in published man pages.
-		const app = new Crust("demo")
-			.meta({ description: "Demo." })
+		const app = new Crust("demo", { description: "Demo." })
 			.add(
-				defineCommand("build", (cmd) =>
-					cmd.meta({ description: "Build the project" }).action(() => {}),
-				),
+				defineCommand("build", { description: "Build the project" }, (cmd) => cmd.action(() => {})),
 			)
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd
-						.meta({ description: "Internal completion entrypoint", hidden: true })
-						.action(() => {}),
+				defineCommand(
+					"__complete",
+					{ description: "Internal completion entrypoint", hidden: true },
+					(cmd) => cmd.action(() => {}),
 				),
 			);
 
@@ -126,8 +117,8 @@ describe("renderManPageMdoc", () => {
 	it("omits the SUBCOMMANDS section entirely when every subcommand is hidden", async () => {
 		const app = new Crust("demo")
 			.add(
-				defineCommand("__complete", (cmd) =>
-					cmd.meta({ hidden: true, description: "Internal" }).action(() => {}),
+				defineCommand("__complete", { hidden: true, description: "Internal" }, (cmd) =>
+					cmd.action(() => {}),
 				),
 			)
 			.action(() => {});
@@ -140,8 +131,7 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("renders flag `choices` as `[choices: ...]` after the description", async () => {
-		const app = new Crust("demo")
-			.meta({ description: "Demo." })
+		const app = new Crust("demo", { description: "Demo." })
 			.flags({
 				name: "target",
 				type: "string",
@@ -159,8 +149,7 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("renders positional-arg `choices` in the ARGUMENTS section", async () => {
-		const app = new Crust("demo")
-			.meta({ description: "Demo." })
+		const app = new Crust("demo", { description: "Demo." })
 			.args({
 				name: "env",
 				type: "string",
@@ -179,8 +168,7 @@ describe("renderManPageMdoc", () => {
 	});
 
 	it("includes long flag aliases (`def.aliases`) alongside the canonical spelling", async () => {
-		const app = new Crust("demo")
-			.meta({ description: "Demo." })
+		const app = new Crust("demo", { description: "Demo." })
 			.flags({
 				name: "output",
 				type: "string",

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -624,11 +624,8 @@ describe("buildManifest", () => {
 		});
 
 		it("preserves instructions across Crust builder cloning", () => {
-			const deploy = defineCommand("deploy", (command) =>
-				annotate(
-					command.meta({ description: "Deploy command" }),
-					"Read the environment carefully before execution.",
-				).action(() => {}),
+			const deploy = defineCommand("deploy", { description: "Deploy command" }, (command) =>
+				annotate(command, "Read the environment carefully before execution.").action(() => {}),
 			);
 			const root = new Crust("app").add(deploy);
 

--- a/packages/skills/src/plugin.test.ts
+++ b/packages/skills/src/plugin.test.ts
@@ -75,8 +75,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("does not install skills that are not yet present", async () => {
-		const app = new Crust("no-auto-install")
-			.meta({ description: "test" })
+		const app = new Crust("no-auto-install", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -93,8 +92,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("renders plugin-provided top-level instructions into SKILL.md", async () => {
-		const app = new Crust("instruction-test")
-			.meta({ description: "test" })
+		const app = new Crust("instruction-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -131,8 +129,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("renders plugin-provided markdown instructions into SKILL.md", async () => {
-		const app = new Crust("markdown-instruction-test")
-			.meta({ description: "test" })
+		const app = new Crust("markdown-instruction-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -172,8 +169,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("auto-updates already-installed skills when version changes", async () => {
-		const app = new Crust("update-test")
-			.meta({ description: "test" })
+		const app = new Crust("update-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -203,8 +199,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("prints auto-update message with Universal label", async () => {
-		const app = new Crust("update-message-test")
-			.meta({ description: "test" })
+		const app = new Crust("update-message-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -247,8 +242,7 @@ describe("skill extension auto-update", () => {
 	it("auto-updates before a later extension short-circuits (registration order matters)", async () => {
 		// Pre-run hooks run in registration order; registering skills first means
 		// its auto-update work happens before any later short-circuit.
-		const app = new Crust("order-test")
-			.meta({ description: "test" })
+		const app = new Crust("order-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -279,8 +273,7 @@ describe("skill extension auto-update", () => {
 	it("does not auto-update during validation mode", async () => {
 		process.env[VALIDATION_MODE_ENV] = "1";
 
-		const app = new Crust("validation-test")
-			.meta({ description: "test" })
+		const app = new Crust("validation-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -316,8 +309,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("does not auto-update when autoUpdate is false", async () => {
-		const app = new Crust("no-update-test")
-			.meta({ description: "test" })
+		const app = new Crust("no-update-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -350,8 +342,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("prints no changes when universal skills are already installed", async () => {
-		const app = new Crust("no-change-test")
-			.meta({ description: "test" })
+		const app = new Crust("no-change-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -399,8 +390,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("runs manual skill update command", async () => {
-		const app = new Crust("manual-update-test")
-			.meta({ description: "test" })
+		const app = new Crust("manual-update-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -432,8 +422,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("reports global scope when updating from the home directory", async () => {
-		const app = new Crust("manual-home-update-test")
-			.meta({ description: "test" })
+		const app = new Crust("manual-home-update-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -479,8 +468,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("reports no updates needed with global scope from the home directory", async () => {
-		const app = new Crust("manual-home-noop-test")
-			.meta({ description: "test" })
+		const app = new Crust("manual-home-noop-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -521,8 +509,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("renders top-level instructions when running manual skill update", async () => {
-		const app = new Crust("manual-update-instructions-test")
-			.meta({ description: "test" })
+		const app = new Crust("manual-update-instructions-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -566,8 +553,7 @@ describe("skill extension auto-update", () => {
 	});
 
 	it("defaults to global scope in non-interactive update when defaultScope is unset", async () => {
-		const app = new Crust("fallback-scope-test")
-			.meta({ description: "test" })
+		const app = new Crust("fallback-scope-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -650,8 +636,7 @@ async function captureSetupError(fn: () => Promise<void>): Promise<{
 
 describe("skillPlugin customSkills validation", () => {
 	it("accepts an empty array", async () => {
-		const app = new Crust("empty-custom")
-			.meta({ description: "test" })
+		const app = new Crust("empty-custom", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -683,8 +668,7 @@ describe("skillPlugin customSkills validation", () => {
 		// `version` is optional and inherits from the plugin when omitted, but
 		// an explicit empty string is still rejected so a typo can't silently
 		// fall through to the plugin-level fallback.
-		const app = new Crust("empty-version-test")
-			.meta({ description: "test" })
+		const app = new Crust("empty-version-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -707,8 +691,7 @@ describe("skillPlugin customSkills validation", () => {
 	});
 
 	it("accepts a URL sourceDir", async () => {
-		const app = new Crust("url-custom")
-			.meta({ description: "test" })
+		const app = new Crust("url-custom", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -729,8 +712,7 @@ describe("skillPlugin customSkills validation", () => {
 	});
 
 	it("accepts an absolute string sourceDir", async () => {
-		const app = new Crust("abs-custom")
-			.meta({ description: "test" })
+		const app = new Crust("abs-custom", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -752,8 +734,7 @@ describe("skillPlugin customSkills validation", () => {
 
 	it("accepts a relative string sourceDir at setup (resolution defers to install)", async () => {
 		// Setup must not throw — resolution-time errors defer to installSkillBundle.
-		const app = new Crust("rel-custom")
-			.meta({ description: "test" })
+		const app = new Crust("rel-custom", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -775,8 +756,7 @@ describe("skillPlugin customSkills validation", () => {
 	});
 
 	it("rejects a name that collides with the main skill", async () => {
-		const app = new Crust("collide-test")
-			.meta({ description: "test" })
+		const app = new Crust("collide-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -799,8 +779,7 @@ describe("skillPlugin customSkills validation", () => {
 	});
 
 	it("rejects duplicate names within the array", async () => {
-		const app = new Crust("dup-test")
-			.meta({ description: "test" })
+		const app = new Crust("dup-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -828,8 +807,7 @@ describe("skillPlugin customSkills validation", () => {
 	});
 
 	it("rejects an invalid skill name", async () => {
-		const app = new Crust("invalid-name-test")
-			.meta({ description: "test" })
+		const app = new Crust("invalid-name-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -891,8 +869,7 @@ describe("skillPlugin customSkills name mismatch", () => {
 			warnings.push(args.join(" "));
 		};
 
-		const app = new Crust("name-mismatch-host")
-			.meta({ description: "test" })
+		const app = new Crust("name-mismatch-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -967,8 +944,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
 		expect((await readInstalledManifest(bundleDir))?.version ?? null).toBe("1.0.0");
 
-		const app = new Crust("bundle-update-host")
-			.meta({ description: "test" })
+		const app = new Crust("bundle-update-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1008,8 +984,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		const sentinel = join(bundleDir, ".sentinel");
 		await writeFile(sentinel, "do-not-touch");
 
-		const app = new Crust("bundle-noop-host")
-			.meta({ description: "test" })
+		const app = new Crust("bundle-noop-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1069,8 +1044,7 @@ describe("skillPlugin customSkills auto-update", () => {
 			warnings.push(args.join(" "));
 		};
 
-		const app = new Crust("bundle-resilience-host")
-			.meta({ description: "test" })
+		const app = new Crust("bundle-resilience-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1120,8 +1094,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
 		expect((await readInstalledManifest(bundleDir))?.version ?? null).toBe("1.0.0");
 
-		const app = new Crust("no-auto-update-host")
-			.meta({ description: "test" })
+		const app = new Crust("no-auto-update-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1161,8 +1134,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		const bundleDir = join(tmpDir, ".agents", "skills", "funnel-builder");
 
-		const app = new Crust("subcmd-skip-host")
-			.meta({ description: "test" })
+		const app = new Crust("subcmd-skip-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1216,8 +1188,7 @@ describe("skillPlugin customSkills auto-update", () => {
 	it("does not install bundles when customSkills is omitted", async () => {
 		// Same as the existing "auto-updates already-installed skills" test but
 		// asserts that no bundle directory is ever created.
-		const app = new Crust("identical-test")
-			.meta({ description: "test" })
+		const app = new Crust("identical-test", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1265,8 +1236,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		// Plugin-level version is bumped to 2.0.0; entry omits `version`, so
 		// it should inherit and trigger a reinstall to 2.0.0.
-		const app = new Crust("inherit-version-host")
-			.meta({ description: "test" })
+		const app = new Crust("inherit-version-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1304,8 +1274,7 @@ describe("skillPlugin customSkills auto-update", () => {
 
 		// Plugin says 2.0.0 but the entry pins itself at 0.3.0 — a vendored
 		// bundle whose cadence is independent of the consuming CLI.
-		const app = new Crust("override-version-host")
-			.meta({ description: "test" })
+		const app = new Crust("override-version-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1344,8 +1313,7 @@ describe("skillPlugin customSkills auto-update", () => {
 		const sentinel = join(bundleDir, ".sentinel");
 		await writeFile(sentinel, "do-not-touch");
 
-		const app = new Crust("inherit-noop-host")
-			.meta({ description: "test" })
+		const app = new Crust("inherit-noop-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1382,8 +1350,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	});
 
 	it("--all installs main + every bundle without prompting", async () => {
-		const app = new Crust("all-flag-host")
-			.meta({ description: "test" })
+		const app = new Crust("all-flag-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1430,8 +1397,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	});
 
 	it("prints sequential per-skill output (heading mentions bundle name)", async () => {
-		const app = new Crust("sequential-output-host")
-			.meta({ description: "test" })
+		const app = new Crust("sequential-output-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1477,8 +1443,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	it("--all honors explicit --scope flag over defaultScope", async () => {
 		// Plugin defaultScope is "project", but `--scope global` should win.
 		// Bundle should land in the global scope, not the project scope.
-		const app = new Crust("all-scope-host")
-			.meta({ description: "test" })
+		const app = new Crust("all-scope-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1523,8 +1488,7 @@ describe("skillPlugin customSkills interactive command", () => {
 	});
 
 	it("--all isolates per-bundle failures and exits non-zero", async () => {
-		const app = new Crust("all-isolation-host")
-			.meta({ description: "test" })
+		const app = new Crust("all-isolation-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1605,8 +1569,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 	});
 
 	it("updates main + every bundle in sequence", async () => {
-		const app = new Crust("update-loop-host")
-			.meta({ description: "test" })
+		const app = new Crust("update-loop-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1676,8 +1639,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 	});
 
 	it("reports per-skill 'No updates needed' when nothing is outdated", async () => {
-		const app = new Crust("update-noop-host")
-			.meta({ description: "test" })
+		const app = new Crust("update-noop-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({
@@ -1752,8 +1714,7 @@ describe("skillPlugin customSkills `skill update`", () => {
 			}),
 		);
 
-		const app = new Crust("update-isolation-host")
-			.meta({ description: "test" })
+		const app = new Crust("update-isolation-host", { description: "test" })
 			.action(() => {})
 			.extend(
 				skillExtension({

--- a/packages/skills/src/plugin.ts
+++ b/packages/skills/src/plugin.ts
@@ -431,7 +431,7 @@ async function autoUpdateCustomSkillsLoop(
  * import { Crust } from "@crustjs/core";
  * import { skill } from "@crustjs/skills";
  *
- * const app = new Crust("my-cli").meta({ description: "My CLI" })
+ * const app = new Crust("my-cli", { description: "My CLI" })
  *   .extend(skill({
  *     version: "1.0.0",
  *     command: "skill", // registers "my-cli skill" subcommand
@@ -651,48 +651,52 @@ function buildSkillCommandGrammar(
 	options: SkillOptions,
 	getCustomSkills: (mainName: string) => readonly CustomSkillConfig[],
 ) {
-	return defineCommand(commandName, (command) =>
-		command
-			.meta({ description: "Manage agent skill installations" })
-			.flags(
-				{
-					name: "scope",
-					type: "string",
-					description: "Install scope (project or global)",
-				},
-				{
-					name: "all",
-					type: "boolean",
-					description: "Install for all detected agents non-interactively (universal + detected)",
-				},
-			)
-			.add(
-				defineCommand("update", (cmd) =>
-					cmd
-						.meta({ description: "Update installed skills to latest version" })
-						.flags({
-							name: "scope",
-							type: "string",
-							description: "Update scope (project or global)",
-						})
-						.action(async (context) => {
-							await runSkillUpdateFlow(
-								context.rootCommand,
-								options,
-								getCustomSkills(context.rootCommand.meta.name),
-								context.flags,
-							);
-						}),
-				),
-			)
-			.action(async (context) => {
-				await runSkillInstallFlow(
-					context.rootCommand,
-					options,
-					getCustomSkills(context.rootCommand.meta.name),
-					context.flags,
-				);
-			}),
+	return defineCommand(
+		commandName,
+		{ description: "Manage agent skill installations" },
+		(command) =>
+			command
+				.flags(
+					{
+						name: "scope",
+						type: "string",
+						description: "Install scope (project or global)",
+					},
+					{
+						name: "all",
+						type: "boolean",
+						description: "Install for all detected agents non-interactively (universal + detected)",
+					},
+				)
+				.add(
+					defineCommand(
+						"update",
+						{ description: "Update installed skills to latest version" },
+						(cmd) =>
+							cmd
+								.flags({
+									name: "scope",
+									type: "string",
+									description: "Update scope (project or global)",
+								})
+								.action(async (context) => {
+									await runSkillUpdateFlow(
+										context.rootCommand,
+										options,
+										getCustomSkills(context.rootCommand.meta.name),
+										context.flags,
+									);
+								}),
+					),
+				)
+				.action(async (context) => {
+					await runSkillInstallFlow(
+						context.rootCommand,
+						options,
+						getCustomSkills(context.rootCommand.meta.name),
+						context.flags,
+					);
+				}),
 	);
 }
 


### PR DESCRIPTION
Stacked on #178 (← #177 ← main).

## What

Removes the chainable `.meta()` from `Crust` and `CommandDefinitionBuilder` (no compat shim) and moves static metadata into builder signatures:

- **Root:** `new Crust(name, { description?, usage? })` — `aliases`/`hidden` are sibling-relative and now rejected on root at compile time
- **Definitions:** `defineCommand(name, { description?, usage?, aliases?, hidden?, requires? }, recipe)`

## Why

- `.meta()` was the only chain method that didn't transform types — declaration data pretending to be a builder step
- Eliminates repeated-`.meta()` silent merge semantics
- Aliases are now known statically on the definition: `.add()`-time alias validation reads data instead of executing the recipe
- One fewer method to keep in parity across `Crust` / `CommandDefinitionBuilder`

## Notes

- `.as(name)` renames a definition; configured aliases travel with it (documented) — adding the same aliased definition twice still collides loudly at `.add()`
- All internal consumers (crust, create-crust + template, extensions, skills), docs guides/api/modules, and doc examples migrated; source grep shows zero `.meta(` remaining
- Changeset: `@crustjs/core` minor (pre-1.0 breaking), patch for dependents

## Gates

- `bun run check:types` ✅
- `bun run test` ✅ (21/21 tasks)
- `bun run check` ✅ (build + lint + format)
