### PR TITLE
refactor(core): tighten materializeCommandDefinition internals

### DIFF
--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -161,9 +161,13 @@ function materializeCommandDefinition(
 	const owner = extensionName
 		? `Extension "${extensionName}" command "${name}"`
 		: `Command "${name}"`;
-	const providedNames = new Set(parent.contexts.map((context) => context.name));
+	const definitionDetails = (reason: string) => ({
+		subject: extensionName ? ("extension" as const) : ("command" as const),
+		name: extensionName ?? name,
+		reason,
+	});
 	for (const ctxName of internal.requiredCtxNames) {
-		if (!providedNames.has(ctxName)) {
+		if (!parent.contexts.some((context) => context.name === ctxName)) {
 			throw new CrustError(
 				"DEFINITION",
 				`${owner} requires Context "${ctxName}", which is not provided on parent command "${parent.meta.name}"`,
@@ -185,7 +189,7 @@ function materializeCommandDefinition(
 	const child = new Crust(name);
 	(child as { _ancestorOwnedFlags: FlagsDef })._ancestorOwnedFlags = parent.ownedFlags;
 	child._node.ownedFlags = { ...parent.ownedFlags };
-	child._node.effectiveFlags = { ...child._node.ownedFlags };
+	child._node.effectiveFlags = { ...parent.ownedFlags };
 	child._node.flagSpellings = cloneFlagSpellings(parent.flagSpellings, child._node.effectiveFlags);
 	(child._node as { contexts: ContextInstance[] }).contexts = [...parent.contexts];
 
@@ -196,22 +200,14 @@ function materializeCommandDefinition(
 		throw new CrustError(
 			"DEFINITION",
 			`${owner} definition must return the same command builder it received`,
-			{
-				subject: extensionName ? "extension" : "command",
-				name: extensionName ?? name,
-				reason: "foreign-command-builder",
-			},
+			definitionDetails("foreign-command-builder"),
 		);
 	}
 	if (configured._node.extensions.length > 0) {
 		throw new CrustError(
 			"DEFINITION",
 			`${owner} cannot register Extensions inside command definitions`,
-			{
-				subject: extensionName ? "extension" : "command",
-				name: extensionName ?? name,
-				reason: "nested-command-extension",
-			},
+			definitionDetails("nested-command-extension"),
 		);
 	}
 


### PR DESCRIPTION
## Summary

Cosmetic cleanup inside `materializeCommandDefinition` (packages/core/src/command/crust.ts) from an over-engineering review of the materialization cluster. No behavior change.

- Replace the `providedNames` Set with a direct `.some()` scan — the parent contexts list is tiny (typically 0–3 entries) and the Set was rebuilt per materialization for one lookup loop.
- Hoist the duplicated `DEFINITION` error details shape (`subject`/`name`/`reason` attribution) into a single `definitionDetails` helper shared by the foreign-builder and nested-extension throws.
- Seed `effectiveFlags` from `parent.ownedFlags` directly instead of re-reading the just-written child copy.

Net −4 lines; error codes, messages, and details are byte-identical.

Reviewed-but-kept items from the same pass: the `_ancestorOwnedFlags` identity check (tested, no smaller alternative) and the trailing `cloneCommandNode` (removal would be behavior-changing for recipe-leaked builders).

## Validation

- `bun test src/command/` — 263 pass, 0 fail
- `tsc --noEmit` — clean
- `oxlint` / `oxfmt --check` — clean

No changeset: internal refactor, not user-visible.
