### PR TITLE
docs: fix stale/inaccurate docs found in implementation audit

### DIFF
--- a/.changeset/clean-docs-audit.md
+++ b/.changeset/clean-docs-audit.md
@@ -1,0 +1,5 @@
+---
+"create-crust": patch
+---
+
+Correct the package name in the create-crust README.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -345,12 +345,12 @@ snapshot(): Promise<CommandSnapshot>
 Prepares a frozen, validated Command Snapshot for tooling such as man-page, skill, and build generators. It materializes Extension contributions and command definitions, then validates the resulting command tree. It does not call Command Actions. Rejects with a [`CrustError`](/docs/api/errors) of code `DEFINITION` when materialization or validation fails.
 
 ```ts
-import type { CommandSnapshot } from "@crustjs/core/tooling";
+import type { CommandSnapshot } from "@crustjs/core";
 
 const snapshot: CommandSnapshot = await app.snapshot();
 ```
 
-The `CommandSnapshot` type is exported from `@crustjs/core/tooling`; see the [core module reference](/docs/modules/core) for the tooling subpath.
+The `CommandSnapshot` type is exported from `@crustjs/core` and re-exported from the `@crustjs/core/tooling` subpath; see the [core module reference](/docs/modules/core).
 
 ## `.run(argv, io?)`
 

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -14,7 +14,7 @@ All exports on these pages come from `@crustjs/core`.
 | [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary   |
 | [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.add()` |
 | `defineContext(name, config?, setup)`                     | Define a named command dependency factory                      |
-| `defineExtension(name, config)`                           | Define an application-wide Extension                           |
+| `defineExtension(name, config?)`                          | Define an application-wide Extension                           |
 | `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition       |
 | `defineArg(name, definition)`                             | Define one named positional argument                           |
 | [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes       |

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -7,6 +7,10 @@ All types on this page are exported from `@crustjs/core`.
 
 ## Definition types
 
+### `Simplify<T>`
+
+An object-type simplification helper used by inferred public builder and flag types; see the [core module reference](/docs/modules/core).
+
 ### `ValueType`
 
 ```ts

--- a/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
+++ b/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
@@ -36,6 +36,6 @@ function didYouMean(options?: DidYouMeanOptions): Extension;
 
 Suggestions compare the unknown token with visible sibling command names and aliases. Alias matches are reported as canonical command names. Hidden commands are omitted.
 
-`didYouMean()` is a presentation-only `onError` Extension. It handles only `CrustError` values with code `COMMAND_NOT_FOUND`, returns `true` when it renders a suggestion, and delegates every other failure to the next presenter. Core sets and preserves the nonzero terminal exit code independently of the selected mode.
+`didYouMean()` is a presentation-only `onError` Extension. It handles only `CrustError` values with code `COMMAND_NOT_FOUND`, returns `true` after rendering, and delegates every other failure to the next presenter. Core sets and preserves the nonzero terminal exit code independently of the selected mode.
 
 `app.run(argv)` does not run presentation hooks; it throws the original `COMMAND_NOT_FOUND` error instead.

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -45,7 +45,7 @@ await app.execute();
 | --------------------------------------------------------------------- | ------------------------------------------------- |
 | [`help()`](/docs/modules/extensions/help)                             | Recursive `--help` / `-h` flag and help rendering |
 | [`renderHelp(command, path?)`](/docs/modules/extensions/help)         | Render help text from a Command Snapshot          |
-| [`version(value?)`](/docs/modules/extensions/version)                 | Root-only `--version` / `-v` flag                 |
+| [`version(value?, options?)`](/docs/modules/extensions/version)       | Root-only `--version` / `-v` flag                 |
 | [`completion(options?)`](/docs/modules/extensions/completion)         | Static bash, zsh, and fish completion command     |
 | [`didYouMean(options?)`](/docs/modules/extensions/did-you-mean)       | `COMMAND_NOT_FOUND` presentation                  |
 | [`noColor()`](/docs/modules/extensions/no-color)                      | Recursive `--color` / `--no-color` flag           |

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -74,7 +74,12 @@ const store = createStore({
 
 const adapter: UpdateNotifierCacheAdapter = {
   read: () => store.read(),
-  write: (state) => store.write(state),
+  write: (state) =>
+    store.write({
+      lastCheckedAt: state.lastCheckedAt,
+      latestVersion: state.latestVersion,
+      lastNotifiedVersion: state.lastNotifiedVersion,
+    }),
 };
 
 const notifier = updateNotifier({

--- a/apps/docs/content/docs/modules/index.mdx
+++ b/apps/docs/content/docs/modules/index.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: Crust packages for authoring, distributing, and supporting CLI applications.
 ---
 
-Install [`@crustjs/core`](/docs/modules/core) and the capabilities your application needs. The framework spine packages share one lockstep version.
+Install [`@crustjs/core`](/docs/modules/core) and the capabilities your application needs. The framework spine packages are versioned together in one fixed release group, so they bump together.
 
 ## Framework spine
 

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -108,6 +108,7 @@ bar.stop("success", "All files translated");
 
 ```ts
 const handle = spinner({ message: "Working...", sigint: false });
+handle.start();
 process.once("SIGINT", () => {
   handle.stop("error", "Cancelled");
   flushLogs();

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -50,7 +50,7 @@ Scope resolution for the interactive command and `skill update`:
 
 1. If `--scope` flag is passed, that scope is used.
 2. If `defaultScope` is set, that scope is used (no prompt).
-3. Otherwise, an interactive prompt asks the user to choose `project` or `global`.
+3. Otherwise, an interactive prompt asks the user to choose `project` or `global`; in non-interactive mode this falls back to `global`.
 
 When the current working directory is the home directory, `project` scope is normalized to `global`. In that case, installs, updates, and status checks all use the global skill locations and update output reports `(global)`.
 
@@ -307,7 +307,7 @@ import { generateSkill, getSkillStatus, uninstallSkill } from "@crustjs/skills";
 
 // Install — universal + agents whose CLI is on PATH.
 const result = await generateSkill({
-  command: rootCommand,
+  command: await rootCommand.snapshot(),
   meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
   scope: "global", // or "project"
 });
@@ -343,7 +343,7 @@ const universal = getUniversalAgents();
 const additional = await detectInstalledAgents();
 
 await generateSkill({
-  command: rootCommand,
+  command: await rootCommand.snapshot(),
   meta: { name: "my-cli", description: "My CLI", version: "1.0.0" },
   agents: [...universal, ...additional], // explicit form
   scope: "global",

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -302,7 +302,7 @@ const state = await store.read();
 - Persisted values override defaults.
 - Missing keys fall back to defaults.
 - Unknown persisted keys are dropped by default (`pruneUnknown: true`). Set `pruneUnknown: false` to preserve them.
-- All values are deep-cloned to prevent shared-reference mutation from defaults.
+- Array defaults are shallow-copied to prevent shared mutation from defaults.
 - Falsy values (`null`, `0`, `""`, `false`) in the persisted file are preserved — only truly missing keys trigger defaults.
 
 <Callout>

--- a/packages/create-crust/README.md
+++ b/packages/create-crust/README.md
@@ -1,4 +1,4 @@
-# @crustjs/create-crust
+# create-crust
 
 Scaffold a new [Crust](https://crustjs.com) CLI project in seconds.
 


### PR DESCRIPTION
## Summary

- `apps/docs/content/docs/api/crust.mdx` — use the root `CommandSnapshot` export and clarify the tooling re-export (`packages/core/src/index.ts`).
- `apps/docs/content/docs/api/index.mdx` — mark `defineExtension` config optional (`packages/core/src/api/extension.ts`).
- `apps/docs/content/docs/api/types.mdx` — document the exported `Simplify<T>` helper (`packages/core/src/index.ts`).
- `apps/docs/content/docs/modules/store.mdx` — describe the actual shallow copy of array defaults instead of a nonexistent deep clone (`packages/store/src/merge.ts`).
- `apps/docs/content/docs/modules/index.mdx` — describe framework packages as a fixed release group that bumps together instead of claiming identical versions (`.changeset/config.json`).
- `packages/create-crust/README.md` — correct the package title to the unscoped npm name (`packages/create-crust/package.json`) and add a patch changeset.
- `apps/docs/content/docs/modules/progress.mdx` — start the spinner before the SIGINT cleanup calls `stop()` (`packages/progress/src/spinner.ts`).
- `apps/docs/content/docs/modules/skills.mdx` — document the non-interactive global scope fallback (`packages/skills/src/extension.ts`).
- `apps/docs/content/docs/modules/skills.mdx` — pass snapshots to both low-level `generateSkill` examples (`packages/skills/src/types.ts`).
- `apps/docs/content/docs/modules/extensions/update-notifier.mdx` — map optional cache state into the store's required-key write shape (`packages/extensions/src/update-notifier.ts`).
- `apps/docs/content/docs/modules/extensions/index.mdx` — include the optional second argument in `version(value?, options?)` (`packages/extensions/src/version.ts`).
- `apps/docs/content/docs/modules/extensions/did-you-mean.mdx` — clarify that every handled `COMMAND_NOT_FOUND` returns `true`, even without a suggestion (`packages/extensions/src/did-you-mean.ts`).

## Validation

- `bun run build:docs`
- `bun run lint && bun run format`
