### PR TITLE
feat(core)!: accept named flag definitions in defineExtension

### DIFF
--- a/.changeset/named-extension-flags.md
+++ b/.changeset/named-extension-flags.md
@@ -4,4 +4,4 @@
 "@crustjs/skills": patch
 ---
 
-Change `defineExtension()` flag authoring to a readonly array of named definitions, matching `.flags()` and `defineContext()`. Replace extension flag records such as `{ verbose: { type: "boolean" } }` with `[{ name: "verbose", type: "boolean" }]`; use an inline definition to set the Extension-only `recursive` option.
+Change `defineExtension()` flag authoring to a readonly array of named definitions, matching `.flags()` and `defineContext()`. Replace extension flag records such as `{ verbose: { type: "boolean" } }` with `[{ name: "verbose", type: "boolean" }]`; an inline definition is the documented way to set the Extension-only `recursive` option. Intra-extension flag spelling collisions now surface when `defineExtension()` is called instead of during application preparation.

--- a/.changeset/named-extension-flags.md
+++ b/.changeset/named-extension-flags.md
@@ -4,4 +4,4 @@
 "@crustjs/skills": patch
 ---
 
-Change `defineExtension()` flag authoring to a readonly array of named definitions, matching `.flags()` and `defineContext()`. Replace extension flag records such as `{ verbose: { type: "boolean" } }` with `[{ name: "verbose", type: "boolean" }]`; an inline definition is the documented way to set the Extension-only `recursive` option. Intra-extension flag spelling collisions now surface when `defineExtension()` is called instead of during application preparation.
+Change `defineExtension()` flag authoring to a readonly array of named definitions, matching `.flags()` and `defineContext()`. Replace extension flag records such as `{ verbose: { type: "boolean" } }` with `[{ name: "verbose", type: "boolean" }]`; an inline definition is the documented way to set the Extension-only `recursive` option. Intra-extension flag spelling collisions now surface when `defineExtension()` is called instead of during application preparation. The exported `InferExtensionFlags`, `ExtensionContext`, `ExtensionHooks`, and `ExtensionConfig` generics now take the readonly named-definition array instead of a record.

--- a/.changeset/named-extension-flags.md
+++ b/.changeset/named-extension-flags.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": patch
+"@crustjs/skills": patch
+---
+
+Change `defineExtension()` flag authoring to a readonly array of named definitions, matching `.flags()` and `defineContext()`. Replace extension flag records such as `{ verbose: { type: "boolean" } }` with `[{ name: "verbose", type: "boolean" }]`; use an inline definition to set the Extension-only `recursive` option.

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -224,9 +224,17 @@ type ExtensionFlagDef = FlagDef & { readonly recursive?: boolean };
 
 An Extension owns contributed flags. `recursive` defaults to `true`; `false` contributes the flag only to the root.
 
-### `InferExtensionFlags<F>`
+### `NamedExtensionFlagDef`
 
-Infers the syntax-parsed values of the flags contributed by an Extension and exposed to its hooks. A flag with `recursive: false` may be `undefined` when a descendant command is invoked because that flag is contributed only to the root.
+```ts
+type NamedExtensionFlagDef = NamedFlagDef & { readonly recursive?: boolean };
+```
+
+The public authoring shape accepted by `ExtensionConfig.flags`: an Extension flag definition carrying its name and optional recursive scope.
+
+### `InferExtensionFlags<Defs>`
+
+Infers the syntax-parsed values from an Extension's named-definition array and exposes them to its hooks. A flag with `recursive: false` may be `undefined` when a descendant command is invoked because that flag is contributed only to the root.
 
 ### `ExtensionContext`
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -33,7 +33,15 @@ Two consequences of the root-only model:
 
 ## Owned flags and commands
 
-Extension flags default to `recursive: true`, which contributes them to every command. Set `recursive: false` for a root-only flag. `defineExtension()` infers owned flags in its hooks, so `ctx.flags.trace` in the example above is `boolean | undefined`; a root-only flag also includes `undefined` because a subcommand does not receive it. Other, command-specific flag names remain accessible as `unknown`. Hook contexts retain syntax-parsed values; schema validation produces separate values for Contexts and the Command Action.
+Extension flags are a readonly array of named definitions. Use `defineFlag()` values for ordinary recursive flags, or write a named definition inline. Extension flags default to `recursive: true`, which contributes them to every command. For a root-only flag, use an inline definition because `recursive` is Extension-specific and is not accepted by `defineFlag()`:
+
+```ts
+const rootOnlyVersion = defineExtension("version", {
+  flags: [{ name: "version", type: "boolean", recursive: false }],
+});
+```
+
+`defineExtension()` infers owned flags in its hooks, so `ctx.flags.trace` in the example above is `boolean | undefined`; a root-only flag also includes `undefined` because a subcommand does not receive it. Other, command-specific flag names remain accessible as `unknown`. Hook contexts retain syntax-parsed values; schema validation produces separate values for Contexts and the Command Action.
 
 Ordinary command flags are always local; Context-owned flags are the application-level propagation mechanism.
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -33,7 +33,7 @@ Two consequences of the root-only model:
 
 ## Owned flags and commands
 
-Extension flags are a readonly array of named definitions. Use `defineFlag()` values for ordinary recursive flags, or write a named definition inline. Extension flags default to `recursive: true`, which contributes them to every command. For a root-only flag, use an inline definition because `recursive` is Extension-specific and is not accepted by `defineFlag()`:
+Extension flags are a readonly array of named definitions. Use `defineFlag()` values for ordinary recursive flags, or write a named definition inline. Extension flags default to `recursive: true`, which contributes them to every command. The documented way to set the Extension-only `recursive` option for a root-only flag is an inline definition:
 
 ```ts
 const rootOnlyVersion = defineExtension("version", {

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -107,16 +107,17 @@ See [Types](/docs/api/types) for field-level definitions.
 
 ## Extension types
 
-| Type                  | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `Extension`           | Named frozen Extension value                                                |
-| `ExtensionConfig`     | Owned flags, `CommandDefinition` commands, and named hooks                  |
-| `ExtensionFlagDef`    | Extension-owned flag with optional `recursive` scope                        |
-| `ExtensionContext`    | Readonly invocation view with inferred Extension-owned flags and `finish()` |
-| `ExtensionHooks`      | Typed `preRun`, `postRun`, and `onError` hook slots                         |
-| `InferExtensionFlags` | Syntax-parsed values inferred from an Extension's contributed flags         |
-| `Finished`            | Opaque token returned by `ExtensionContext.finish()`                        |
-| `InvocationOutcome`   | Completed, short-circuited, or failed invocation result                     |
+| Type                    | Description                                                                 |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `Extension`             | Named frozen Extension value                                                |
+| `ExtensionConfig`       | Owned flags, `CommandDefinition` commands, and named hooks                  |
+| `ExtensionFlagDef`      | Extension-owned flag with optional `recursive` scope                        |
+| `ExtensionContext`      | Readonly invocation view with inferred Extension-owned flags and `finish()` |
+| `ExtensionHooks`        | Typed `preRun`, `postRun`, and `onError` hook slots                         |
+| `InferExtensionFlags`   | Syntax-parsed values inferred from an Extension's contributed flags         |
+| `NamedExtensionFlagDef` | Named Extension flag accepted by `ExtensionConfig.flags`                    |
+| `Finished`              | Opaque token returned by `ExtensionContext.finish()`                        |
+| `InvocationOutcome`     | Completed, short-circuited, or failed invocation result                     |
 
 ## Error types
 

--- a/apps/docs/examples/extensions/diagnostics.ts
+++ b/apps/docs/examples/extensions/diagnostics.ts
@@ -3,12 +3,13 @@ import { type ExtensionContext, defineCommand, defineExtension } from "@crustjs/
 const timers = new WeakMap<ExtensionContext, number>();
 
 export const diagnostics = defineExtension("diagnostics", {
-  flags: {
-    trace: {
+  flags: [
+    {
+      name: "trace",
       type: "boolean",
       description: "Print diagnostic timing",
     },
-  },
+  ],
   commands: [
     defineCommand("doctor", { description: "Check the installation" }, (command) =>
       command.action(({ rootCommand, stdout }) => stdout(`checking ${rootCommand.meta.name}`)),

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -65,9 +65,7 @@ describe("public beta API", () => {
 	it("loads extensions separately from command context", async () => {
 		let wrapperCalled = false;
 		const version = defineExtension("version", {
-			flags: {
-				version: { type: "boolean" },
-			},
+			flags: [{ name: "version", type: "boolean" }],
 			hooks: {
 				preRun() {
 					wrapperCalled = true;
@@ -88,9 +86,7 @@ describe("public beta API", () => {
 	it("can execute repeatedly without freezing or accumulating extension setup on the source builder", async () => {
 		let runCount = 0;
 		const debug = defineExtension("debug", {
-			flags: {
-				debug: { type: "boolean" },
-			},
+			flags: [{ name: "debug", type: "boolean" }],
 		});
 		const app = new Crust("repeat").extend(debug).action(({ flags }) => {
 			if ((flags as Record<string, unknown>).debug) {

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -411,7 +411,7 @@ describe("Context-owned flags", () => {
 	it("rejects Extension collisions regardless of fluent registration order", async () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, () => ({}));
 		const extension = defineExtension("auth-extension", {
-			flags: { other: { type: "string", aliases: ["api-key"] } },
+			flags: [{ name: "other", type: "string", aliases: ["api-key"] }],
 		});
 
 		await expect(new Crust("cli").extend(extension).provide(auth()).run([])).rejects.toThrow(

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -8,6 +8,7 @@ import type {
 	NamedFlagDef,
 	NamedFlagsRecord,
 } from "../types.ts";
+import { validateSchemaExclusivity } from "../validation/args.ts";
 import { validateIncomingFlag, type ValidateNamedFlagDefs } from "../validation/flags.ts";
 
 export type ContextMap = Record<string, unknown>;
@@ -204,6 +205,7 @@ export function defineContext(
 	const ownedFlags: FlagsDef = {};
 	for (const def of config.flags ?? []) {
 		const { name: flagName, ...rest } = def;
+		validateSchemaExclusivity("flag", flagName, rest as FlagDef);
 		validateIncomingFlag({ name: flagName, def: rest as FlagDef }, ownedFlags, `Context "${name}"`);
 		ownedFlags[flagName] = rest as FlagDef;
 	}

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -209,7 +209,7 @@ export function defineExtension<const Defs extends readonly NamedExtensionFlagDe
 	const ownedFlags: FlagsDef = {};
 	for (const def of config.flags ?? []) {
 		const { name: flagName, ...rest } = def;
-		if (flagName in ownedFlags) {
+		if (Object.hasOwn(ownedFlags, flagName)) {
 			throw new CrustError(
 				"DEFINITION",
 				`Extension "${name}" flag "--${flagName}" is already defined`,

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -9,6 +9,7 @@ import type {
 	NamedFlagDef,
 	NamedFlagsRecord,
 } from "../types.ts";
+import { validateSchemaExclusivity } from "../validation/args.ts";
 import { validateIncomingFlag, type ValidateNamedFlagDefs } from "../validation/flags.ts";
 import type { Awaitable } from "./context.ts";
 
@@ -170,11 +171,18 @@ export interface ExtensionConfig<
 	Defs extends readonly NamedExtensionFlagDef[] = readonly NamedExtensionFlagDef[],
 > {
 	/** Flags this Extension owns and contributes to the application */
-	readonly flags?: ValidateNamedFlagDefs<Defs>;
+	readonly flags?: Defs;
 	/** Root command definitions this Extension owns and contributes to the application */
 	readonly commands?: readonly CommandDefinition<any>[];
 	readonly hooks?: ExtensionHooks<Defs>;
 }
+
+// Branding lives on the defineExtension signature, not on ExtensionConfig
+// itself, so docs render the readable array type while duplicate/alias
+// collisions still fail at the call site — mirrors defineContext.
+type ValidateExtensionConfig<Defs extends readonly NamedExtensionFlagDef[]> = {
+	readonly flags?: ValidateNamedFlagDefs<Defs>;
+};
 
 /**
  * An application-wide reusable capability. A plain frozen structural value —
@@ -192,12 +200,13 @@ export interface Extension {
  *
  * Extensions apply to the whole application and own the flags and commands
  * they contribute; contributed names must not collide with application or
- * other Extension definitions (collisions are definition errors, surfaced
- * when the application runs).
+ * other Extension definitions. Collisions within one Extension throw here at
+ * define time; collisions with application or other Extension definitions
+ * surface when the application prepares.
  */
 export function defineExtension<const Defs extends readonly NamedExtensionFlagDef[] = []>(
 	name: string,
-	config: ExtensionConfig<Defs> = {},
+	config: ExtensionConfig<Defs> & ValidateExtensionConfig<Defs> = {},
 ): Extension {
 	if (!name.trim()) {
 		throw new CrustError("DEFINITION", "Extension name must be a non-empty string", {
@@ -209,13 +218,7 @@ export function defineExtension<const Defs extends readonly NamedExtensionFlagDe
 	const ownedFlags: FlagsDef = {};
 	for (const def of config.flags ?? []) {
 		const { name: flagName, ...rest } = def;
-		if (Object.hasOwn(ownedFlags, flagName)) {
-			throw new CrustError(
-				"DEFINITION",
-				`Extension "${name}" flag "--${flagName}" is already defined`,
-				{ subject: "flag", name: flagName, reason: "flag-collision" },
-			);
-		}
+		validateSchemaExclusivity("flag", flagName, rest as FlagDef);
 		validateIncomingFlag(
 			{ name: flagName, def: rest as FlagDef },
 			ownedFlags,

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -1,7 +1,15 @@
 import type { CommandDefinition } from "../command/crust.ts";
 import type { CommandSnapshot } from "../command/snapshot.ts";
 import { CrustError } from "../errors.ts";
-import type { FlagDef, InferFlags, InvocationIO } from "../types.ts";
+import type {
+	FlagDef,
+	FlagsDef,
+	InferFlags,
+	InvocationIO,
+	NamedFlagDef,
+	NamedFlagsRecord,
+} from "../types.ts";
+import { validateIncomingFlag, type ValidateNamedFlagDefs } from "../validation/flags.ts";
 import type { Awaitable } from "./context.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -36,7 +44,7 @@ export type InvocationOutcome =
  * Examples below assume the `tool deploy api --trace -- --dry-run` invocation.
  */
 export interface ExtensionContext<
-	F extends Record<string, ExtensionFlagDef> = {},
+	Defs extends readonly NamedExtensionFlagDef[] = [],
 > extends Readonly<InvocationIO> {
 	/**
 	 * Complete argv passed to the application, including routed command names.
@@ -81,7 +89,7 @@ export interface ExtensionContext<
 	 *
 	 * @example `{ trace: true }`
 	 */
-	readonly flags: Readonly<InferExtensionFlags<F> & Record<string, unknown>>;
+	readonly flags: Readonly<InferExtensionFlags<Defs> & Record<string, unknown>>;
 	/**
 	 * Positional values that appeared after the `--` separator.
 	 *
@@ -101,18 +109,18 @@ export interface ExtensionContext<
 	readonly finish: () => Finished;
 }
 
-export interface ExtensionHooks<F extends Record<string, ExtensionFlagDef> = {}> {
+export interface ExtensionHooks<Defs extends readonly NamedExtensionFlagDef[] = []> {
 	/**
 	 * Runs after routing and syntax parsing, before validation, in `.extend()` order.
 	 * Return `ctx.finish()` to end the invocation successfully; later pre-run hooks,
 	 * validation, schemas, Contexts, and the Command Action do not run.
 	 */
-	readonly preRun?: (ctx: ExtensionContext<F>) => Awaitable<void | Finished>;
+	readonly preRun?: (ctx: ExtensionContext<Defs>) => Awaitable<void | Finished>;
 	/**
 	 * Runs after the invocation settles, in reverse `.extend()` order. This is the
 	 * `finally` slot for cleanup and post-run side effects.
 	 */
-	readonly postRun?: (ctx: ExtensionContext<F>, outcome: InvocationOutcome) => Awaitable<void>;
+	readonly postRun?: (ctx: ExtensionContext<Defs>, outcome: InvocationOutcome) => Awaitable<void>;
 	/**
 	 * Renders a failure in `execute()` only. Return true when rendered to stop the
 	 * chain; falsy values delegate to the next Extension and then Core's renderer.
@@ -129,6 +137,9 @@ export interface ExtensionHooks<F extends Record<string, ExtensionFlagDef> = {}>
  */
 export type ExtensionFlagDef = FlagDef & { readonly recursive?: boolean };
 
+/** A named flag definition accepted by {@link defineExtension}. */
+export type NamedExtensionFlagDef = NamedFlagDef & { readonly recursive?: boolean };
+
 type InferPreSchemaExtensionFlag<F extends ExtensionFlagDef> = F extends { schema: unknown }
 	? F extends { multiple: true }
 		? F extends { type: "boolean" }
@@ -144,19 +155,25 @@ type InferPreSchemaExtensionFlag<F extends ExtensionFlagDef> = F extends { schem
 					InferFlags<{ value: F }>["value"] | undefined
 		: InferFlags<{ value: F }>["value"];
 
+type InferExtensionFlag<F> = F extends ExtensionFlagDef
+	? F extends { recursive: false }
+		? InferPreSchemaExtensionFlag<F> | undefined
+		: InferPreSchemaExtensionFlag<F>
+	: never;
+
 /** Infer the syntax-parsed values visible to an Extension's hooks. */
-export type InferExtensionFlags<F extends Record<string, ExtensionFlagDef>> = {
-	[K in keyof F]: F[K] extends { recursive: false }
-		? InferPreSchemaExtensionFlag<F[K]> | undefined
-		: InferPreSchemaExtensionFlag<F[K]>;
+export type InferExtensionFlags<Defs extends readonly NamedExtensionFlagDef[]> = {
+	[K in keyof NamedFlagsRecord<Defs>]: InferExtensionFlag<NamedFlagsRecord<Defs>[K]>;
 };
 
-export interface ExtensionConfig<F extends Record<string, ExtensionFlagDef> = {}> {
+export interface ExtensionConfig<
+	Defs extends readonly NamedExtensionFlagDef[] = readonly NamedExtensionFlagDef[],
+> {
 	/** Flags this Extension owns and contributes to the application */
-	readonly flags?: Readonly<F>;
+	readonly flags?: ValidateNamedFlagDefs<Defs>;
 	/** Root command definitions this Extension owns and contributes to the application */
 	readonly commands?: readonly CommandDefinition<any>[];
-	readonly hooks?: ExtensionHooks<F>;
+	readonly hooks?: ExtensionHooks<Defs>;
 }
 
 /**
@@ -178,9 +195,9 @@ export interface Extension {
  * other Extension definitions (collisions are definition errors, surfaced
  * when the application runs).
  */
-export function defineExtension<const F extends Record<string, ExtensionFlagDef> = {}>(
+export function defineExtension<const Defs extends readonly NamedExtensionFlagDef[] = []>(
 	name: string,
-	config: ExtensionConfig<F> = {},
+	config: ExtensionConfig<Defs> = {},
 ): Extension {
 	if (!name.trim()) {
 		throw new CrustError("DEFINITION", "Extension name must be a non-empty string", {
@@ -188,6 +205,29 @@ export function defineExtension<const F extends Record<string, ExtensionFlagDef>
 			reason: "empty-name",
 		});
 	}
-	// The runtime registry erases F after defineExtension contextually types its own hooks.
-	return Object.freeze({ ...config, name }) as Extension;
+
+	const ownedFlags: FlagsDef = {};
+	for (const def of config.flags ?? []) {
+		const { name: flagName, ...rest } = def;
+		if (flagName in ownedFlags) {
+			throw new CrustError(
+				"DEFINITION",
+				`Extension "${name}" flag "--${flagName}" is already defined`,
+				{ subject: "flag", name: flagName, reason: "flag-collision" },
+			);
+		}
+		validateIncomingFlag(
+			{ name: flagName, def: rest as FlagDef },
+			ownedFlags,
+			`Extension "${name}"`,
+		);
+		ownedFlags[flagName] = rest as ExtensionFlagDef;
+	}
+
+	// The runtime registry erases Defs after defineExtension contextually types its own hooks.
+	return Object.freeze({
+		...config,
+		...(config.flags === undefined ? {} : { flags: ownedFlags }),
+		name,
+	}) as Extension;
 }

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1044,6 +1044,20 @@ describe("Crust .extend()", () => {
 		expect(ext.name).toBe("typed-flags");
 	});
 
+	it("infers defineFlag() values attached to an Extension", () => {
+		const trace = defineFlag("trace", { type: "boolean", default: false });
+		const ext = defineExtension("defined-flags", {
+			flags: [trace],
+			hooks: {
+				preRun(ctx) {
+					type _trace = Expect<Equal<typeof ctx.flags.trace, boolean>>;
+				},
+			},
+		});
+
+		expect(ext.flags?.trace).toEqual({ type: "boolean", default: false });
+	});
+
 	it("defineExtension() accepts only the named array authoring shape", () => {
 		const typecheckRecordShape = () => {
 			// @ts-expect-error -- Extension flags no longer accept the internal record shape

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1000,26 +1000,31 @@ describe("Crust .extend()", () => {
 	});
 
 	it("defineExtension() returns a frozen plain config", () => {
-		const ext = defineExtension("frozen", { flags: { x: { type: "boolean" } } });
+		const ext = defineExtension("frozen", { flags: [{ name: "x", type: "boolean" }] });
 
 		expect(Object.isFrozen(ext)).toBe(true);
 		expect(ext.name).toBe("frozen");
-		expect(ext.flags?.x?.type).toBe("boolean");
+		expect(ext.flags).toEqual({ x: { type: "boolean" } });
 	});
 
 	it("infers Extension-owned flags in hook contexts", () => {
 		const ext = defineExtension("typed-flags", {
-			flags: {
-				verbose: { type: "boolean", default: false },
-				rootPort: { type: "number", default: 3000, recursive: false },
-				token: { type: "string", required: true },
-				endpoint: { type: "string", schema: {} as StandardSchema<string | undefined, URL> },
-				tags: {
+			flags: [
+				{ name: "verbose", type: "boolean", default: false },
+				{ name: "rootPort", type: "number", default: 3000, recursive: false },
+				{ name: "token", type: "string", required: true },
+				{
+					name: "endpoint",
+					type: "string",
+					schema: {} as StandardSchema<string | undefined, URL>,
+				},
+				{
+					name: "tags",
 					type: "string",
 					multiple: true,
 					schema: {} as StandardSchema<string[], string[]>,
 				},
-			},
+			],
 			hooks: {
 				preRun(ctx) {
 					type _verbose = Expect<Equal<typeof ctx.flags.verbose, boolean>>;
@@ -1037,6 +1042,26 @@ describe("Crust .extend()", () => {
 		});
 
 		expect(ext.name).toBe("typed-flags");
+	});
+
+	it("defineExtension() accepts only the named array authoring shape", () => {
+		const typecheckRecordShape = () => {
+			// @ts-expect-error -- Extension flags no longer accept the internal record shape
+			defineExtension("record-flags", { flags: { mode: { type: "string" } } });
+		};
+		void typecheckRecordShape;
+		expect(true).toBe(true);
+	});
+
+	it("defineExtension() rejects duplicate owned flag names", () => {
+		const flags = [
+			{ name: "mode", type: "string" },
+			{ name: "mode", type: "number" },
+		] as const;
+
+		expect(() => defineExtension("duplicate-flags", { flags: flags as never })).toThrow(
+			'Extension "duplicate-flags" flag "--mode" is already defined',
+		);
 	});
 
 	it("defineExtension() rejects an empty name", () => {
@@ -1084,7 +1109,7 @@ describe("Extension application at prepare time", () => {
 	it("recursive Extension flags reach every command, including Extension commands", async () => {
 		const seen: Record<string, unknown>[] = [];
 		const debug = defineExtension("debug", {
-			flags: { debug: { type: "boolean" } },
+			flags: [{ name: "debug", type: "boolean" }],
 		});
 
 		const app = new Crust("cli").extend(debug).add(
@@ -1102,7 +1127,7 @@ describe("Extension application at prepare time", () => {
 
 	it("non-recursive Extension flags stay on the root", async () => {
 		const version = defineExtension("version", {
-			flags: { version: { type: "boolean", recursive: false } },
+			flags: [{ name: "version", type: "boolean", recursive: false }],
 		});
 
 		const app = new Crust("cli")
@@ -1114,7 +1139,9 @@ describe("Extension application at prepare time", () => {
 	});
 
 	it("Extension flag colliding with an application flag is a DEFINITION error", async () => {
-		const clash = defineExtension("clash", { flags: { verbose: { type: "boolean" } } });
+		const clash = defineExtension("clash", {
+			flags: [{ name: "verbose", type: "boolean" }],
+		});
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean" })
 			.extend(clash)
@@ -1125,7 +1152,7 @@ describe("Extension application at prepare time", () => {
 
 	it("Extension flag short/alias collisions are DEFINITION errors at prepare time", async () => {
 		const clash = defineExtension("clash", {
-			flags: { loud: { type: "boolean", short: "v" } },
+			flags: [{ name: "loud", type: "boolean", short: "v" }],
 		});
 		const app = new Crust("cli")
 			.flags({ name: "verbose", type: "boolean", short: "v" })
@@ -1136,8 +1163,8 @@ describe("Extension application at prepare time", () => {
 	});
 
 	it("Extension flag colliding with another Extension's flag is a DEFINITION error", async () => {
-		const a = defineExtension("a", { flags: { shared: { type: "boolean" } } });
-		const b = defineExtension("b", { flags: { shared: { type: "boolean" } } });
+		const a = defineExtension("a", { flags: [{ name: "shared", type: "boolean" }] });
+		const b = defineExtension("b", { flags: [{ name: "shared", type: "boolean" }] });
 		const app = new Crust("cli").extend(a, b).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
@@ -1159,7 +1186,7 @@ describe("Extension application at prepare time", () => {
 			],
 		});
 		const verbose = defineExtension("verbose", {
-			flags: { verbose: { type: "boolean" } },
+			flags: [{ name: "verbose", type: "boolean" }],
 		});
 
 		const app = new Crust("cli").extend(completion, verbose).action(() => {});
@@ -1249,7 +1276,9 @@ describe("Extension application at prepare time", () => {
 
 	it("does not mutate the source builder across executions", async () => {
 		let runCount = 0;
-		const debug = defineExtension("debug", { flags: { debug: { type: "boolean" } } });
+		const debug = defineExtension("debug", {
+			flags: [{ name: "debug", type: "boolean" }],
+		});
 		const app = new Crust("repeat").extend(debug).action(({ flags }) => {
 			if ((flags as Record<string, unknown>).debug) runCount++;
 		});
@@ -1904,7 +1933,7 @@ describe("Crust .execute()", () => {
 		let receivedFlags: Record<string, unknown> = {};
 
 		const version = defineExtension("version", {
-			flags: { version: { type: "boolean", short: "V" } },
+			flags: [{ name: "version", type: "boolean", short: "V" }],
 		});
 
 		const app = new Crust("test").extend(version).action((ctx) => {
@@ -1920,7 +1949,7 @@ describe("Crust .execute()", () => {
 		let receivedFlags: Record<string, unknown> = {};
 
 		const helpLike = defineExtension("help-like", {
-			flags: { help: { type: "boolean" } },
+			flags: [{ name: "help", type: "boolean" }],
 		});
 		const skillLike = defineExtension("inject-subcommand", {
 			commands: [
@@ -2081,7 +2110,9 @@ describe("Crust .execute()", () => {
 	});
 
 	it("Extension apply error is rendered and sets exitCode", async () => {
-		const clash = defineExtension("clash", { flags: { verbose: { type: "boolean" } } });
+		const clash = defineExtension("clash", {
+			flags: [{ name: "verbose", type: "boolean" }],
+		});
 		const app = new Crust("test")
 			.flags({ name: "verbose", type: "boolean" })
 			.extend(clash)
@@ -2251,9 +2282,7 @@ describe("Invocation pipeline internal seam — validation mode", () => {
 describe("Crust.snapshot", () => {
 	it("returns a frozen snapshot with Extension flags applied", async () => {
 		const docs = defineExtension("doc-test", {
-			flags: {
-				extra: { type: "boolean", description: "Injected for docs" },
-			},
+			flags: [{ name: "extra", type: "boolean", description: "Injected for docs" }],
 		});
 
 		const app = new Crust("cli", { description: "Test" }).extend(docs);
@@ -2285,7 +2314,7 @@ describe("Crust.snapshot", () => {
 
 	it("rejects with CrustError DEFINITION on an invalid command tree", async () => {
 		const clash = defineExtension("clash", {
-			flags: { verbose: { type: "boolean", short: "v" } },
+			flags: [{ name: "verbose", type: "boolean", short: "v" }],
 		});
 		const app = new Crust("cli")
 			.flags({ name: "version", type: "boolean", short: "v" })

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -127,7 +127,11 @@ describe("Crust .flags()", () => {
 	});
 
 	it("deep copies flag definitions (decoupled from caller)", async () => {
-		const flagDef = { name: "verbose" as const, type: "boolean" as const, short: "v" };
+		const flagDef = {
+			name: "verbose" as const,
+			type: "boolean" as const,
+			short: "v",
+		};
 
 		const app = new Crust("test").flags(flagDef);
 
@@ -146,7 +150,10 @@ describe("Crust .flags()", () => {
 	});
 
 	it("throws CrustError DEFINITION at parse time on flag name starting with no-", async () => {
-		const app = new Crust("test").flags({ name: "no-cache", type: "boolean" } as never);
+		const app = new Crust("test").flags({
+			name: "no-cache",
+			type: "boolean",
+		} as never);
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
 	});
@@ -296,7 +303,11 @@ describe("Crust .flags()", () => {
 			// @ts-expect-error -- flag parsers must be synchronous
 			{ name: "file", type: "string", parse: async (raw) => raw },
 		);
-		new Crust("test").flags({ name: "url", type: "string", parse: (raw) => new URL(raw) });
+		new Crust("test").flags({
+			name: "url",
+			type: "string",
+			parse: (raw) => new URL(raw),
+		});
 
 		expect(true).toBe(true);
 	});
@@ -428,7 +439,11 @@ describe("Crust .args()", () => {
 	});
 
 	it("throws CrustError DEFINITION when an arg follows a variadic from an earlier call", () => {
-		const app = new Crust("test").args({ name: "files", type: "string", variadic: true });
+		const app = new Crust("test").args({
+			name: "files",
+			type: "string",
+			variadic: true,
+		});
 		expect(() =>
 			app.args(
 				// @ts-expect-error -- the variadic position is also guarded at runtime
@@ -497,7 +512,11 @@ describe("command metadata", () => {
 			.args({ name: "file", type: "string" });
 
 		expect(await app.snapshot()).toMatchObject({
-			meta: { name: "test", description: "A test command", usage: "test [options]" },
+			meta: {
+				name: "test",
+				description: "A test command",
+				usage: "test [options]",
+			},
 			flags: { verbose: { type: "boolean" } },
 			args: [{ name: "file", type: "string" }],
 		});
@@ -1000,7 +1019,9 @@ describe("Crust .extend()", () => {
 	});
 
 	it("defineExtension() returns a frozen plain config", () => {
-		const ext = defineExtension("frozen", { flags: [{ name: "x", type: "boolean" }] });
+		const ext = defineExtension("frozen", {
+			flags: [{ name: "x", type: "boolean" }],
+		});
 
 		expect(Object.isFrozen(ext)).toBe(true);
 		expect(ext.name).toBe("frozen");
@@ -1067,14 +1088,55 @@ describe("Crust .extend()", () => {
 		expect(true).toBe(true);
 	});
 
-	it("defineExtension() rejects duplicate owned flag names", () => {
+	it("defineExtension() rejects duplicate owned flag names at define time", () => {
 		const flags = [
 			{ name: "mode", type: "string" },
 			{ name: "mode", type: "number" },
 		] as const;
+		const define = () => defineExtension("duplicate-flags", { flags: flags as never });
 
-		expect(() => defineExtension("duplicate-flags", { flags: flags as never })).toThrow(
-			'Extension "duplicate-flags" flag "--mode" is already defined',
+		expect(define).toThrow(CrustError);
+		try {
+			define();
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toMatchObject({
+				code: "DEFINITION",
+				message:
+					'Extension "duplicate-flags" flag "--mode" spelling "mode" collides with flag "--mode"',
+			});
+		}
+	});
+
+	it("defineExtension() surfaces intra-extension spelling collisions at define time", () => {
+		const flags = [
+			{ name: "loud", type: "boolean", short: "v" },
+			{ name: "verbose", type: "boolean", short: "v" },
+		] as const;
+
+		expect(() => defineExtension("short-clash", { flags: flags as never })).toThrow(
+			'Extension "short-clash" flag "--verbose" spelling "v" collides with flag "--loud"',
+		);
+	});
+
+	it("defineExtension() rejects a flag definition without a name", () => {
+		expect(() => defineExtension("nameless", { flags: [{ type: "boolean" }] as never })).toThrow(
+			"Every flag definition must carry a non-empty name",
+		);
+	});
+
+	it("defineExtension() rejects mixing a schema with core options", () => {
+		const flags = [
+			{
+				name: "endpoint",
+				type: "string",
+				schema: {} as StandardSchema<string | undefined, URL>,
+				default: "http://localhost",
+			},
+		] as const;
+
+		expect(() => defineExtension("schema-mix", { flags: flags as never })).toThrow(
+			/schema exclusively owns/,
 		);
 	});
 
@@ -1149,7 +1211,9 @@ describe("Extension application at prepare time", () => {
 			.add(defineCommand("sub", (cmd) => cmd.action(() => {})));
 
 		// --version is unknown on the subcommand → PARSE error
-		await expect(app.run(["sub", "--version"])).rejects.toMatchObject({ code: "PARSE" });
+		await expect(app.run(["sub", "--version"])).rejects.toMatchObject({
+			code: "PARSE",
+		});
 	});
 
 	it("Extension flag colliding with an application flag is a DEFINITION error", async () => {
@@ -1177,8 +1241,12 @@ describe("Extension application at prepare time", () => {
 	});
 
 	it("Extension flag colliding with another Extension's flag is a DEFINITION error", async () => {
-		const a = defineExtension("a", { flags: [{ name: "shared", type: "boolean" }] });
-		const b = defineExtension("b", { flags: [{ name: "shared", type: "boolean" }] });
+		const a = defineExtension("a", {
+			flags: [{ name: "shared", type: "boolean" }],
+		});
+		const b = defineExtension("b", {
+			flags: [{ name: "shared", type: "boolean" }],
+		});
 		const app = new Crust("cli").extend(a, b).action(() => {});
 
 		await expect(app.run([])).rejects.toMatchObject({ code: "DEFINITION" });
@@ -1190,7 +1258,12 @@ describe("Extension application at prepare time", () => {
 			commands: [
 				defineCommand("completion", (command) =>
 					command
-						.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh"] })
+						.args({
+							name: "shell",
+							type: "string",
+							required: true,
+							choices: ["bash", "zsh"],
+						})
 						.action(({ args, flags, rootCommand }) => {
 							lines.push(
 								`completion:${args.shell}:${(flags as Record<string, unknown>).verbose}:${rootCommand.meta.name}`,
@@ -1207,8 +1280,12 @@ describe("Extension application at prepare time", () => {
 
 		await app.run(["completion", "bash", "--verbose"]);
 		expect(lines).toEqual(["completion:bash:true:cli"]);
-		await expect(app.run(["completion", "fish"])).rejects.toMatchObject({ code: "PARSE" });
-		await expect(app.run(["completion"])).rejects.toMatchObject({ code: "VALIDATION" });
+		await expect(app.run(["completion", "fish"])).rejects.toMatchObject({
+			code: "PARSE",
+		});
+		await expect(app.run(["completion"])).rejects.toMatchObject({
+			code: "VALIDATION",
+		});
 	});
 
 	it("Extension command requirements name the Extension and missing Context", async () => {
@@ -1236,7 +1313,9 @@ describe("Extension application at prepare time", () => {
 			.add(defineCommand("sub", (cmd) => cmd.action(() => {})))
 			.extend(clash);
 
-		await expect(app.run(["sub"])).rejects.toMatchObject({ code: "DEFINITION" });
+		await expect(app.run(["sub"])).rejects.toMatchObject({
+			code: "DEFINITION",
+		});
 	});
 
 	it("rejects non-definition Extension commands", async () => {
@@ -1375,7 +1454,9 @@ describe("Extension named hooks", () => {
 		expect(outcomes).toEqual(["second:failed", "first:failed"]);
 
 		outcomes.length = 0;
-		const gate = defineExtension("gate", { hooks: { preRun: (ctx) => ctx.finish() } });
+		const gate = defineExtension("gate", {
+			hooks: { preRun: (ctx) => ctx.finish() },
+		});
 		await new Crust("cli")
 			.extend(first, gate, second)
 			.action(() => {})
@@ -1428,7 +1509,9 @@ describe("Extension named hooks", () => {
 		await app.run(["known"], { stdout: (line) => lines.push(line) });
 		expect(lines).toEqual(["probe:known"]);
 		preRunCalled = false;
-		await expect(app.run(["unknown"])).rejects.toMatchObject({ code: "COMMAND_NOT_FOUND" });
+		await expect(app.run(["unknown"])).rejects.toMatchObject({
+			code: "COMMAND_NOT_FOUND",
+		});
 		expect(preRunCalled).toBe(false);
 	});
 
@@ -1628,7 +1711,10 @@ describe("Crust .run()", () => {
 			ctx.stderr("to err");
 		});
 
-		await app.run([], { stdout: (t) => out.push(t), stderr: (t) => err.push(t) });
+		await app.run([], {
+			stdout: (t) => out.push(t),
+			stderr: (t) => err.push(t),
+		});
 
 		expect(out).toEqual(["to out"]);
 		expect(err).toEqual(["to err"]);
@@ -1645,7 +1731,10 @@ describe("Crust .run()", () => {
 
 		await app.run(["a.txt", "--verbose"]);
 
-		expect(received).toEqual({ args: { file: "a.txt" }, flags: { verbose: true } });
+		expect(received).toEqual({
+			args: { file: "a.txt" },
+			flags: { verbose: true },
+		});
 	});
 });
 

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -540,12 +540,6 @@ export class Crust<
 		for (const def of defs) {
 			// Destructuring also decouples the stored def from the caller's object
 			const { name, ...rest } = def as NamedFlagDef;
-			if (typeof name !== "string" || name.length === 0) {
-				throw new CrustError("DEFINITION", "Every flag definition must carry a non-empty name", {
-					subject: "flag",
-					reason: "missing-name",
-				});
-			}
 			if (Object.hasOwn(copiedFlags, name)) {
 				throw new CrustError("DEFINITION", `Flag "--${name}" is already defined`, {
 					subject: "flag",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
 	ExtensionHooks,
 	Finished,
 	InferExtensionFlags,
+	NamedExtensionFlagDef,
 	InvocationOutcome,
 } from "./api/extension.ts";
 export { defineExtension } from "./api/extension.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,8 +18,8 @@ export type {
 	ExtensionHooks,
 	Finished,
 	InferExtensionFlags,
-	NamedExtensionFlagDef,
 	InvocationOutcome,
+	NamedExtensionFlagDef,
 } from "./api/extension.ts";
 export { defineExtension } from "./api/extension.ts";
 export { defineArg, defineFlag } from "./api/flags.ts";

--- a/packages/core/src/validation/flags.test.ts
+++ b/packages/core/src/validation/flags.test.ts
@@ -288,6 +288,19 @@ describe("validateIncomingFlag", () => {
 		).toThrow(/reserved spelling "__proto__"/);
 	});
 
+	it("rejects a definition without a non-empty name", () => {
+		expect(() =>
+			validateIncomingFlag(
+				{ name: undefined as never, def: { type: "boolean" } },
+				{},
+				'Extension "nameless"',
+			),
+		).toThrow(/must carry a non-empty name/);
+		expect(() =>
+			validateIncomingFlag({ name: "", def: { type: "boolean" } }, {}, 'Context "nameless"'),
+		).toThrow(/must carry a non-empty name/);
+	});
+
 	it("rejects duplicate spellings within the incoming definition", () => {
 		expect(() =>
 			validateIncomingFlag(

--- a/packages/core/src/validation/flags.test.ts
+++ b/packages/core/src/validation/flags.test.ts
@@ -275,6 +275,19 @@ describe("validateIncomingFlag", () => {
 		).toThrow(/spelling "loud"/);
 	});
 
+	it('rejects "__proto__" as a flag name or alias', () => {
+		expect(() =>
+			validateIncomingFlag({ name: "__proto__", def: { type: "boolean" } }, {}, 'Extension "evil"'),
+		).toThrow(/reserved spelling "__proto__"/);
+		expect(() =>
+			validateIncomingFlag(
+				{ name: "proto", def: { type: "boolean", aliases: ["__proto__"] } },
+				{},
+				'Extension "evil"',
+			),
+		).toThrow(/reserved spelling "__proto__"/);
+	});
+
 	it("rejects duplicate spellings within the incoming definition", () => {
 		expect(() =>
 			validateIncomingFlag(

--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -250,6 +250,15 @@ export function validateIncomingFlag(
 	existing: FlagsDef,
 	ownerLabel: string,
 ): void {
+	// Shared guard for plain-JS callers of `.flags()`, `defineContext`, and
+	// `defineExtension`: a nameless def would otherwise register under the
+	// literal key "undefined" and surface as `--undefined` in help.
+	if (typeof incoming.name !== "string" || incoming.name.length === 0) {
+		throw new CrustError("DEFINITION", "Every flag definition must carry a non-empty name", {
+			subject: "flag",
+			reason: "missing-name",
+		});
+	}
 	const incomingSpellings = flagDefinitionSpellings(incoming.name, incoming.def);
 	// Flag defs and parse results live in plain-object records; a "__proto__" key
 	// hits the Object.prototype setter and the flag silently vanishes. Fail loud.

--- a/packages/core/src/validation/flags.ts
+++ b/packages/core/src/validation/flags.ts
@@ -251,6 +251,15 @@ export function validateIncomingFlag(
 	ownerLabel: string,
 ): void {
 	const incomingSpellings = flagDefinitionSpellings(incoming.name, incoming.def);
+	// Flag defs and parse results live in plain-object records; a "__proto__" key
+	// hits the Object.prototype setter and the flag silently vanishes. Fail loud.
+	if (incomingSpellings.includes("__proto__")) {
+		throw new CrustError(
+			"DEFINITION",
+			`${ownerLabel} flag "--${incoming.name}" uses reserved spelling "__proto__"`,
+			{ subject: "flag", name: incoming.name, reason: "reserved-name" },
+		);
+	}
 	const duplicate = incomingSpellings.find(
 		(spelling, index) => incomingSpellings.indexOf(spelling) !== index,
 	);

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -241,9 +241,7 @@ describe("integration: Extension adds flag visible to subcommand action", () => 
 
 	it("Extension flag on root is parsed and available to root action", async () => {
 		const versionFlag = defineExtension("version-extension", {
-			flags: {
-				version: { type: "boolean", short: "V", recursive: false },
-			},
+			flags: [{ name: "version", type: "boolean", short: "V", recursive: false }],
 		});
 
 		const app = new Crust("cli").extend(versionFlag).action((ctx) => {

--- a/packages/extensions/src/extensions.test.ts
+++ b/packages/extensions/src/extensions.test.ts
@@ -250,7 +250,7 @@ describe("built-in extensions", () => {
 
 	it("recursive false Extension flags stay root-only", async () => {
 		const rootOnly = defineExtension("root-only", {
-			flags: { root: { type: "boolean", recursive: false } },
+			flags: [{ name: "root", type: "boolean", recursive: false }],
 		});
 		const app = new Crust("app")
 			.extend(rootOnly)

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -108,7 +108,9 @@ export function renderHelp(command: CommandSnapshot, path?: readonly string[]): 
 
 export function help(): Extension {
 	return defineExtension("help", {
-		flags: { help: { type: "boolean", short: "h", noNegate: true, description: "Show help" } },
+		flags: [
+			{ name: "help", type: "boolean", short: "h", noNegate: true, description: "Show help" },
+		],
 		hooks: {
 			preRun(context) {
 				if (context.flags.help !== true && context.command.hasAction) return;

--- a/packages/extensions/src/no-color.ts
+++ b/packages/extensions/src/no-color.ts
@@ -30,12 +30,13 @@ const colorRuns = new WeakMap<ExtensionContext, true>();
 
 export function noColor(): Extension {
 	return defineExtension("no-color", {
-		flags: {
-			color: {
+		flags: [
+			{
+				name: "color",
 				type: "boolean",
 				description: "Enable colored output",
 			},
-		},
+		],
 		hooks: {
 			preRun(context) {
 				const flagValue = context.flags.color;

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -20,15 +20,16 @@ export function version(
 	const { format } = options;
 
 	return defineExtension("version", {
-		flags: {
-			version: {
+		flags: [
+			{
+				name: "version",
 				type: "boolean",
 				short: "v",
 				noNegate: true,
 				description: "Show version number",
 				recursive: false,
 			},
-		},
+		],
 		hooks: {
 			preRun(context) {
 				// Root invocation with --version only


### PR DESCRIPTION
## Summary

- `defineExtension()` now accepts extension flags as a readonly array of named definitions (`NamedExtensionFlagDef = NamedFlagDef & { recursive?: boolean }`), matching the `.flags(...defs)` and `defineContext(name, { flags: [...] })` authoring surfaces — one public flag vocabulary, no record shape and no dual-shape overload
- the array is normalized to the existing internal record inside `defineExtension`, so `Extension.flags`, preparation, collision checking, and the parser are untouched; duplicate names within one extension throw `CrustError("DEFINITION")` at define time (via `Object.hasOwn` + `validateIncomingFlag`), which also moves intra-extension spelling collisions from prepare time to `defineExtension()` time
- hook typing is preserved through `NamedFlagsRecord<Defs>`: `recursive: false` → `T | undefined`, `required` pre-validation → `T | undefined`, schema flags → raw token type, foreign flags → `unknown`, `onError` untyped — all locked by type tests, including the headline `defineFlag()`-value-attached-to-extension scenario
- migrated every first-party caller (`help`, `version`, `no-color`, extensions tests, skills extension surface), docs guide + examples, and API/module type references; recorded a minor changeset for `@crustjs/core` and patch changesets for `@crustjs/extensions` and `@crustjs/skills`

Closes #206

## Validation

- `bun run check:types` — passed
- `bun run check` — passed
- `cd packages/core && bun test` — 620 pass, 0 fail
- `cd packages/extensions && bun test` — 246 pass, 5 environment skips, 0 fail
- `cd packages/skills && bun test` — 321 pass, 0 fail

## Review findings

Two independent fresh-context reviews (correctness/type-regressions and spec/docs) found **no blockers**. All fixes worth doing now were applied in the follow-up commit:

- corrected a false doc/changeset claim about `defineFlag()` rejecting `recursive` (it structurally passes through; inline named definitions remain the documented way to set it)
- documented the new `NamedExtensionFlagDef` export in `api/types.mdx` and `modules/core.mdx`
- switched the duplicate-name guard to `Object.hasOwn` (prototype-chain false positive for flags named e.g. `toString`)
- added a type-level test attaching a `defineFlag()` result to `defineExtension`
- updated the `InferExtensionFlags` generic-param docs and export ordering
- noted the define-time collision timing change in the core changeset
