### PR TITLE
test(crust): lock default build validation behavior and clarify docs

### DIFF
--- a/.changeset/default-build-materialization.md
+++ b/.changeset/default-build-materialization.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/crust": patch
+---
+
+Clarify `crust build` validation help text and docs: validation materializes the full command tree by default (unchanged behavior); use `--no-validate` for entry modules with unavoidable import-time side effects. Locks the default-on behavior with an integration test.

--- a/.changeset/default-build-materialization.md
+++ b/.changeset/default-build-materialization.md
@@ -1,5 +1,0 @@
----
-"@crustjs/crust": patch
----
-
-Clarify `crust build` validation help text and docs: validation materializes the full command tree by default (unchanged behavior); use `--no-validate` for entry modules with unavoidable import-time side effects. Locks the default-on behavior with an integration test.

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -32,20 +32,20 @@ crust build --env-file .env.production
 
 ## Flags
 
-| Flag          | Alias | Type                    | Default       | Description                                                |
-| ------------- | ----- | ----------------------- | ------------- | ---------------------------------------------------------- |
-| `--entry`     | `-e`  | `"string"`              | `src/cli.ts`  | Entry file path                                            |
-| `--outfile`   | `-o`  | `"string"`              | —             | Output file path (single-target only)                      |
-| `--name`      | `-n`  | `"string"`              | auto-detected | Binary name                                                |
-| `--minify`    | —     | `"boolean"`             | `true`        | Minify the output                                          |
-| `--target`    | `-t`  | `"string"` (repeatable) | all platforms | Canonical Bun target(s), e.g. `bun-darwin-arm64`           |
-| `--outdir`    | `-d`  | `"string"`              | `dist`        | Output directory for compiled binaries                     |
-| `--resolver`  | `-r`  | `"string"`              | `cli`         | Resolver script filename (multi-target only, no extension) |
-| `--env-file`  | —     | `"string"` (repeatable) | —             | Explicit env file(s) used for build-time constants         |
-| `--validate`  | —     | `"boolean"`             | `true`        | Pre-compile validation of command definitions              |
-| `--package`   | —     | `"boolean"`             | `false`       | Stage npm packages in `dist/npm` instead of raw binaries   |
-| `--stage-dir` | —     | `"string"`              | `dist/npm`    | Package staging directory; only used with `--package`      |
-| `--man`       | —     | `"boolean"`             | `false`       | Write an mdoc(7) page from the prepared Command Snapshot   |
+| Flag                           | Alias | Type                    | Default       | Description                                                |
+| ------------------------------ | ----- | ----------------------- | ------------- | ---------------------------------------------------------- |
+| `--entry`                      | `-e`  | `"string"`              | `src/cli.ts`  | Entry file path                                            |
+| `--outfile`                    | `-o`  | `"string"`              | —             | Output file path (single-target only)                      |
+| `--name`                       | `-n`  | `"string"`              | auto-detected | Binary name                                                |
+| `--minify`                     | —     | `"boolean"`             | `true`        | Minify the output                                          |
+| `--target`                     | `-t`  | `"string"` (repeatable) | all platforms | Canonical Bun target(s), e.g. `bun-darwin-arm64`           |
+| `--outdir`                     | `-d`  | `"string"`              | `dist`        | Output directory for compiled binaries                     |
+| `--resolver`                   | `-r`  | `"string"`              | `cli`         | Resolver script filename (multi-target only, no extension) |
+| `--env-file`                   | —     | `"string"` (repeatable) | —             | Explicit env file(s) used for build-time constants         |
+| `--validate` / `--no-validate` | —     | `"boolean"`             | `true`        | Materialize command definitions before compiling           |
+| `--package`                    | —     | `"boolean"`             | `false`       | Stage npm packages in `dist/npm` instead of raw binaries   |
+| `--stage-dir`                  | —     | `"string"`              | `dist/npm`    | Package staging directory; only used with `--package`      |
+| `--man`                        | —     | `"boolean"`             | `false`       | Write an mdoc(7) page from the prepared Command Snapshot   |
 
 ## Supported Targets
 
@@ -167,9 +167,15 @@ See [Environment Variables](/docs/guide/environment) for the full env model, inc
 
 ## Pre-compile Validation
 
-Before compiling, `crust build` prepares your CLI's Command Snapshot by running the entry file in a subprocess. This catches definition errors — such as flag alias collisions, reserved `no-` prefix misuse, and other structural issues — **before** the binary is compiled, rather than at runtime when users invoke it.
+By default, `crust build` materializes your full command tree before compiling. It runs the entry file in a subprocess to prepare a Command Snapshot, forcing all command recipes and Extensions. This catches definition errors — such as flag alias collisions, reserved `no-` prefix misuse, and other structural issues — **before** the binary is compiled, rather than at runtime when users invoke it.
 
 `crust build` sets `CRUST_INTERNAL_SNAPSHOT_PATH` in the subprocess environment, pointing at a temporary file. `.execute()` prepares and validates the full command graph, including subcommands and Extension-owned flags and commands, writes its JSON snapshot to that file, and exits without executing Command Actions or code after `await app.execute()`.
+
+<Callout type="warn">
+  Materialization imports your entry module, so its top-level side effects run before compilation.
+  Keep entry modules side-effect-free when possible. Use `--no-validate` when import-time side
+  effects are unavoidable.
+</Callout>
 
 When `--man` is enabled, the same subprocess supplies both validation and man generation; the entry point does not need to export its `Crust` builder. `--man --no-validate` still prepares a snapshot because the manual renderer requires it.
 
@@ -196,7 +202,7 @@ Validation is enabled by default. To skip it:
 crust build --no-validate
 ```
 
-This can be useful if the snapshot subprocess cannot resolve your project's dependencies in a particular environment (e.g., non-standard module resolution setups), or if the entry never calls `await app.execute()` — such entries fail validation with a missing-snapshot error. It does not skip snapshot preparation when `--man` is enabled.
+Use this escape hatch for entries with unavoidable import-time side effects. It can also help when the snapshot subprocess cannot resolve your project's dependencies in a particular environment (for example, a non-standard module resolution setup), or when the entry never calls `await app.execute()` — such entries fail validation with a missing-snapshot error. It does not skip snapshot preparation when `--man` is enabled.
 
 ## Per-OS Distribution with `--package`
 

--- a/packages/crust/src/commands/build.integration.test.ts
+++ b/packages/crust/src/commands/build.integration.test.ts
@@ -135,6 +135,76 @@ console.log("hello from crust build test");
 		},
 	);
 
+	it("validates definitions by default before compiling and supports --no-validate", async () => {
+		process.cwd = () => tmpDir;
+
+		const entry = join(tmpDir, "src", "invalid-cli.ts");
+		const outPath = join(tmpDir, "dist", "invalid-cli");
+		writeFileSync(
+			entry,
+			`import { Crust, defineCommand } from ${JSON.stringify(corePath)};
+const app = new Crust("fixture").add(
+  defineCommand("parent", (parent) => parent.add(
+    defineCommand("child", (child) => child.flags(
+      { name: "force", type: "boolean", short: "f" },
+      { name: "format", type: "string", short: "f" },
+    )),
+  )),
+);
+await app.execute();
+`,
+		);
+
+		const originalError = console.error;
+		const errors: string[] = [];
+		console.error = (...args: unknown[]) => {
+			errors.push(args.map(String).join(" "));
+		};
+
+		try {
+			process.exitCode = 0;
+			const app = new Crust("test").add(buildCommand);
+			await app.execute({
+				argv: [
+					"build",
+					"--entry",
+					"src/invalid-cli.ts",
+					"--outfile",
+					outPath,
+					"--target",
+					"bun-linux-x64-baseline",
+				],
+			});
+
+			expect(process.exitCode).toBe(1);
+			expect(errors.join("\n")).toContain("DEFINITION");
+			expect(errors.join("\n")).toContain(
+				'Command "child" flag "--format" spelling "f" collides with flag "--force"',
+			);
+			expect(existsSync(outPath)).toBe(false);
+
+			process.exitCode = 0;
+			await app.execute({
+				argv: [
+					"build",
+					"--entry",
+					"src/invalid-cli.ts",
+					"--outfile",
+					outPath,
+					"--target",
+					"bun-linux-x64-baseline",
+					"--no-validate",
+				],
+			});
+
+			expect(process.exitCode).toBe(0);
+			expect(existsSync(outPath)).toBe(true);
+		} finally {
+			process.exitCode = 0;
+			console.error = originalError;
+		}
+	});
+
 	it("builds without --minify when --no-minify is passed", async () => {
 		process.cwd = () => tmpDir;
 

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -325,7 +325,7 @@ export const buildCommand = defineCommand(
 					name: "validate",
 					type: "boolean",
 					description:
-						"Validate command runtime rules before compiling (disable with --no-validate)",
+						"Materialize command definitions before compiling (disable with --no-validate)",
 					default: true,
 				},
 				{


### PR DESCRIPTION
Closes #214.

## What

Issue #214 asked to make `crust build` validate by materializing the CLI, on by default with `--no-validate` to opt out. **The premise turned out to be stale**: at HEAD (and since `@crustjs/crust@0.0.24`), `--validate` already defaults to `true` and the snapshot/materialization pass already runs before `bun build` is spawned.

This PR therefore locks the behavior instead of re-implementing it:

- **Integration test** (`packages/crust/src/commands/build.integration.test.ts`): a definition error (duplicate flag spelling on a nested subcommand) exits non-zero with the `DEFINITION` message and produces no binary; `--no-validate` on the same project proceeds to bundling.
- **Docs** (`guide/build.mdx`): default-on validation, the entry import-time side-effect caveat, and `--no-validate` as the escape hatch.
- **Help text**: `--validate` description now says what it does ("Materialize command definitions before compiling").
- **Changeset**: `patch` (no behavior change in this release — the default flip already shipped and is in the CHANGELOG).

## Verification

- `bun test` — 2,342 pass, 8 skip, 0 fail
- `bun run check:types`, `bun run lint`, `bun run format` — green
- Independent two-axis review (spec vs #214, repo standards) — pass; its one major finding (changeset wrongly announced a default flip as `minor`) fixed before this PR.

## Notes

- Deliberately does not depend on #213 (core normalization refactor); no `packages/core` changes.
