### PR TITLE
feat(prompts): type keys() with a named-key union for autocomplete

### DIFF
--- a/.changeset/typed-key-names.md
+++ b/.changeset/typed-key-names.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/prompts": patch
+"@crustjs/testing": patch
+---
+
+`keys()` on the prompt/interactive test harnesses now autocompletes named key names. The `@crustjs/prompts/testing` subpath exports the new `Key` and `NamedKey` types; `ctrl+<letter>` and single printable characters remain accepted.

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -90,7 +90,7 @@ test("accepts a name", async () => {
 });
 ```
 
-Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey` and the types `PromptTestIO` and `RenderedPrompt`.
+Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey` and the types `Key`, `NamedKey`, `PromptTestIO`, and `RenderedPrompt`; `keys()` autocompletes named key names while still accepting `ctrl+<letter>` and single characters.
 
 ## Prompts
 

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -3,7 +3,7 @@ import { stripVTControlCharacters } from "node:util";
 
 import type { PromptIO } from "./core/renderer.ts";
 
-const namedKeys: Record<string, string> = {
+const namedKeys = {
 	return: "\r",
 	enter: "\r",
 	backspace: "\x7f",
@@ -17,7 +17,15 @@ const namedKeys: Record<string, string> = {
 	tab: "\t",
 	space: " ",
 	escape: "\x1B",
-};
+} as const;
+
+export type NamedKey = keyof typeof namedKeys;
+
+/**
+ * Key argument for `keys()` / {@link encodeKey}: named keys get editor
+ * autocomplete; `ctrl+<letter>` and single printable characters stay legal.
+ */
+export type Key = NamedKey | `ctrl+${string}` | (string & {});
 
 /**
  * Encode a named terminal key as its raw input sequence.
@@ -26,8 +34,8 @@ const namedKeys: Record<string, string> = {
  * printable characters. Anything else throws — silently typing a misspelled
  * key name (e.g. `"pageup"`) into the prompt would corrupt the test input.
  */
-export function encodeKey(key: string): string {
-	if (key in namedKeys) return namedKeys[key] ?? "";
+export function encodeKey(key: Key): string {
+	if (key in namedKeys) return namedKeys[key as NamedKey];
 
 	const ctrl = /^ctrl\+([a-z])$/i.exec(key);
 	if (ctrl?.[1]) return String.fromCharCode(ctrl[1].toUpperCase().charCodeAt(0) & 0x1f);
@@ -109,7 +117,7 @@ class FakeTerminal {
 export interface PromptTestIO {
 	readonly io: Required<PromptIO>;
 	type(text: string): void;
-	keys(...namedKeys: string[]): void;
+	keys(...namedKeys: Key[]): void;
 	screen(): string;
 	output(): string;
 }
@@ -153,7 +161,7 @@ export function createPromptIO({ isTTY = true }: { isTTY?: boolean } = {}): Prom
 
 export interface RenderedPrompt<Answer> {
 	type(text: string): void;
-	keys(...namedKeys: string[]): void;
+	keys(...namedKeys: Key[]): void;
 	screen(): string;
 	readonly answer: Promise<Answer>;
 }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,6 +1,6 @@
 import type { InvocationIO } from "@crustjs/core";
 import { withPromptIO } from "@crustjs/prompts";
-import { createPromptIO } from "@crustjs/prompts/testing";
+import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 
 /** Structural io shape shared by `run()` and `execute()` captures. */
 export type CaptureIO = Partial<InvocationIO>;
@@ -114,7 +114,7 @@ async function captureExecuteExclusive(
 export interface InteractiveRun {
 	waitFor(pattern: RegExp, timeoutMs?: number): Promise<void>;
 	type(text: string): void;
-	keys(...namedKeys: string[]): void;
+	keys(...namedKeys: Key[]): void;
 	screen(): string;
 	readonly done: Promise<void>;
 }


### PR DESCRIPTION
## Summary

`keys()` on the test harnesses (`PromptTestIO`, `RenderedPrompt` in `@crustjs/prompts/testing`, and `InteractiveRun` in `@crustjs/testing`) took bare `string[]`, so editors offered no autocomplete for named keys like `"return"` or `"escape"`.

- Derive `NamedKey` from the key table via `as const` — single source of truth; adding a key to the table extends the type automatically.
- Expose ``Key = NamedKey | `ctrl+${string}` | (string & {})`` so named keys autocomplete while `ctrl+<letter>` and single printable characters stay legal.
- Note: a `satisfies` clause on the table would break `isolatedDeclarations` emit (TS9010); plain `as const` is emit-safe (commented inline).
- Docs (`modules/prompts.mdx`) and a patch changeset for both packages included.

## Verification

- `tsc --noEmit` on `packages/prompts` and `packages/testing` — clean
- `oxlint` — clean
- `bun test packages/prompts packages/testing` — 335 pass, 0 fail
