### PR TITLE
refactor(core): reuse Partial<InvocationIO> for optional IO overrides

### DIFF
--- a/.changeset/plain-trees-kneel.md
+++ b/.changeset/plain-trees-kneel.md
@@ -3,4 +3,4 @@
 "@crustjs/testing": patch
 ---
 
-Reuse the canonical InvocationIO type for optional command IO overrides.
+Reuse the canonical InvocationIO type for optional command IO overrides. Type-level only; no runtime behavior change.

--- a/.changeset/plain-trees-kneel.md
+++ b/.changeset/plain-trees-kneel.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/core": patch
+"@crustjs/testing": patch
+---
+
+Reuse the canonical InvocationIO type for optional command IO overrides.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -364,6 +364,8 @@ import type { InvocationIO } from "@crustjs/core";
 run(argv: readonly string[], io?: Partial<InvocationIO>): Promise<void>
 ```
 
+The [`InvocationIO`](/docs/api/types#invocationio) type is exported from `@crustjs/core`.
+
 Invokes an application programmatically. `argv` is required and does not include the executable name.
 
 ```ts
@@ -379,8 +381,6 @@ await app.run(["Ada"], {
 ## `.execute(options?)`
 
 ```ts
-import type { InvocationIO } from "@crustjs/core";
-
 execute(options?: {
   argv?: string[];
   io?: Partial<InvocationIO>;

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -359,13 +359,9 @@ The `CommandSnapshot` type is exported from `@crustjs/core/tooling`; see the [co
 ## `.run(argv, io?)`
 
 ```ts
-run(
-  argv: readonly string[],
-  io?: {
-    stdout?: (text: string) => void;
-    stderr?: (text: string) => void;
-  },
-): Promise<void>
+import type { InvocationIO } from "@crustjs/core";
+
+run(argv: readonly string[], io?: Partial<InvocationIO>): Promise<void>
 ```
 
 Invokes an application programmatically. `argv` is required and does not include the executable name.
@@ -383,12 +379,11 @@ await app.run(["Ada"], {
 ## `.execute(options?)`
 
 ```ts
+import type { InvocationIO } from "@crustjs/core";
+
 execute(options?: {
   argv?: string[];
-  io?: {
-    stdout?: (text: string) => void;
-    stderr?: (text: string) => void;
-  };
+  io?: Partial<InvocationIO>;
 }): Promise<void>
 ```
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -16,10 +16,9 @@ bun add -d @crustjs/testing
 `captureRun()` and `runInteractive()` accept the exported `RunnableApp` structural contract:
 
 ```ts
-interface CaptureIO {
-  readonly stdout?: (text: string) => void;
-  readonly stderr?: (text: string) => void;
-}
+import type { InvocationIO } from "@crustjs/core";
+
+type CaptureIO = Partial<InvocationIO>;
 
 interface RunnableApp {
   run(argv: readonly string[], io?: CaptureIO): Promise<void>;

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -25,6 +25,8 @@ interface RunnableApp {
 }
 ```
 
+See [`InvocationIO`](/docs/api/types#invocationio) for the underlying IO callback shape.
+
 `captureExecute()` instead accepts an `ExecutableApp`:
 
 ```ts

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -803,13 +803,7 @@ export class Crust<
 	 * @param io - Optional `stdout(text)` / `stderr(text)` callbacks, also
 	 *             exposed to Command Actions and Extensions
 	 */
-	async run(
-		argv: readonly string[],
-		io?: {
-			stdout?: (text: string) => void;
-			stderr?: (text: string) => void;
-		},
-	): Promise<void> {
+	async run(argv: readonly string[], io?: Partial<InvocationIO>): Promise<void> {
 		// Programmatic calls preserve raw failures and never change process status.
 		await runInvocation(this._node, argv, io, materializeCommandDefinition);
 	}
@@ -827,10 +821,7 @@ export class Crust<
 	 *                   `io` for in-process testing of exit codes and
 	 *                   rendered failures)
 	 */
-	async execute(options?: {
-		argv?: string[];
-		io?: { stdout?: (text: string) => void; stderr?: (text: string) => void };
-	}): Promise<void> {
+	async execute(options?: { argv?: string[]; io?: Partial<InvocationIO> }): Promise<void> {
 		// Terminal calls render failures and set process exit status instead of throwing.
 		await executeInvocation(this._node, options, materializeCommandDefinition);
 	}

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -322,7 +322,7 @@ async function renderFailure(
 export async function runInvocation(
 	node: CommandNode,
 	argv: readonly string[],
-	io: { stdout?: (text: string) => void; stderr?: (text: string) => void } | undefined,
+	io: Partial<InvocationIO> | undefined,
 	materializeCommandDefinition: MaterializeCommandDefinition,
 ): Promise<void> {
 	const resolvedIO: InvocationIO = { ...DEFAULT_IO, ...io };
@@ -336,7 +336,7 @@ export async function executeInvocation(
 	options:
 		| {
 				argv?: string[];
-				io?: { stdout?: (text: string) => void; stderr?: (text: string) => void };
+				io?: Partial<InvocationIO>;
 		  }
 		| undefined,
 	materializeCommandDefinition: MaterializeCommandDefinition,

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,11 +1,9 @@
+import type { InvocationIO } from "@crustjs/core";
 import { withPromptIO } from "@crustjs/prompts";
 import { createPromptIO } from "@crustjs/prompts/testing";
 
 /** Structural io shape shared by `run()` and `execute()` captures. */
-export interface CaptureIO {
-	readonly stdout?: (text: string) => void;
-	readonly stderr?: (text: string) => void;
-}
+export type CaptureIO = Partial<InvocationIO>;
 
 /** Minimal structural surface invoked by the testing helpers. */
 export interface RunnableApp {


### PR DESCRIPTION
## Summary

`InvocationIO` (`packages/core/src/types.ts`) was duplicated as inline `{ stdout?: (text: string) => void; stderr?: (text: string) => void }` object types at every optional-IO boundary. This replaces those with `Partial<InvocationIO>` so the shape has a single source of truth.

## Changes

- `packages/core/src/command/crust.ts` — `run()` / `execute()` signatures use `Partial<InvocationIO>`
- `packages/core/src/command/invocation.ts` — `runInvocation()` / `executeInvocation()` likewise
- `packages/testing/src/index.ts` — `CaptureIO` is now `type CaptureIO = Partial<InvocationIO>` (was a structurally identical interface; drops declaration merging, no assignability change)
- `apps/docs/content/docs/api/crust.mdx`, `apps/docs/content/docs/modules/testing.mdx` — doc signatures synced
- Changeset: patch for `@crustjs/core` and `@crustjs/testing` (emitted `.d.ts` changes; runtime behavior unchanged)

## Validation

- `bun run check:types` — 21/21 pass
- `bun run test` — 116 tests, 0 fail
- `bun run lint`, `bun run format` — clean

No tests added: type-level refactor with identical caller semantics.