### PR TITLE
perf(core): defer flag validation behind a distributive conditional

### DIFF
--- a/.changeset/defer-flag-validation.md
+++ b/.changeset/defer-flag-validation.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Faster type-checking for `.flags()` calls: flag validation is now deferred behind a distributive conditional so the pipeline is only instantiated once definitions are concrete (−8.8% type instantiations on the core package). Emitted validation brands are unchanged.

--- a/packages/core/src/validation/flags.test.ts
+++ b/packages/core/src/validation/flags.test.ts
@@ -186,6 +186,9 @@ describe("ValidateNamedFlagDefs", () => {
 		expect(true).toBe(true);
 	});
 
+	// Tripwire: this alias-free def is branded via the `Validated` slot, so it
+	// proves the validation pipeline still fires through the always-true deferral
+	// conditional in ValidateNamedFlagDefs (flags.ts). Do not remove or reroute.
 	it('brands a flag name starting with "no-"', () => {
 		type Defs = readonly [{ name: "no-cache"; type: "boolean" }];
 		type Result = ValidateNamedFlagDefs<Defs>;

--- a/packages/core/src/validation/flags.test.ts
+++ b/packages/core/src/validation/flags.test.ts
@@ -70,6 +70,42 @@ describe("ValidateNamedFlagDefs", () => {
 		expect(true).toBe(true);
 	});
 
+	it("keeps alias-free and aliased duplicate-name validation in parity", () => {
+		type AliasFree = ValidateNamedFlagDefs<
+			readonly [{ name: "mode"; type: "string" }, { name: "mode"; type: "number" }]
+		>;
+		type Aliased = ValidateNamedFlagDefs<
+			readonly [
+				{ name: "mode"; type: "string"; aliases: ["text-mode"] },
+				{ name: "mode"; type: "number"; aliases: ["number-mode"] },
+			]
+		>;
+		type _sameFirstBrand = Expect<
+			Equal<AliasFree[0]["FIX_ALIAS_COLLISION"], Aliased[0]["FIX_ALIAS_COLLISION"]>
+		>;
+		type _sameSecondBrand = Expect<
+			Equal<AliasFree[1]["FIX_ALIAS_COLLISION"], Aliased[1]["FIX_ALIAS_COLLISION"]>
+		>;
+		type _sameBrands = Expect<
+			Equal<
+				Extract<keyof AliasFree[0], `FIX_${string}`>,
+				Extract<keyof Aliased[0], `FIX_${string}`>
+			>
+		>;
+		type CleanAliasFree = ValidateNamedFlagDefs<readonly [{ name: "output"; type: "string" }]>;
+		type CleanAliased = ValidateNamedFlagDefs<
+			readonly [{ name: "output"; type: "string"; aliases: ["out"] }]
+		>;
+		type _aliasFreeRemainsUnbranded = Expect<
+			Equal<Extract<keyof CleanAliasFree[0], `FIX_${string}`>, never>
+		>;
+		type _aliasedRemainsUnbranded = Expect<
+			Equal<Extract<keyof CleanAliased[0], `FIX_${string}`>, never>
+		>;
+
+		expect(true).toBe(true);
+	});
+
 	it("brands a short alias equal to its own flag name", () => {
 		type Defs = readonly [{ name: "m"; type: "string"; short: "m" }];
 		type Result = ValidateNamedFlagDefs<Defs>;
@@ -97,6 +133,21 @@ describe("ValidateNamedFlagDefs", () => {
 		type Result = ValidateNamedFlagDefs<Defs, "verbose" | "v">;
 		type _check = Expect<
 			Equal<Result[0]["FIX_ALIAS_COLLISION"], 'Flag spelling "v" collides with an existing flag'>
+		>;
+
+		expect(true).toBe(true);
+	});
+
+	it("brands an alias-free name that collides with an existing spelling", () => {
+		type Result = ValidateNamedFlagDefs<
+			readonly [{ name: "verbose"; type: "boolean" }],
+			"verbose" | "v"
+		>;
+		type _check = Expect<
+			Equal<
+				Result[0]["FIX_ALIAS_COLLISION"],
+				'Flag spelling "verbose" collides with an existing flag'
+			>
 		>;
 
 		expect(true).toBe(true);

--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -58,8 +58,14 @@ export type ValidateNamedFlagDefs<
 	Existing extends string = never,
 	// Hoisted out of the per-element map below: both are invariant w.r.t. `I`,
 	// so computing them once as defaulted params avoids re-instantiating them
-	// for every definition in the call.
-	Validated = ValidateNoPrefixedFlags<ValidateFlagAliases<NamedFlagsRecord<Defs>>>,
+	// for every definition in the call. The always-true distributive conditional
+	// on the naked `Defs` param exists purely for perf: it defers instantiating
+	// the validation pipeline until `Defs` is concrete instead of speculatively
+	// re-instantiating it during inference (measured −52k instantiations on core;
+	// the non-distributive `[Defs] extends [Defs]` form recovers only −18k).
+	Validated = Defs extends Defs
+		? ValidateNoPrefixedFlags<ValidateFlagAliases<NamedFlagsRecord<Defs>>>
+		: never,
 	Dups extends string = DuplicateNames<Defs>,
 > = {
 	[I in keyof Defs]: Defs[I] &

--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -63,6 +63,9 @@ export type ValidateNamedFlagDefs<
 	// the validation pipeline until `Defs` is concrete instead of speculatively
 	// re-instantiating it during inference (measured −52k instantiations on core;
 	// the non-distributive `[Defs] extends [Defs]` form recovers only −18k).
+	// Do not simplify or box this conditional — it looks like dead code but is
+	// load-bearing. It distributes over union `Defs`, which is unreachable via
+	// `.flags(...defs)` tuple inference.
 	Validated = Defs extends Defs
 		? ValidateNoPrefixedFlags<ValidateFlagAliases<NamedFlagsRecord<Defs>>>
 		: never,


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #189** — base is `perf/type-check-optimizations`. Retarget to `main` after #189 merges.

Follow-up to #189 covering both deferred items: the alias-free fast path (item A) and the `.add()` Sibs superlinearity investigation (item B).

## Item A — shipped as a deferral wrapper, not a fast path

The planned alias-free fast path (`Defs[number] extends { short?: undefined; aliases?: undefined } ? …`) was implemented, measured, and **rejected by measurement**:

- The original predicate is dead code under TS's weak-type rule (all-optional target shares no properties with an alias-free def → always slow path). Two independent reviewers proved this via branch-poisoning.
- With the predicate fixed (`{ name: string; short?: undefined; aliases?: undefined }`), the fast path fires at ~200 call sites but measures **worse** than a trivial conditional with identical branches (578,063 vs 576,662 whole-core), and **identical** on an isolated 60-call alias-free `.flags()` chain (87,370 both). Post-#189, the alias scan is vacuous-cheap without aliases (`ExtractAllAliases = never`), so there is nothing to skip.
- The entire win comes from the **conditional deferring `Validated`'s instantiation** until `Defs` is concrete. The distributive form on the naked param is load-bearing:

| Variant | Whole-core instantiations |
|---|---:|
| Baseline (this branch, pre-change) | 596,613 |
| Anchored fast path | 578,063 |
| Non-distributive `[Defs] extends [Defs]` | 578,062 |
| **Distributive `Defs extends Defs` (shipped)** | **543,890 (−8.8%)** |

Isolated 60-call alias-free chain fixture: 87,370 → 60,081 (−31%). Consumer scaling fixture (100 commands): 731,492 → 630,906.

Semantics: verified brand-identical to the pre-change form for `any`, widened `NamedFlagDef[]`, empty tuples, concrete tuples, and the `Existing` param (probe-verified by a fresh reviewer). Distribution changes results only for union-of-tuples `Defs`, which is unreachable via the public API (`.flags(...defs)` always infers a tuple) — and per-member validation is arguably more correct there anyway.

## Item B — closed, no code change

Regenerated consumer fixtures at 10/50/100/300 commands on the post-Sp baseline and isolated the components:

| Fixture variant | marginal inst/command 10→50 | 50→100 | 100→300 |
|---|---:|---:|---:|
| `.add()` only | 495.0 | 495.0 | 495.0 |
| Rich flags/args, no contexts | 5,907.0 | 5,907.0 | 5,907.0 |
| Context-only | 1,017.8 | 1,893.9 | 5,292.7 |

**`Sibs` collision validation (`ValidateCommandDefinitions`) is linear** — the old superlinear consumer numbers were contaminated by the pre-Sp flags quadratic. The residual superlinearity is attributable to growing context breadth / `ContextRequirementErrors`, not `Sibs`; no Sibs optimization is warranted. The CI `100/10 scaling ratio` row remains the tripwire.

## Validation

- `bunx tsc -p packages/core/tsconfig.json --noEmit --extendedDiagnostics` — 0 errors, 543,890 instantiations
- `bun run check:types` — 21/21 tasks (all exact-brand-message and Sp accumulator type tests pin)
- `cd packages/core && bunx bunup && bun test` — 613 pass
- `bun run lint`, `bun run format` — clean
- Changeset: patch for `@crustjs/core`; docs untouched (change is invisible)
- Worker implementation + 4 fresh-context reviewer passes (type-contracts, tests-validation, simplicity-docs, final semantics probe); review-driven redesign from fast path → deferral wrapper