### PR TITLE
feat(store): require explicit store names

### DIFF
--- a/.changeset/cozy-otters-think.md
+++ b/.changeset/cozy-otters-think.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/store": minor
+---
+
+Require `name` when creating a store and remove the implicit `config.json` filename. Pass `name: "config"` to preserve the previous file path.

--- a/apps/docs/content/docs/guide/types.mdx
+++ b/apps/docs/content/docs/guide/types.mdx
@@ -114,6 +114,7 @@ new Crust("serve").flags({ name: "port", type: "string", schema: Port }).action(
 
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: { port: { schema: Port.default(3000) } },
 });
 const config = await store.read();

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -5,7 +5,7 @@ description: DX-first, typed persistence for CLI apps with config/data/state/cac
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-`@crustjs/store` gives your CLI production-ready local persistence with near-zero setup. Provide a `fields` definition, pick a storage intent, and get a typed store with read/write/update/patch/reset — no manual type annotations needed.
+`@crustjs/store` gives your CLI production-ready local persistence with near-zero setup. Provide a directory, store name, and `fields` definition to get a typed store with read/write/update/patch/reset — no manual type annotations needed.
 
 ## Install
 
@@ -20,6 +20,7 @@ import { createStore, configDir } from "@crustjs/store";
 
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     theme: { type: "string", default: "light" },
     fontSize: { type: "number", default: 14 },
@@ -73,6 +74,7 @@ import { createStore, configDir, dataDir, stateDir, cacheDir } from "@crustjs/st
 // User preferences → ~/.config/my-cli/config.json
 const config = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     theme: { type: "string", default: "light" },
     verbose: { type: "boolean", default: false },
@@ -82,6 +84,7 @@ const config = createStore({
 // App data → ~/.local/share/my-cli/config.json
 const data = createStore({
   dirPath: dataDir("my-cli"),
+  name: "config",
   fields: {
     bookmarks: { type: "string", array: true, default: [] },
   },
@@ -90,6 +93,7 @@ const data = createStore({
 // Runtime state → ~/.local/state/my-cli/config.json
 const state = createStore({
   dirPath: stateDir("my-cli"),
+  name: "config",
   fields: {
     lastOpened: { type: "string", default: "" },
     scrollY: { type: "number", default: 0 },
@@ -99,6 +103,7 @@ const state = createStore({
 // Cache → ~/.cache/my-cli/config.json
 const cache = createStore({
   dirPath: cacheDir("my-cli"),
+  name: "config",
   fields: {
     etag: { type: "string", default: "" },
     payload: { type: "string", default: "" },
@@ -126,16 +131,17 @@ The optional `env` parameter on each helper accepts a `PlatformEnv` object for d
 
 ### Multiple Stores
 
-Use the `name` option to maintain separate JSON files under the same directory:
+Give each store a `name` to maintain separate JSON files under the same directory:
 
 ```ts
 import { createStore, configDir } from "@crustjs/store";
 
 const dir = configDir("my-cli");
 
-// ~/.config/my-cli/config.json (default)
+// ~/.config/my-cli/config.json
 const settingsStore = createStore({
   dirPath: dir,
+  name: "config",
   fields: {
     theme: { type: "string", default: "light" },
     fontSize: { type: "number", default: 14 },
@@ -155,13 +161,13 @@ const authStore = createStore({
 
 Each store is fully independent — reading, writing, updating, and resetting one does not affect the others.
 
-`name` defaults to `"config"` (producing `config.json`). It must not contain path separators or the `.json` extension.
+`name` is required and becomes the JSON filename. It must not contain path separators or the `.json` extension.
 
 ## API
 
 ### `createStore(options)`
 
-Creates a typed async store backed by a local JSON file. The file path is resolved once at creation time from `dirPath` and optional `name`.
+Creates a typed async store backed by a local JSON file. The file path is resolved once at creation time from the required `dirPath` and `name`.
 
 ```ts
 const store = createStore(options);
@@ -285,6 +291,7 @@ When a persisted file exists, `read()` fills missing keys from field `defaults`:
 ```ts
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     theme: { type: "string", default: "light" },
     fontSize: { type: "number", default: 14 },
@@ -317,6 +324,7 @@ Add a `validate` function to individual field definitions to validate values dur
 ```ts
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     port: {
       type: "number",
@@ -345,6 +353,7 @@ import { z } from "zod";
 
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     theme: { schema: z.enum(["light", "dark"]).default("light") },
     verbose: { type: "boolean", default: false },
@@ -360,6 +369,7 @@ import { configDir, createStore } from "@crustjs/store";
 
 const store = createStore({
   dirPath: configDir("my-cli"),
+  name: "config",
   fields: {
     theme: { schema: Schema.standardSchemaV1(Schema.Literal("light", "dark")) },
   },

--- a/packages/store/src/path.test.ts
+++ b/packages/store/src/path.test.ts
@@ -508,7 +508,7 @@ describe("resolveStorePath", () => {
 	describe("dirPath validation", () => {
 		it("should reject empty dirPath", () => {
 			try {
-				resolveStorePath("");
+				resolveStorePath("", "config");
 				expect.unreachable("should have thrown");
 			} catch (err) {
 				expect(err).toBeInstanceOf(CrustStoreError);
@@ -519,7 +519,7 @@ describe("resolveStorePath", () => {
 
 		it("should reject relative dirPath", () => {
 			try {
-				resolveStorePath("relative/path");
+				resolveStorePath("relative/path", "config");
 				expect.unreachable("should have thrown");
 			} catch (err) {
 				expect(err).toBeInstanceOf(CrustStoreError);
@@ -530,7 +530,7 @@ describe("resolveStorePath", () => {
 
 		it("should reject dirPath ending in .json", () => {
 			try {
-				resolveStorePath("/absolute/path/config.json");
+				resolveStorePath("/absolute/path/config.json", "config");
 				expect.unreachable("should have thrown");
 			} catch (err) {
 				expect(err).toBeInstanceOf(CrustStoreError);
@@ -540,20 +540,20 @@ describe("resolveStorePath", () => {
 		});
 
 		it("should accept valid absolute dirPath", () => {
-			const result = resolveStorePath("/home/user/.config/my-cli");
+			const result = resolveStorePath("/home/user/.config/my-cli", "config");
 			expect(result).toBe(join("/home/user/.config/my-cli", "config.json"));
 		});
 
 		it("should accept Windows-style absolute dirPath", () => {
-			const result = resolveStorePath("C:\\Users\\test\\config-dir");
+			const result = resolveStorePath("C:\\Users\\test\\config-dir", "config");
 			expect(result).toBe(join("C:\\Users\\test\\config-dir", "config.json"));
 		});
 	});
 
 	describe("name parameter", () => {
-		it("should default to config.json when name is not provided", () => {
-			const result = resolveStorePath("/home/user/.config/my-cli");
-			expect(result).toEndWith("config.json");
+		it("should reject a missing name at runtime", () => {
+			const resolveWithoutName = resolveStorePath as (dirPath: string) => string;
+			expect(() => resolveWithoutName("/home/user/.config/my-cli")).toThrow(CrustStoreError);
 		});
 
 		it("should use custom name as filename", () => {
@@ -608,7 +608,7 @@ describe("resolveStorePath", () => {
 
 		it("should compose dataDir + resolveStorePath", () => {
 			const dir = dataDir("my-cli", linuxEnv());
-			const path = resolveStorePath(dir);
+			const path = resolveStorePath(dir, "config");
 			expect(path).toBe(join("/home/testuser", ".local", "share", "my-cli", "config.json"));
 		});
 

--- a/packages/store/src/path.ts
+++ b/packages/store/src/path.ts
@@ -7,12 +7,6 @@ import { join, win32 } from "node:path";
 
 import { CrustStoreError } from "./errors.ts";
 
-/**
- * Default store name used when no explicit `name` is provided.
- * Produces `config.json` as the filename.
- */
-const DEFAULT_STORE_NAME = "config";
-
 // ────────────────────────────────────────────────────────────────────────────
 // Platform environment — injectable for testing
 // ────────────────────────────────────────────────────────────────────────────
@@ -329,18 +323,12 @@ export function cacheDir(appName: string, env?: PlatformEnv): string {
  * `<dirPath>/<name>.json`.
  *
  * @param dirPath - Absolute directory path.
- * @param name - Optional store name (defaults to `"config"`).
+ * @param name - Store name used as the JSON filename.
  * @returns Absolute path to the store file.
  * @throws {CrustStoreError} `PATH` if `dirPath` or `name` is invalid.
  */
-export function resolveStorePath(dirPath: string, name?: string): string {
+export function resolveStorePath(dirPath: string, name: string): string {
 	validateDirPath(dirPath);
-
-	// Resolve store name (validate only when explicitly provided)
-	const storeName = name ?? DEFAULT_STORE_NAME;
-	if (name !== undefined) {
-		validateName(name);
-	}
-
-	return join(dirPath, `${storeName}.json`);
+	validateName(name);
+	return join(dirPath, `${name}.json`);
 }

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 
 import { CrustStoreError } from "./errors.ts";
 import { createStore } from "./store.ts";
-import type { FieldsDef } from "./types.ts";
+import type { CreateStoreOptions, FieldsDef } from "./types.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Test helpers
@@ -66,6 +66,7 @@ describe("createStore", () => {
 	it("should return a store with read, write, update, patch, and reset methods", () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -80,6 +81,7 @@ describe("createStore", () => {
 		expect(() =>
 			createStore({
 				dirPath: "relative/path",
+				name: "config",
 				fields: BASIC_FIELDS,
 			}),
 		).toThrow(CrustStoreError);
@@ -89,6 +91,7 @@ describe("createStore", () => {
 		expect(() =>
 			createStore({
 				dirPath: "/tmp/config.json",
+				name: "config",
 				fields: BASIC_FIELDS,
 			}),
 		).toThrow(CrustStoreError);
@@ -129,16 +132,13 @@ describe("createStore", () => {
 		expect(JSON.parse(raw)).toEqual({ theme: "dark", verbose: true });
 	});
 
-	it("should default to config.json when name is not provided", async () => {
-		const store = createStore({
-			dirPath: tempDir,
-			fields: BASIC_FIELDS,
-		});
-
-		await store.write({ theme: "dark", verbose: true });
-
-		const configPath = join(tempDir, "config.json");
-		expect(existsSync(configPath)).toBe(true);
+	it("should throw when name is not provided at runtime", () => {
+		expect(() =>
+			createStore({
+				dirPath: tempDir,
+				fields: BASIC_FIELDS,
+			} as unknown as CreateStoreOptions<typeof BASIC_FIELDS>),
+		).toThrow(CrustStoreError);
 	});
 
 	// POSIX-only: Windows ignores Unix permission bits (it uses ACLs).
@@ -186,6 +186,7 @@ describe("store.read", () => {
 	it("should return defaults when no persisted file exists", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -198,6 +199,7 @@ describe("store.read", () => {
 	it("should omit optional fields (no default) when no persisted file exists", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: MIXED_FIELDS,
 		});
 
@@ -211,6 +213,7 @@ describe("store.read", () => {
 	it("should return persisted values overriding defaults", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -227,6 +230,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -242,6 +246,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: MIXED_FIELDS,
 		});
 
@@ -255,6 +260,7 @@ describe("store.read", () => {
 	it("should not auto-persist merged defaults back to disk", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -278,6 +284,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -294,6 +301,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -318,6 +326,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -337,6 +346,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -367,6 +377,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -386,6 +397,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -404,6 +416,7 @@ describe("store.read", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -431,6 +444,7 @@ describe("store.write", () => {
 	it("should persist config to disk", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -445,6 +459,7 @@ describe("store.write", () => {
 		const nestedDir = join(tempDir, "deep", "nested");
 		const store = createStore({
 			dirPath: nestedDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -459,6 +474,7 @@ describe("store.write", () => {
 	it("should overwrite existing config", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -473,6 +489,7 @@ describe("store.write", () => {
 	it("should persist optional fields when provided", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: MIXED_FIELDS,
 		});
 
@@ -494,6 +511,7 @@ describe("store.write", () => {
 	it("should run field validators on write", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -514,6 +532,7 @@ describe("store.write", () => {
 	it("should not persist when validation fails", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -541,6 +560,7 @@ describe("store.write", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -570,6 +590,7 @@ describe("store.update", () => {
 	it("should read, apply updater, and persist", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -584,6 +605,7 @@ describe("store.update", () => {
 	it("should use field defaults as current when no persisted file", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -600,6 +622,7 @@ describe("store.update", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -616,6 +639,7 @@ describe("store.update", () => {
 	it("should work with optional fields", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: MIXED_FIELDS,
 		});
 
@@ -635,6 +659,7 @@ describe("store.update", () => {
 	it("should run field validators on update", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -671,6 +696,7 @@ describe("store.patch", () => {
 	it("should apply partial update to current config", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -685,6 +711,7 @@ describe("store.patch", () => {
 	it("should preserve existing keys not in the partial", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -699,6 +726,7 @@ describe("store.patch", () => {
 	it("should run field validators on patch", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -718,6 +746,7 @@ describe("store.patch", () => {
 	it("should work when no persisted file exists (patches defaults)", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -748,6 +777,7 @@ describe("store.reset", () => {
 	it("should delete persisted config file", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -762,6 +792,7 @@ describe("store.reset", () => {
 	it("should not throw when no persisted file exists", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -772,6 +803,7 @@ describe("store.reset", () => {
 	it("should return to defaults-on-read behavior after reset", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -790,6 +822,7 @@ describe("store.reset", () => {
 	it("should return field defaults after reset (optional fields undefined)", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: MIXED_FIELDS,
 		});
 
@@ -826,6 +859,7 @@ describe("store lifecycle", () => {
 	it("should support full read → write → update → patch → reset cycle", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -864,6 +898,7 @@ describe("store lifecycle", () => {
 	it("should support multiple write → read cycles", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -878,6 +913,7 @@ describe("store lifecycle", () => {
 	it("should handle array fields across lifecycle", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: ARRAY_FIELDS,
 		});
 
@@ -918,6 +954,7 @@ describe("multiple stores with name option", () => {
 	it("should support multiple independent stores under the same directory", async () => {
 		const configStore = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 
@@ -956,6 +993,7 @@ describe("multiple stores with name option", () => {
 	it("should write to different JSON files based on name", async () => {
 		const defaultStore = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: BASIC_FIELDS,
 		});
 		await defaultStore.write({ theme: "dark", verbose: true });
@@ -993,6 +1031,7 @@ describe("field validation", () => {
 	it("should pass when all field validators succeed", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -1021,6 +1060,7 @@ describe("field validation", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -1054,6 +1094,7 @@ describe("field validation", () => {
 
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields,
 		});
 
@@ -1070,6 +1111,7 @@ describe("field validation", () => {
 	it("should include field path in validation error details", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -1088,6 +1130,7 @@ describe("field validation", () => {
 	it("should include operation in validation error details", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: VALIDATED_FIELDS,
 		});
 
@@ -1151,7 +1194,7 @@ describe("FieldDef.validate contract", () => {
 			},
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		try {
 			await store.write({ name: "bad" });
@@ -1195,6 +1238,7 @@ describe("schema transform persistence", () => {
 	it("materializes schema defaults from missing persisted values", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: { name: { schema: z.string().default("x") } },
 		});
 
@@ -1204,6 +1248,7 @@ describe("schema transform persistence", () => {
 	it("preserves optional schema output for missing persisted values", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: { name: { schema: z.string().optional() } },
 		});
 
@@ -1213,6 +1258,7 @@ describe("schema transform persistence", () => {
 	it("rejects missing values when the schema requires a value", async () => {
 		const store = createStore({
 			dirPath: tempDir,
+			name: "config",
 			fields: { name: { schema: z.string() } },
 		});
 
@@ -1226,7 +1272,11 @@ describe("schema transform persistence", () => {
 		]) {
 			let caught: unknown;
 			try {
-				createStore({ dirPath: tempDir, fields: { name: field } as unknown as FieldsDef });
+				createStore({
+					dirPath: tempDir,
+					name: "config",
+					fields: { name: field } as unknown as FieldsDef,
+				});
 			} catch (error) {
 				caught = error;
 			}
@@ -1240,7 +1290,7 @@ describe("schema transform persistence", () => {
 			name: { schema: z.string().transform((s) => s.trim()) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.write({ name: "  hi  " });
 
@@ -1254,7 +1304,7 @@ describe("schema transform persistence", () => {
 			name: { schema: z.string().transform((s) => s.trim()) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.update(() => ({ name: "  spaced  " }));
 
@@ -1268,7 +1318,7 @@ describe("schema transform persistence", () => {
 			name: { schema: z.string().transform((s) => s.trim()) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.patch({ name: "  patched  " });
 
@@ -1288,7 +1338,7 @@ describe("schema transform persistence", () => {
 			name: { schema: z.string().transform((s) => s.trim()) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		const result = await store.read();
 		expect(result.name).toBe("  hi  ");
@@ -1306,7 +1356,7 @@ describe("schema transform persistence", () => {
 			x: { schema: z.string().transform((s) => s.length) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		let caught: unknown;
 		try {
@@ -1343,7 +1393,7 @@ describe("schema transform persistence", () => {
 			tags: { schema: z.array(z.string()) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.write({ tags: ["a", "b"] });
 
@@ -1361,7 +1411,7 @@ describe("schema transform persistence", () => {
 			tags: { schema: z.array(z.string().transform((s) => s.trim())) },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.write({ tags: ["  a  ", "b "] });
 
@@ -1375,7 +1425,7 @@ describe("schema transform persistence", () => {
 			theme: { type: "string", default: "x" },
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		await store.write({ theme: "dark" });
 
@@ -1399,7 +1449,7 @@ describe("schema transform persistence", () => {
 			},
 		} as const satisfies FieldsDef;
 
-		const store = createStore({ dirPath: tempDir, fields });
+		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
 		// Accept on no-throw: writes 8080 successfully.
 		await store.write({ port: 8080 });

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -56,7 +56,7 @@ function isFieldValueResult(r: unknown): r is { value: unknown } {
  * Creates a typed async config store backed by a local JSON file.
  *
  * The store resolves its file path once at creation time from `dirPath` and
- * optional `name`. Core field definitions infer from `type` and `default`;
+ * `name`. Core field definitions infer from `type` and `default`;
  * schema-backed fields use the Standard Schema's exact output type.
  *
  * @typeParam F - Field definitions record (inferred via `const` generic).
@@ -70,6 +70,7 @@ function isFieldValueResult(r: unknown): r is { value: unknown } {
  *
  * const store = createStore({
  *   dirPath: configDir("my-cli"),
+ *   name: "config",
  *   fields: {
  *     theme: { type: "string", default: "light" },
  *     verbose: { type: "boolean", default: false },

--- a/packages/store/src/types.test.ts
+++ b/packages/store/src/types.test.ts
@@ -201,6 +201,20 @@ describe("FieldDef", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("CreateStoreOptions", () => {
+	it("should require a store name", () => {
+		const fields = {
+			theme: { type: "string", default: "light" },
+		} as const satisfies FieldsDef;
+
+		// @ts-expect-error — stores must have an explicit name
+		const options: CreateStoreOptions<typeof fields> = {
+			dirPath: "/tmp/test",
+			fields,
+		};
+
+		expect(options).toBeDefined();
+	});
+
 	it("should accept valid options with fields", () => {
 		const fields = {
 			theme: { type: "string", default: "light" },
@@ -209,6 +223,7 @@ describe("CreateStoreOptions", () => {
 
 		const options: CreateStoreOptions<typeof fields> = {
 			dirPath: "/tmp/test",
+			name: "config",
 			fields,
 		};
 
@@ -216,7 +231,7 @@ describe("CreateStoreOptions", () => {
 		expect(options.fields.theme.default).toBe("light");
 	});
 
-	it("should accept optional name", () => {
+	it("should accept a name", () => {
 		const fields = {
 			theme: { type: "string", default: "light" },
 		} as const satisfies FieldsDef;
@@ -243,6 +258,7 @@ describe("CreateStoreOptions", () => {
 
 		const options: CreateStoreOptions<typeof fields> = {
 			dirPath: "/tmp/test",
+			name: "config",
 			fields,
 		};
 
@@ -256,6 +272,7 @@ describe("CreateStoreOptions", () => {
 
 		const options: CreateStoreOptions<typeof fields> = {
 			dirPath: "/tmp/test",
+			name: "config",
 			fields,
 			pruneUnknown: false,
 		};
@@ -270,11 +287,13 @@ describe("CreateStoreOptions", () => {
 
 		const privateOptions: CreateStoreOptions<typeof fields> = {
 			dirPath: "/tmp/test",
+			name: "config",
 			fields,
 			access: "private",
 		};
 		const explicitOptions: CreateStoreOptions<typeof fields> = {
 			dirPath: "/tmp/test",
+			name: "config",
 			fields,
 			access: { file: 0o600, directory: 0o700 },
 		};
@@ -291,6 +310,7 @@ describe("CreateStoreOptions", () => {
 
 		const result = acceptOptions({
 			dirPath: "/tmp/test",
+			name: "config",
 			fields: {
 				theme: { type: "string", default: "light" },
 				verbose: { type: "boolean", default: false },

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -255,6 +255,7 @@ export type StoreAccess = "default" | "private" | StorePermissionBits;
  * ```ts
  * const store = createStore({
  *   dirPath: configDir("my-cli"),
+ *   name: "config",
  *   fields: {
  *     theme: { type: "string", default: "light" },
  *     verbose: { type: "boolean", default: false },
@@ -275,13 +276,10 @@ export interface CreateStoreOptions<F extends FieldsDef> {
 	/**
 	 * Store name used as the JSON filename in the directory.
 	 *
-	 * Defaults to `"config"`, producing `config.json`. Set to a different value
-	 * to create multiple stores under the same directory
-	 * (e.g. `name: "auth"` → `auth.json`).
-	 *
-	 * Must not contain path separators or the `.json` extension.
+	 * For example, `name: "auth"` produces `auth.json`. Must not contain path
+	 * separators or the `.json` extension.
 	 */
-	name?: string;
+	name: string;
 
 	/**
 	 * Field definitions that declare the store's config schema.
@@ -356,6 +354,7 @@ export type StoreUpdater<TConfig> = (current: TConfig) => NoInfer<TConfig>;
  * ```ts
  * const store = createStore({
  *   dirPath: configDir("my-cli"),
+ *   name: "config",
  *   fields: {
  *     theme: { type: "string", default: "light" },
  *     verbose: { type: "boolean", default: false },


### PR DESCRIPTION
## Summary

- require both `dirPath` and `name` when creating a store
- remove the implicit `config.json` filename while retaining runtime validation for JavaScript callers
- update store tests, documentation examples, and migration guidance

## Breaking change

`createStore` no longer defaults `name` to `"config"`. Pass `name: "config"` to preserve the previous `config.json` path.

## Verification

- `bun run --cwd packages/store test` — 238 passed
- `bun run --cwd packages/store check:types`
- `bun run --cwd packages/store build`
- `bunx oxlint packages/store/src/path.ts packages/store/src/path.test.ts packages/store/src/store.ts packages/store/src/store.test.ts packages/store/src/types.ts packages/store/src/types.test.ts`
- `bunx oxfmt --check ...`
- `bun run build:docs`
