### PR TITLE
feat(testing): autocomplete argv command and flag spellings

### DIFF
--- a/.changeset/testing-argv-hints.md
+++ b/.changeset/testing-argv-hints.md
@@ -1,0 +1,8 @@
+---
+"@crustjs/core": minor
+"@crustjs/testing": minor
+---
+
+Testing helpers now autocomplete argv. `captureRun()`, `captureExecute()`, and `runInteractive()` are generic over the app, and their `argv` parameter suggests the command names, aliases, and dashed flag spellings the application statically declares — including flags and subcommands defined inside `defineCommand` recipes — while continuing to accept arbitrary strings for positionals and flag values. The hint union is exported as `ArgvHints<App>`.
+
+To support this, `@crustjs/core` threads a new trailing `Hints` type parameter through `Crust`, `CommandDefinitionBuilder`, and `CommandDefinition`: `defineCommand()` captures the recipe's statically known nested spellings, and `.add()` folds them into the parent. All new parameters are trailing and defaulted, so existing annotations keep working. Widened (non-literal) definitions and Extension-contributed commands or flags contribute no hints.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -88,19 +88,28 @@ A `CommandDefinition<R>` is a frozen value carrying its name, static config, and
 ### `defineCommand(name, config?, recipe)`
 
 ```ts
-defineCommand<const Name extends string>(
+defineCommand<
+  const Name extends string,
+  B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
+>(
   name: Name,
-  recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
-): CommandDefinition<{}, Name>;
+  recipe: (command: CommandDefinitionBuilder) => B,
+): CommandDefinition<{}, Name, readonly string[], BuilderHints<B>>;
 
 interface CommandConfig extends Omit<CommandMeta, "name">, CommandRequirements {}
 
-defineCommand<const Name extends string, const C extends CommandConfig>(
+defineCommand<
+  const Name extends string,
+  const C extends CommandConfig,
+  B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
+>(
   name: Name,
   config: C & ValidateCommandConfig<Name, C>,
-  recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
-): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>>;
+  recipe: (command: CommandDefinitionBuilder) => B,
+): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>, BuilderHints<B>>;
 ```
+
+`B` captures the recipe's returned builder, so the nested command and flag spellings it accumulated feed the definition's `Hints` parameter.
 
 Creates an inert reusable definition under a required name. Static `description`, `usage`, `aliases`, `hidden`, and Context `requires` belong in `config`. The recipe builder is typed from the requirement values:
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -49,6 +49,7 @@ interface CommandDefinitionBuilder<
   Ctx,
   Sibs,
   Sp extends string = SpellingsOf<Eff>,
+  H extends string = never,
 > {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
@@ -66,7 +67,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. Both are trailing defaulted parameters, so annotations with up to five generic arguments keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All are trailing defaulted parameters, so annotations with up to five generic arguments keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -75,13 +76,14 @@ interface CommandDefinition<
   R extends CommandRequirements = {},
   Name extends string = string,
   Aliases extends readonly string[] = readonly string[],
+  Hints extends string = string,
 > {
   readonly name: Name;
-  as<const N extends string>(name: N): CommandDefinition<R, N, Aliases>;
+  as<const N extends string>(name: N): CommandDefinition<R, N, Aliases, Hints>;
 }
 ```
 
-A `CommandDefinition<R>` is a frozen value carrying its name, static config, and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. Configured aliases travel with the renamed definition and must remain unique among siblings. It has no command node or execution methods.
+A `CommandDefinition<R>` is a frozen value carrying its name, static config, and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. Configured aliases travel with the renamed definition and must remain unique among siblings. It has no command node or execution methods. `Hints` carries the recipe's statically known nested command and flag spellings; `.add()` folds them into the parent's `H` parameter for tooling autocomplete.
 
 ### `defineCommand(name, config?, recipe)`
 
@@ -136,6 +138,7 @@ class Crust<
   Ctx,
   Sibs,
   Sp extends string = SpellingsOf<Eff>,
+  H extends string = never,
 >
 
 new Crust(name: string, meta?: RootCommandMeta)
@@ -302,7 +305,8 @@ add<const Ds extends readonly CommandDefinition<any>[]>(
   Eff,
   Ctx,
   Sibs | CommandDefinitionSpellings<Ds[number]>,
-  Sp
+  Sp,
+  H | DefinitionHints<Ds[number]>
 >
 ```
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -37,6 +37,17 @@ interface ExecutableApp {
 
 Any application that implements the required shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` implements neither contract and must first be added to an application.
 
+## Argv autocomplete
+
+When `app` is a `Crust` builder, the `argv` parameter of every helper suggests the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes — while still accepting any string for positionals and flag values:
+
+```ts
+await captureRun(app, ["deploy", "api", "--env", "staging"]);
+//                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
+```
+
+Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
+
 ## `captureRun(app, argv)`
 
 Run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. If the application throws, `error` contains that value and output written before the failure is retained.

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -46,7 +46,7 @@ await captureRun(app, ["deploy", "api", "--env", "staging"]);
 //                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
 ```
 
-Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
+Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear, and `--no-<flag>` negation forms are not emitted. The union is also flat — every spelling is suggested at every position; parsing still validates ordering at runtime. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
 
 ## `captureRun(app, argv)`
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -819,25 +819,50 @@ describe("Crust .add() type-level tests", () => {
 	});
 
 	it("accumulates argv hints from flags and nested command definitions", () => {
-		const login = defineCommand("login", (command) =>
-			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
+		const login = defineCommand("login", { aliases: ["l"] }, (command) =>
+			command
+				.flags({ name: "token", type: "string", short: "t", aliases: ["tok"] })
+				.action(() => {}),
 		);
 		const auth = defineCommand("auth", (command) => command.add(login));
 		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(auth);
 
 		type Hints = Parameters<(typeof app)["_types"]["hints"]>[0];
-		type _Hints = Expect<Equal<Hints, "auth" | "--verbose" | "-v" | "login" | "--token" | "-t">>;
+		type _Hints = Expect<
+			Equal<Hints, "auth" | "--verbose" | "-v" | "login" | "l" | "--token" | "-t" | "--tok">
+		>;
 
 		// .as() renames the definition but keeps its nested hints
 		const renamed = new Crust("cli").add(auth.as("account"));
 		type RenamedHints = Parameters<(typeof renamed)["_types"]["hints"]>[0];
-		type _RenamedHints = Expect<Equal<RenamedHints, "account" | "login" | "--token" | "-t">>;
+		type _RenamedHints = Expect<
+			Equal<RenamedHints, "account" | "login" | "l" | "--token" | "-t" | "--tok">
+		>;
 
 		// widened definitions opt out of hints without collapsing the union
 		const widened: CommandDefinition = defineCommand("static", (command) => command);
 		const mixed = new Crust("cli").add(login).add(widened);
 		type MixedHints = Parameters<(typeof mixed)["_types"]["hints"]>[0];
-		type _MixedHints = Expect<Equal<MixedHints, "login" | "--token" | "-t">>;
+		type _MixedHints = Expect<Equal<MixedHints, "login" | "l" | "--token" | "-t" | "--tok">>;
+
+		// explicit type arguments still work — trailing builder param is defaulted
+		const explicit = defineCommand<"deploy">("deploy", (command) => command.action(() => {}));
+		type _ExplicitName = Expect<Equal<(typeof explicit)["name"], "deploy">>;
+
+		// hints flow through deep nesting and .provide()-owned flags
+		const leaf = defineCommand("leaf", (command) =>
+			command.flags({ name: "deep", type: "boolean" }).action(() => {}),
+		);
+		const mid = defineCommand("mid", (command) =>
+			command
+				.provide(
+					defineContext("log", { flags: [{ name: "trace", type: "boolean" }] }, () => ({}))(),
+				)
+				.add(leaf),
+		);
+		const deep = new Crust("cli").add(defineCommand("top", (command) => command.add(mid)));
+		type DeepHints = Parameters<(typeof deep)["_types"]["hints"]>[0];
+		type _DeepHints = Expect<Equal<DeepHints, "top" | "mid" | "leaf" | "--trace" | "--deep">>;
 
 		expect(true).toBe(true);
 	});

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -11,6 +11,7 @@ import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
 import type { FlagsDef } from "../types.ts";
 import {
+	type CommandDefinition,
 	type CommandDefinitionBuilder,
 	Crust,
 	defineCommand,
@@ -813,6 +814,30 @@ describe("Crust .add() type-level tests", () => {
 			defineCommand("issue", { aliases: ["issue"] }, (command) => command);
 		};
 		void typecheckAliasShapes;
+
+		expect(true).toBe(true);
+	});
+
+	it("accumulates argv hints from flags and nested command definitions", () => {
+		const login = defineCommand("login", (command) =>
+			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
+		);
+		const auth = defineCommand("auth", (command) => command.add(login));
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(auth);
+
+		type Hints = Parameters<(typeof app)["_types"]["hints"]>[0];
+		type _Hints = Expect<Equal<Hints, "auth" | "--verbose" | "-v" | "login" | "--token" | "-t">>;
+
+		// .as() renames the definition but keeps its nested hints
+		const renamed = new Crust("cli").add(auth.as("account"));
+		type RenamedHints = Parameters<(typeof renamed)["_types"]["hints"]>[0];
+		type _RenamedHints = Expect<Equal<RenamedHints, "account" | "login" | "--token" | "-t">>;
+
+		// widened definitions opt out of hints without collapsing the union
+		const widened: CommandDefinition = defineCommand("static", (command) => command);
+		const mixed = new Crust("cli").add(login).add(widened);
+		type MixedHints = Parameters<(typeof mixed)["_types"]["hints"]>[0];
+		type _MixedHints = Expect<Equal<MixedHints, "login" | "--token" | "-t">>;
 
 		expect(true).toBe(true);
 	});

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -138,7 +138,7 @@ type DashSpelling<S extends string> = S extends `${infer First}${infer Rest}`
  * Exposed through the `_types.hints` phantom so tooling (e.g.
  * `@crustjs/testing` argv autocomplete) can extract it structurally.
  */
-type ArgvHints<Sibs extends string, Sp extends string, H extends string> =
+type HintUnion<Sibs extends string, Sp extends string, H extends string> =
 	| Sibs
 	| DashSpelling<Sp>
 	| H;
@@ -344,7 +344,7 @@ export interface CommandDefinitionBuilder<
 	H extends string = never,
 > {
 	/** @internal — phantom exposing accumulated argv hints for tooling autocomplete */
-	readonly _types?: { hints(hint: ArgvHints<Sibs, Sp, H>): void };
+	readonly _types?: { hints(hint: HintUnion<Sibs, Sp, H>): void };
 
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
@@ -403,14 +403,17 @@ export interface CommandDefinitionBuilder<
  * Static metadata and Context requirements belong in `config`. Use `.as(name)`
  * to add one definition under a different name; configured aliases travel with it.
  */
-export function defineCommand<const Name extends string, B extends AnyCommandDefinitionBuilder>(
+export function defineCommand<
+	const Name extends string,
+	B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
+>(
 	name: Name,
 	recipe: CommandRecipe<{}, B>,
 ): CommandDefinition<{}, Name, readonly string[], BuilderHints<B>>;
 export function defineCommand<
 	const Name extends string,
 	const C extends CommandConfig,
-	B extends AnyCommandDefinitionBuilder,
+	B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
 >(
 	name: Name,
 	config: C & ValidateCommandConfig<Name, C>,
@@ -504,7 +507,7 @@ export class Crust<
 		spellings(spelling: Sp): void;
 		// Argv literals for tooling autocomplete (command spellings, dashed
 		// flag spellings, and hints from added definitions).
-		hints(hint: ArgvHints<Sibs, Sp, H>): void;
+		hints(hint: HintUnion<Sibs, Sp, H>): void;
 	};
 
 	/** @internal */

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -108,9 +108,9 @@ type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, 
 // Child builders start at `Eff = {}`: collisions with ancestor-owned flags
 // are runtime-only, caught while the definition materializes against its
 // parent's normalized flags.
-type CommandRecipe<R extends CommandRequirements> = (
+type CommandRecipe<R extends CommandRequirements, B extends AnyCommandDefinitionBuilder> = (
 	command: CommandDefinitionBuilder<{}, {}, [], EffectiveFlags<{}>, RequirementContext<R>>,
-) => AnyCommandDefinitionBuilder;
+) => B;
 
 const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
 
@@ -121,21 +121,60 @@ interface CommandDefinitionInternal {
 	readonly requiredCtxNames: readonly string[];
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Argv hints — static command/flag spellings for tooling autocomplete
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Dashed argv form of a flag spelling: `-x` for one character, `--name` otherwise. */
+type DashSpelling<S extends string> = S extends `${infer First}${infer Rest}`
+	? Rest extends ""
+		? `-${First}`
+		: `--${S}`
+	: never;
+
+/**
+ * Every argv literal a command's static type knows about: sibling command
+ * spellings, dashed flag spellings, and hints carried by added definitions.
+ * Exposed through the `_types.hints` phantom so tooling (e.g.
+ * `@crustjs/testing` argv autocomplete) can extract it structurally.
+ */
+type ArgvHints<Sibs extends string, Sp extends string, H extends string> =
+	| Sibs
+	| DashSpelling<Sp>
+	| H;
+
+/** Hints carried by a definition; widened definitions (`Hints = string`) opt out. */
+type DefinitionHints<D> = D extends { readonly _hints?: infer H extends string }
+	? string extends H
+		? never
+		: H
+	: never;
+
+/** Extract the accumulated argv hints from a recipe's returned builder. */
+type BuilderHints<B> = B extends {
+	readonly _types?: { hints(hint: infer H): void } | undefined;
+}
+	? H & string
+	: never;
+
 export interface CommandDefinition<
 	R extends CommandRequirements = {},
 	Name extends string = string,
 	Aliases extends readonly string[] = readonly string[],
+	Hints extends string = string,
 > {
 	/** The subcommand name this definition is added under */
 	readonly name: Name;
 	/** The same definition under a different name; configured aliases travel with it. */
-	as<const N extends string>(name: N): CommandDefinition<R, N, Aliases>;
+	as<const N extends string>(name: N): CommandDefinition<R, N, Aliases, Hints>;
 	/** @internal */
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
 	/** @internal — phantom carrying the requirements for add-time checks */
 	readonly _requirements?: R;
 	/** @internal — phantom carrying configured alias literals for add-time checks */
 	readonly _aliases?: Aliases;
+	/** @internal — phantom carrying nested command and flag argv spellings for tooling hints */
+	readonly _hints?: Hints;
 }
 
 /**
@@ -302,7 +341,11 @@ export interface CommandDefinitionBuilder<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Eff>,
+	H extends string = never,
 > {
+	/** @internal — phantom exposing accumulated argv hints for tooling autocomplete */
+	readonly _types?: { hints(hint: ArgvHints<Sibs, Sp, H>): void };
+
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): CommandDefinitionBuilder<
@@ -312,12 +355,13 @@ export interface CommandDefinitionBuilder<
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
-		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
+		H
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp>;
+	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> & ValidateContextNames<Ctx, Cs>
@@ -328,7 +372,8 @@ export interface CommandDefinitionBuilder<
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
+		H
 	>;
 
 	add<const Ds extends readonly CommandDefinition<any>[]>(
@@ -340,12 +385,13 @@ export interface CommandDefinitionBuilder<
 		Eff,
 		Ctx,
 		Sibs | CommandDefinitionSpellings<Ds[number]>,
-		Sp
+		Sp,
+		H | DefinitionHints<Ds[number]>
 	>;
 
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Sp>;
+	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
 }
 
 /**
@@ -357,19 +403,23 @@ export interface CommandDefinitionBuilder<
  * Static metadata and Context requirements belong in `config`. Use `.as(name)`
  * to add one definition under a different name; configured aliases travel with it.
  */
-export function defineCommand<const Name extends string>(
+export function defineCommand<const Name extends string, B extends AnyCommandDefinitionBuilder>(
 	name: Name,
-	recipe: CommandRecipe<{}>,
-): CommandDefinition<{}, Name>;
-export function defineCommand<const Name extends string, const C extends CommandConfig>(
+	recipe: CommandRecipe<{}, B>,
+): CommandDefinition<{}, Name, readonly string[], BuilderHints<B>>;
+export function defineCommand<
+	const Name extends string,
+	const C extends CommandConfig,
+	B extends AnyCommandDefinitionBuilder,
+>(
 	name: Name,
 	config: C & ValidateCommandConfig<Name, C>,
-	recipe: CommandRecipe<ConfigRequirements<C>>,
-): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>>;
+	recipe: CommandRecipe<ConfigRequirements<C>, B>,
+): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>, BuilderHints<B>>;
 export function defineCommand(
 	name: string,
-	configOrRecipe: CommandConfig | CommandRecipe<CommandRequirements>,
-	maybeRecipe?: CommandRecipe<CommandRequirements>,
+	configOrRecipe: CommandConfig | CommandRecipe<CommandRequirements, AnyCommandDefinitionBuilder>,
+	maybeRecipe?: CommandRecipe<CommandRequirements, AnyCommandDefinitionBuilder>,
 ): CommandDefinition<CommandRequirements> {
 	const hasConfig = typeof configOrRecipe !== "function";
 	const config: CommandConfig = hasConfig ? configOrRecipe : {};
@@ -420,6 +470,7 @@ export function defineCommand(
  * - `Ctx` — provided Context values
  * - `Sibs` — sibling command names and aliases already registered
  * - `Sp` — accumulated flag spellings used for collision checks
+ * - `H` — argv hint literals accumulated from added command definitions
  *
  * @example
  * ```ts
@@ -439,6 +490,7 @@ export class Crust<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Eff>,
+	H extends string = never,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
@@ -450,6 +502,9 @@ export class Crust<
 		// Method syntax keeps broad/legacy Crust annotations assignable while
 		// exposing Sp to type-level tests through Parameters<>.
 		spellings(spelling: Sp): void;
+		// Argv literals for tooling autocomplete (command spellings, dashed
+		// flag spellings, and hints from added definitions).
+		hints(hint: ArgvHints<Sibs, Sp, H>): void;
 	};
 
 	/** @internal */
@@ -521,7 +576,8 @@ export class Crust<
 		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
-		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
+		H
 	> {
 		const localFlags: FlagsDef = { ...this._node.localFlags };
 		const effectiveFlags: FlagsDef = { ...this._node.effectiveFlags };
@@ -553,7 +609,8 @@ export class Crust<
 			EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 			Ctx,
 			Sibs,
-			Sp | SpellingsOf<NamedFlagsRecord<Defs>>
+			Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
+			H
 		>;
 	}
 
@@ -571,10 +628,10 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp> {
+	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H> {
 		return this._clone({
 			args: normalizeArgs(this._node.args, defs as ArgsDef),
-		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp>;
+		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -600,7 +657,8 @@ export class Crust<
 		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
+		H
 	> {
 		const ownedFlags = { ...this._node.ownedFlags };
 		const effectiveFlags = { ...this._node.effectiveFlags };
@@ -620,7 +678,8 @@ export class Crust<
 			EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>,
 			Sibs,
-			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
+			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
+			H
 		>;
 	}
 
@@ -640,7 +699,7 @@ export class Crust<
 	 */
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp> {
+	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
@@ -650,7 +709,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -662,7 +721,7 @@ export class Crust<
 	 *
 	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp> {
+	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
 		const names = new Set(this._node.extensions.map((extension) => extension.name));
 		for (const extension of extensions) {
 			if (names.has(extension.name)) {
@@ -676,7 +735,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -688,8 +747,17 @@ export class Crust<
 	 */
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Sp> {
-		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp>;
+	): Crust<
+		Local,
+		Owned,
+		A,
+		Eff,
+		Ctx,
+		Sibs | CommandDefinitionSpellings<Ds[number]>,
+		Sp,
+		H | DefinitionHints<Ds[number]>
+	> {
+		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
@@ -700,18 +768,19 @@ export class Crust<
 			Eff,
 			Ctx,
 			Sibs | CommandDefinitionSpellings<Ds[number]>,
-			Sp
+			Sp,
+			H | DefinitionHints<Ds[number]>
 		>;
 	}
 
 	private _addDefinition(
 		definition: CommandDefinition,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp> {
+	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp>;
+		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
 	}
 
 	/**

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it } from "bun:test";
 
-import { Crust, defineExtension } from "@crustjs/core";
+import { Crust, defineCommand, defineExtension } from "@crustjs/core";
 import { input } from "@crustjs/prompts";
 
-import { captureExecute, captureRun, runInteractive, type RunnableApp } from "./index.ts";
+import {
+	type ArgvHints,
+	captureExecute,
+	captureRun,
+	runInteractive,
+	type RunnableApp,
+} from "./index.ts";
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+describe("argv hints", () => {
+	it("derives command and flag spellings from the app type while accepting any string", async () => {
+		const login = defineCommand("login", (command) =>
+			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
+		);
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(login);
+
+		type _Hints = Expect<
+			Equal<ArgvHints<typeof app>, "login" | "--verbose" | "-v" | "--token" | "-t">
+		>;
+		// structural apps without the phantom fall back to no hints
+		type _None = Expect<Equal<ArgvHints<RunnableApp>, never>>;
+
+		// arbitrary strings (positionals, flag values) remain accepted
+		const result = await captureRun(app, ["login", "--token", "abc"]);
+		expect(result.error).toBeUndefined();
+	});
+});
 
 describe("captureRun", () => {
 	it("captures output from a structural runnable as lines", async () => {

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -28,7 +28,16 @@ describe("argv hints", () => {
 		// structural apps without the phantom fall back to no hints
 		type _None = Expect<Equal<ArgvHints<RunnableApp>, never>>;
 
-		// arbitrary strings (positionals, flag values) remain accepted
+		// arbitrary strings (positionals, flag values) remain accepted by every helper,
+		// including widened string[] arrays — the common consumer pattern
+		const typecheckLooseArgv = () => {
+			const widened: string[] = ["login", "free-text"];
+			void captureRun(app, widened);
+			void captureExecute(app, ["login", "free-text"]);
+			void runInteractive(app, ["login", "free-text"]);
+		};
+		void typecheckLooseArgv;
+
 		const result = await captureRun(app, ["login", "--token", "abc"]);
 		expect(result.error).toBeUndefined();
 	});

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -10,6 +10,25 @@ export interface RunnableApp {
 	run(argv: readonly string[], io?: CaptureIO): Promise<void>;
 }
 
+/**
+ * Argv literals a Crust app's static type knows about — command spellings and
+ * dashed flag spellings, including those defined inside `defineCommand`
+ * recipes — extracted from the `_types.hints` phantom. Apps without the
+ * phantom resolve to `never`.
+ */
+export type ArgvHints<App> = App extends {
+	readonly _types: { hints(hint: infer H extends string): void };
+}
+	? H
+	: never;
+
+/**
+ * argv for the testing helpers: any strings are accepted (positionals and
+ * flag values are free text), while known command and flag spellings
+ * autocomplete in the editor.
+ */
+export type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
+
 export interface CapturedRun {
 	readonly stdout: string;
 	readonly stderr: string;
@@ -17,7 +36,10 @@ export interface CapturedRun {
 }
 
 /** Run an application and capture its text output without throwing invocation errors. */
-export async function captureRun(app: RunnableApp, argv: readonly string[]): Promise<CapturedRun> {
+export async function captureRun<App extends RunnableApp>(
+	app: App,
+	argv: Argv<App>,
+): Promise<CapturedRun> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
 	const stdoutLines: string[] = [];
@@ -69,9 +91,9 @@ let captureExecuteChain: Promise<unknown> = Promise.resolve();
  * Concurrent calls are serialized because the exit-code protocol is
  * process-global.
  */
-export function captureExecute(
-	app: ExecutableApp,
-	argv: readonly string[],
+export function captureExecute<App extends ExecutableApp>(
+	app: App,
+	argv: Argv<App>,
 ): Promise<CapturedExecute> {
 	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
 	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
@@ -120,7 +142,7 @@ export interface InteractiveRun {
 }
 
 /** Run an application with fake terminal streams for its prompts and stderr output. */
-export function runInteractive(app: RunnableApp, argv: readonly string[]): InteractiveRun {
+export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output!;
 	const done = withPromptIO(harness.io, () =>

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -27,7 +27,7 @@ export type ArgvHints<App> = App extends {
  * flag values are free text), while known command and flag spellings
  * autocomplete in the editor.
  */
-export type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
+type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
 
 export interface CapturedRun {
 	readonly stdout: string;


### PR DESCRIPTION
## What

Testing helpers now autocomplete argv. `captureRun()`, `captureExecute()`, and `runInteractive()` are generic over the app, and their `argv` parameter suggests every statically known command name, alias, and dashed flag spelling — including flags and subcommands defined inside `defineCommand` recipes — while still accepting arbitrary strings for positionals and flag values.

```ts
await captureRun(app, ["deploy", "api", "--env", "staging"]);
//                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
```

The hint union is exported as `ArgvHints<App>` (`argv` elements are `ArgvHints<App> | (string & {})`, the standard loose-autocomplete pattern).

## How

- **core**: a new trailing `Hints`/`H` type parameter on `CommandDefinition`, `CommandDefinitionBuilder`, and `Crust`. `defineCommand()` now infers the recipe's returned builder type and captures its nested command/flag spellings in a `_hints` phantom; `.add()` folds them into the parent. The root exposes the full union through the `_types.hints` phantom (same method-syntax pattern as `spellings`, keeping broad/legacy annotations assignable).
- **testing**: extracts the union structurally from `_types.hints` — no new runtime dependency, no runtime change at all. Structural (non-Crust) apps fall back to plain `string`.

All new type parameters are trailing and defaulted, so existing annotations keep working. Type-only change; zero runtime diff.

## Known limits (documented)

- Widened (non-literal) command names and Extension-contributed commands/flags (e.g. `help`, `--help`) contribute no hints.
- `--no-<flag>` negation forms are not emitted.
- Hints are a flat union, not position-aware — parsing still validates ordering at runtime.

## Verification

- Type-level tests in `crust.test.ts` (nested definitions, `.as()` rename carry, widened opt-out) and `index.test.ts` (extraction + structural fallback).
- `oxlint`, `oxfmt --check`, `turbo check:types` (21/21), `turbo test` all green.
- Changeset: minor for `@crustjs/core` and `@crustjs/testing`.