### PR TITLE
refactor(core): future-proof FlagDefBrand key projection with FIX_ template pattern

### DIFF
--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -9,7 +9,7 @@ import type { AsyncParseBrand, DefName, Overlap } from "./shared.ts";
 
 /** Extract only the branded error properties from a validated record value. */
 type FlagDefBrand<Name, V> = Name extends keyof V
-	? Pick<V[Name], Extract<keyof V[Name], "FIX_ALIAS_COLLISION" | "FIX_NO_PREFIX">>
+	? Pick<V[Name], Extract<keyof V[Name], `FIX_${string}`>>
 	: {};
 
 /** Brand an incoming definition when one of its spellings is already claimed. */


### PR DESCRIPTION
## What

One-line change in `packages/core/src/validation/flags.ts`:

```ts
type FlagDefBrand<Name, V> = Name extends keyof V
-	? Pick<V[Name], Extract<keyof V[Name], "FIX_ALIAS_COLLISION" | "FIX_NO_PREFIX">>
+	? Pick<V[Name], Extract<keyof V[Name], `FIX_${string}`>>
	: {};
```

## Why

`FlagDefBrand` projects branded error keys from the record-validated pipeline (`ValidateFlagAliases` → `ValidateNoPrefixedFlags`) back onto the tuple elements of `.flags(...defs)`. The projected keys were a hardcoded two-member union — if a future record-level validator is added to the `Validated` pipeline emitting a new `FIX_*` key, the projection would silently drop it and the compile-time error would never reach the offending argument.

The `` `FIX_${string}` `` template pattern is already the repo's brand-selector convention (used throughout `flags.test.ts` / `args.test.ts` parity assertions), so this unifies on it and closes the drift class permanently.

Audit note: this was the **only** hardcoded brand-key projection in the codebase — all other brand sites (args, contexts, commands) apply their brands per-element directly with no projection step.

## Behavior

Preserving. The record pipeline currently emits exactly `FIX_ALIAS_COLLISION` and `FIX_NO_PREFIX`; no key was renamed or rerouted, so tests and docs referencing brand keys are unaffected.

## Validation

- `tsc --noEmit` — clean
- `bun test` (core) — 614 pass, 0 fail
- `tsc --extendedDiagnostics` vs baseline — 586,533 vs 585,988 instantiations (+0.09%), check time unchanged at 0.349s (flags.ts documents instantiation counts as load-bearing; measured neutral)

No changeset: no user-visible change.