### PR TITLE
refactor(core): single-source definition validation, drop synthetic argv from tree walk

### DIFF
--- a/.changeset/single-source-definition-validation.md
+++ b/.changeset/single-source-definition-validation.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Build-tree validation and the runtime parser now share one definition-validation gate (`validateDefinition`) instead of the tree walk fabricating a synthetic argv. Variadic-arg position violations on dynamically installed commands are now always caught — previously the build walk only caught them when a required arg happened to follow the variadic one, and `parseArgs` now fails fast with a `DEFINITION` error instead of silently mis-parsing.

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -14,6 +14,7 @@ import type {
 	ParseResult,
 	ValueType,
 } from "../types.ts";
+import { validateVariadicArgPosition } from "../validation/args.ts";
 import { coerceJson, coercePath, coerceUrl } from "./coercers.ts";
 import { flagSpellings, type FlagSpelling } from "./spellings.ts";
 
@@ -433,6 +434,38 @@ function validateNoNegateUsage(argv: string[], spellings: ReadonlyMap<string, Fl
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// validateDefinition — Definition-class validation
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a command's arg/flag *definitions* — checks that are pure
+ * functions of the definitions and involve no argv:
+ *
+ * - Flag alias collisions (across `effectiveFlags`, so Context-owned and
+ *   local flags share one namespace)
+ * - Reserved `no-` prefix violations and invalid flag types
+ * - Async `parse` functions
+ * - Variadic arg position (only the last positional may be variadic)
+ *
+ * Called at the top of {@link parseArgs} so runtime parsing fails fast on
+ * misconfigured commands, and directly by `validateCommandTree` so build
+ * validation exercises the exact same rules. Definition rules live only
+ * here — add new ones to this function, never to the tree walk.
+ *
+ * @throws {CrustError} `DEFINITION` on violation
+ */
+export function validateDefinition(command: CommandNode): void {
+	const argsDef = command.args;
+	const flagsDef = command.effectiveFlags;
+
+	validateAsyncParse(flagsDef, argsDef);
+	// Building the spelling table throws on collisions / no- prefix / bad types.
+	flagSpellings(flagsDef);
+
+	argsDef?.forEach((def, index) => validateVariadicArgPosition(def, index, argsDef.length));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // parseArgs — Main parsing function
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -459,9 +492,9 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 	const argsDef = command.args;
 	const flagsDef = command.effectiveFlags;
 
-	// CONFIG-class validation: reject async parse fns up-front so the parser
-	// never sees a Promise where a value was expected.
-	validateAsyncParse(flagsDef, argsDef);
+	// Definition-class validation up-front so misconfigured commands fail
+	// fast, through the same gate build validation uses.
+	validateDefinition(command);
 
 	const spellings = flagSpellings(flagsDef);
 	const { options: parseOptions, aliasToName } = buildParseArgsOptionDescriptor(spellings);

--- a/packages/core/src/validation/tree.test.ts
+++ b/packages/core/src/validation/tree.test.ts
@@ -128,7 +128,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 		node.localFlags = localFlags;
 		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
-		// Should pass because createValidationArgv generates --token sample
+		// Required flags are a runtime input concern, not a definition error.
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 
@@ -234,7 +234,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 		);
 	});
 
-	it("required ancestor-owned flag included in validation argv", () => {
+	it("required ancestor-owned flag does not fail build validation", () => {
 		// The ancestor-owned flags include a required string flag
 		const ancestorOwnedFlags = {
 			token: {
@@ -249,7 +249,7 @@ describe("validateCommandTree — CommandNode tree", () => {
 		node.localFlags = localFlags;
 		node.effectiveFlags = computeEffectiveFlags(ancestorOwnedFlags, localFlags);
 
-		// Should NOT throw — createValidationArgv includes --token sample
+		// Should NOT throw — required flags are an input error, not a definition error
 		expect(() => validateCommandTree(node)).not.toThrow();
 	});
 

--- a/packages/core/src/validation/tree.ts
+++ b/packages/core/src/validation/tree.ts
@@ -1,87 +1,28 @@
 import { sortContexts } from "../api/context.ts";
 import type { CommandNode } from "../command/node.ts";
 import { CrustError } from "../errors.ts";
-import { parseArgs, validateParsed } from "../parsing/parser.ts";
-import type { ArgDef, FlagDef } from "../types.ts";
+import { validateDefinition } from "../parsing/parser.ts";
 import { validateIncomingAliases } from "./commands.ts";
-
-// ────────────────────────────────────────────────────────────────────────────
-// Internal helpers
-// ────────────────────────────────────────────────────────────────────────────
-
-/** Returns a synthetic token that satisfies `parseArgs` for the given type. */
-function sampleToken(def: ArgDef | FlagDef): string {
-	// When `choices` is declared, picking any value outside the list now
-	// throws at parse time. Use the first declared choice so the
-	// synthetic argv always passes the choices gate.
-	const choices = (def as { choices?: readonly string[] }).choices;
-	if (choices !== undefined && choices.length > 0) return choices[0] as string;
-	switch (def.type) {
-		case "number":
-			return "1";
-		case "boolean":
-			return "true";
-		case "url":
-			return "https://example.com";
-		case "json":
-			return "null";
-		default:
-			return "sample";
-	}
-}
-
-/**
- * Build a synthetic argv that satisfies `parseArgs` for the given command.
- *
- * Uses `effectiveFlags` so propagated required flags are included in the
- * synthetic argv.
- */
-function createValidationArgv(command: CommandNode): string[] {
-	const argv: string[] = [];
-
-	const flags = command.effectiveFlags;
-
-	for (const [name, def] of Object.entries(flags as Record<string, FlagDef>)) {
-		// Skip flags that are optional or have defaults — parseArgs won't
-		// complain about them being absent.
-		if (def.required !== true || def.default !== undefined) continue;
-
-		argv.push(`--${name}`);
-		if (def.type !== "boolean") {
-			argv.push(sampleToken(def));
-		}
-	}
-
-	const args = command.args;
-
-	if (args) {
-		for (const def of args) {
-			// Skip args that are optional or have defaults.
-			if (def.required !== true || def.default !== undefined) continue;
-
-			argv.push(sampleToken(def));
-		}
-	}
-
-	return argv;
-}
 
 // ────────────────────────────────────────────────────────────────────────────
 // validateCommandTree — Tree validation
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
- * Validate an entire command tree by walking each node and calling `parseArgs`
- * with a synthetic argv derived from the node's flag/arg definitions.
+ * Validate an entire command tree by walking each node and running the
+ * definition-class checks the runtime parser itself uses
+ * (`validateDefinition`), plus Context dependency resolution.
  *
  * This catches:
- * - Alias collisions (including between Context-owned and local flags)
- * - `no-` prefix violations
- * - Required flag/arg validation
+ * - Flag alias collisions (including between Context-owned and local flags,
+ *   via `effectiveFlags`)
+ * - `no-` prefix violations and invalid flag types
+ * - Async `parse` functions
  * - Variadic arg position violations
+ * - Missing/cyclic Context dependencies
  *
- * Uses `effectiveFlags` (Context-owned + local merged) so alias collisions
- * between a Context-owned flag and a local flag are caught.
+ * The rules themselves live in `validateDefinition` and `sortContexts` —
+ * this walk only provides tree coverage and path-labelled errors.
  *
  * @param root - The root command node to validate
  * @throws {CrustError} `DEFINITION` with the full command path on failure
@@ -101,8 +42,7 @@ export function validateCommandTree(root: CommandNode): void {
 		visited.add(command);
 
 		try {
-			const parsed = parseArgs(command, createValidationArgv(command));
-			validateParsed(command, parsed);
+			validateDefinition(command);
 			// Context dependency resolution (missing deps, cycles) fails at
 			// build validation, not first dispatch.
 			sortContexts(command.contexts, `the "${path.join(" ")}" command path`);


### PR DESCRIPTION
## Why

`validateCommandTree` validated each node by fabricating a synthetic argv (`sampleToken` / `createValidationArgv`) and round-tripping it through `parseArgs` to smoke out definition errors. That re-encoded parser assumptions outside the parser — which types accept what token, that `choices` gates raw values, that booleans take no value — and it had already drifted once (the `choices` patch comment in `tree.ts`). Drift here can also *silently pass*: the synthetic argv only supplied required flags, so rules that fire on optional-flag shapes were never exercised.

## What

- **`parsing/parser.ts`**: new exported `validateDefinition(command)` — the definition-class checks that are pure functions of the node and involve no argv: async `parse` rejection, `flagSpellings` (alias collisions, `no-` prefix, invalid types), and `validateVariadicArgPosition`. `parseArgs` calls it up front; its doc states definition rules live only there.
- **`validation/tree.ts`**: the walk now calls `validateDefinition` + `sortContexts` directly. `sampleToken`, `createValidationArgv`, and the synthetic parse round-trip are deleted (−78 lines). The file no longer encodes any parser assumptions.
- **`tree.test.ts`**: stale comments referencing `createValidationArgv` updated; all assertions untouched (behavior-based, so they double as the refactor's proof).

## Behavior change (deliberate)

Variadic-arg position violations on commands installed outside the builder (extensions mutating `subCommands`) were previously only caught when a *required* arg happened to follow the variadic one — a silent false-pass. Now `validateDefinition` checks position directly, so both build validation and `parseArgs` fail fast with a `DEFINITION` error. Changeset included (patch).

## Verification

- `bun test` (core): 614 pass, 0 fail
- `bun run test` (all packages): green
- `bun run check:types`, `oxlint`, `oxfmt --check`: clean