### PR TITLE
ci: report per-PR TypeScript type-check performance impact

### DIFF
--- a/.github/workflows/type-perf.yml
+++ b/.github/workflows/type-perf.yml
@@ -10,7 +10,6 @@ on:
       - "package.json"
       - "bun.lock"
       - "scripts/type-perf-report.ts"
-      - "scripts/type-perf-report.test.ts"
       - ".github/workflows/type-perf.yml"
 
 concurrency:
@@ -62,6 +61,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           marker='<!-- type-perf-report -->'
           {
@@ -70,8 +70,14 @@ jobs:
             echo
             bun scripts/type-perf-report.ts compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json"
           } > "$RUNNER_TEMP/comment.md"
+          cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
+          # Fork PRs get a read-only GITHUB_TOKEN; the step summary above is their report.
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "Fork PR: skipping PR comment (read-only token)."
+            exit 0
+          fi
           comment_id=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- type-perf-report -->")))][0].id // empty')
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\")))][0].id // empty")
           if [ -n "$comment_id" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$comment_id" -F "body=@$RUNNER_TEMP/comment.md"
           else

--- a/.github/workflows/type-perf.yml
+++ b/.github/workflows/type-perf.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/core/**"
+      - "packages/config/**"
       - "package.json"
       - "bun.lock"
       - "scripts/type-perf-report.ts"

--- a/.github/workflows/type-perf.yml
+++ b/.github/workflows/type-perf.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Measure head
         run: |
           bun ci
+          cd packages/core && bun run build && cd ../..
           bun scripts/type-perf-report.ts measure "$RUNNER_TEMP/head.json"
 
       - name: Checkout base
@@ -51,7 +52,7 @@ jobs:
         run: |
           cd base
           bun ci
-          cd ..
+          cd packages/core && bun run build && cd ../../..
           # Head's script measures both trees so old base refs need no copy of it.
           bun scripts/type-perf-report.ts measure "$RUNNER_TEMP/base.json" base
 

--- a/.github/workflows/type-perf.yml
+++ b/.github/workflows/type-perf.yml
@@ -1,0 +1,77 @@
+name: Type Performance
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/core/**"
+      - "package.json"
+      - "bun.lock"
+      - "scripts/type-perf-report.ts"
+      - "scripts/type-perf-report.test.ts"
+      - ".github/workflows/type-perf.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  type-performance:
+    # Bot-created release PRs cannot use GITHUB_TOKEN to start this workflow.
+    if: github.head_ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Measure head
+        run: |
+          bun ci
+          bun scripts/type-perf-report.ts measure "$RUNNER_TEMP/head.json"
+
+      - name: Checkout base
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Measure base
+        run: |
+          cd base
+          bun ci
+          cd ..
+          # Head's script measures both trees so old base refs need no copy of it.
+          bun scripts/type-perf-report.ts measure "$RUNNER_TEMP/base.json" base
+
+      - name: Comment type performance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker='<!-- type-perf-report -->'
+          {
+            echo "$marker"
+            echo '## 🧠 Type-check performance'
+            echo
+            bun scripts/type-perf-report.ts compare "$RUNNER_TEMP/base.json" "$RUNNER_TEMP/head.json"
+          } > "$RUNNER_TEMP/comment.md"
+          comment_id=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- type-perf-report -->")))][0].id // empty')
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$comment_id" -F "body=@$RUNNER_TEMP/comment.md"
+          else
+            gh api "repos/$REPO/issues/$PR/comments" -F "body=@$RUNNER_TEMP/comment.md"
+          fi

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -109,6 +109,5 @@ describe("type performance report", () => {
 		expect(output).toContain("### Consumer scaling (synthetic app vs dist)");
 		expect(output).toContain("| 50 | 25,000 | 27,000 | +2,000 (+8.0%) |");
 		expect(output).toContain("| 100/10 scaling ratio ⚠️ | 5.00× | 6.00× | +1.00 (+20.0%) |");
-		expect(output).toContain("TypeScript 7.0.2 · `packages/core/tsconfig.json`");
 	});
 });

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	formatComparison,
+	parseExtendedDiagnostics,
+	type TypePerfMetrics,
+} from "./type-perf-report.ts";
+
+const diagnostics = `Symbols:         221923
+Types:            93419
+Instantiations:  282284
+Memory used:    142714K
+Check time:      0.322s
+Total time:      0.376s`;
+
+const base: TypePerfMetrics = {
+	typescriptVersion: "7.0.2",
+	instantiations: 100_000,
+	types: 50_000,
+	symbols: 80_000,
+	memoryUsedKb: 120_000,
+	checkTimeSeconds: 0.3,
+	totalTimeSeconds: 0.4,
+};
+
+describe("type performance report", () => {
+	it("parses every required extended-diagnostics metric", () => {
+		expect(parseExtendedDiagnostics(diagnostics, "7.0.2")).toEqual({
+			typescriptVersion: "7.0.2",
+			instantiations: 282_284,
+			types: 93_419,
+			symbols: 221_923,
+			memoryUsedKb: 142_714,
+			checkTimeSeconds: 0.322,
+			totalTimeSeconds: 0.376,
+		});
+	});
+
+	it("fails when a required metric is absent", () => {
+		expect(() =>
+			parseExtendedDiagnostics(diagnostics.replace(/^Symbols:.*$/m, ""), "7.0.2"),
+		).toThrow("Missing symbols");
+	});
+
+	it("formats base-to-head deltas and warns above ten percent", () => {
+		const report = formatComparison(base, {
+			...base,
+			instantiations: 112_000,
+			types: 55_000,
+			checkTimeSeconds: 0.33,
+		});
+
+		expect(report).toContain("| Instantiations ⚠️ | 100,000 | 112,000 | +12,000 (+12.0%) |");
+		expect(report).toContain("| Types | 50,000 | 55,000 | +5,000 (+10.0%) |");
+		expect(report).toContain("Check time (informational — noisy on shared runners)");
+		expect(report).toContain("TypeScript 7.0.2 · `packages/core/tsconfig.json`");
+	});
+});

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import {
 	formatComparison,
+	generateConsumerFixture,
+	generateConsumerSource,
 	parseExtendedDiagnostics,
 	type TypePerfMetrics,
+	type TypePerfReport,
 } from "./type-perf-report.ts";
 
 const diagnostics = `Symbols:         221923
@@ -13,15 +19,43 @@ Memory used:    142714K
 Check time:      0.322s
 Total time:      0.376s`;
 
-const base: TypePerfMetrics = {
+const metrics = (instantiations: number): TypePerfMetrics => ({
 	typescriptVersion: "7.0.2",
-	instantiations: 100_000,
+	instantiations,
 	types: 50_000,
 	symbols: 80_000,
 	memoryUsedKb: 120_000,
 	checkTimeSeconds: 0.3,
 	totalTimeSeconds: 0.4,
-};
+});
+
+const report = (instantiations: number, scaling: [number, number, number]): TypePerfReport => ({
+	...metrics(instantiations),
+	scaling: {
+		10: metrics(scaling[0]),
+		50: metrics(scaling[1]),
+		100: metrics(scaling[2]),
+	},
+});
+
+const repoRoot = resolve(import.meta.dir, "..");
+const corePackage = join(repoRoot, "packages/core");
+const tsc = join(repoRoot, "node_modules/.bin/tsc");
+let fixtureDir: string;
+
+beforeAll(() => {
+	const build = Bun.spawnSync(["bun", "run", "build"], {
+		cwd: corePackage,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (build.exitCode !== 0) {
+		throw new Error(`core build failed:\n${build.stdout.toString()}${build.stderr.toString()}`);
+	}
+	fixtureDir = mkdtempSync(join(tmpdir(), "crust-type-perf-test-"));
+});
+
+afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
 
 describe("type performance report", () => {
 	it("parses every required extended-diagnostics metric", () => {
@@ -42,17 +76,39 @@ describe("type performance report", () => {
 		).toThrow("Missing symbols");
 	});
 
-	it("formats base-to-head deltas and warns above ten percent", () => {
-		const report = formatComparison(base, {
-			...base,
-			instantiations: 112_000,
-			types: 55_000,
-			checkTimeSeconds: 0.33,
+	it("generates deterministic scaling fixtures", () => {
+		expect(generateConsumerSource(10)).toBe(generateConsumerSource(10));
+		expect(generateConsumerSource(10)).toContain(".flags(");
+		expect(generateConsumerSource(10)).toContain(".provide(context0(), context1(), context2())");
+		expect(generateConsumerSource(10).match(/const command\d+ = defineCommand/g)).toHaveLength(10);
+	});
+
+	it("compiles the size-10 consumer fixture against built dist declarations", () => {
+		const consumerDir = join(fixtureDir, "consumer-10");
+		generateConsumerFixture(consumerDir, corePackage, 10);
+		const result = Bun.spawnSync([tsc, "--noEmit", "--incremental", "false", "-p", consumerDir], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
 		});
 
-		expect(report).toContain("| Instantiations ⚠️ | 100,000 | 112,000 | +12,000 (+12.0%) |");
-		expect(report).toContain("| Types | 50,000 | 55,000 | +5,000 (+10.0%) |");
-		expect(report).toContain("Check time (informational — noisy on shared runners)");
-		expect(report).toContain("TypeScript 7.0.2 · `packages/core/tsconfig.json`");
+		expect(result.stdout.toString() + result.stderr.toString()).toBe("");
+		expect(result.exitCode).toBe(0);
+	});
+
+	it("formats core and consumer scaling deltas and warns on ratio regressions", () => {
+		const base = report(100_000, [10_000, 25_000, 50_000]);
+		const head = report(112_000, [10_000, 27_000, 60_000]);
+		head.types = 55_000;
+		head.checkTimeSeconds = 0.33;
+		const output = formatComparison(base, head);
+
+		expect(output).toContain("| Instantiations ⚠️ | 100,000 | 112,000 | +12,000 (+12.0%) |");
+		expect(output).toContain("| Types | 50,000 | 55,000 | +5,000 (+10.0%) |");
+		expect(output).toContain("Check time (informational — noisy on shared runners)");
+		expect(output).toContain("### Consumer scaling (synthetic app vs dist)");
+		expect(output).toContain("| 50 | 25,000 | 27,000 | +2,000 (+8.0%) |");
+		expect(output).toContain("| 100/10 scaling ratio ⚠️ | 5.00× | 6.00× | +1.00 (+20.0%) |");
+		expect(output).toContain("TypeScript 7.0.2 · `packages/core/tsconfig.json`");
 	});
 });

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -23,13 +23,13 @@ const metrics = (instantiations: number): TypePerfMetrics => ({
 	typescriptVersion: "7.0.2",
 	instantiations,
 	types: 50_000,
-	symbols: 80_000,
-	memoryUsedKb: 120_000,
 	checkTimeSeconds: 0.3,
-	totalTimeSeconds: 0.4,
 });
 
-const report = (instantiations: number, scaling: [number, number, number]): TypePerfReport => ({
+const report = (
+	instantiations: number,
+	scaling: [number, number, number],
+): TypePerfReport => ({
 	...metrics(instantiations),
 	scaling: {
 		10: metrics(scaling[0]),
@@ -41,21 +41,6 @@ const report = (instantiations: number, scaling: [number, number, number]): Type
 const repoRoot = resolve(import.meta.dir, "..");
 const corePackage = join(repoRoot, "packages/core");
 const tsc = join(repoRoot, "node_modules/.bin/tsc");
-let fixtureDir: string;
-
-beforeAll(() => {
-	const build = Bun.spawnSync(["bun", "run", "build"], {
-		cwd: corePackage,
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	if (build.exitCode !== 0) {
-		throw new Error(`core build failed:\n${build.stdout.toString()}${build.stderr.toString()}`);
-	}
-	fixtureDir = mkdtempSync(join(tmpdir(), "crust-type-perf-test-"));
-});
-
-afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
 
 describe("type performance report", () => {
 	it("parses every required extended-diagnostics metric", () => {
@@ -63,51 +48,95 @@ describe("type performance report", () => {
 			typescriptVersion: "7.0.2",
 			instantiations: 282_284,
 			types: 93_419,
-			symbols: 221_923,
-			memoryUsedKb: 142_714,
 			checkTimeSeconds: 0.322,
-			totalTimeSeconds: 0.376,
 		});
 	});
 
 	it("fails when a required metric is absent", () => {
 		expect(() =>
-			parseExtendedDiagnostics(diagnostics.replace(/^Symbols:.*$/m, ""), "7.0.2"),
-		).toThrow("Missing symbols");
+			parseExtendedDiagnostics(diagnostics.replace(/^Types:.*$/m, ""), "7.0.2"),
+		).toThrow("Missing types");
 	});
 
 	it("generates deterministic scaling fixtures", () => {
 		expect(generateConsumerSource(10)).toBe(generateConsumerSource(10));
 		expect(generateConsumerSource(10)).toContain(".flags(");
-		expect(generateConsumerSource(10)).toContain(".provide(context0(), context1(), context2())");
-		expect(generateConsumerSource(10).match(/const command\d+ = defineCommand/g)).toHaveLength(10);
+		expect(
+			generateConsumerSource(10).match(/const command\d+ = defineCommand/g),
+		).toHaveLength(10);
 	});
 
 	it("compiles the size-10 consumer fixture against built dist declarations", () => {
-		const consumerDir = join(fixtureDir, "consumer-10");
-		generateConsumerFixture(consumerDir, corePackage, 10);
-		const result = Bun.spawnSync([tsc, "--noEmit", "--incremental", "false", "-p", consumerDir], {
-			cwd: repoRoot,
+		const build = Bun.spawnSync(["bun", "run", "build"], {
+			cwd: corePackage,
 			stdout: "pipe",
 			stderr: "pipe",
 		});
+		if (build.exitCode !== 0) {
+			throw new Error(
+				`core build failed:\n${build.stdout.toString()}${build.stderr.toString()}`,
+			);
+		}
+		const fixtureDir = mkdtempSync(join(tmpdir(), "crust-type-perf-test-"));
+		try {
+			const consumerDir = join(fixtureDir, "consumer-10");
+			generateConsumerFixture(consumerDir, corePackage, 10);
+			const result = Bun.spawnSync(
+				[tsc, "--noEmit", "--incremental", "false", "-p", consumerDir],
+				{ cwd: repoRoot, stdout: "pipe", stderr: "pipe" },
+			);
 
-		expect(result.stdout.toString() + result.stderr.toString()).toBe("");
-		expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString() + result.stderr.toString()).toBe("");
+			expect(result.exitCode).toBe(0);
+		} finally {
+			rmSync(fixtureDir, { recursive: true, force: true });
+		}
 	});
 
-	it("formats core and consumer scaling deltas and warns on ratio regressions", () => {
+	it("formats core and consumer scaling deltas and warns on regressions", () => {
 		const base = report(100_000, [10_000, 25_000, 50_000]);
 		const head = report(112_000, [10_000, 27_000, 60_000]);
 		head.types = 55_000;
 		head.checkTimeSeconds = 0.33;
 		const output = formatComparison(base, head);
 
-		expect(output).toContain("| Instantiations ⚠️ | 100,000 | 112,000 | +12,000 (+12.0%) |");
+		expect(output).toContain(
+			"| Instantiations ⚠️ | 100,000 | 112,000 | +12,000 (+12.0%) |",
+		);
 		expect(output).toContain("| Types | 50,000 | 55,000 | +5,000 (+10.0%) |");
-		expect(output).toContain("Check time (informational — noisy on shared runners)");
+		expect(output).toContain(
+			"Check time (informational — noisy on shared runners)",
+		);
 		expect(output).toContain("### Consumer scaling (synthetic app vs dist)");
 		expect(output).toContain("| 50 | 25,000 | 27,000 | +2,000 (+8.0%) |");
-		expect(output).toContain("| 100/10 scaling ratio ⚠️ | 5.00× | 6.00× | +1.00 (+20.0%) |");
+		expect(output).toContain("| 100 ⚠️ | 50,000 | 60,000 | +10,000 (+20.0%) |");
+		expect(output).toContain(
+			"| 100/10 scaling ratio ⚠️ | 5.00× | 6.00× | +1.00 (+20.0%) |",
+		);
+		expect(output).toContain(
+			"TypeScript 7.0.2 · ⚠️ marks compiler-work increases above 10%.",
+		);
+	});
+
+	it("renders n/a when a base scaling fixture failed to compile", () => {
+		const base = report(100_000, [10_000, 25_000, 50_000]);
+		base.scaling[100] = null;
+		const head = report(100_000, [10_000, 25_000, 50_000]);
+		const output = formatComparison(base, head);
+
+		expect(output).toContain("| 100 | n/a | 50,000 | n/a |");
+		expect(output).toContain("| 100/10 scaling ratio | n/a | n/a | n/a |");
+	});
+
+	it("handles a zero base and flags a TypeScript version mismatch", () => {
+		const base = report(0, [10_000, 25_000, 50_000]);
+		const head = report(100, [10_000, 25_000, 50_000]);
+		head.typescriptVersion = "7.1.0";
+		const output = formatComparison(base, head);
+
+		expect(output).toContain("| Instantiations ⚠️ | 0 | 100 | +100 (n/a) |");
+		expect(output).toContain(
+			"⚠️ TypeScript version differs (base 7.0.2 → head 7.1.0) — deltas include compiler changes, not just this PR.",
+		);
 	});
 });

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -66,8 +66,6 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
 		`| Types${warns.types} | ${number.format(base.types)} | ${number.format(head.types)} | ${delta(base.types, head.types)} |`,
 		`| Check time (informational — noisy on shared runners) | ${base.checkTimeSeconds.toFixed(3)}s | ${head.checkTimeSeconds.toFixed(3)}s | ${delta(base.checkTimeSeconds, head.checkTimeSeconds, 3)} |`,
 		"",
-		`TypeScript ${head.typescriptVersion} · \`packages/core/tsconfig.json\` · ⚠️ marks compiler-work increases above 10%.`,
-		"",
 		"### Consumer scaling (synthetic app vs dist)",
 		"",
 		"| Commands | Base instantiations | Head instantiations | Δ |",
@@ -77,8 +75,6 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
 				`| ${size} | ${number.format(base.scaling[size].instantiations)} | ${number.format(head.scaling[size].instantiations)} | ${delta(base.scaling[size].instantiations, head.scaling[size].instantiations)} |`,
 		),
 		`| 100/10 scaling ratio${ratioWarning} | ${baseRatio.toFixed(2)}× | ${headRatio.toFixed(2)}× | ${delta(baseRatio, headRatio, 2)} |`,
-		"",
-		"Fixtures consume built `@crustjs/core` declarations. The ratio highlights superlinear growth; ⚠️ appears when it worsens by more than 10%.",
 	].join("\n");
 }
 

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -6,26 +13,22 @@ export interface TypePerfMetrics {
 	typescriptVersion: string;
 	instantiations: number;
 	types: number;
-	symbols: number;
-	memoryUsedKb: number;
 	checkTimeSeconds: number;
-	totalTimeSeconds: number;
 }
 
 export const scalingSizes = [10, 50, 100] as const;
 export type ScalingSize = (typeof scalingSizes)[number];
 
+// null scaling entry = the generated fixture failed to compile against this tree's
+// dist (e.g. the PR changed the public API); rendered as "n/a" instead of failing.
 export interface TypePerfReport extends TypePerfMetrics {
-	scaling: Record<ScalingSize, TypePerfMetrics>;
+	scaling: Record<ScalingSize, TypePerfMetrics | null>;
 }
 
 const metricPatterns = {
 	instantiations: /^Instantiations:\s+(\d+)$/m,
 	types: /^Types:\s+(\d+)$/m,
-	symbols: /^Symbols:\s+(\d+)$/m,
-	memoryUsedKb: /^Memory used:\s+(\d+)K$/m,
 	checkTimeSeconds: /^Check time:\s+([\d.]+)s$/m,
-	totalTimeSeconds: /^Total time:\s+([\d.]+)s$/m,
 } as const;
 
 export function parseExtendedDiagnostics(
@@ -35,7 +38,8 @@ export function parseExtendedDiagnostics(
 	const parsed: Record<string, number | string> = { typescriptVersion };
 	for (const [name, pattern] of Object.entries(metricPatterns)) {
 		const match = output.match(pattern);
-		if (!match) throw new Error(`Missing ${name} in TypeScript extended diagnostics`);
+		if (!match)
+			throw new Error(`Missing ${name} in TypeScript extended diagnostics`);
 		parsed[name] = Number(match[1]);
 	}
 	return parsed as unknown as TypePerfMetrics;
@@ -51,14 +55,28 @@ const percentage = (base: number, head: number) =>
 const delta = (base: number, head: number, digits = 0) =>
 	`${signed(head - base, digits)} (${percentage(base, head)})`;
 
-export function formatComparison(base: TypePerfReport, head: TypePerfReport): string {
+export function formatComparison(
+	base: TypePerfReport,
+	head: TypePerfReport,
+): string {
 	const warns = {
 		instantiations: head.instantiations > base.instantiations * 1.1 ? " ⚠️" : "",
 		types: head.types > base.types * 1.1 ? " ⚠️" : "",
 	};
-	const baseRatio = base.scaling[100].instantiations / base.scaling[10].instantiations;
-	const headRatio = head.scaling[100].instantiations / head.scaling[10].instantiations;
-	const ratioWarning = headRatio > baseRatio * 1.1 ? " ⚠️" : "";
+	const ratio = (report: TypePerfReport) =>
+		report.scaling[10] && report.scaling[100]
+			? report.scaling[100].instantiations / report.scaling[10].instantiations
+			: null;
+	const baseRatio = ratio(base);
+	const headRatio = ratio(head);
+	const ratioWarning =
+		baseRatio !== null && headRatio !== null && headRatio > baseRatio * 1.1
+			? " ⚠️"
+			: "";
+	const footer =
+		base.typescriptVersion === head.typescriptVersion
+			? `TypeScript ${head.typescriptVersion} · ⚠️ marks compiler-work increases above 10%.`
+			: `⚠️ TypeScript version differs (base ${base.typescriptVersion} → head ${head.typescriptVersion}) — deltas include compiler changes, not just this PR.`;
 	return [
 		"| Metric | Base | Head | Δ |",
 		"|---|---:|---:|---:|",
@@ -70,11 +88,23 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
 		"",
 		"| Commands | Base instantiations | Head instantiations | Δ |",
 		"|---:|---:|---:|---:|",
-		...scalingSizes.map(
-			(size) =>
-				`| ${size} | ${number.format(base.scaling[size].instantiations)} | ${number.format(head.scaling[size].instantiations)} | ${delta(base.scaling[size].instantiations, head.scaling[size].instantiations)} |`,
-		),
-		`| 100/10 scaling ratio${ratioWarning} | ${baseRatio.toFixed(2)}× | ${headRatio.toFixed(2)}× | ${delta(baseRatio, headRatio, 2)} |`,
+		...scalingSizes.map((size) => {
+			const baseMetrics = base.scaling[size];
+			const headMetrics = head.scaling[size];
+			if (!baseMetrics || !headMetrics) {
+				return `| ${size} | ${baseMetrics ? number.format(baseMetrics.instantiations) : "n/a"} | ${headMetrics ? number.format(headMetrics.instantiations) : "n/a"} | n/a |`;
+			}
+			const warn =
+				headMetrics.instantiations > baseMetrics.instantiations * 1.1
+					? " ⚠️"
+					: "";
+			return `| ${size}${warn} | ${number.format(baseMetrics.instantiations)} | ${number.format(headMetrics.instantiations)} | ${delta(baseMetrics.instantiations, headMetrics.instantiations)} |`;
+		}),
+		baseRatio !== null && headRatio !== null
+			? `| 100/10 scaling ratio${ratioWarning} | ${baseRatio.toFixed(2)}× | ${headRatio.toFixed(2)}× | ${delta(baseRatio, headRatio, 2)} |`
+			: "| 100/10 scaling ratio | n/a | n/a | n/a |",
+		"",
+		footer,
 	].join("\n");
 }
 
@@ -84,7 +114,8 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
  * max(3, ceil(size / 10)); every tenth command also owns one nested subcommand.
  */
 export function generateConsumerSource(size: number): string {
-	if (!Number.isInteger(size) || size < 1) throw new Error("size must be a positive integer");
+	if (!Number.isInteger(size) || size < 1)
+		throw new Error("size must be a positive integer");
 	const contextCount = Math.max(3, Math.ceil(size / 10));
 	const lines = [
 		'import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";',
@@ -138,7 +169,8 @@ export function generateConsumerSource(size: number): string {
 		'\t.flags({ name: "root-config", type: "string", short: "c", aliases: ["config"] })',
 		`\t.provide(${Array.from({ length: contextCount }, (_, index) => `context${index}()`).join(", ")})`,
 	);
-	for (let index = 0; index < size; index++) lines.push(`\t.add(command${index})`);
+	for (let index = 0; index < size; index++)
+		lines.push(`\t.add(command${index})`);
 	lines.push("\t.action(() => {});", "");
 	return lines.join("\n");
 }
@@ -151,7 +183,11 @@ export function generateConsumerFixture(
 	const fixtureDir = resolve(outputDir);
 	const packageDir = resolve(corePackageDir);
 	mkdirSync(join(fixtureDir, "node_modules/@crustjs"), { recursive: true });
-	symlinkSync(packageDir, join(fixtureDir, "node_modules/@crustjs/core"), "dir");
+	symlinkSync(
+		packageDir,
+		join(fixtureDir, "node_modules/@crustjs/core"),
+		"dir",
+	);
 	writeFileSync(join(fixtureDir, "consumer.ts"), generateConsumerSource(size));
 	writeFileSync(
 		join(fixtureDir, "tsconfig.json"),
@@ -173,7 +209,11 @@ export function generateConsumerFixture(
 }
 
 function run(command: string[], cwd: string): string {
-	const result = Bun.spawnSync(command, { cwd, stdout: "pipe", stderr: "pipe" });
+	const result = Bun.spawnSync(command, {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
 	if (result.exitCode !== 0) {
 		throw new Error(
 			`Command failed (${command.join(" ")}):\n${result.stdout.toString()}${result.stderr.toString()}`,
@@ -187,21 +227,51 @@ function measure(outputPath: string, rootDir = "."): void {
 	const tsc = join(root, "node_modules/.bin/tsc");
 	const version = run([tsc, "--version"], root).replace(/^Version\s+/, "");
 	const diagnostics = run(
-		[tsc, "--noEmit", "--incremental", "false", "--extendedDiagnostics", "-p", "packages/core"],
+		[
+			tsc,
+			"--noEmit",
+			"--incremental",
+			"false",
+			"--extendedDiagnostics",
+			"-p",
+			"packages/core",
+		],
 		root,
 	);
-	const report = parseExtendedDiagnostics(diagnostics, version) as TypePerfReport;
+	const report = parseExtendedDiagnostics(
+		diagnostics,
+		version,
+	) as TypePerfReport;
 	const fixtureRoot = mkdtempSync(join(tmpdir(), "crust-type-perf-"));
 	try {
-		report.scaling = {} as Record<ScalingSize, TypePerfMetrics>;
+		report.scaling = {} as Record<ScalingSize, TypePerfMetrics | null>;
 		for (const size of scalingSizes) {
 			const fixtureDir = join(fixtureRoot, String(size));
 			generateConsumerFixture(fixtureDir, join(root, "packages/core"), size);
-			const fixtureDiagnostics = run(
-				[tsc, "--noEmit", "--incremental", "false", "--extendedDiagnostics", "-p", fixtureDir],
-				root,
-			);
-			report.scaling[size] = parseExtendedDiagnostics(fixtureDiagnostics, version);
+			try {
+				const fixtureDiagnostics = run(
+					[
+						tsc,
+						"--noEmit",
+						"--incremental",
+						"false",
+						"--extendedDiagnostics",
+						"-p",
+						fixtureDir,
+					],
+					root,
+				);
+				report.scaling[size] = parseExtendedDiagnostics(
+					fixtureDiagnostics,
+					version,
+				);
+			} catch (error) {
+				// Fixture compile failure: expected when the PR changed the public API, so
+				// head's generated fixture can't compile against base dist. Report "n/a"
+				// rather than failing a report-only job.
+				console.error(`scaling fixture (size ${size}) failed:\n${error}`);
+				report.scaling[size] = null;
+			}
 		}
 	} finally {
 		rmSync(fixtureRoot, { recursive: true, force: true });
@@ -215,15 +285,14 @@ if (import.meta.main) {
 	try {
 		if (mode === "measure" && args[0]) {
 			measure(args[0], args[1]);
-		} else if (mode === "generate" && args[0] && args[1]) {
-			const root = resolve(args[2] ?? ".");
-			generateConsumerFixture(args[1], join(root, "packages/core"), Number(args[0]));
 		} else if (mode === "compare" && args.length === 2) {
-			const [base, head] = args.map((path) => JSON.parse(readFileSync(path, "utf8")));
+			const [base, head] = args.map((path) =>
+				JSON.parse(readFileSync(path, "utf8")),
+			);
 			console.log(formatComparison(base, head));
 		} else {
 			throw new Error(
-				"usage: bun scripts/type-perf-report.ts measure <output.json> [rootDir] | generate <size> <outputDir> [rootDir] | compare <base.json> <head.json>",
+				"usage: bun scripts/type-perf-report.ts measure <output.json> [rootDir] | compare <base.json> <head.json>",
 			);
 		}
 	} catch (error) {

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -1,0 +1,111 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface TypePerfMetrics {
+	typescriptVersion: string;
+	instantiations: number;
+	types: number;
+	symbols: number;
+	memoryUsedKb: number;
+	checkTimeSeconds: number;
+	totalTimeSeconds: number;
+}
+
+const metricPatterns = {
+	instantiations: /^Instantiations:\s+(\d+)$/m,
+	types: /^Types:\s+(\d+)$/m,
+	symbols: /^Symbols:\s+(\d+)$/m,
+	memoryUsedKb: /^Memory used:\s+(\d+)K$/m,
+	checkTimeSeconds: /^Check time:\s+([\d.]+)s$/m,
+	totalTimeSeconds: /^Total time:\s+([\d.]+)s$/m,
+} as const;
+
+export function parseExtendedDiagnostics(
+	output: string,
+	typescriptVersion: string,
+): TypePerfMetrics {
+	const parsed: Record<string, number | string> = { typescriptVersion };
+	for (const [name, pattern] of Object.entries(metricPatterns)) {
+		const match = output.match(pattern);
+		if (!match) throw new Error(`Missing ${name} in TypeScript extended diagnostics`);
+		parsed[name] = Number(match[1]);
+	}
+	return parsed as unknown as TypePerfMetrics;
+}
+
+const number = new Intl.NumberFormat("en-US");
+const signed = (value: number, digits = 0) =>
+	`${value > 0 ? "+" : value < 0 ? "−" : "±"}${digits === 0 ? number.format(Math.abs(value)) : Math.abs(value).toFixed(digits)}`;
+const percentage = (base: number, head: number) =>
+	base === 0
+		? "n/a"
+		: `${head > base ? "+" : head < base ? "−" : "±"}${Math.abs(((head - base) / base) * 100).toFixed(1)}%`;
+const delta = (base: number, head: number, digits = 0) =>
+	`${signed(head - base, digits)} (${percentage(base, head)})`;
+
+export function formatComparison(base: TypePerfMetrics, head: TypePerfMetrics): string {
+	const warns = {
+		instantiations: head.instantiations > base.instantiations * 1.1 ? " ⚠️" : "",
+		types: head.types > base.types * 1.1 ? " ⚠️" : "",
+	};
+	return [
+		"| Metric | Base | Head | Δ |",
+		"|---|---:|---:|---:|",
+		`| Instantiations${warns.instantiations} | ${number.format(base.instantiations)} | ${number.format(head.instantiations)} | ${delta(base.instantiations, head.instantiations)} |`,
+		`| Types${warns.types} | ${number.format(base.types)} | ${number.format(head.types)} | ${delta(base.types, head.types)} |`,
+		`| Check time (informational — noisy on shared runners) | ${base.checkTimeSeconds.toFixed(3)}s | ${head.checkTimeSeconds.toFixed(3)}s | ${delta(base.checkTimeSeconds, head.checkTimeSeconds, 3)} |`,
+		"",
+		`TypeScript ${head.typescriptVersion} · \`packages/core/tsconfig.json\` · ⚠️ marks compiler-work increases above 10%.`,
+	].join("\n");
+}
+
+function run(command: string[], cwd: string): string {
+	const result = Bun.spawnSync(command, { cwd, stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		throw new Error(
+			`Command failed (${command.join(" ")}):\n${result.stdout.toString()}${result.stderr.toString()}`,
+		);
+	}
+	return result.stdout.toString().trim();
+}
+
+function measure(outputPath: string, rootDir = "."): void {
+	const root = resolve(rootDir);
+	const diagnostics = run(
+		[
+			"bunx",
+			"tsc",
+			"--noEmit",
+			"--incremental",
+			"false",
+			"--extendedDiagnostics",
+			"-p",
+			"packages/core",
+		],
+		root,
+	);
+	const version = run(["bunx", "tsc", "--version"], root).replace(/^Version\s+/, "");
+	writeFileSync(
+		resolve(outputPath),
+		`${JSON.stringify(parseExtendedDiagnostics(diagnostics, version), null, 2)}\n`,
+	);
+}
+
+if (import.meta.main) {
+	const [mode, ...args] = process.argv.slice(2);
+	try {
+		if (mode === "measure" && args[0]) {
+			measure(args[0], args[1]);
+		} else if (mode === "compare" && args.length === 2) {
+			const [base, head] = args.map((path) => JSON.parse(readFileSync(path, "utf8")));
+			console.log(formatComparison(base, head));
+		} else {
+			throw new Error(
+				"usage: bun scripts/type-perf-report.ts measure <output.json> [rootDir] | compare <base.json> <head.json>",
+			);
+		}
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : error);
+		process.exit(1);
+	}
+}

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
 export interface TypePerfMetrics {
 	typescriptVersion: string;
@@ -9,6 +10,13 @@ export interface TypePerfMetrics {
 	memoryUsedKb: number;
 	checkTimeSeconds: number;
 	totalTimeSeconds: number;
+}
+
+export const scalingSizes = [10, 50, 100] as const;
+export type ScalingSize = (typeof scalingSizes)[number];
+
+export interface TypePerfReport extends TypePerfMetrics {
+	scaling: Record<ScalingSize, TypePerfMetrics>;
 }
 
 const metricPatterns = {
@@ -43,11 +51,14 @@ const percentage = (base: number, head: number) =>
 const delta = (base: number, head: number, digits = 0) =>
 	`${signed(head - base, digits)} (${percentage(base, head)})`;
 
-export function formatComparison(base: TypePerfMetrics, head: TypePerfMetrics): string {
+export function formatComparison(base: TypePerfReport, head: TypePerfReport): string {
 	const warns = {
 		instantiations: head.instantiations > base.instantiations * 1.1 ? " ⚠️" : "",
 		types: head.types > base.types * 1.1 ? " ⚠️" : "",
 	};
+	const baseRatio = base.scaling[100].instantiations / base.scaling[10].instantiations;
+	const headRatio = head.scaling[100].instantiations / head.scaling[10].instantiations;
+	const ratioWarning = headRatio > baseRatio * 1.1 ? " ⚠️" : "";
 	return [
 		"| Metric | Base | Head | Δ |",
 		"|---|---:|---:|---:|",
@@ -56,7 +67,113 @@ export function formatComparison(base: TypePerfMetrics, head: TypePerfMetrics): 
 		`| Check time (informational — noisy on shared runners) | ${base.checkTimeSeconds.toFixed(3)}s | ${head.checkTimeSeconds.toFixed(3)}s | ${delta(base.checkTimeSeconds, head.checkTimeSeconds, 3)} |`,
 		"",
 		`TypeScript ${head.typescriptVersion} · \`packages/core/tsconfig.json\` · ⚠️ marks compiler-work increases above 10%.`,
+		"",
+		"### Consumer scaling (synthetic app vs dist)",
+		"",
+		"| Commands | Base instantiations | Head instantiations | Δ |",
+		"|---:|---:|---:|---:|",
+		...scalingSizes.map(
+			(size) =>
+				`| ${size} | ${number.format(base.scaling[size].instantiations)} | ${number.format(head.scaling[size].instantiations)} | ${delta(base.scaling[size].instantiations, head.scaling[size].instantiations)} |`,
+		),
+		`| 100/10 scaling ratio${ratioWarning} | ${baseRatio.toFixed(2)}× | ${headRatio.toFixed(2)}× | ${delta(baseRatio, headRatio, 2)} |`,
+		"",
+		"Fixtures consume built `@crustjs/core` declarations. The ratio highlights superlinear growth; ⚠️ appears when it worsens by more than 10%.",
 	].join("\n");
+}
+
+/**
+ * Generate a deterministic downstream app with `size` top-level sibling commands.
+ * Each command has three chained flags and two chained args. Context count is
+ * max(3, ceil(size / 10)); every tenth command also owns one nested subcommand.
+ */
+export function generateConsumerSource(size: number): string {
+	if (!Number.isInteger(size) || size < 1) throw new Error("size must be a positive integer");
+	const contextCount = Math.max(3, Math.ceil(size / 10));
+	const lines = [
+		'import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";',
+		"",
+	];
+
+	for (let index = 0; index < contextCount; index++) {
+		lines.push(
+			`const contextFlag${index} = defineFlag("context-${index}-token", { type: "string", aliases: ["ctx-${index}-token"] });`,
+		);
+		if (index === 0) {
+			lines.push(
+				`const context${index} = defineContext("context-${index}", { flags: [contextFlag${index}] }, ({ flags }) => ({ value: flags["context-${index}-token"] ?? "" }));`,
+			);
+		} else {
+			lines.push(
+				`const context${index} = defineContext("context-${index}", { flags: [contextFlag${index}], requires: [context${index - 1}] }, ({ flags, ctx }) => ({ value: ctx["context-${index - 1}"].value + (flags["context-${index}-token"] ?? "") }));`,
+			);
+		}
+	}
+	lines.push("");
+
+	for (let index = 0; index < size; index++) {
+		const contextIndex = index % contextCount;
+		lines.push(
+			`const command${index} = defineCommand("command-${index}", { aliases: ["cmd-${index}", "c-${index}"], requires: [context${contextIndex}] }, (command) =>`,
+			"\tcommand",
+			`\t\t.flags({ name: "command-${index}-verbose", type: "boolean", short: "v", aliases: ["verbose-${index}"] })`,
+			`\t\t.flags({ name: "command-${index}-output", type: "string", short: "o", aliases: ["output-${index}"] })`,
+			`\t\t.flags({ name: "command-${index}-force", type: "boolean", short: "f", aliases: ["force-${index}"] })`,
+			`\t\t.args({ name: "source-${index}", type: "string", required: true })`,
+			`\t\t.args({ name: "destination-${index}", type: "string" })`,
+		);
+		if (index % 10 === 0) {
+			lines.push(
+				`\t\t.add(defineCommand("nested-${index}", { aliases: ["n-${index}"], requires: [context${contextIndex}] }, (nested) =>`,
+				`\t\t\tnested.flags({ name: "nested-${index}-mode", type: "string", short: "m", aliases: ["mode-${index}"] }).action(({ flags, ctx }) => { void flags["nested-${index}-mode"]; void ctx["context-${contextIndex}"]; }),`,
+				"\t\t))",
+			);
+		}
+		lines.push(
+			`\t\t.action(({ flags, args, ctx }) => { void flags["command-${index}-output"]; void args["source-${index}"]; void ctx["context-${contextIndex}"]; }),`,
+			");",
+			"",
+		);
+	}
+
+	lines.push(
+		'export const app = new Crust("type-perf-consumer", { description: "Synthetic type-performance fixture" })',
+		'\t.flags({ name: "root-verbose", type: "boolean", short: "v", aliases: ["verbose"] })',
+		'\t.flags({ name: "root-config", type: "string", short: "c", aliases: ["config"] })',
+		`\t.provide(${Array.from({ length: contextCount }, (_, index) => `context${index}()`).join(", ")})`,
+	);
+	for (let index = 0; index < size; index++) lines.push(`\t.add(command${index})`);
+	lines.push("\t.action(() => {});", "");
+	return lines.join("\n");
+}
+
+export function generateConsumerFixture(
+	outputDir: string,
+	corePackageDir: string,
+	size: number,
+): void {
+	const fixtureDir = resolve(outputDir);
+	const packageDir = resolve(corePackageDir);
+	mkdirSync(join(fixtureDir, "node_modules/@crustjs"), { recursive: true });
+	symlinkSync(packageDir, join(fixtureDir, "node_modules/@crustjs/core"), "dir");
+	writeFileSync(join(fixtureDir, "consumer.ts"), generateConsumerSource(size));
+	writeFileSync(
+		join(fixtureDir, "tsconfig.json"),
+		`${JSON.stringify(
+			{
+				compilerOptions: {
+					module: "esnext",
+					moduleResolution: "bundler",
+					target: "esnext",
+					strict: true,
+					noEmit: true,
+				},
+				include: ["consumer.ts"],
+			},
+			null,
+			2,
+		)}\n`,
+	);
 }
 
 function run(command: string[], cwd: string): string {
@@ -71,24 +188,30 @@ function run(command: string[], cwd: string): string {
 
 function measure(outputPath: string, rootDir = "."): void {
 	const root = resolve(rootDir);
+	const tsc = join(root, "node_modules/.bin/tsc");
+	const version = run([tsc, "--version"], root).replace(/^Version\s+/, "");
 	const diagnostics = run(
-		[
-			"bunx",
-			"tsc",
-			"--noEmit",
-			"--incremental",
-			"false",
-			"--extendedDiagnostics",
-			"-p",
-			"packages/core",
-		],
+		[tsc, "--noEmit", "--incremental", "false", "--extendedDiagnostics", "-p", "packages/core"],
 		root,
 	);
-	const version = run(["bunx", "tsc", "--version"], root).replace(/^Version\s+/, "");
-	writeFileSync(
-		resolve(outputPath),
-		`${JSON.stringify(parseExtendedDiagnostics(diagnostics, version), null, 2)}\n`,
-	);
+	const report = parseExtendedDiagnostics(diagnostics, version) as TypePerfReport;
+	const fixtureRoot = mkdtempSync(join(tmpdir(), "crust-type-perf-"));
+	try {
+		report.scaling = {} as Record<ScalingSize, TypePerfMetrics>;
+		for (const size of scalingSizes) {
+			const fixtureDir = join(fixtureRoot, String(size));
+			generateConsumerFixture(fixtureDir, join(root, "packages/core"), size);
+			const fixtureDiagnostics = run(
+				[tsc, "--noEmit", "--incremental", "false", "--extendedDiagnostics", "-p", fixtureDir],
+				root,
+			);
+			report.scaling[size] = parseExtendedDiagnostics(fixtureDiagnostics, version);
+		}
+	} finally {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+	}
+	mkdirSync(dirname(resolve(outputPath)), { recursive: true });
+	writeFileSync(resolve(outputPath), `${JSON.stringify(report, null, 2)}\n`);
 }
 
 if (import.meta.main) {
@@ -96,12 +219,15 @@ if (import.meta.main) {
 	try {
 		if (mode === "measure" && args[0]) {
 			measure(args[0], args[1]);
+		} else if (mode === "generate" && args[0] && args[1]) {
+			const root = resolve(args[2] ?? ".");
+			generateConsumerFixture(args[1], join(root, "packages/core"), Number(args[0]));
 		} else if (mode === "compare" && args.length === 2) {
 			const [base, head] = args.map((path) => JSON.parse(readFileSync(path, "utf8")));
 			console.log(formatComparison(base, head));
 		} else {
 			throw new Error(
-				"usage: bun scripts/type-perf-report.ts measure <output.json> [rootDir] | compare <base.json> <head.json>",
+				"usage: bun scripts/type-perf-report.ts measure <output.json> [rootDir] | generate <size> <outputDir> [rootDir] | compare <base.json> <head.json>",
 			);
 		}
 	} catch (error) {


### PR DESCRIPTION
## What

Adds per-PR **type-check performance reporting**: one workflow measures both the library's internal cost and what a downstream consumer app pays, on PR base and head, and maintains a single sticky comment with the deltas.

Example comment body (real local output):

| Metric | Base | Head | Δ |
|---|---:|---:|---:|
| Instantiations ⚠️ | 282,284 | 338,740 | +56,456 (+20.0%) |
| Types | 93,419 | 98,089 | +4,670 (+5.0%) |
| Check time (informational — noisy on shared runners) | 0.244s | 0.244s | ±0.000 (±0.0%) |

### Consumer scaling (synthetic app vs dist)

| Commands | Base instantiations | Head instantiations | Δ |
|---:|---:|---:|---:|
| 10 | 109,183 | 109,183 | ±0 (±0.0%) |
| 50 | 275,756 | 275,756 | ±0 (±0.0%) |
| 100 | 495,626 | 495,626 | ±0 (±0.0%) |
| 100/10 scaling ratio | 4.54× | 4.54× | ±0.00 (±0.0%) |

TypeScript 7.0.2 · ⚠️ marks compiler-work increases above 10%.

The footer flags loudly when base and head were measured with different TypeScript versions (deltas would include compiler changes, not just the PR).

## Two metrics, two questions

1. **`packages/core` whole-program** — did this PR make the library's own types more expensive? (Deterministic instantiation counts; wall time reported but informational — shared runners are too noisy to gate on.)
2. **Consumer scaling fixtures** — did it make *users'* editors/CI slower, and does the cost grow superlinearly with app size? Deterministic generated CLIs (N=10/50/100 commands with proportional flags, aliased siblings, args, and context dependency chains) are compiled against **built dist declarations** (the symlink technique from `tests/declaration-emission.test.ts`), which is what real consumers type-check against. Each scaling row gets its own ⚠️ when head instantiations exceed base by >10% (catches uniform downstream regressions the ratio can't see), and the **100/10 ratio row** is the superlinear tripwire: ⚠️ when head's ratio worsens >10% vs base. If a scaling fixture fails to compile (e.g. the PR changed the public API, so head's generated fixture can't compile against base dist), that cell renders `n/a` instead of failing the report-only job.

Baseline finding: current main is comfortably sublinear (4.54× work for 10× commands — fixed declaration-loading overhead dominates at small N).

## Design

- Base is recompiled per PR (own `bun ci` + core build) — no stored baseline to drift
- Report-only; gates can be added once normal variance is known
- Comment upsert reuses the `gh api` + HTML-marker pattern from `package-size.yml`; no new third-party actions
- The report is also written to the job step summary; fork PRs (read-only `GITHUB_TOKEN`) get only the summary and skip the PR comment instead of failing
- Full scaling sweep costs ~2s locally; installs dominate job time

## Investigated and deliberately not included

- **`@ark/attest` per-call-site budgets**: spiked; `@ark/attest@0.56.3` breaks under the native TS 7 compiler (calls removed API `ts.parseConfigFileTextToJson`). Revisit when attest supports TS7.
- **Benchmark history DB / charts**: redundant — base is recompiled per PR.
- **`--generateTrace`**: diagnosis tool for explaining a regression, not a per-PR gate.
- **tsserver latency harness**: truest editor metric, but wall-clock noisy on shared runners; the N=100 instantiation count is the stable stand-in.
- Prior-art note: Elysia has type *correctness* tests only (`expect-type`); ArkType is the actual prior art.

## Verification

- `bun test scripts/`: 7 tests (parser, formatter incl. n/a and TS-version-mismatch paths, generator determinism, fixture-compiles smoke) — green
- `actionlint`: clean · root lint/format: green
- Local end-to-end: measure → JSON → compare → markdown (tables above are real output)

