### PR TITLE
fix(core): reject pre-subcommand flags the routed subcommand cannot parse

### DIFF
--- a/.changeset/router-forwardable-flag-gate.md
+++ b/.changeset/router-forwardable-flag-gate.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Routing now rejects a pre-subcommand flag the routed subcommand cannot parse. Previously `app --quiet sub` with a root-local `--quiet` routed to `sub` and then failed with a confusing `Unknown flag "--quiet"` from the subcommand's parser; it now fails at routing with `PARSE: Flag "--quiet" cannot be used before subcommand "sub" because "sub" does not accept it.` Propagating (Context-owned and recursive Extension) flags before a subcommand are unaffected and keep routing through.

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -98,7 +98,7 @@ const app = new Crust("app").provide(logging()).add(deploy);
 
 The Context declares, parses, and consumes `--verbose`, then wraps the invocation's injected `stderr` as behavior. Actions call the logging capability without re-checking the flag. Renaming the flag or deriving log levels later changes the Context rather than every action.
 
-Context-owned flags are parsed and shown in help at the provider and later-added descendants. They can appear before, between, or after subcommand names. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
+Context-owned flags are parsed and shown in help at the provider and later-added descendants. They can appear before, between, or after subcommand names. Command-local flags do not propagate: writing one before a subcommand name is a `PARSE` error, because the routed subcommand cannot parse it. See [Contexts: Owned flags](/docs/guide/contexts#owned-flags).
 
 If an action needs the raw value, expose it from the owning Context as part of that capability. Cross-command dependencies are always Context capabilities; raw flags are never injected into an added action's types.
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1865,6 +1865,44 @@ describe("Crust .execute()", () => {
 		expect(subFlags.port).toBeUndefined();
 	});
 
+	it("dispatches a Context-owned flag written before the subcommand", async () => {
+		let subFlags: Record<string, unknown> = {};
+		const verbose = defineFlag("verbose", { type: "boolean" });
+		const logging = defineContext("logging", { flags: [verbose] }, () => ({}));
+
+		const app = new Crust("cli").provide(logging()).add(
+			defineCommand("sub", (cmd) =>
+				cmd.action((ctx) => {
+					subFlags = ctx.flags;
+				}),
+			),
+		);
+
+		await app.execute({ argv: ["--verbose", "sub"] });
+
+		expect(subFlags.verbose).toBe(true);
+	});
+
+	it("rejects a parent-local flag written before the subcommand", async () => {
+		let subRan = false;
+
+		const app = new Crust("cli").flags({ name: "quiet", type: "boolean" }).add(
+			defineCommand("sub", (cmd) =>
+				cmd.action(() => {
+					subRan = true;
+				}),
+			),
+		);
+
+		await app.execute({ argv: ["--quiet", "sub"] });
+
+		expect(subRan).toBe(false);
+		expect(process.exitCode).toBe(1);
+		expect(stderrChunks.join("\n")).toContain(
+			'Flag "--quiet" cannot be used before subcommand "sub"',
+		);
+	});
+
 	it("argv override works", async () => {
 		let receivedDir = "";
 

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -144,8 +144,6 @@ function prepareInvocation(
 	const rootNode = cloneCommandNode(node);
 	const extensions = node.extensions;
 
-	// Commands first, then flags, so recursive Extension flags also reach
-	// Extension-contributed commands (e.g. --help on "completion").
 	for (const extension of extensions) {
 		applyExtensionCommands(rootNode, extension, materializeCommandDefinition);
 	}
@@ -171,12 +169,12 @@ async function dispatch(
 
 	const rootSnapshot = snapshotCommand(rootNode);
 	const extensionContext: ExtensionContext = Object.freeze({
-		argv: [...argv] as readonly string[],
+		argv: [...argv],
 		rootCommand: rootSnapshot,
 		command: resolvedNode === rootNode ? rootSnapshot : snapshotCommand(resolvedNode),
 		commandPath: Object.freeze([...resolved.commandPath]),
-		args: parsed.args as Readonly<Record<string, unknown>>,
-		flags: parsed.flags as Readonly<Record<string, unknown>>,
+		args: parsed.args,
+		flags: parsed.flags,
 		rawArgs: parsed.rawArgs,
 		finish: finishInvocation,
 		stdout: io.stdout,

--- a/packages/core/src/command/router.test.ts
+++ b/packages/core/src/command/router.test.ts
@@ -568,13 +568,16 @@ describe("resolveCommand — aliases", () => {
 
 describe("resolveCommand — known-flag skipping", () => {
 	function makeContextOwnedRoot(): CommandNode {
-		const service = makeNode({ meta: "service", run: () => {} });
-		const deploy = makeNode({ meta: "deploy", subCommands: { service } });
+		// Context-owned flags propagate into every descendant's effectiveFlags;
+		// the fixture mirrors that so routing's forwardability gate passes.
+		const owned: FlagsDef = {
+			"api-key": { type: "string", short: "k", aliases: ["token"] },
+		};
+		const service = makeNode({ meta: "service", flags: owned, run: () => {} });
+		const deploy = makeNode({ meta: "deploy", flags: owned, subCommands: { service } });
 		return makeNode({
 			meta: "app",
-			flags: {
-				"api-key": { type: "string", short: "k", aliases: ["token"] },
-			},
+			flags: owned,
 			subCommands: { deploy },
 		});
 	}
@@ -602,19 +605,23 @@ describe("resolveCommand — known-flag skipping", () => {
 	});
 
 	function makeRoot(): CommandNode {
+		// Propagating flags exist on the child too — routing only forwards
+		// flags the resolved command can actually parse.
+		const shared: FlagsDef = {
+			quiet: { type: "boolean", short: "q", description: "quiet" },
+			verbose: { type: "boolean", noNegate: true, description: "verbose" },
+			config: { type: "string", short: "c", aliases: ["conf"], description: "config file" },
+		};
 		const translate = makeNode({
 			meta: "translate",
+			flags: shared,
 			run() {
 				/* noop */
 			},
 		});
 		return makeNode({
 			meta: "app",
-			flags: {
-				quiet: { type: "boolean", short: "q", description: "quiet" },
-				verbose: { type: "boolean", noNegate: true, description: "verbose" },
-				config: { type: "string", short: "c", aliases: ["conf"], description: "config file" },
-			},
+			flags: shared,
 			subCommands: { translate },
 		});
 	}
@@ -675,11 +682,11 @@ describe("resolveCommand — known-flag skipping", () => {
 
 	it("routes past bundled known short booleans", () => {
 		const root = makeRoot();
-		// add a second short boolean for bundling
-		root.effectiveFlags = {
-			...root.effectiveFlags,
-			force: { type: "boolean", short: "f", description: "force" },
-		};
+		// add a second short boolean for bundling (on both levels, like propagation)
+		const force: FlagsDef[string] = { type: "boolean", short: "f", description: "force" };
+		root.effectiveFlags = { ...root.effectiveFlags, force };
+		const translate = root.subCommands.translate as CommandNode;
+		translate.effectiveFlags = { ...translate.effectiveFlags, force };
 		const result = resolveCommand(root, ["-qf", "translate"]);
 		expect(result.commandPath).toEqual(["app", "translate"]);
 		expect(result.argv).toEqual(["-qf"]);
@@ -698,24 +705,93 @@ describe("resolveCommand — known-flag skipping", () => {
 	});
 
 	it("skips flags at multiple routing levels and preserves token order", () => {
+		const quiet: FlagsDef[string] = { type: "boolean", description: "quiet" };
+		const deep: FlagsDef[string] = { type: "boolean", description: "deep" };
 		const leaf = makeNode({
 			meta: "leaf",
+			flags: { quiet, deep },
 			run() {
 				/* noop */
 			},
 		});
 		const mid = makeNode({
 			meta: "mid",
-			flags: { deep: { type: "boolean", description: "deep" } },
+			flags: { quiet, deep },
 			subCommands: { leaf },
 		});
 		const root = makeNode({
 			meta: "app",
-			flags: { quiet: { type: "boolean", description: "quiet" } },
+			flags: { quiet },
 			subCommands: { mid },
 		});
 		const result = resolveCommand(root, ["--quiet", "mid", "--deep", "leaf", "rest"]);
 		expect(result.commandPath).toEqual(["app", "mid", "leaf"]);
 		expect(result.argv).toEqual(["--quiet", "--deep", "rest"]);
+	});
+
+	it("keeps a skipped flag ahead of the -- terminator", () => {
+		const result = resolveCommand(makeRoot(), ["--quiet", "--", "translate"]);
+		expect(result.commandPath).toEqual(["app"]);
+		expect(result.argv).toEqual(["--quiet", "--", "translate"]);
+	});
+
+	it("rejects a parent-local flag before a subcommand that cannot parse it", () => {
+		const translate = makeNode({ meta: "translate", run() {} });
+		const root = makeNode({
+			meta: "app",
+			flags: { quiet: { type: "boolean", description: "quiet" } },
+			subCommands: { translate },
+		});
+		expect(() => resolveCommand(root, ["--quiet", "translate"])).toThrow(
+			'Flag "--quiet" cannot be used before subcommand "translate"',
+		);
+		try {
+			resolveCommand(root, ["--quiet", "translate"]);
+		} catch (error) {
+			expect(error).toBeInstanceOf(CrustError);
+			expect((error as CrustError).code).toBe("PARSE");
+		}
+	});
+
+	it("rejects a forwarded flag whose child spelling has a different token shape", () => {
+		// Parent: --config <value>; child: --config as boolean. The value token
+		// was already consumed under the parent's shape, so forwarding would
+		// misparse — routing must reject instead.
+		const translate = makeNode({
+			meta: "translate",
+			flags: { config: { type: "boolean", description: "config toggle" } },
+			run() {},
+		});
+		const root = makeNode({
+			meta: "app",
+			flags: { config: { type: "string", description: "config file" } },
+			subCommands: { translate },
+		});
+		expect(() => resolveCommand(root, ["--config", "a.json", "translate"])).toThrow(
+			'Flag "--config" cannot be used before subcommand "translate"',
+		);
+	});
+
+	it("rejects a flag committed at one level when a deeper descend cannot parse it", () => {
+		const quiet: FlagsDef[string] = { type: "boolean", description: "quiet" };
+		const leaf = makeNode({ meta: "leaf", run() {} });
+		const mid = makeNode({ meta: "mid", flags: { quiet }, subCommands: { leaf } });
+		const root = makeNode({ meta: "app", flags: { quiet }, subCommands: { mid } });
+		expect(() => resolveCommand(root, ["--quiet", "mid", "leaf"])).toThrow(
+			'Flag "--quiet" cannot be used before subcommand "leaf"',
+		);
+	});
+
+	it("validates forwarded flags when descending through an alias", () => {
+		const translate = makeNode({ meta: "translate", run() {} });
+		translate.meta.aliases = ["tr"];
+		const root = makeNode({
+			meta: "app",
+			flags: { quiet: { type: "boolean", description: "quiet" } },
+			subCommands: { translate },
+		});
+		expect(() => resolveCommand(root, ["--quiet", "tr"])).toThrow(
+			'Flag "--quiet" cannot be used before subcommand "tr"',
+		);
 	});
 });

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -98,6 +98,11 @@ function matchKnownFlagToken(
  * 2. If `argv[0]` matches a sibling's `meta.aliases` entry, recurse into
  *    that sibling and record the **canonical** name in `commandPath`
  * 3. If no match and the current command has `run()`, return it (args passed to parser)
+ * 3a. Known flags encountered before a subcommand name are set aside and
+ *     re-prepended for the resolved command's parser — but only if every
+ *     command routing descends into recognizes them with the same token
+ *     shape. A flag the subcommand cannot parse (e.g. a parent-local flag)
+ *     is a PARSE error at the descend, never a silent forward-then-fail.
  * 4. If no match and the current command has NO `run()`, it signals the caller
  *    should show help (the `showHelp` flag is set in the result)
  * 5. Unknown subcommands produce a structured COMMAND_NOT_FOUND error whose
@@ -113,6 +118,7 @@ function matchKnownFlagToken(
  * @param argv - The argv array to resolve against
  * @returns The resolved command, argv, and the command path
  * @throws {CrustError} COMMAND_NOT_FOUND when an unknown subcommand is given and the parent has no run()
+ * @throws {CrustError} PARSE when a flag set aside during routing is not parseable by the subcommand being descended into
  */
 export function resolveCommand(command: CommandNode, argv: string[]): CommandRoute {
 	const path = [command.meta.name];
@@ -123,6 +129,31 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 	// set aside during routing and re-prepended for the resolved command's
 	// parser, preserving token order.
 	const skippedFlagTokens: string[] = [];
+	// Flag tokens (values excluded) among skippedFlagTokens, with the token
+	// shape the parent's definition implied. Re-validated against every
+	// command routing descends into so the resolved command is guaranteed to
+	// parse the re-prepended tokens.
+	const skippedFlagChecks: { token: string; consumesValue: boolean }[] = [];
+
+	// Every skipped flag must be recognized by the child with the same token
+	// shape — a same-spelling flag that is boolean here and value-taking there
+	// would mis-consume the already-split tokens. On violation this throws
+	// rather than falling back to the parent: `app --quiet sub` with a
+	// root-local `--quiet` almost certainly meant to run `sub`, and rule 3
+	// makes a positional spelled like a subcommand name unreachable anyway.
+	const assertFlagsForwardable = (child: CommandNode, candidate: string): void => {
+		if (skippedFlagChecks.length === 0) return;
+		const childSpellings = flagSpellings(child.effectiveFlags);
+		for (const { token, consumesValue } of skippedFlagChecks) {
+			const match = matchKnownFlagToken(childSpellings, token);
+			if (match !== null && match.consumesValue === consumesValue) continue;
+			throw new CrustError(
+				"PARSE",
+				`Flag "${token}" cannot be used before subcommand "${candidate}" because "${candidate}" does not accept it.`,
+				{ flag: token, reason: "flag-not-forwardable" },
+			);
+		}
+	};
 
 	while (routedArgv.length > 0) {
 		const subCommands = current.subCommands;
@@ -143,6 +174,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 			const match = matchKnownFlagToken(flagSpellings(current.effectiveFlags), candidate);
 			if (!match) break;
 			skippedFlagTokens.push(candidate);
+			skippedFlagChecks.push({ token: candidate, consumesValue: match.consumesValue });
 			routedArgv = routedArgv.slice(1);
 			const value = routedArgv[0];
 			if (match.consumesValue && value !== undefined) {
@@ -154,6 +186,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 
 		// Check if it matches a known subcommand by canonical name
 		if (candidate in subCommands && subCommands[candidate]) {
+			assertFlagsForwardable(subCommands[candidate], candidate);
 			current = subCommands[candidate];
 			path.push(candidate);
 			routedArgv = routedArgv.slice(1);
@@ -165,6 +198,7 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 		// help/extensions assume `commandPath` only ever contains canonical names.
 		const aliasMatch = findAliasMatch(subCommands, candidate);
 		if (aliasMatch) {
+			assertFlagsForwardable(aliasMatch.node, candidate);
 			current = aliasMatch.node;
 			path.push(aliasMatch.canonicalName);
 			routedArgv = routedArgv.slice(1);

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -601,7 +601,7 @@ export function validateParsed<A extends ArgsDef = ArgsDef, F extends FlagsDef =
 	// Re-validate args: check for required args that are undefined
 	if (argsDef) {
 		for (const def of argsDef) {
-			const { name } = def as ArgDef;
+			const { name } = def;
 			const label = `argument "<${name}>"`;
 			const value = args[name as keyof InferArgs<A>];
 

--- a/packages/core/src/parsing/spellings.test.ts
+++ b/packages/core/src/parsing/spellings.test.ts
@@ -34,7 +34,11 @@ describe("flagSpellings", () => {
 		const root = createCommandNode("app");
 		root.localFlags = flags;
 		root.effectiveFlags = flags;
-		root.subCommands.run = createCommandNode("run");
+		// Routing only forwards pre-subcommand flags the child can parse, so the
+		// child carries the same flags (as Context propagation would).
+		const run = createCommandNode("run");
+		run.effectiveFlags = flags;
+		root.subCommands.run = run;
 
 		expect(resolveCommand(root, ["--config=app.json", "run"])).toMatchObject({
 			commandPath: ["app", "run"],


### PR DESCRIPTION
## Problem

Routing set aside any flag known to the current command and re-prepended it for the resolved subcommand's parser. That works for propagating (Context-owned) flags, but a **parent-local** flag routed fine and then failed downstream:

```
app --quiet sub
# Error: Unknown flag "--quiet"   ← attributed to "sub", but --quiet is a real root flag
```

Accept-then-fail matches no framework's convention: cobra/clap/commander all scope pre-subcommand flags explicitly (persistent/global declarations), and clig.dev treats flag placement as scope.

## Fix

`resolveCommand` now re-validates **every** skipped flag against **each** command it descends into (canonical and alias descents). The child must recognize the same spelling with the same token shape (boolean vs value-taking), otherwise routing fails fast:

```
Error: Flag "--quiet" cannot be used before subcommand "sub" because "sub" does not accept it.
```

| Input | Before | After |
|---|---|---|
| Context-owned flag before subcommand | routes + dispatches | unchanged ✅ |
| Parent-local flag before subcommand | routes, then `Unknown flag` from child | `PARSE` error naming flag + subcommand |
| Same spelling, different shape (parent string / child boolean) | forwarded, misparsed | `PARSE` error |
| Flag valid at `mid` but not `leaf` (multi-level) | forwarded, failed at leaf | `PARSE` error at the `leaf` descend |
| Unknown flag / `--` stops routing | parser reports | unchanged ✅ |

Erroring (rather than silently falling back to the parent) is deliberate: subcommand names shadow positionals, so a parent-only interpretation of `app --quiet sub` is unreachable anyway, and a root without an action would otherwise exit 0 silently.

## Changes

- `router.ts` — record token shape for each skipped flag; `assertFlagsForwardable` gate on every descend
- `router.test.ts` — fixtures now mirror real propagation (children carry inherited flags); 5 new tests (parent-local rejection, shape mismatch, deep-descend rejection, alias-descend validation, `--` ordering)
- `crust.test.ts` — 2 end-to-end `.execute()` tests (Context flag before subcommand dispatches; parent-local flag errors, exit code 1, subcommand never runs)
- `spellings.test.ts` — fixture updated for the gate
- `flags.mdx` — documents that command-local flags before a subcommand are a `PARSE` error
- changeset: `@crustjs/core` patch
- drive-by cleanup: redundant casts/stale comment in `invocation.ts` / `parser.ts`

## Validation

- `bun test packages/` — 2324 pass / 0 fail
- `bun run check:types`, `lint`, `format` — all green