### PR TITLE
perf: TypeScript compiler-performance pass (spelling accumulator, inference guards, scripts tsconfig)

### DIFF
--- a/.changeset/calm-flags-check.md
+++ b/.changeset/calm-flags-check.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/core": patch
+"@crustjs/core": minor
 ---
 
 Cache accumulated flag spellings in the trailing, defaulted `Sp` generic parameter on `Crust` and `CommandDefinitionBuilder`, reducing type-check work for repeated `.flags()` calls while preserving existing generic annotations. Known spellings now remain collision-checked after an intervening widened flag definition.

--- a/.changeset/calm-flags-check.md
+++ b/.changeset/calm-flags-check.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Cache accumulated flag spellings in the trailing, defaulted `Sp` generic parameter on `Crust` and `CommandDefinitionBuilder`, reducing type-check work for repeated `.flags()` calls while preserving existing generic annotations. Known spellings now remain collision-checked after an intervening widened flag definition.

--- a/.changeset/neat-builders-order.md
+++ b/.changeset/neat-builders-order.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Reorder the trailing `Deps` and `Sibs` generic parameters on `Crust` and `CommandDefinitionBuilder`. This is a breaking change: positional annotations with six or more generic arguments must swap their `Sibs` and `Deps` arguments. The break is loud because the `string` and `ContextDeps` constraints are incompatible.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -123,7 +123,17 @@ The recipe does not execute when the definition is created. It executes once for
 ```ts
 type RootCommandMeta = Pick<CommandMeta, "description" | "usage">;
 
-class Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp extends string = SpellingsOf<Eff>>
+class Crust<
+  Local,
+  Owned,
+  A,
+  Eff,
+  Ctx,
+  Sibs,
+  Deps,
+  Sp extends string = SpellingsOf<Eff>,
+>
+
 new Crust(name: string, meta?: RootCommandMeta)
 ```
 
@@ -183,7 +193,7 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls accumulate local flags and cache their statically known spellings in the trailing defaulted `Sp` parameter. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<E extends FlagsDef>(app: Crust<Local, Owned, A, E, Ctx>)`) defer the default `Sp = SpellingsOf<E>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead, whose default `SpellingsOf<any>` is `never` — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
+Repeated `.flags()` calls accumulate local flags and cache their statically known spellings — the union of flag names and aliases that `SpellingsOf` computes — in the trailing defaulted `Sp` parameter. Because `Sp` accumulates per call, spellings registered before a widened (dynamically typed) `.flags()` call stay collision-checked at compile time; previously any widened call deferred all subsequent collision checks to runtime. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<E extends FlagsDef>(app: Crust<Local, Owned, A, E, Ctx>)`) defer the default `Sp = SpellingsOf<E>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead, whose default `SpellingsOf<any>` is `never` — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
 
 Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -47,8 +47,8 @@ interface CommandDefinitionBuilder<
   A,
   Eff,
   Ctx,
-  Sibs,
   Deps,
+  Sibs,
   Sp extends string = SpellingsOf<Eff>,
 > {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
@@ -61,7 +61,7 @@ interface CommandDefinitionBuilder<
 }
 ```
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Deps` accumulates the Context dependency edges declared through `.provide()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. All three are trailing defaulted parameters, so existing annotations keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Deps` accumulates the Context dependency edges declared through `.provide()`, `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. All three are trailing defaulted parameters, so annotations with up to five generic arguments keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -129,8 +129,8 @@ class Crust<
   A,
   Eff,
   Ctx,
-  Sibs,
   Deps,
+  Sibs,
   Sp extends string = SpellingsOf<Eff>,
 >
 
@@ -218,8 +218,8 @@ provide<const Cs extends readonly ContextInstance[]>(
   A,
   EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
   MergeContext<Ctx, ContextsOutput<Cs>>,
-  Sibs,
   MergeContextDeps<Deps, Cs>,
+  Sibs,
   Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 >
 ```
@@ -298,8 +298,8 @@ add<const Ds extends readonly CommandDefinition<any>[]>(
   A,
   Eff,
   Ctx,
-  Sibs | CommandDefinitionSpellings<Ds[number]>,
   Deps,
+  Sibs | CommandDefinitionSpellings<Ds[number]>,
   Sp
 >
 ```

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -41,7 +41,16 @@ type ContextRequirements = readonly AnyContextFactory[];
 ### `CommandDefinitionBuilder`
 
 ```ts
-interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Deps> {
+interface CommandDefinitionBuilder<
+  Local,
+  Owned,
+  A,
+  Eff,
+  Ctx,
+  Sibs,
+  Deps,
+  Sp extends string = SpellingsOf<Eff>,
+> {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
@@ -52,7 +61,7 @@ interface CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Deps> {
 }
 ```
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Deps` accumulates the Context dependency edges declared through `.provide()`; both power the compile-time collision and cycle checks and default to empty, so existing annotations keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Deps` accumulates the Context dependency edges declared through `.provide()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. All three are trailing defaulted parameters, so existing annotations keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -114,6 +123,7 @@ The recipe does not execute when the definition is created. It executes once for
 ```ts
 type RootCommandMeta = Pick<CommandMeta, "description" | "usage">;
 
+class Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp extends string = SpellingsOf<Eff>>
 new Crust(name: string, meta?: RootCommandMeta)
 ```
 
@@ -159,7 +169,7 @@ const app = new Crust("serve").args({ name: "port", schema: z.coerce.number().in
 
 ```ts
 flags<const Defs extends readonly NamedFlagDef[]>(
-  ...defs: ValidateNamedFlagDefs<Defs, SpellingsOf<Eff>>,
+  ...defs: ValidateNamedFlagDefs<Defs, Sp>,
 ): Crust
 ```
 
@@ -173,7 +183,7 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls accumulate local flags. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<E extends FlagsDef>(app: Crust<Local, Owned, A, E, Ctx>)`) defer the collision check and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
+Repeated `.flags()` calls accumulate local flags and cache their statically known spellings in the trailing defaulted `Sp` parameter. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<E extends FlagsDef>(app: Crust<Local, Owned, A, E, Ctx>)`) defer the default `Sp = SpellingsOf<E>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead, whose default `SpellingsOf<any>` is `never` — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
 
 Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
@@ -191,7 +201,7 @@ const app = new Crust("serve").flags({
 
 ```ts
 provide<const Cs extends readonly ContextInstance[]>(
-  ...instances: ProvideChecks<Eff, Cs> & ValidateContextCycles<Deps, Cs>,
+  ...instances: ProvideChecks<Sp, Cs> & ValidateContextCycles<Deps, Cs>,
 ): Crust<
   Local,
   MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
@@ -199,7 +209,8 @@ provide<const Cs extends readonly ContextInstance[]>(
   EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
   MergeContext<Ctx, ContextsOutput<Cs>>,
   Sibs,
-  MergeContextDeps<Deps, Cs>
+  MergeContextDeps<Deps, Cs>,
+  Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 >
 ```
 
@@ -278,7 +289,8 @@ add<const Ds extends readonly CommandDefinition<any>[]>(
   Eff,
   Ctx,
   Sibs | CommandDefinitionSpellings<Ds[number]>,
-  Deps
+  Deps,
+  Sp
 >
 ```
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -467,7 +467,7 @@ describe("compile-time Context dependency cycles", () => {
 			new Crust("cli").provide(widened);
 
 			const provideThroughGenericGraph = <Deps extends ContextDeps>(
-				app: Crust<any, any, any, any, any, any, Deps>,
+				app: Crust<any, any, any, any, any, Deps, any>,
 				instance: ContextInstance<"dynamic">,
 			) => app.provide(instance);
 			void provideThroughGenericGraph;

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -248,9 +248,9 @@ describe("Crust .flags()", () => {
 			(typeof app)["_types"]["args"],
 			(typeof app)["_types"]["effective"],
 			(typeof app)["_types"]["ctx"],
-			never,
-			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins legacy 7-argument annotations
-			{}
+			{},
+			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins the new 7-argument order
+			never
 		> = app;
 		void legacy;
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -231,6 +231,49 @@ describe("Crust .flags()", () => {
 		);
 	});
 
+	it("retains known spellings across widened definitions and other fluent calls", () => {
+		const dynamicDefs: { name: string; type: "boolean" }[] = [{ name: "dynamic", type: "boolean" }];
+		const app = new Crust("test")
+			.flags({ name: "verbose", type: "boolean", short: "v" })
+			.flags(...dynamicDefs)
+			.args({ name: "file", type: "string" })
+			.extend(defineExtension("noop"));
+
+		type _Spellings = Expect<
+			Equal<Parameters<(typeof app)["_types"]["spellings"]>[0], "verbose" | "v">
+		>;
+		const legacy: Crust<
+			(typeof app)["_types"]["local"],
+			(typeof app)["_types"]["owned"],
+			(typeof app)["_types"]["args"],
+			(typeof app)["_types"]["effective"],
+			(typeof app)["_types"]["ctx"],
+			never,
+			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins legacy 7-argument annotations
+			{}
+		> = app;
+		void legacy;
+
+		expect(() =>
+			app.flags(
+				// @ts-expect-error -- the accumulator retains "v" from before the widened call
+				{ name: "version", type: "boolean", short: "v" },
+			),
+		).toThrow(/spelling "v" collides with flag "--verbose"/);
+
+		const colliding = defineContext(
+			"colliding",
+			{ flags: [defineFlag("vv", { type: "boolean", short: "v" })] },
+			() => ({}),
+		);
+		expect(() =>
+			app.provide(
+				// @ts-expect-error -- Context-owned short "v" collides with the retained spelling
+				colliding(),
+			),
+		).toThrow(/spelling "v" collides with flag "--verbose"/);
+	});
+
 	it("rejects Promise-returning custom flag parsers at compile time", () => {
 		new Crust("test").flags(
 			// @ts-expect-error -- flag parsers must be synchronous

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -274,6 +274,21 @@ describe("Crust .flags()", () => {
 		).toThrow(/spelling "v" collides with flag "--verbose"/);
 	});
 
+	it("accumulates Context-owned spellings for later .flags() collision checks", () => {
+		const owner = defineContext(
+			"owner",
+			{ flags: [defineFlag("vv", { type: "boolean", short: "v" })] },
+			() => ({}),
+		);
+		const app = new Crust("test").provide(owner());
+		expect(() =>
+			app.flags(
+				// @ts-expect-error -- short "v" collides with the Context-owned flag provided earlier
+				{ name: "version", type: "boolean", short: "v" },
+			),
+		).toThrow(/spelling "v" collides with flag "--vv"/);
+	});
+
 	it("rejects Promise-returning custom flag parsers at compile time", () => {
 		new Crust("test").flags(
 			// @ts-expect-error -- flag parsers must be synchronous

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -293,6 +293,12 @@ type AddChecks<
 		ContextRequirementErrors<Ctx, RequirementContext<DefinitionRequirements<Ds[I]>>>;
 };
 
+/**
+ * Configure-only command builder.
+ *
+ * Generic parameters mirror {@link Crust}; `Sp` caches the flag spellings
+ * accumulated by `.flags()` and `.provide()` for compile-time collision checks.
+ */
 export interface CommandDefinitionBuilder<
 	Local extends FlagsDef = {},
 	Owned extends FlagsDef = {},
@@ -301,9 +307,10 @@ export interface CommandDefinitionBuilder<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Deps extends ContextDeps = {},
+	Sp extends string = SpellingsOf<Eff>,
 > {
 	flags<const Defs extends readonly NamedFlagDef[]>(
-		...defs: ValidateNamedFlagDefs<Defs, SpellingsOf<Eff>>
+		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): CommandDefinitionBuilder<
 		MergeFlags<Local, NamedFlagsRecord<Defs>>,
 		Owned,
@@ -311,15 +318,16 @@ export interface CommandDefinitionBuilder<
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
-		Deps
+		Deps,
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps>;
+	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<Eff, Cs> &
+		...instances: ProvideChecks<Sp, Cs> &
 			ValidateContextCycles<Deps, Cs> &
 			ValidateContextNames<Ctx, Cs>
 	): CommandDefinitionBuilder<
@@ -329,7 +337,8 @@ export interface CommandDefinitionBuilder<
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		MergeContextDeps<Deps, Cs>
+		MergeContextDeps<Deps, Cs>,
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	>;
 
 	add<const Ds extends readonly CommandDefinition<any>[]>(
@@ -341,12 +350,13 @@ export interface CommandDefinitionBuilder<
 		Eff,
 		Ctx,
 		Sibs | CommandDefinitionSpellings<Ds[number]>,
-		Deps
+		Deps,
+		Sp
 	>;
 
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Deps>;
+	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 }
 
 /**
@@ -421,6 +431,7 @@ export function defineCommand(
  * - `Ctx` — provided Context values
  * - `Sibs` — sibling command names and aliases already registered
  * - `Deps` — provided Context dependency edges used for cycle detection
+ * - `Sp` — accumulated flag spellings used for collision checks
  *
  * @example
  * ```ts
@@ -440,6 +451,7 @@ export class Crust<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Deps extends ContextDeps = {},
+	Sp extends string = SpellingsOf<Eff>,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
@@ -448,6 +460,9 @@ export class Crust<
 		args: A;
 		effective: Eff;
 		ctx: Ctx;
+		// Method syntax keeps broad/legacy Crust annotations assignable while
+		// exposing Sp to type-level tests through Parameters<>.
+		spellings(spelling: Sp): void;
 	};
 
 	/** @internal */
@@ -509,7 +524,7 @@ export class Crust<
 	 * @throws {CrustError} `DEFINITION` on duplicate names or spellings, or schema-exclusivity violations
 	 */
 	flags<const Defs extends readonly NamedFlagDef[]>(
-		...defs: ValidateNamedFlagDefs<Defs, SpellingsOf<Eff>>
+		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): Crust<
 		MergeFlags<Local, NamedFlagsRecord<Defs>>,
 		Owned,
@@ -517,7 +532,8 @@ export class Crust<
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
-		Deps
+		Deps,
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	> {
 		const copiedFlags: FlagsDef = { ...this._node.localFlags };
 		for (const def of defs) {
@@ -557,7 +573,8 @@ export class Crust<
 			EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 			Ctx,
 			Sibs,
-			Deps
+			Deps,
+			Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 		>;
 	}
 
@@ -575,7 +592,7 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps> {
+	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
 			const argName = (def as ArgDef).name;
@@ -608,7 +625,7 @@ export class Crust<
 
 		return this._clone({
 			args: copiedArgs,
-		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps>;
+		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**
@@ -625,7 +642,7 @@ export class Crust<
 	 *                      this command path
 	 */
 	provide<const Cs extends readonly ContextInstance[]>(
-		...instances: ProvideChecks<Eff, Cs> &
+		...instances: ProvideChecks<Sp, Cs> &
 			ValidateContextCycles<Deps, Cs> &
 			ValidateContextNames<Ctx, Cs>
 	): Crust<
@@ -635,7 +652,8 @@ export class Crust<
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		MergeContextDeps<Deps, Cs>
+		MergeContextDeps<Deps, Cs>,
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	> {
 		const contexts = [...this._node.contexts];
 		const ownedFlags = { ...this._node.ownedFlags };
@@ -660,7 +678,8 @@ export class Crust<
 			EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>,
 			Sibs,
-			MergeContextDeps<Deps, Cs>
+			MergeContextDeps<Deps, Cs>,
+			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 		>;
 	}
 
@@ -706,7 +725,7 @@ export class Crust<
 	 */
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps> {
+	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
@@ -716,7 +735,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps>;
+		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**
@@ -728,7 +747,7 @@ export class Crust<
 	 *
 	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps> {
+	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
 		const names = new Set(this._node.extensions.map((extension) => extension.name));
 		for (const extension of extensions) {
 			if (names.has(extension.name)) {
@@ -742,7 +761,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps>;
+		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**
@@ -754,30 +773,31 @@ export class Crust<
 	 */
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Deps> {
-		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps>;
+	): Crust<Local, Owned, A, Eff, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Deps, Sp> {
+		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
-		return result as Crust<
+		return result as unknown as Crust<
 			Local,
 			Owned,
 			A,
 			Eff,
 			Ctx,
 			Sibs | CommandDefinitionSpellings<Ds[number]>,
-			Deps
+			Deps,
+			Sp
 		>;
 	}
 
 	private _addDefinition(
 		definition: CommandDefinition,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps> {
+	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps>;
+		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -305,8 +305,8 @@ export interface CommandDefinitionBuilder<
 	A extends ArgsDef = ArgsDef,
 	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
-	Sibs extends string = never,
 	Deps extends ContextDeps = {},
+	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Eff>,
 > {
 	flags<const Defs extends readonly NamedFlagDef[]>(
@@ -317,14 +317,14 @@ export interface CommandDefinitionBuilder<
 		A,
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
-		Sibs,
 		Deps,
+		Sibs,
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp>;
+	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Deps, Sibs, Sp>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> &
@@ -336,8 +336,8 @@ export interface CommandDefinitionBuilder<
 		A,
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
-		Sibs,
 		MergeContextDeps<Deps, Cs>,
+		Sibs,
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	>;
 
@@ -349,14 +349,14 @@ export interface CommandDefinitionBuilder<
 		A,
 		Eff,
 		Ctx,
-		Sibs | CommandDefinitionSpellings<Ds[number]>,
 		Deps,
+		Sibs | CommandDefinitionSpellings<Ds[number]>,
 		Sp
 	>;
 
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>;
 }
 
 /**
@@ -429,8 +429,8 @@ export function defineCommand(
  * - `A` — positional argument definitions
  * - `Eff` — effective flags (merged local + owned flags)
  * - `Ctx` — provided Context values
- * - `Sibs` — sibling command names and aliases already registered
  * - `Deps` — provided Context dependency edges used for cycle detection
+ * - `Sibs` — sibling command names and aliases already registered
  * - `Sp` — accumulated flag spellings used for collision checks
  *
  * @example
@@ -449,8 +449,8 @@ export class Crust<
 	A extends ArgsDef = ArgsDef,
 	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
-	Sibs extends string = never,
 	Deps extends ContextDeps = {},
+	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Eff>,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
@@ -531,8 +531,8 @@ export class Crust<
 		A,
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
-		Sibs,
 		Deps,
+		Sibs,
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	> {
 		const copiedFlags: FlagsDef = { ...this._node.localFlags };
@@ -572,8 +572,8 @@ export class Crust<
 			A,
 			EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 			Ctx,
-			Sibs,
 			Deps,
+			Sibs,
 			Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 		>;
 	}
@@ -592,7 +592,7 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp> {
+	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Deps, Sibs, Sp> {
 		for (const def of defs) {
 			const record = def as unknown as Record<string, unknown>;
 			const argName = (def as ArgDef).name;
@@ -625,7 +625,7 @@ export class Crust<
 
 		return this._clone({
 			args: copiedArgs,
-		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Deps, Sibs, Sp>;
 	}
 
 	/**
@@ -651,8 +651,8 @@ export class Crust<
 		A,
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
-		Sibs,
 		MergeContextDeps<Deps, Cs>,
+		Sibs,
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	> {
 		const contexts = [...this._node.contexts];
@@ -677,8 +677,8 @@ export class Crust<
 			A,
 			EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>,
-			Sibs,
 			MergeContextDeps<Deps, Cs>,
+			Sibs,
 			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 		>;
 	}
@@ -725,7 +725,7 @@ export class Crust<
 	 */
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
+	): Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
@@ -735,7 +735,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>;
 	}
 
 	/**
@@ -747,7 +747,7 @@ export class Crust<
 	 *
 	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
+	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp> {
 		const names = new Set(this._node.extensions.map((extension) => extension.name));
 		for (const extension of extensions) {
 			if (names.has(extension.name)) {
@@ -761,7 +761,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>;
 	}
 
 	/**
@@ -773,8 +773,8 @@ export class Crust<
 	 */
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Deps, Sp> {
-		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+	): Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs | CommandDefinitionSpellings<Ds[number]>, Sp> {
+		let result = this as Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
@@ -784,20 +784,20 @@ export class Crust<
 			A,
 			Eff,
 			Ctx,
-			Sibs | CommandDefinitionSpellings<Ds[number]>,
 			Deps,
+			Sibs | CommandDefinitionSpellings<Ds[number]>,
 			Sp
 		>;
 	}
 
 	private _addDefinition(
 		definition: CommandDefinition,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp> {
+	): Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -735,7 +735,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**
@@ -761,7 +761,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**
@@ -778,7 +778,7 @@ export class Crust<
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
-		return result as unknown as Crust<
+		return result as Crust<
 			Local,
 			Owned,
 			A,
@@ -797,7 +797,7 @@ export class Crust<
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as unknown as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Deps, Sp>;
 	}
 
 	/**

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -56,6 +56,24 @@ describe("command definitions", () => {
 		});
 	});
 
+	it("accumulates flag spellings across builder calls for compile-time collision checks", () => {
+		// The CommandDefinitionBuilder interface mirrors Crust's Sp accumulator
+		// type-only; this pins the recipe path so the mirror cannot drift.
+		const definition = defineCommand("serve", (command) =>
+			command
+				.flags({ name: "verbose", type: "boolean", short: "v" })
+				.args({ name: "file", type: "string" })
+				.flags(
+					// @ts-expect-error -- "v" collides with the earlier .flags() call
+					{ name: "version", type: "boolean", short: "v" },
+				)
+				.action(() => {}),
+		);
+		expect(() => new Crust("cli").add(definition)).toThrow(
+			/spelling "v" collides with flag "--verbose"/,
+		);
+	});
+
 	it("rejects a second action on the definition builder", () => {
 		const definition = defineCommand("duplicate", (command) =>
 			command.action(() => {}).action(() => {}),

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -58,10 +58,14 @@ describe("command definitions", () => {
 
 	it("accumulates flag spellings across builder calls for compile-time collision checks", () => {
 		// The CommandDefinitionBuilder interface mirrors Crust's Sp accumulator
-		// type-only; this pins the recipe path so the mirror cannot drift.
+		// type-only; this pins the recipe path so the mirror cannot drift. The
+		// widened call in between proves Sp retains earlier literals instead of
+		// recomputing from the (now-widened) Eff.
+		const dynamicDefs: { name: string; type: "boolean" }[] = [{ name: "dynamic", type: "boolean" }];
 		const definition = defineCommand("serve", (command) =>
 			command
 				.flags({ name: "verbose", type: "boolean", short: "v" })
+				.flags(...dynamicDefs)
 				.args({ name: "file", type: "string" })
 				.flags(
 					// @ts-expect-error -- "v" collides with the earlier .flags() call
@@ -71,6 +75,26 @@ describe("command definitions", () => {
 		);
 		expect(() => new Crust("cli").add(definition)).toThrow(
 			/spelling "v" collides with flag "--verbose"/,
+		);
+	});
+
+	it("accumulates Context-owned spellings for later .flags() calls on the builder", () => {
+		const owner = defineContext(
+			"owner",
+			{ flags: [defineFlag("vv", { type: "boolean", short: "v" })] },
+			() => ({}),
+		);
+		const definition = defineCommand("serve", (command) =>
+			command
+				.provide(owner())
+				.flags(
+					// @ts-expect-error -- short "v" collides with the Context-owned flag provided earlier
+					{ name: "version", type: "boolean", short: "v" },
+				)
+				.action(() => {}),
+		);
+		expect(() => new Crust("cli").add(definition)).toThrow(
+			/spelling "v" collides with flag "--vv"/,
 		);
 	});
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -552,9 +552,7 @@ type InferArgValue<A extends ArgDef> = A extends {
 	schema: infer S extends StandardSchema;
 }
 	? InferOutput<S>
-	: A extends {
-				type: infer _T extends ValueType;
-		  }
+	: A extends { type: ValueType }
 		? A extends { variadic: true }
 			? ResolveBaseType<A>[]
 			: A extends { required: true }
@@ -616,24 +614,17 @@ type InferFlagValue<F extends FlagDef> = F extends {
 	schema: infer S extends StandardSchema;
 }
 	? InferOutput<S>
-	: F extends {
-				type: infer _T extends ValueType;
-		  }
-		? F extends { multiple: true }
-			? F extends { required: true }
+	: F extends { multiple: true }
+		? F extends { required: true }
+			? ResolveBaseType<F>[]
+			: F extends { default: readonly unknown[] }
 				? ResolveBaseType<F>[]
-				: // See InferArgValue: narrow on default presence. With `parse`,
-					// the raw default is `string[]` while ResolveBaseType<F> is the
-					// parsed element type.
-					F extends { default: readonly unknown[] }
-					? ResolveBaseType<F>[]
-					: ResolveBaseType<F>[] | undefined
-			: F extends { required: true }
+				: ResolveBaseType<F>[] | undefined
+		: F extends { required: true }
+			? ResolveBaseType<F>
+			: F extends { default: unknown }
 				? ResolveBaseType<F>
-				: F extends { default: unknown }
-					? ResolveBaseType<F>
-					: ResolveBaseType<F> | undefined
-		: never;
+				: ResolveBaseType<F> | undefined;
 
 /**
  * Maps a full FlagsDef record to resolved flag types.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -617,7 +617,10 @@ type InferFlagValue<F extends FlagDef> = F extends {
 	: F extends { multiple: true }
 		? F extends { required: true }
 			? ResolveBaseType<F>[]
-			: F extends { default: readonly unknown[] }
+			: // See InferArgValue: narrow on default presence. With `parse`,
+				// the raw default is `string[]` while ResolveBaseType<F> is the
+				// parsed element type.
+				F extends { default: readonly unknown[] }
 				? ResolveBaseType<F>[]
 				: ResolveBaseType<F>[] | undefined
 		: F extends { required: true }

--- a/packages/core/src/validation/flags.test.ts
+++ b/packages/core/src/validation/flags.test.ts
@@ -148,8 +148,9 @@ describe("ValidateNamedFlagDefs", () => {
 		expect(true).toBe(true);
 	});
 
-	it("opts widened definitions out of compile-time checks", () => {
-		// Widened records have no statically knowable spellings.
+	it("opts widened definitions themselves out of compile-time checks", () => {
+		// Widened records have no statically knowable spellings. A fluent builder
+		// still retains spellings accumulated before a widened .flags() call.
 		type _widenedRecord = Expect<Equal<SpellingsOf<FlagsDef>, never>>;
 
 		// Widened names/aliases fall back to runtime validation instead of
@@ -160,7 +161,7 @@ describe("ValidateNamedFlagDefs", () => {
 
 		// Context instances with widened owned flags opt out of provide-site checks.
 		type Provided = ProvideChecks<
-			{ verbose: { type: "boolean"; short: "v" } },
+			"verbose" | "v",
 			readonly [{ readonly _requires?: { ownedFlags: FlagsDef } }]
 		>;
 		type _noProvideBrand = Expect<Equal<Extract<keyof Provided[0], `FIX_${string}`>, never>>;

--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -49,8 +49,9 @@ type DuplicateNameBrand<F, Dups extends string> =
  * so collisions, `no-` prefixes, and async parsers error on the offending argument.
  *
  * Bounded-generic wrappers (e.g. `<E extends FlagsDef>(app: Crust<L, O, A, E, C>)`)
- * keep `SpellingsOf<E>` deferred and will not typecheck against `Existing`;
- * type wrapper parameters as `Crust<any, ...>` instead (see tests/helpers.ts).
+ * keep the default `Sp = SpellingsOf<E>` deferred and will not typecheck against
+ * `Existing`; type wrapper parameters as `Crust<any, ...>` instead, whose default
+ * `SpellingsOf<any>` is `never` (see tests/helpers.ts).
  */
 export type ValidateNamedFlagDefs<
 	Defs extends readonly NamedFlagDef[],
@@ -220,14 +221,14 @@ type ContextFlagCollisionBrand<C, Existing extends string> =
 		: never;
 
 /**
- * Validate Context-owned flags against existing flags.
+ * Validate Context-owned flags against accumulated existing spellings.
  *
- * Only compares each instance against `Eff`: collisions between two instances
+ * Only compares each instance against `Sp`: collisions between two instances
  * in the same `.provide(a(), b())` call stay runtime-only — a type-level
  * pairwise check cost ~9k extra instantiations for a rare misuse.
  */
-export type ProvideChecks<Eff extends FlagsDef, Cs extends readonly unknown[]> = {
-	[I in keyof Cs]: Cs[I] & ContextFlagCollisionBrand<Cs[I], SpellingsOf<Eff>>;
+export type ProvideChecks<Sp extends string, Cs extends readonly unknown[]> = {
+	[I in keyof Cs]: Cs[I] & ContextFlagCollisionBrand<Cs[I], Sp>;
 };
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -28,6 +28,9 @@ export const flags = [
 	defineFlag("quiet", { type: "boolean", short: "q", description: "Quiet mode" }),
 ];
 
+// Inferred builder type exposes the accumulated spelling-literal union
+export const flagged = new Crust("flagged").flags(...flags);
+
 export const apiKey = defineFlag("api-key", { type: "string", short: "k" });
 export const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 	apiKey: flags["api-key"],

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../packages/config/tsconfig.base.json",
+	"include": ["."]
+}

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -205,6 +205,7 @@ export function generateConsumerFixture(
 					target: "esnext",
 					strict: true,
 					noEmit: true,
+					skipLibCheck: true,
 				},
 				include: ["consumer.ts"],
 			},


### PR DESCRIPTION
## Summary

Whole-repo TypeScript compiler-performance pass. Three validated, behavior-preserving optimizations found by a subagent audit of every workspace package, each independently reviewed before merge.

| Measurement | Before | After | Δ |
|---|---:|---:|---:|
| `packages/core` instantiations | 635,828 | 586,582¹ | **−7.7%** |
| 60-flag builder chain | 204,634 | 134,701 | **−34%** |
| 100/10 consumer scaling ratio | 8.11× | 8.02× | −1.0% |
| `scripts/` editor project load | ~0.40s | ~0.04s | ~9× |

¹ 580,367 before the new test coverage this PR adds (−8.5%); tests deliberately exercise the new accumulator.

## Changes

### 1. `perf(core)`: spelling accumulator (`Sp` generic)

`SpellingsOf<Eff>` was recomputed over the entire accumulated flag intersection on every `.flags()`/`.provide()` call — O(n) per call, **O(n²) per chain**, the single largest term in core's check cost. This adds a trailing, defaulted `Sp extends string = SpellingsOf<Eff>` parameter to `Crust` and `CommandDefinitionBuilder` that accumulates incrementally (same pattern as the existing `Sibs` accumulator):

- `.flags()` returns `Sp | SpellingsOf<NamedFlagsRecord<Defs>>`; `.provide()` returns `Sp | SpellingsOf<ContextsOwnedFlags<Cs>>`; all other fluent methods thread `Sp` unchanged.
- Internal `ProvideChecks` re-parameterized from `Eff` to `Sp` (not exported; no external impact).
- Trailing + defaulted, so existing annotations (`Crust<L,O,A,E,C,Sibs,Deps>`, `Crust<any,…>` wrappers) keep working — pinned by tests.
- **One deliberate strictness gain:** spellings accumulated *before* a widened `.flags(...defs: NamedFlagDef[])` call now stay collision-checked at compile time (previously all checks silently deferred to runtime after any widened call). Runtime behavior is unchanged — it already threw. Pinned by new tests on both the `Crust` class and the `defineCommand` builder path.

### 2. `refactor(core)`: drop redundant inference guards

Remove the unused `infer _T extends ValueType` constraint in `InferArgValue` and the unreachable `type` guard level in `InferFlagValue` (every non-schema `FlagDef` variant requires a literal `type`). Verified equivalent via type-level probes over the full unions, `any`, `never`, and union distribution.

### 3. `perf(scripts)`: tsconfig coverage + fixture fidelity

- `scripts/tsconfig.json` extending the shared base config: kills false `TS5097` editor diagnostics and drops inferred-project load from ~0.40s to ~0.04s.
- Type-perf consumer fixtures now generate with `skipLibCheck: true`, matching real consumers and the repo base config. Removes a constant ~42.6k instantiations of default-lib/d.ts-internal checking that diluted the CI scaling signal. Base and head are always measured by head's script, so PR deltas stay comparable.

### 4. `refactor(core)!`: reorder trailing `Deps`/`Sibs` generics

Follow-up from review: swap generic positions 6 and 7 so the list reads `<Local, Owned, A, Eff, Ctx, Deps, Sibs, Sp>` — `Deps` (context dependency edges) sits next to `Ctx`, and `Sibs` (sibling spellings) next to `Sp` (flag spellings).

**Breaking (loud):** positional annotations with 6+ generic arguments must swap `Sibs`/`Deps`. The `string` vs `ContextDeps` constraints are incompatible, so stale annotations fail to compile rather than silently misbehave. ≤5-argument annotations are unaffected. Pinned in the failing direction by the legacy-annotation test (`{}` at position 6 errors if swapped back). Docs, JSDoc, and changeset (minor, per pre-1.0 precedent) updated in the same commit.

## Tradeoff (measured, accepted)

Exported inferred builder types carry a spelling-literal union in consumer `.d.ts` (same class of cost `Sibs` already imposes): +0.3–1.4% constant on synthetic consumer fixtures, while superlinearity (the thing that actually hurts at scale) improves. Declaration-emission test extended to lock TS2742-safety of the union.

## Validation

- `tsc --noEmit` clean on all 14 workspace projects; turbo `check:types` 21/21 green
- `bun test`: 611/611 in core (incl. declaration-emission against rebuilt dist, deep-chain 60/40/30 guards unchanged); full repo suite green
- `oxlint` + `oxfmt --check` clean
- 3 fresh-context subagent reviews (type contracts, tests/validation, docs/simplicity): no blockers; all findings addressed (builder-path `Sp` test, `.extend()`/provide-after-widened coverage, restored comment cross-reference)
- Changesets: minor bump for `@crustjs/core` (spelling-accumulator strictness gain + generic reorder)

## Deferred (documented, not implemented)

- Alias-free fast path for `ValidateFlagAliases` (upper bound −18% on long chains) — revisit after this baseline lands
- `.add()` `Sibs` superlinearity — a 300-command fixture still checks in 3.6s; CI scaling ratio already watches it

