### PR TITLE
fix: narrow choices to literal unions in core and prompts

### DIFF
--- a/.changeset/choices-literal-narrowing.md
+++ b/.changeset/choices-literal-narrowing.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Narrow string flag/arg types to the literal union of their `choices`. A definition like `{ type: "string", choices: ["staging", "production"] as const }` now infers `"staging" | "production"` in the action instead of `string`. Raw args (no `type`/`schema`) with literal choices narrow the same way instead of `unknown`. Choices widened to `readonly string[]` still infer `string`.

--- a/.changeset/choices-literal-narrowing.md
+++ b/.changeset/choices-literal-narrowing.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/core": patch
+"@crustjs/core": minor
 ---
 
-Narrow string flag/arg types to the literal union of their `choices`. A definition like `{ type: "string", choices: ["staging", "production"] as const }` now infers `"staging" | "production"` in the action instead of `string`. Raw args (no `type`/`schema`) with literal choices narrow the same way instead of `unknown`. Choices widened to `readonly string[]` still infer `string`.
+Narrow string flag/arg types to the literal union of their `choices`. A definition like `{ type: "string", choices: ["staging", "production"] as const }` now infers `"staging" | "production"` in the action instead of `string`. Raw args (no `type`/`schema`) with literal choices narrow the same way instead of `unknown`. Choices widened to `readonly string[]` still infer `string`, and `parse` still owns the output type when present.

--- a/.changeset/prompts-choices-narrowing.md
+++ b/.changeset/prompts-choices-narrowing.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/prompts": patch
+---
+
+`select`, `multiselect`, `filter`, and `multifilter` now narrow their result type to the union of the literal choice values (`choices: ["dev", "prod"]` → `"dev" | "prod"`), for both plain string and `{ label, value }` object choices. Added via a new overload, so explicit-type-arg calls (`select<number>(…)`) and widened `string[]` choices keep their previous types. The new `ChoiceValue` helper type is exported.

--- a/.changeset/prompts-choices-narrowing.md
+++ b/.changeset/prompts-choices-narrowing.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/prompts": patch
+"@crustjs/prompts": minor
 ---
 
-`select`, `multiselect`, `filter`, and `multifilter` now narrow their result type to the union of the literal choice values (`choices: ["dev", "prod"]` → `"dev" | "prod"`), for both plain string and `{ label, value }` object choices. Added via a new overload, so explicit-type-arg calls (`select<number>(…)`) and widened `string[]` choices keep their previous types. The new `ChoiceValue` helper type is exported.
+`select`, `multiselect`, `filter`, and `multifilter` now narrow their result type to the union of the literal choice values (`choices: ["dev", "prod"]` → `"dev" | "prod"`), for both plain string and `{ label, value }` object choices. Added via new overloads: literal non-empty tuples narrow, widened `string[]` choices now infer `string` (previously `unknown`), and explicit-type-arg calls (`select<number>(…)`) and generic wrappers over the options types keep their previous contract. The new `ChoiceValue` helper type is exported.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ coverage
 out/
 build
 dist
+*.bun-build
 
 
 # Debug

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -55,6 +55,8 @@ Use `choices` for a static string set:
 
 A declared default outside the choices is a `DEFINITION` error when `.args()` runs. An argv value outside the choices is a `PARSE` error during invocation.
 
+As with flags, a literal choices tuple narrows the argument's inferred type to the union of those literals (`"bun" | "node"` above); a widened `string[]` keeps it as `string`.
+
 ## Standard Schemas
 
 A `schema` receives the raw positional token (`string | undefined`, or `string[]` for a variadic argument) and determines the Command Action's output type:

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -59,6 +59,8 @@ Both values are non-optional in the Command Action. Other flags include `undefin
 
 Choices are supported on string flags. A declared default outside this set is a `DEFINITION` error when `.flags()` runs; an argv value outside it is a `PARSE` error during invocation.
 
+When the choices list is a literal tuple (an inline array as above, or a variable declared `as const`), the flag's inferred type narrows to the union of those literals — `"bun" | "node"` here instead of `string`. A widened `string[]` variable keeps the type as plain `string`.
+
 ## Reusing flag definitions
 
 Flags declared with `.flags()` belong only to that command. Define a descriptor once and attach it to each command that parses the value directly:

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -196,6 +196,8 @@ const port = await select({
 });
 ```
 
+When the choices list is written inline (or declared `as const`), the result narrows to the union of the choice values — `80 | 443` above, or `"react" | "vue" | "svelte"` for string choices. A widened `string[]` keeps `string`. The same applies to `multiselect`, `filter`, and `multifilter` (element type of the returned array).
+
 <auto-type-table
   path="../../../../../packages/prompts/src/prompts/select.ts"
   name="SelectOptions"

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -455,6 +455,7 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 | `CreatePromptsOptions`    | Options for `createPrompts()`                                                       |
 | `PromptsInstance`         | Themed prompt functions returned by `createPrompts()`                               |
 | `Choice<T>`               | Choice item: string or `{ label, value, hint? }`                                    |
+| `ChoiceValue<C>`          | Union of the values in a choices tuple (drives literal narrowing)                   |
 | `ValidateFn<T>`           | Validation function type — `(value: T) => void \| Promise<void>`, throws on failure |
 | `KeypressEvent`           | Structured keypress event                                                           |
 | `PromptConfig<S,T>`       | Configuration for `runPrompt()`                                                     |

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
+import type { StandardSchema } from "@crustjs/utils/schema";
+
 import type { Simplify } from "./api/context.ts";
 import type {
 	ArgDef,
@@ -55,6 +57,33 @@ describe("InferArgs type inference", () => {
 
 		const val: Result = { flag: undefined };
 		expect(val).toBeDefined();
+	});
+
+	it("narrows raw args (no type/schema) with literal choices", () => {
+		type Args = readonly [
+			{ name: "mode"; choices: readonly ["dev", "prod"] },
+			{ name: "env"; choices: readonly ["a", "b"]; default: "a" },
+			{ name: "tags"; choices: readonly ["x", "y"]; variadic: true },
+		];
+		type Result = InferArgs<Args>;
+		type _check = Expect<
+			Equal<
+				Result,
+				{
+					mode: "dev" | "prod" | undefined;
+					env: "a" | "b";
+					tags: ("x" | "y")[];
+				}
+			>
+		>;
+		expect(true).toBe(true);
+	});
+
+	it("schema args infer the schema output, untouched by choices narrowing", () => {
+		type Args = readonly [{ name: "url"; schema: StandardSchema<string | undefined, URL> }];
+		type Result = InferArgs<Args>;
+		type _check = Expect<Equal<Result, { url: URL }>>;
+		expect(true).toBe(true);
 	});
 
 	it("maps required arg to non-optional type", () => {
@@ -214,26 +243,6 @@ describe("InferFlags type inference", () => {
 		type Flags = { env: { type: "string"; choices: readonly string[] } };
 		type Result = InferFlags<Flags>;
 		type _check = Expect<Equal<Result, { env: string | undefined }>>;
-		expect(true).toBe(true);
-	});
-
-	it("narrows raw args (no type/schema) with literal choices", () => {
-		type Args = readonly [
-			{ name: "mode"; choices: readonly ["dev", "prod"] },
-			{ name: "env"; choices: readonly ["a", "b"]; default: "a" },
-			{ name: "tags"; choices: readonly ["x", "y"]; variadic: true },
-		];
-		type Result = InferArgs<Args>;
-		type _check = Expect<
-			Equal<
-				Result,
-				{
-					mode: "dev" | "prod" | undefined;
-					env: "a" | "b";
-					tags: ("x" | "y")[];
-				}
-			>
-		>;
 		expect(true).toBe(true);
 	});
 
@@ -776,6 +785,15 @@ describe("InferFlags — parse field inference", () => {
 		type _check = Expect<Equal<Result, { x: number }>>;
 		const val: Result = { x: 42 };
 		expect(val.x).toBe(42);
+	});
+
+	it("parse wins over literal choices (parse owns the output type)", () => {
+		type Flags = {
+			x: { type: "string"; choices: readonly ["1", "2"]; parse: (s: string) => number };
+		};
+		type Result = InferFlags<Flags>;
+		type _check = Expect<Equal<Result, { x: number | undefined }>>;
+		expect(true).toBe(true);
 	});
 
 	it("narrows inference when parse + raw default are both present", () => {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -188,6 +188,55 @@ describe("InferFlags type inference", () => {
 		expect(val.port).toBe(8080);
 	});
 
+	it("narrows a string flag with literal choices to the literal union", () => {
+		type Flags = {
+			env: { type: "string"; choices: readonly ["staging", "production"]; default: "staging" };
+			mode: { type: "string"; choices: readonly ["a", "b"] };
+			tags: { type: "string"; multiple: true; choices: readonly ["x", "y"] };
+		};
+		type Result = InferFlags<Flags>;
+		type _check = Expect<
+			Equal<
+				Result,
+				{
+					env: "staging" | "production";
+					mode: "a" | "b" | undefined;
+					tags: ("x" | "y")[] | undefined;
+				}
+			>
+		>;
+
+		const val: Result = { env: "staging", mode: undefined, tags: undefined };
+		expect(val.env).toBe("staging");
+	});
+
+	it("keeps plain string for choices widened to readonly string[]", () => {
+		type Flags = { env: { type: "string"; choices: readonly string[] } };
+		type Result = InferFlags<Flags>;
+		type _check = Expect<Equal<Result, { env: string | undefined }>>;
+		expect(true).toBe(true);
+	});
+
+	it("narrows raw args (no type/schema) with literal choices", () => {
+		type Args = readonly [
+			{ name: "mode"; choices: readonly ["dev", "prod"] },
+			{ name: "env"; choices: readonly ["a", "b"]; default: "a" },
+			{ name: "tags"; choices: readonly ["x", "y"]; variadic: true },
+		];
+		type Result = InferArgs<Args>;
+		type _check = Expect<
+			Equal<
+				Result,
+				{
+					mode: "dev" | "prod" | undefined;
+					env: "a" | "b";
+					tags: ("x" | "y")[];
+				}
+			>
+		>;
+		expect(true).toBe(true);
+	});
+
 	it("maps multiple flags together", () => {
 		type Flags = {
 			verbose: { type: "boolean" };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -570,17 +570,18 @@ type InferArgValue<A extends ArgDef> = A extends {
 					: ResolveBaseType<A> | undefined
 		: // Raw args (no `type`, no `schema`) still enforce `choices` at parse
 			// time, so a literal tuple narrows the raw string token the same way.
-			A extends { choices: readonly (infer C extends string)[] }
-			? A extends { variadic: true }
-				? C[]
-				: A extends { required: true }
-					? C
-					: A extends { default: unknown }
-						? C
-						: C | undefined
-			: A extends { variadic: true }
-				? unknown[]
-				: unknown;
+			// One ladder serves both raw variants: without choices the base is
+			// `unknown`, and `unknown | undefined` collapses back to `unknown`.
+			A extends { variadic: true }
+			? RawArgBase<A>[]
+			: A extends { required: true }
+				? RawArgBase<A>
+				: A extends { default: unknown }
+					? RawArgBase<A>
+					: RawArgBase<A> | undefined;
+
+/** Base type of a raw arg: the literal `choices` union when present, else `unknown`. */
+type RawArgBase<A> = A extends { choices: readonly (infer C extends string)[] } ? C : unknown;
 
 /**
  * Recursively converts an ArgsDef tuple into a named object type.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,16 +42,19 @@ type Resolve<T extends ValueType> = {
  * Resolve the inferred runtime type for a flag/arg definition.
  *
  * When the def declares a `parse` escape hatch (only allowed on `"string"`
- * variants), the inferred type is `ReturnType<typeof parse>`. Otherwise it
- * delegates to {@link Resolve} on the declared `type`.
+ * variants), the inferred type is `ReturnType<typeof parse>`. String defs
+ * with a literal `choices` tuple narrow to the union of those literals.
+ * Otherwise it delegates to {@link Resolve} on the declared `type`.
  */
 type ResolveBaseType<F> = F extends {
 	parse: (raw: string) => infer R;
 }
 	? R
-	: F extends { type: infer T extends ValueType }
-		? Resolve<T>
-		: never;
+	: F extends { type: "string"; choices: readonly (infer C extends string)[] }
+		? C
+		: F extends { type: infer T extends ValueType }
+			? Resolve<T>
+			: never;
 
 // ────────────────────────────────────────────────────────────────────────────
 // ArgDef — Positional argument definition (discriminated by `type`)
@@ -565,9 +568,19 @@ type InferArgValue<A extends ArgDef> = A extends {
 					A extends { default: unknown }
 					? ResolveBaseType<A>
 					: ResolveBaseType<A> | undefined
-		: A extends { variadic: true }
-			? unknown[]
-			: unknown;
+		: // Raw args (no `type`, no `schema`) still enforce `choices` at parse
+			// time, so a literal tuple narrows the raw string token the same way.
+			A extends { choices: readonly (infer C extends string)[] }
+			? A extends { variadic: true }
+				? C[]
+				: A extends { required: true }
+					? C
+					: A extends { default: unknown }
+						? C
+						: C | undefined
+			: A extends { variadic: true }
+				? unknown[]
+				: unknown;
 
 /**
  * Recursively converts an ArgsDef tuple into a named object type.

--- a/packages/prompts/src/core/types.ts
+++ b/packages/prompts/src/core/types.ts
@@ -81,6 +81,20 @@ export type Choice<T> =
 	| string
 	| { readonly label: string; readonly value: T; readonly hint?: string };
 
+/**
+ * Extract the value union from a choices tuple: a plain string choice is its
+ * own value (see `normalizeChoices`), an object choice contributes its
+ * `value`. With the prompts' `const C` generics, a literal choices tuple
+ * narrows the prompt's return type to the union of its values
+ * (e.g. `["dev", "prod"]` → `"dev" | "prod"`); a widened
+ * `readonly string[]` stays `string`.
+ */
+export type ChoiceValue<C extends readonly Choice<unknown>[]> = C[number] extends infer E
+	? E extends { readonly value: infer V }
+		? V
+		: E
+	: never;
+
 // ────────────────────────────────────────────────────────────────────────────
 // Validation
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -7,7 +7,13 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 export type { FuzzyFilterResult, FuzzyMatchResult } from "./core/fuzzy.ts";
-export type { Choice, PartialPromptTheme, PromptTheme, ValidateFn } from "./core/types.ts";
+export type {
+	Choice,
+	ChoiceValue,
+	PartialPromptTheme,
+	PromptTheme,
+	ValidateFn,
+} from "./core/types.ts";
 export type { NormalizedChoice } from "./core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/prompts/filter.test.ts
+++ b/packages/prompts/src/prompts/filter.test.ts
@@ -606,7 +606,7 @@ describe("filter — no message", () => {
 
 describe("filter — non-TTY", () => {
 	function nonTTY<T>(options: FilterOptions<T>): Promise<T> {
-		return filter(options, nonTTYIO());
+		return filter<T>(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -658,3 +658,17 @@ describe("filter — non-TTY", () => {
 		expect(result).toBe("a");
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+async function _filterTypeInferenceTests() {
+	const pick = await filter({ message: "?", choices: ["prettier", "eslint"] });
+	type _PickNarrows = Expect<Equal<typeof pick, "prettier" | "eslint">>;
+}
+void _filterTypeInferenceTests;

--- a/packages/prompts/src/prompts/filter.test.ts
+++ b/packages/prompts/src/prompts/filter.test.ts
@@ -606,7 +606,9 @@ describe("filter — no message", () => {
 
 describe("filter — non-TTY", () => {
 	function nonTTY<T>(options: FilterOptions<T>): Promise<T> {
-		return filter<T>(options, nonTTYIO());
+		// No explicit type arg: pins that generic pass-through wrappers still
+		// resolve to the generic overload and return Promise<T>.
+		return filter(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -670,5 +672,18 @@ type Expect<T extends true> = T;
 async function _filterTypeInferenceTests() {
 	const pick = await filter({ message: "?", choices: ["prettier", "eslint"] });
 	type _PickNarrows = Expect<Equal<typeof pick, "prettier" | "eslint">>;
+
+	const port = await filter({
+		message: "?",
+		choices: [
+			{ label: "HTTP", value: 80 },
+			{ label: "HTTPS", value: 443 },
+		],
+	});
+	type _PortNarrows = Expect<Equal<typeof port, 80 | 443>>;
+
+	const widened: string[] = ["a", "b"];
+	const loose = await filter({ message: "?", choices: widened });
+	type _LooseIsString = Expect<Equal<typeof loose, string>>;
 }
 void _filterTypeInferenceTests;

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -224,11 +224,15 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-// Narrowing overload — see `select` for the pattern rationale.
-export function filter<const C extends readonly Choice<unknown>[]>(
+// Narrowing overloads — see `select` for the pattern rationale.
+export function filter<const C extends readonly [Choice<unknown>, ...Choice<unknown>[]]>(
 	options: FilterOptions<ChoiceValue<C>> & { readonly choices: C },
 	io?: PromptIO,
 ): Promise<ChoiceValue<C>>;
+export function filter(
+	options: FilterOptions<string> & { readonly choices: readonly string[] },
+	io?: PromptIO,
+): Promise<string>;
 export function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T>;
 export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -9,7 +9,7 @@ import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { CURSOR_INDICATOR, PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { handleTextEdit, renderTextWithCursor } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type { Choice, PartialPromptTheme, PromptTheme } from "../core/types.ts";
+import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
 import {
 	calculateScrollOffset,
@@ -224,6 +224,12 @@ function renderSubmitted<T>(
  * });
  * ```
  */
+// Narrowing overload — see `select` for the pattern rationale.
+export function filter<const C extends readonly Choice<unknown>[]>(
+	options: FilterOptions<ChoiceValue<C>> & { readonly choices: C },
+	io?: PromptIO,
+): Promise<ChoiceValue<C>>;
+export function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T>;
 export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -74,7 +74,9 @@ describe("multifilter — initial / default", () => {
 
 describe("multifilter — non-TTY", () => {
 	function nonTTY<T>(options: MultifilterOptions<T>): Promise<T[]> {
-		return multifilter<T>(options, nonTTYIO());
+		// No explicit type arg: pins that generic pass-through wrappers still
+		// resolve to the generic overload and return Promise<T[]>.
+		return multifilter(options, nonTTYIO());
 	}
 
 	it("returns default array in non-TTY environment", async () => {
@@ -207,5 +209,18 @@ type Expect<T extends true> = T;
 async function _multifilterTypeInferenceTests() {
 	const picks = await multifilter({ message: "?", choices: ["a", "b"] });
 	type _PicksNarrow = Expect<Equal<typeof picks, ("a" | "b")[]>>;
+
+	const ports = await multifilter({
+		message: "?",
+		choices: [
+			{ label: "HTTP", value: 80 },
+			{ label: "HTTPS", value: 443 },
+		],
+	});
+	type _PortsNarrow = Expect<Equal<typeof ports, (80 | 443)[]>>;
+
+	const widened: string[] = ["a", "b"];
+	const loose = await multifilter({ message: "?", choices: widened });
+	type _LooseIsStrings = Expect<Equal<typeof loose, string[]>>;
 }
 void _multifilterTypeInferenceTests;

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -74,7 +74,7 @@ describe("multifilter — initial / default", () => {
 
 describe("multifilter — non-TTY", () => {
 	function nonTTY<T>(options: MultifilterOptions<T>): Promise<T[]> {
-		return multifilter(options, nonTTYIO());
+		return multifilter<T>(options, nonTTYIO());
 	}
 
 	it("returns default array in non-TTY environment", async () => {
@@ -195,3 +195,17 @@ describe("multifilter — interactive", () => {
 		expect(result).toEqual(["gamma"]);
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+async function _multifilterTypeInferenceTests() {
+	const picks = await multifilter({ message: "?", choices: ["a", "b"] });
+	type _PicksNarrow = Expect<Equal<typeof picks, ("a" | "b")[]>>;
+}
+void _multifilterTypeInferenceTests;

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -15,7 +15,7 @@ import {
 } from "../core/symbols.ts";
 import { handleTextEdit, renderTextWithCursor } from "../core/textEdit.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type { Choice, PartialPromptTheme, PromptTheme } from "../core/types.ts";
+import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
 import {
 	calculateScrollOffset,
@@ -263,6 +263,12 @@ function renderSubmitted<T>(
  * In non-interactive environments (no TTY), the `default` values are returned
  * automatically if provided.
  */
+// Narrowing overload — see `select` for the pattern rationale.
+export function multifilter<const C extends readonly Choice<unknown>[]>(
+	options: MultifilterOptions<ChoiceValue<C>> & { readonly choices: C },
+	io?: PromptIO,
+): Promise<ChoiceValue<C>[]>;
+export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
 	if (options.initial !== undefined) {
 		return [...options.initial];

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -263,11 +263,15 @@ function renderSubmitted<T>(
  * In non-interactive environments (no TTY), the `default` values are returned
  * automatically if provided.
  */
-// Narrowing overload — see `select` for the pattern rationale.
-export function multifilter<const C extends readonly Choice<unknown>[]>(
+// Narrowing overloads — see `select` for the pattern rationale.
+export function multifilter<const C extends readonly [Choice<unknown>, ...Choice<unknown>[]]>(
 	options: MultifilterOptions<ChoiceValue<C>> & { readonly choices: C },
 	io?: PromptIO,
 ): Promise<ChoiceValue<C>[]>;
+export function multifilter(
+	options: MultifilterOptions<string> & { readonly choices: readonly string[] },
+	io?: PromptIO,
+): Promise<string[]>;
 export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
 	if (options.initial !== undefined) {

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -699,7 +699,7 @@ describe("multiselect — no message", () => {
 
 describe("multiselect — non-TTY", () => {
 	function nonTTY<T>(options: MultiselectOptions<T>): Promise<T[]> {
-		return multiselect(options, nonTTYIO());
+		return multiselect<T>(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -751,3 +751,17 @@ describe("multiselect — non-TTY", () => {
 		expect(result).toEqual(["a"]);
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+async function _multiselectTypeInferenceTests() {
+	const tags = await multiselect({ message: "?", choices: ["a", "b"] });
+	type _TagsNarrow = Expect<Equal<typeof tags, ("a" | "b")[]>>;
+}
+void _multiselectTypeInferenceTests;

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -699,7 +699,9 @@ describe("multiselect — no message", () => {
 
 describe("multiselect — non-TTY", () => {
 	function nonTTY<T>(options: MultiselectOptions<T>): Promise<T[]> {
-		return multiselect<T>(options, nonTTYIO());
+		// No explicit type arg: pins that generic pass-through wrappers still
+		// resolve to the generic overload and return Promise<T[]>.
+		return multiselect(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -763,5 +765,18 @@ type Expect<T extends true> = T;
 async function _multiselectTypeInferenceTests() {
 	const tags = await multiselect({ message: "?", choices: ["a", "b"] });
 	type _TagsNarrow = Expect<Equal<typeof tags, ("a" | "b")[]>>;
+
+	const ports = await multiselect({
+		message: "?",
+		choices: [
+			{ label: "HTTP", value: 80 },
+			{ label: "HTTPS", value: 443 },
+		],
+	});
+	type _PortsNarrow = Expect<Equal<typeof ports, (80 | 443)[]>>;
+
+	const widened: string[] = ["a", "b"];
+	const loose = await multiselect({ message: "?", choices: widened });
+	type _LooseIsStrings = Expect<Equal<typeof loose, string[]>>;
 }
 void _multiselectTypeInferenceTests;

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -12,7 +12,7 @@ import {
 	PREFIX_SYMBOL,
 } from "../core/symbols.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type { Choice, PartialPromptTheme, PromptTheme } from "../core/types.ts";
+import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
 import {
 	DEFAULT_MAX_VISIBLE,
@@ -288,6 +288,12 @@ function renderSubmitted<T>(
  * });
  * ```
  */
+// Narrowing overload — see `select` for the pattern rationale.
+export function multiselect<const C extends readonly Choice<unknown>[]>(
+	options: MultiselectOptions<ChoiceValue<C>> & { readonly choices: C },
+	io?: PromptIO,
+): Promise<ChoiceValue<C>[]>;
+export function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -288,11 +288,15 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-// Narrowing overload — see `select` for the pattern rationale.
-export function multiselect<const C extends readonly Choice<unknown>[]>(
+// Narrowing overloads — see `select` for the pattern rationale.
+export function multiselect<const C extends readonly [Choice<unknown>, ...Choice<unknown>[]]>(
 	options: MultiselectOptions<ChoiceValue<C>> & { readonly choices: C },
 	io?: PromptIO,
 ): Promise<ChoiceValue<C>[]>;
+export function multiselect(
+	options: MultiselectOptions<string> & { readonly choices: readonly string[] },
+	io?: PromptIO,
+): Promise<string[]>;
 export function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
 	// Short-circuit: return initial value immediately without rendering

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -504,7 +504,7 @@ describe("select — no message", () => {
 
 describe("select — non-TTY", () => {
 	function nonTTY<T>(options: SelectOptions<T>): Promise<T> {
-		return select(options, nonTTYIO());
+		return select<T>(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -556,3 +556,33 @@ describe("select — non-TTY", () => {
 		expect(result).toBe("a");
 	});
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-level inference (compile-time only — never executed at runtime)
+// ────────────────────────────────────────────────────────────────────────────
+
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+async function _selectTypeInferenceTests() {
+	// Literal string choices narrow to the literal union via `const T`.
+	const env = await select({ message: "?", choices: ["dev", "staging", "prod"] });
+	type _EnvNarrows = Expect<Equal<typeof env, "dev" | "staging" | "prod">>;
+
+	// Object choices narrow on their literal `value`s.
+	const port = await select({
+		message: "?",
+		choices: [
+			{ label: "HTTP", value: 80 },
+			{ label: "HTTPS", value: 443 },
+		],
+	});
+	type _PortNarrows = Expect<Equal<typeof port, 80 | 443>>;
+
+	// A widened string[] variable keeps plain string.
+	const widened: string[] = ["a", "b"];
+	const loose = await select({ message: "?", choices: widened });
+	type _LooseIsString = Expect<Equal<typeof loose, string>>;
+}
+void _selectTypeInferenceTests;

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import { createPrompts } from "../create-prompts.ts";
 import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { select, type SelectOptions } from "./select.ts";
 
@@ -504,7 +505,9 @@ describe("select — no message", () => {
 
 describe("select — non-TTY", () => {
 	function nonTTY<T>(options: SelectOptions<T>): Promise<T> {
-		return select<T>(options, nonTTYIO());
+		// No explicit type arg: pins that generic pass-through wrappers still
+		// resolve to the generic overload and return Promise<T>.
+		return select(options, nonTTYIO());
 	}
 
 	it("throws NonInteractiveError when stdin is not a TTY", async () => {
@@ -584,5 +587,17 @@ async function _selectTypeInferenceTests() {
 	const widened: string[] = ["a", "b"];
 	const loose = await select({ message: "?", choices: widened });
 	type _LooseIsString = Expect<Equal<typeof loose, string>>;
+
+	// An explicit type argument still resolves to the generic overload.
+	const explicit = await select<number>({
+		message: "?",
+		choices: [{ label: "HTTP", value: 80 }],
+	});
+	type _ExplicitWins = Expect<Equal<typeof explicit, number>>;
+
+	// createPrompts instances pass narrowing through (`typeof select`).
+	const p = createPrompts();
+	const themed = await p.select({ message: "?", choices: ["a", "b"] });
+	type _ThemedNarrows = Expect<Equal<typeof themed, "a" | "b">>;
 }
 void _selectTypeInferenceTests;

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -6,7 +6,7 @@ import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts"
 import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { CURSOR_INDICATOR, PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { resolveTheme } from "../core/theme.ts";
-import type { Choice, PartialPromptTheme, PromptTheme } from "../core/types.ts";
+import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
 import {
 	calculateScrollOffset,
@@ -200,6 +200,14 @@ function renderSubmitted<T>(
  * });
  * ```
  */
+// Narrowing overload: a literal choices tuple narrows the result to the
+// union of its values. The generic overload below keeps explicit-type-arg
+// and wrapper call sites (`select<T>(...)`) on the old contract.
+export function select<const C extends readonly Choice<unknown>[]>(
+	options: SelectOptions<ChoiceValue<C>> & { readonly choices: C },
+	io?: PromptIO,
+): Promise<ChoiceValue<C>>;
+export function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T>;
 export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering
 	if (options.initial !== undefined) {

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -200,13 +200,19 @@ function renderSubmitted<T>(
  * });
  * ```
  */
-// Narrowing overload: a literal choices tuple narrows the result to the
-// union of its values. The generic overload below keeps explicit-type-arg
-// and wrapper call sites (`select<T>(...)`) on the old contract.
-export function select<const C extends readonly Choice<unknown>[]>(
+// Narrowing overloads: a literal non-empty choices tuple narrows the result
+// to the union of its values, and widened `readonly string[]` choices keep
+// `string`. Non-tuple `readonly Choice<T>[]` (e.g. generic wrappers over
+// SelectOptions<T>) matches neither and falls through to the generic
+// overload, so `select(options)` inside a wrapper stays `Promise<T>`.
+export function select<const C extends readonly [Choice<unknown>, ...Choice<unknown>[]]>(
 	options: SelectOptions<ChoiceValue<C>> & { readonly choices: C },
 	io?: PromptIO,
 ): Promise<ChoiceValue<C>>;
+export function select(
+	options: SelectOptions<string> & { readonly choices: readonly string[] },
+	io?: PromptIO,
+): Promise<string>;
 export function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T>;
 export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
 	// Short-circuit: return initial value immediately without rendering


### PR DESCRIPTION
## Problem

Literal `choices` never narrowed inferred types anywhere in the framework:

- `defineFlag("env", { type: "string", choices: ["staging", "production"], … })` → action saw `string`, not `"staging" | "production"` — even though the `const` generic preserved the tuple, `ResolveBaseType` never consulted `choices`.
- Raw args (no `type`/`schema`) with `choices` inferred `unknown`, despite the parser enforcing choices on them at runtime.
- All four choice-based prompts (`select`, `multiselect`, `filter`, `multifilter`) widened to `string`/`string[]`: `Choice<T>`'s plain-string branch never binds `T`, and `initial`/`default` inference candidates outrank choices.

## Fix

**core** — a `choices` branch in `ResolveBaseType` (typed string flags/args) and a parallel branch in `InferArgValue` (raw args). `parse` still owns the output type when present; `readonly string[]` (widened) stays `string`.

**prompts** — new exported `ChoiceValue<C>` extraction type + an additive narrowing overload on each of the four prompts, generic on the `const` choices tuple:

```ts
const env = await select({ choices: ["dev", "staging", "prod"] }); // "dev" | "staging" | "prod"
const port = await select({ choices: [{ label: "HTTP", value: 80 }, { label: "HTTPS", value: 443 }] }); // 80 | 443
```

The original generic signature remains as the second overload, so explicit-type-arg calls (`select<number>(…)`), generic wrappers, `createPrompts`, and widened `string[]` choices keep their previous contract — no breaking changes.

## Not changed

Schema mode is untouched: `choices` stays `never` there (schema exclusively owns validation, `InferOutput<S>` already narrows).

## Verification

- Type-level regression tests in `core/types.test.ts` and all four prompt test files (narrowing + widened-stays-`string` cases)
- `bun test` — 2308 pass across the repo
- `bun run check` (build + oxlint + oxfmt) — green
- Docs updated: `guide/flags.mdx`, `guide/arguments.mdx`, `modules/prompts.mdx`; changesets for both packages (patch)