### PR TITLE
refactor(core): extract context provide checks into validation/contexts.ts

### DIFF
--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -35,11 +35,12 @@ import {
 	type ValidateCommandConfig,
 	type ValidateCommandDefinitions,
 } from "../validation/commands.ts";
-import type {
-	ContextDeps,
-	MergeContextDeps,
-	ValidateContextCycles,
-	ValidateContextNames,
+import {
+	type ContextDeps,
+	type MergeContextDeps,
+	validateIncomingContext,
+	type ValidateContextCycles,
+	type ValidateContextNames,
 } from "../validation/contexts.ts";
 import {
 	type ProvideChecks,
@@ -659,7 +660,7 @@ export class Crust<
 		const ownedFlags = { ...this._node.ownedFlags };
 		const effectiveFlags = { ...this._node.effectiveFlags };
 		for (const instance of instances) {
-			this._assertContextProvidable(instance as ContextInstance, contexts);
+			validateIncomingContext(instance as ContextInstance, contexts);
 			for (const [name, def] of Object.entries(instance.ownedFlags)) {
 				validateIncomingFlag({ name, def }, effectiveFlags, `Context "${instance.name}"`);
 				ownedFlags[name] = def;
@@ -681,32 +682,6 @@ export class Crust<
 			Sibs,
 			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 		>;
-	}
-
-	private _assertContextProvidable(
-		instance: ContextInstance,
-		existing: readonly ContextInstance[],
-	): void {
-		// Catches plain-JS misuse, most commonly passing the factory instead
-		// of an instance (.provide(db) instead of .provide(db())).
-		if ((instance as Partial<ContextInstance> | null)?.kind !== "context") {
-			throw new CrustError(
-				"DEFINITION",
-				"provide() requires Context instances — invoke the factory returned by defineContext() (e.g. .provide(db(options)))",
-				{ subject: "context", reason: "not-a-context" },
-			);
-		}
-		if (existing.some((entry) => entry.name === instance.name)) {
-			throw new CrustError(
-				"DEFINITION",
-				`Context "${instance.name}" is already provided on this command path`,
-				{
-					subject: "context",
-					name: instance.name,
-					reason: "duplicate-context",
-				},
-			);
-		}
 	}
 
 	/**

--- a/packages/core/src/validation/contexts.ts
+++ b/packages/core/src/validation/contexts.ts
@@ -1,4 +1,5 @@
 import type { ContextInstance, ContextMap } from "../api/context.ts";
+import { CrustError } from "../errors.ts";
 import type { DefName, Overlap } from "./shared.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -129,3 +130,38 @@ export type ValidateContextCycles<
 > = {
 	[I in keyof Cs]: Cs[I] & ContextCycleBrand<Cs[I], Merged>;
 };
+
+// ────────────────────────────────────────────────────────────────────────────
+// Runtime validation
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate one incoming Context instance against those already provided on
+ * the command path. The type system already rejects both misuses; this
+ * catches plain-JS callers.
+ */
+export function validateIncomingContext(
+	instance: ContextInstance,
+	existing: readonly ContextInstance[],
+): void {
+	// Catches plain-JS misuse, most commonly passing the factory instead
+	// of an instance (.provide(db) instead of .provide(db())).
+	if ((instance as Partial<ContextInstance> | null)?.kind !== "context") {
+		throw new CrustError(
+			"DEFINITION",
+			"provide() requires Context instances — invoke the factory returned by defineContext() (e.g. .provide(db(options)))",
+			{ subject: "context", reason: "not-a-context" },
+		);
+	}
+	if (existing.some((entry) => entry.name === instance.name)) {
+		throw new CrustError(
+			"DEFINITION",
+			`Context "${instance.name}" is already provided on this command path`,
+			{
+				subject: "context",
+				name: instance.name,
+				reason: "duplicate-context",
+			},
+		);
+	}
+}


### PR DESCRIPTION
## What

Moves the runtime `.provide()` guards (non-instance misuse, duplicate context name) from the private `Crust._assertContextProvidable` method into a free `validateIncomingContext(instance, existing)` in `src/validation/contexts.ts`, under a new **Runtime validation** section.

## Why

Every other `validation/*.ts` module (`flags`, `args`, `commands`) owns both the compile-time brand types and the runtime guards for its subject — `contexts.ts` was the only outlier, holding compile-time types only. This aligns it with the established pattern (`validateIncomingFlag`, `validateIncomingAliases`).

`sortContexts` stays in `api/context.ts` deliberately: it is ordering machinery that `buildContexts` depends on, not a validation helper.

## Notes

- No behavior change; error messages and metadata are identical.
- No changeset: internal refactor, not user-visible.

## Verification

- `tsc --noEmit` — exit 0
- `bun test` (packages/core) — 614 pass / 0 fail
- `biome check` — no new findings (8 pre-existing `noExplicitAny` on main, unchanged)