### PR TITLE
feat(core): scope Context construction to a command's requires closure

### DIFF
--- a/.changeset/requires-scoped-context-construction.md
+++ b/.changeset/requires-scoped-context-construction.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Context construction is now `requires`-scoped, not path-scoped. A command added with `defineCommand` constructs only the Contexts it provides itself plus the transitive `requires` closure of its declared requirements; inherited Contexts it does not require are never constructed (matching the recipe's `ctx` typing, which never exposed them). The root command's own action still constructs everything provided on it. Providing Contexts once at the root is now free for commands that don't require them.

--- a/.changeset/requires-scoped-context-construction.md
+++ b/.changeset/requires-scoped-context-construction.md
@@ -2,4 +2,6 @@
 "@crustjs/core": minor
 ---
 
-Context construction is now `requires`-scoped, not path-scoped. A command added with `defineCommand` constructs only the Contexts it provides itself plus the transitive `requires` closure of its declared requirements; inherited Contexts it does not require are never constructed (matching the recipe's `ctx` typing, which never exposed them). The root command's own action still constructs everything provided on it. Providing Contexts once at the root is now free for commands that don't require them.
+Context construction is now `requires`-scoped, not path-scoped. A command added with `defineCommand` constructs only the Contexts it provides itself plus the transitive `requires` closure of its declared requirements and of those self-provided Contexts; inherited Contexts outside that closure are never constructed (matching the recipe's `ctx` typing, which never exposed them). The root command's own action still constructs everything provided on it. Providing Contexts once at the root is now free for commands that don't require them.
+
+If a command relied on an inherited Context constructing without declaring it (for example for setup side effects), declare it in `requires`.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -227,7 +227,7 @@ provide<const Cs extends readonly ContextInstance[]>(
 >
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only for the resolved command path, and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only when the resolved command requires them (self-provided Contexts plus the transitive `requires` closure of a defined command; the root action constructs everything provided on it), and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -227,7 +227,7 @@ provide<const Cs extends readonly ContextInstance[]>(
 >
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only when the resolved command requires them (self-provided Contexts plus the transitive `requires` closure of a defined command; the root action constructs everything provided on it), and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only when the resolved command requires them (a defined command's self-provided Contexts plus the transitive `requires` closure of its declared requirements and of those self-provides; the root action constructs everything provided on it), and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -193,7 +193,7 @@ interface ContextSetup<Options, RC, OF> extends InvocationIO {
   name="ContextInstance"
 />
 
-Attach an instance with `.provide()`. Core constructs it lazily on the resolved path, topologically ordered by declared capability requirements.
+Attach an instance with `.provide()`. Core constructs it lazily, only when the resolved command requires it, topologically ordered by declared capability requirements.
 
 ### `ContextMap`
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -57,9 +57,11 @@ The child requires `ctx.api`, not the raw flag. If an action also needs the raw 
 
 ## Lazy construction and inheritance
 
-Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only for the resolved command path. An Extension that returns `ctx.finish()` does not construct them.
+Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only the Contexts the resolved command actually uses. For a command added with `defineCommand`, that means the Contexts it provides itself plus the transitive `requires` closure of its declared requirements; inherited Contexts it does not require are never constructed. The root command's own action constructs everything provided on it. An Extension that returns `ctx.finish()` does not construct them.
 
-Contexts are inherited by descendant commands. An added command lists the factories it depends on in `requires`, which types `ctx` in its action:
+This makes the provide site agnostic: provide every Context once at the root and each command pays only for what it declares.
+
+Contexts are inherited by descendant commands. An added command lists the factories it depends on in `requires`, which types `ctx` in its action and scopes construction:
 
 ```ts
 import { defineCommand } from "@crustjs/core";

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -57,7 +57,7 @@ The child requires `ctx.api`, not the raw flag. If an action also needs the raw 
 
 ## Lazy construction and inheritance
 
-Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only the Contexts the resolved command actually uses. For a command added with `defineCommand`, that means the Contexts it provides itself plus the transitive `requires` closure of its declared requirements; inherited Contexts it does not require are never constructed. The root command's own action constructs everything provided on it. An Extension that returns `ctx.finish()` does not construct them.
+Context values are constructed only after a command is routed, parsed, processed by `preRun` hooks, and validated — and only the Contexts the resolved command actually uses. For a command added with `defineCommand`, that means the Contexts it provides itself plus the transitive `requires` closure of its declared requirements and of those self-provided Contexts; inherited Contexts outside that closure are never constructed. Their owned flags still parse and appear in help, but are accepted without constructing the owning Context. The root command's own action constructs everything provided on it. An Extension that returns `ctx.finish()` does not construct them.
 
 This makes the provide site agnostic: provide every Context once at the root and each command pays only for what it declares.
 

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -32,7 +32,7 @@ It requires explicit argv, honors injected writers, throws the original error, d
 4. **Run `preRun` hooks** — invoke Extension hooks in `.extend()` order. A hook can return `ctx.finish()` to skip the remaining hooks, validation, schemas, Contexts, and the Command Action.
 5. **Validate structure** — enforce required values, choices, and other core rules.
 6. **Apply schemas** — validate and transform every schema-backed input, aggregating issues.
-7. **Construct Contexts** — create the Context values provided on the resolved path in topological order of their declared capability requirements (registration order among independent Contexts), passing each setup only its validated owned flags.
+7. **Construct Contexts** — create the Context values the resolved command requires (its self-provided Contexts plus their transitive `requires` closure and that of its declared requirements) in topological order of their declared capability requirements (registration order among independent Contexts), passing each setup only its validated owned flags.
 8. **Run the Command Action**.
 9. **Dispose Contexts** — run `Symbol.dispose` or `Symbol.asyncDispose` in reverse construction order, including after failure.
 10. **Run `postRun` hooks** — invoke every Extension hook in reverse `.extend()` order with the completed, finished, or failed outcome. This is the invocation-level `finally` slot.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -46,7 +46,7 @@ $ greet --help
 - **Schema-first validation** — Place any Standard Schema on an argument or flag definition; the action receives its output type
 - **Composable, not monolithic** — Every capability ships as its own module with zero runtime dependencies in core. Install only what you need — `@crustjs/core` for the framework, `@crustjs/extensions` for official extensions, `@crustjs/crust` for build tooling.
 - **Extensions** — App-wide capabilities like help, version, completion, and update notices, attached once at the root
-- **Contexts** — Named command dependencies created lazily for the resolved command path
+- **Contexts** — Named command dependencies constructed lazily, only when the resolved command requires them
 - **Subcommands** — Nested command trees with automatic resolution and Context-owned flag propagation
 - **Built for Bun** — Targets the Bun runtime from the ground up. No Node compatibility layers, no legacy baggage.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -37,7 +37,7 @@ $ greet --help
 - **Plain values, immutable builders.** Definitions and Extensions are frozen data; every fluent call returns a new builder.
 - **Fail loud at definition time.** Collisions and malformed definitions are `DEFINITION` errors at startup and in `crust build` — never warn-and-skip.
 - **Standards over lock-in.** Standard Schema for validation, `NO_COLOR`/`FORCE_COLOR` and OSC 8 conventions, native `Symbol.dispose` cleanup.
-- **Pay only for what you use.** Zero-dependency core, composable modules, Contexts constructed lazily for the resolved path only.
+- **Pay only for what you use.** Zero-dependency core, composable modules, Contexts constructed lazily, only when the resolved command requires them.
 
 ## Feature highlight
 

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -152,7 +152,7 @@ describe("Crust .provide()", () => {
 		expect(seen).toEqual(["root-db"]);
 	});
 
-	it("does not construct Contexts for commands off the resolved path", async () => {
+	it("does not construct inherited Contexts a command does not require", async () => {
 		let built = 0;
 		const lazy = defineContext("lazy", () => {
 			built++;
@@ -162,11 +162,45 @@ describe("Crust .provide()", () => {
 		const app = new Crust("cli")
 			.provide(lazy())
 			.add(defineCommand("a", (cmd) => cmd.action(() => {})))
-			.add(defineCommand("b", (cmd) => cmd.action(() => {})));
+			.add(defineCommand("b", { requires: [lazy] }, (cmd) => cmd.action(() => {})));
 
-		// Resolving "a" builds the inherited context once; "b" not executed
+		// "a" declares no requirements, so the inherited context never builds.
 		await app.run(["a"]);
+		expect(built).toBe(0);
+
+		// "b" requires it, so resolving "b" builds it once.
+		await app.run(["b"]);
 		expect(built).toBe(1);
+	});
+
+	it("constructs the transitive requires closure for a required Context", async () => {
+		const builtNames: string[] = [];
+		const base = defineContext("base", () => {
+			builtNames.push("base");
+			return "base";
+		});
+		const db = defineContext("db", { requires: [base] }, ({ ctx }) => {
+			builtNames.push("db");
+			return `db(${ctx.base})`;
+		});
+		const unrelated = defineContext("unrelated", () => {
+			builtNames.push("unrelated");
+			return "unrelated";
+		});
+
+		const seen: string[] = [];
+		const app = new Crust("cli").provide(base(), db(), unrelated()).add(
+			defineCommand("query", { requires: [db] }, (cmd) =>
+				cmd.action(({ ctx }) => {
+					seen.push(ctx.db);
+				}),
+			),
+		);
+
+		await app.run(["query"]);
+
+		expect(builtNames).toEqual(["base", "db"]);
+		expect(seen).toEqual(["db(base)"]);
 	});
 
 	it("does not backfill added children with later parent provides", async () => {

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -179,9 +179,13 @@ describe("Crust .provide()", () => {
 			builtNames.push("base");
 			return "base";
 		});
-		const db = defineContext("db", { requires: [base] }, ({ ctx }) => {
+		const mid = defineContext("mid", { requires: [base] }, ({ ctx }) => {
+			builtNames.push("mid");
+			return `mid(${ctx.base})`;
+		});
+		const db = defineContext("db", { requires: [mid] }, ({ ctx }) => {
 			builtNames.push("db");
-			return `db(${ctx.base})`;
+			return `db(${ctx.mid})`;
 		});
 		const unrelated = defineContext("unrelated", () => {
 			builtNames.push("unrelated");
@@ -189,7 +193,7 @@ describe("Crust .provide()", () => {
 		});
 
 		const seen: string[] = [];
-		const app = new Crust("cli").provide(base(), db(), unrelated()).add(
+		const app = new Crust("cli").provide(base(), mid(), db(), unrelated()).add(
 			defineCommand("query", { requires: [db] }, (cmd) =>
 				cmd.action(({ ctx }) => {
 					seen.push(ctx.db);
@@ -199,8 +203,69 @@ describe("Crust .provide()", () => {
 
 		await app.run(["query"]);
 
-		expect(builtNames).toEqual(["base", "db"]);
-		expect(seen).toEqual(["db(base)"]);
+		// A ≥3-node chain distinguishes true transitivity from a one-hop keep.
+		expect(builtNames).toEqual(["base", "mid", "db"]);
+		expect(seen).toEqual(["db(mid(base))"]);
+	});
+
+	it("constructs each Context in a diamond requires closure exactly once", async () => {
+		const builtNames: string[] = [];
+		const a = defineContext("a", () => {
+			builtNames.push("a");
+			return "a";
+		});
+		const b = defineContext("b", { requires: [a] }, () => {
+			builtNames.push("b");
+			return "b";
+		});
+		const c = defineContext("c", { requires: [a] }, () => {
+			builtNames.push("c");
+			return "c";
+		});
+		const d = defineContext("d", { requires: [b, c] }, () => {
+			builtNames.push("d");
+			return "d";
+		});
+
+		const app = new Crust("cli")
+			.provide(a(), b(), c(), d())
+			.add(defineCommand("go", { requires: [d] }, (cmd) => cmd.action(() => {})));
+
+		await app.run(["go"]);
+
+		expect(builtNames.slice().sort()).toEqual(["a", "b", "c", "d"]);
+		expect(builtNames[0]).toBe("a");
+		expect(builtNames[3]).toBe("d");
+	});
+
+	it("constructs an inherited dependency of a self-provided Context without declared requires", async () => {
+		const builtNames: string[] = [];
+		const session = defineContext("session", () => {
+			builtNames.push("session");
+			return "session";
+		});
+		const unrelated = defineContext("unrelated", () => {
+			builtNames.push("unrelated");
+			return "unrelated";
+		});
+		const user = defineContext("user", { requires: [session] }, ({ ctx }) => {
+			builtNames.push("user");
+			return `user(${ctx.session})`;
+		});
+
+		const seen: string[] = [];
+		const app = new Crust("cli").provide(session(), unrelated()).add(
+			defineCommand("account", (cmd) =>
+				cmd.provide(user()).action(({ ctx }) => {
+					seen.push(ctx.user);
+				}),
+			),
+		);
+
+		await app.run(["account"]);
+
+		expect(builtNames).toEqual(["session", "user"]);
+		expect(seen).toEqual(["user(session)"]);
 	});
 
 	it("does not backfill added children with later parent provides", async () => {

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -48,7 +48,7 @@ interface ContextSetupInput<
 /**
  * A named command dependency produced by invoking a Context factory.
  * Attach with `.provide()`; the value is constructed only when the
- * resolved command path executes.
+ * resolved command requires it.
  *
  * Generic parameter `RC` carries the declared Context requirements.
  */
@@ -164,7 +164,7 @@ export type RequirementCtxOf<R extends { readonly requires?: ContextRequirements
  * `.provide()`, while `requires` declares Context capabilities from the command
  * path. Setup receives the validated owned flags, declared Context values (`ctx`),
  * and the invocation's injectable output callbacks. Dependencies drive construction
- * order: Contexts on the resolved command path are constructed topologically, regardless of
+ * order: Contexts the resolved command requires are constructed topologically, regardless of
  * `.provide()` order.
  *
  * Cleanup belongs to the value itself: implement `Symbol.dispose` or

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -138,6 +138,32 @@ export interface CommandDefinition<
 	readonly _aliases?: Aliases;
 }
 
+/**
+ * Scope a materialized definition's Contexts to what its recipe can see:
+ * Contexts provided inside the recipe plus the transitive `requires`
+ * closure over inherited ones. Inherited Contexts outside that closure are
+ * never constructed for this command, matching the recipe's `ctx` typing.
+ */
+function scopeContexts(
+	contexts: readonly ContextInstance[],
+	inherited: ReadonlySet<string>,
+	required: readonly string[],
+): ContextInstance[] {
+	const keep = new Set(required);
+	for (const context of contexts) {
+		if (!inherited.has(context.name)) keep.add(context.name);
+	}
+	// Topological order (dependencies first) lets one reverse pass collect
+	// the transitive closure of Context `requires` chains.
+	for (let i = contexts.length - 1; i >= 0; i--) {
+		const context = contexts[i] as ContextInstance;
+		if (keep.has(context.name)) {
+			for (const dep of context.requiredCtx) keep.add(dep);
+		}
+	}
+	return contexts.filter((context) => keep.has(context.name));
+}
+
 function materializeCommandDefinition(
 	definition: CommandDefinition,
 	parent: CommandNode,
@@ -213,6 +239,12 @@ function materializeCommandDefinition(
 
 	const childNode = cloneCommandNode(configured._node);
 	childNode.meta = { name, ...internal.meta };
+	const inheritedCtxNames = new Set(parent.contexts.map((context) => context.name));
+	childNode.contexts = scopeContexts(
+		childNode.contexts,
+		inheritedCtxNames,
+		internal.requiredCtxNames,
+	);
 	return childNode;
 }
 
@@ -550,8 +582,9 @@ export class Crust<
 	 * Attach Contexts — named command dependencies — to this command.
 	 *
 	 * Contexts are inherited by descendant commands, constructed
-	 * topologically (by declared capability requirements) only for the resolved
-	 * command path, and exposed to the Command Action as `ctx`. Within one
+	 * topologically (by declared capability requirements) only when the
+	 * resolved command requires them, and exposed to the Command Action as
+	 * `ctx`. Within one
 	 * `.provide()` call, dependencies may appear after their dependents.
 	 * Values implementing `Symbol.dispose` or `Symbol.asyncDispose` are
 	 * disposed in reverse construction order after success or failure.

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -155,8 +155,7 @@ function scopeContexts(
 	}
 	// Topological order (dependencies first) lets one reverse pass collect
 	// the transitive closure of Context `requires` chains.
-	for (let i = contexts.length - 1; i >= 0; i--) {
-		const context = contexts[i] as ContextInstance;
+	for (const context of contexts.toReversed()) {
 		if (keep.has(context.name)) {
 			for (const dep of context.requiredCtx) keep.add(dep);
 		}

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -232,6 +232,27 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		expect(result.stdout).toContain("output=json");
 		expect(result.exitCode).toBe(0);
 	});
+
+	it("accepts an owned flag of an unrequired Context without constructing it", async () => {
+		let built = 0;
+		const token = defineFlag("token", { type: "string" });
+		const auth = defineContext("auth", { flags: [token] }, ({ flags }) => {
+			built++;
+			return flags;
+		});
+		const app = new Crust("cli").provide(auth()).add(
+			defineCommand("deploy", (command) =>
+				command.action(({ flags }) => {
+					console.log(`token=${String((flags as { token?: string }).token)}`);
+				}),
+			),
+		);
+
+		const result = await executeCrust(app, ["deploy", "--token", "secret"]);
+		expect(result.stdout).toContain("token=secret");
+		expect(result.exitCode).toBe(0);
+		expect(built).toBe(0);
+	});
 });
 
 describe("integration: Extension adds flag visible to subcommand action", () => {
@@ -316,6 +337,31 @@ describe("integration: nested added definitions end-to-end", () => {
 		]);
 		expect(result.stdout).toContain("add remote=origin verbose=true timeout=60");
 		expect(result.exitCode).toBe(0);
+	});
+
+	it("a descendant constructs a root Context its parent command does not require", async () => {
+		const builtNames: string[] = [];
+		const db = defineContext("db", () => {
+			builtNames.push("db");
+			return "root-db";
+		});
+		const app = new Crust("cli").provide(db()).add(
+			defineCommand("sub", (cmd) =>
+				cmd.add(
+					// @ts-expect-error -- typed API brands this shape (`sub` must redeclare
+					// db); runtime scoping is per-node, so untyped consumers can require a
+					// root Context their parent command never declares.
+					defineCommand("g", { requires: [db] }, (child) =>
+						child.action(({ ctx }) => console.log(`db=${ctx.db}`)),
+					),
+				),
+			),
+		);
+
+		const result = await executeCrust(app, ["sub", "g"]);
+		expect(result.stdout).toContain("db=root-db");
+		expect(result.exitCode).toBe(0);
+		expect(builtNames).toEqual(["db"]);
 	});
 
 	it("parent with an action falls back when unknown subcommand given as positional", async () => {


### PR DESCRIPTION
## Problem

`requires` on `defineCommand` was only a typing/add-time contract — it never filtered construction. Every command on the resolved path constructed **all** inherited Contexts (`invocation.ts` built `resolvedNode.contexts` wholesale, and materialization copied `[...parent.contexts]` onto every child). Providing a Context at the root meant paying its setup cost on every command, even ones whose `ctx` typing never exposed it. Users had to game `.add()`/`.provide()` ordering to avoid unwanted construction.

## Fix

Construction is now `requires`-scoped, applied once at materialize time (`scopeContexts` in `crust.ts`) so invocation, snapshots, and docs all see the same truth:

- A command added with `defineCommand` keeps only its **self-provided** Contexts plus the **transitive `requires` closure** of its declared requirements. The context list is already topologically sorted, so one reverse pass collects the closure.
- Inline root actions keep constructing everything provided on them — their `ctx` is typed with all provides, so filtering there would leave typed-but-undefined entries.
- Provide sites become placement-agnostic: provide once at the root; each command constructs only what it declares.

## Not changed

Owned flags of unconstructed Contexts still parse and show in help everywhere on the path — the CLI surface is unchanged; only construction is scoped.

## Tests & docs

- Flipped the eager-behavior test: a non-requiring command builds `0` inherited Contexts; a requiring sibling builds `1`.
- New test: `base ← db ← query` builds `base, db` in order, never an unrelated sibling Context.
- Updated `guide/contexts.mdx`, `api/crust.mdx`, `index.mdx`, JSDoc, and added a changeset (`@crustjs/core` minor).

Gates: `bun run test` (all packages, 0 fail), `check:types`, `lint`, `format` — all green.