### PR TITLE
feat(skills): render flag spellings from the doc model

### DIFF
--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -297,6 +297,20 @@ describe("buildManifest", () => {
 			]);
 		});
 
+		it("omits negation spellings for a noNegate boolean flag", () => {
+			const cmd = makeCommand({
+				meta: { name: "test" },
+				flags: {
+					quiet: { type: "boolean", noNegate: true },
+				},
+				run() {},
+			});
+
+			const node = buildManifest(snapshotCommand(cmd));
+
+			expect(node.flags[0]?.spellings).toEqual(["--quiet"]);
+		});
+
 		it("normalizes a required string flag with short alias", () => {
 			const cmd = makeCommand({
 				meta: { name: "deploy" },

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -287,6 +287,7 @@ describe("buildManifest", () => {
 			expect(node.flags).toEqual([
 				{
 					name: "verbose",
+					spellings: ["--verbose", "--no-verbose"],
 					type: "boolean",
 					description: "Enable verbose output",
 					required: false,
@@ -337,6 +338,7 @@ describe("buildManifest", () => {
 
 			expect(flag?.short).toBe("o");
 			expect(flag?.aliases).toEqual(["dest", "out"]);
+			expect(flag?.spellings).toEqual(["-o", "--output", "--out", "--dest"]);
 		});
 
 		it("normalizes a multiple flag", () => {

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -45,6 +45,7 @@ function normalizeArg(arg: DocumentationArg): ManifestArg {
 function normalizeFlag(flag: DocumentationFlag): ManifestFlag {
 	const result: ManifestFlag = {
 		name: flag.name,
+		spellings: flag.spellings,
 		type: manifestType(flag.type),
 		required: flag.required,
 		multiple: flag.multiple,

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -713,7 +713,7 @@ describe("renderSkill", () => {
 			expect(deploy?.content).toContain("API credential");
 		});
 
-		it("renders a flags table with aliases and defaults", () => {
+		it("renders a flags table with doc-model spellings and defaults", () => {
 			const cmd = makeCommand({
 				meta: { name: "build" },
 				flags: {
@@ -721,6 +721,7 @@ describe("renderSkill", () => {
 						type: "boolean",
 						description: "Enable verbose output",
 						short: "v",
+						aliases: ["debug"],
 					},
 					output: {
 						type: "string",
@@ -747,8 +748,10 @@ describe("renderSkill", () => {
 			const build = findFile(files, "commands/build.md");
 
 			expect(build?.content).toContain("## Flags");
-			expect(build?.content).toContain("`--output`, `-o`");
-			expect(build?.content).toContain("`--verbose`, `-v`");
+			expect(build?.content).toContain("`-o`, `--output`");
+			expect(build?.content).toContain(
+				"`-v`, `--verbose`, `--debug`, `--no-verbose`, `--no-debug`",
+			);
 			expect(build?.content).toContain("`--target`");
 			expect(build?.content).toContain("Default: `dist`");
 			expect(build?.content).toContain("| Yes |");
@@ -973,7 +976,7 @@ describe("renderSkill", () => {
 			const files = renderSkill(manifest, meta);
 			const test = findFile(files, "commands/test.md");
 
-			expect(test?.content).toContain("| `--quiet` | boolean | No | - |");
+			expect(test?.content).toContain("| `--quiet`, `--no-quiet` | boolean | No | - |");
 		});
 	});
 
@@ -1349,7 +1352,7 @@ describe("renderSkill", () => {
 			expect(cloneFile?.content).toContain("# `git clone`");
 			expect(cloneFile?.content).toContain("## Arguments");
 			expect(cloneFile?.content).toContain("## Flags");
-			expect(cloneFile?.content).toContain("`--branch`, `-b`");
+			expect(cloneFile?.content).toContain("`-b`, `--branch`");
 			expect(cloneFile?.content).toContain("git clone <url> [directory] [options]");
 
 			// Verify remote is rendered as group (has children) but also runnable

--- a/packages/skills/src/render.ts
+++ b/packages/skills/src/render.ts
@@ -426,29 +426,13 @@ function renderFlagsTable(flags: ManifestFlag[]): string[] {
 	lines.push("| ---- | ---- | -------- | ----------- |");
 
 	for (const flag of flags) {
-		const name = formatFlagName(flag);
+		const name = flag.spellings.map((spelling) => `\`${spelling}\``).join(", ");
 		const required = flag.required ? "Yes" : "No";
 		const desc = escapeTableCell(formatFlagDescription(flag));
 		lines.push(`| ${name} | ${flag.type} | ${required} | ${desc} |`);
 	}
 
 	return lines;
-}
-
-/**
- * Formats the flag name cell with aliases.
- *
- * Example: `--verbose`, `-v` or `--output`, `-o`, `-O`
- */
-function formatFlagName(flag: ManifestFlag): string {
-	const parts = [`\`--${flag.name}\``];
-	if (flag.short) {
-		parts.push(`\`-${flag.short}\``);
-	}
-	for (const alias of flag.aliases) {
-		parts.push(`\`--${alias}\``);
-	}
-	return parts.join(", ");
 }
 
 /**

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -185,11 +185,13 @@ export interface ManifestArg {
 /**
  * Describes a single named flag in the canonical manifest.
  *
- * Normalized from `FlagSnapshot` in `@crustjs/core` to a flat, serializable shape.
+ * Normalized from `DocumentationFlag` in `@crustjs/core/tooling` to a flat, serializable shape.
  */
 export interface ManifestFlag {
 	/** Flag name (the key from `FlagsDef`) */
 	name: string;
+	/** All accepted CLI spellings in documentation order */
+	spellings: readonly string[];
 	/** Value type: "string", "number", or "boolean" */
 	type: "string" | "number" | "boolean";
 	/** Human-readable description */
@@ -222,7 +224,7 @@ export interface ManifestFlag {
  *   description: "Add a new remote",
  *   runnable: true,
  *   args: [{ name: "name", type: "string", required: true, variadic: false }],
- *   flags: [{ name: "fetch", type: "boolean", required: false, multiple: false, aliases: ["f"] }],
+ *   flags: [{ name: "fetch", spellings: ["--fetch", "--no-fetch"], type: "boolean", required: false, multiple: false, aliases: [] }],
  *   children: [],
  * };
  * ```

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -165,7 +165,7 @@ export type SkillKind = "generated" | "bundle";
 /**
  * Describes a single positional argument in the canonical manifest.
  *
- * Normalized from `ArgSnapshot` in `@crustjs/core` to a flat, serializable shape.
+ * Normalized from `DocumentationArg` in `@crustjs/core/tooling` to a flat, serializable shape.
  */
 export interface ManifestArg {
 	/** Argument name (from `ArgDef.name`) */
@@ -190,7 +190,7 @@ export interface ManifestArg {
 export interface ManifestFlag {
 	/** Flag name (the key from `FlagsDef`) */
 	name: string;
-	/** All accepted CLI spellings in documentation order */
+	/** All accepted CLI spellings in documentation order — the sole source for rendered flag labels */
 	spellings: readonly string[];
 	/** Value type: "string", "number", or "boolean" */
 	type: "string" | "number" | "boolean";
@@ -223,6 +223,7 @@ export interface ManifestFlag {
  *   path: ["git", "remote", "add"],
  *   description: "Add a new remote",
  *   runnable: true,
+ *   usage: "git remote add <name>",
  *   args: [{ name: "name", type: "string", required: true, variadic: false }],
  *   flags: [{ name: "fetch", spellings: ["--fetch", "--no-fetch"], type: "boolean", required: false, multiple: false, aliases: [] }],
  *   children: [],


### PR DESCRIPTION
## Summary

- thread `DocumentationFlag.spellings` through the skills manifest
- render generated skill flag tables in the shared short → canonical → alias → negation order
- remove the package-local flag-label builder and update behavioral expectations
- record a patch changeset for `@crustjs/skills`

Closes #166

PR 1/6 of the skills-refactor stack (#166 -> #181 -> #182 -> #184), based on main.

## Validation

- `bun run check:types` — passed (21/21 tasks)
- `bun run check` — passed (package builds, oxlint, oxfmt)
- `cd packages/skills && bun test` — passed (319 pass, 0 fail)

## Review findings

Independent review returned **NO FINDINGS**. No review fixes were required: the implementation matches issue #166 and the PR brief, the changed markdown ordering and negation spellings are covered end-to-end, the changeset is correct, and no documentation examples were stale.
