### PR TITLE
refactor(core): trim Crust and builder generics from eight params to six

### DIFF
--- a/.changeset/six-crust-params.md
+++ b/.changeset/six-crust-params.md
@@ -2,4 +2,4 @@
 "@crustjs/core": minor
 ---
 
-Replace the eight generic parameters on `Crust` and `CommandDefinitionBuilder` with six by unifying local and Context-owned flags into one `Flags` parameter and removing the redundant effective-flags cache. This is a breaking change for explicit positional generic annotations; prefer inference or migrate to `Crust<Flags, A, Ctx, Sibs, Sp, H>`.
+Replace the eight generic parameters on `Crust` and `CommandDefinitionBuilder` with six by unifying local and Context-owned flags into one `Flags` parameter and removing the redundant effective-flags cache. This is a breaking change for explicit positional generic annotations; prefer inference or migrate positionally: `Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>` becomes `Crust<Flags, A, Ctx, Sibs, Sp, H>` with `Flags = Local & Owned` and `Eff` dropped.

--- a/.changeset/six-crust-params.md
+++ b/.changeset/six-crust-params.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Replace the eight generic parameters on `Crust` and `CommandDefinitionBuilder` with six by unifying local and Context-owned flags into one `Flags` parameter and removing the redundant effective-flags cache. This is a breaking change for explicit positional generic annotations; prefer inference or migrate to `Crust<Flags, A, Ctx, Sibs, Sp, H>`.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -42,13 +42,11 @@ type ContextRequirements = readonly AnyContextFactory[];
 
 ```ts
 interface CommandDefinitionBuilder<
-  Local,
-  Owned,
+  Flags,
   A,
-  Eff,
   Ctx,
-  Sibs,
-  Sp extends string = SpellingsOf<Eff>,
+  Sibs extends string = never,
+  Sp extends string = SpellingsOf<Flags>,
   H extends string = never,
 > {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
@@ -56,7 +54,7 @@ interface CommandDefinitionBuilder<
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
   add(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
   action(
-    action: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
+    action: (ctx: CrustCommandContext<A, Flags, Ctx>) => void | Promise<void>,
   ): CommandDefinitionBuilder;
 }
 ```
@@ -67,7 +65,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine local argument, flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All are trailing defaulted parameters, so annotations with up to five generic arguments keep working. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -140,13 +138,11 @@ The recipe does not execute when the definition is created. It executes once for
 type RootCommandMeta = Pick<CommandMeta, "description" | "usage">;
 
 class Crust<
-  Local,
-  Owned,
+  Flags,
   A,
-  Eff,
   Ctx,
-  Sibs,
-  Sp extends string = SpellingsOf<Eff>,
+  Sibs extends string = never,
+  Sp extends string = SpellingsOf<Flags>,
   H extends string = never,
 >
 
@@ -209,7 +205,7 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls accumulate local flags and cache their statically known spellings — the union of flag names and aliases that `SpellingsOf` computes — in the trailing defaulted `Sp` parameter. Because `Sp` accumulates per call, spellings registered before a widened (dynamically typed) `.flags()` call stay collision-checked at compile time; previously any widened call deferred all subsequent collision checks to runtime. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<E extends FlagsDef>(app: Crust<Local, Owned, A, E, Ctx>)`) defer the default `Sp = SpellingsOf<E>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead, whose default `SpellingsOf<any>` is `never` — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
+Repeated `.flags()` calls accumulate local flags and cache their statically known spellings — the union of flag names and aliases that `SpellingsOf` computes — in the `Sp` parameter. Because `Sp` accumulates per call, spellings registered before a widened (dynamically typed) `.flags()` call stay collision-checked at compile time; previously any widened call deferred all subsequent collision checks to runtime. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<F extends FlagsDef>(app: Crust<F, A, Ctx>)`) defer the default `Sp = SpellingsOf<F>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any, any>` instead — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
 
 Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
@@ -229,17 +225,16 @@ const app = new Crust("serve").flags({
 provide<const Cs extends readonly ContextInstance[]>(
   ...instances: ProvideChecks<Sp, Cs> & ValidateContextNames<Ctx, Cs>,
 ): Crust<
-  Local,
-  MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+  MergeFlags<Flags, ContextsOwnedFlags<Cs>>,
   A,
-  EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
   MergeContext<Ctx, ContextsOutput<Cs>>,
   Sibs,
-  Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
+  Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
+  H
 >
 ```
 
-Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only when the resolved command requires them (a defined command's self-provided Contexts plus the transitive `requires` closure of its declared requirements and of those self-provides; the root action constructs everything provided on it), and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's owned and effective flag types.
+Attaches Contexts produced by invoking `defineContext()` factories. Contexts are inherited by descendants, constructed only when the resolved command requires them (a defined command's self-provided Contexts plus the transitive `requires` closure of its declared requirements and of those self-provides; the root action constructs everything provided on it), and available through `ctx` in the Command Action. The return type merges every instance's owned `flags` into the builder's accumulated flag type.
 
 ```ts
 import { defineContext, Crust } from "@crustjs/core";
@@ -286,7 +281,7 @@ See [Extensions](/docs/guide/extensions) for authoring custom Extensions.
 
 ```ts
 action(
-  action: (ctx: CrustCommandContext<A, Eff, Ctx>) => void | Promise<void>,
+  action: (ctx: CrustCommandContext<A, Flags, Ctx>) => void | Promise<void>,
 ): Crust
 ```
 
@@ -308,10 +303,8 @@ The context contains typed `args`, typed effective `flags`, typed Context values
 add<const Ds extends readonly CommandDefinition<any>[]>(
   ...definitions: Ds & AddChecks<Ctx, Sibs, Ds>,
 ): Crust<
-  Local,
-  Owned,
+  Flags,
   A,
-  Eff,
   Ctx,
   Sibs | CommandDefinitionSpellings<Ds[number]>,
   Sp,

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -400,13 +400,9 @@ describe("Context-owned flags", () => {
 		const output = defineContext("output", { flags: [format] }, () => ({}));
 		const app = new Crust("cli").provide(auth(), output());
 
-		type _OwnedKeys = Assert<IsEqual<keyof (typeof app)["_types"]["owned"], "api-key" | "format">>;
-		type _EffectiveApiKey = Assert<
-			IsEqual<(typeof app)["_types"]["effective"]["api-key"]["type"], "string">
-		>;
-		type _EffectiveFormat = Assert<
-			IsEqual<(typeof app)["_types"]["effective"]["format"]["type"], "string">
-		>;
+		type _FlagKeys = Assert<IsEqual<keyof (typeof app)["_types"]["flags"], "api-key" | "format">>;
+		type _ApiKey = Assert<IsEqual<(typeof app)["_types"]["flags"]["api-key"]["type"], "string">>;
+		type _Format = Assert<IsEqual<(typeof app)["_types"]["flags"]["format"]["type"], "string">>;
 	});
 
 	it("keeps owned flags when later .flags() calls accumulate local flags", async () => {

--- a/packages/core/src/api/flags.test.ts
+++ b/packages/core/src/api/flags.test.ts
@@ -33,10 +33,10 @@ describe("defineFlag", () => {
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const app = new Crust("cli").flags(verbose, { name: "output", type: "string", short: "o" });
 
-		type Local = (typeof app)["_types"]["local"];
-		type _Verbose = Assert<IsEqual<Local["verbose"], { readonly type: "boolean" }>>;
+		type Flags = (typeof app)["_types"]["flags"];
+		type _Verbose = Assert<IsEqual<Flags["verbose"], { readonly type: "boolean" }>>;
 		type _Output = Assert<
-			IsEqual<Local["output"], { readonly type: "string"; readonly short: "o" }>
+			IsEqual<Flags["output"], { readonly type: "string"; readonly short: "o" }>
 		>;
 		expect((await app.snapshot()).flags).toEqual({
 			verbose: { type: "boolean" },

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -262,16 +262,16 @@ describe("Crust .flags()", () => {
 		type _Spellings = Expect<
 			Equal<Parameters<(typeof app)["_types"]["spellings"]>[0], "verbose" | "v">
 		>;
-		const legacy: Crust<
-			(typeof app)["_types"]["local"],
-			(typeof app)["_types"]["owned"],
+		const explicit: Crust<
+			(typeof app)["_types"]["flags"],
 			(typeof app)["_types"]["args"],
-			(typeof app)["_types"]["effective"],
 			(typeof app)["_types"]["ctx"],
-			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins the new 6-argument order
+			never,
+			"verbose" | "v",
+			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins all six parameters
 			never
 		> = app;
-		void legacy;
+		void explicit;
 
 		expect(() =>
 			app.flags(
@@ -558,20 +558,20 @@ describe("command metadata", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("Crust type-level tests", () => {
-	it(".flags() updates Local generic", () => {
+	it(".flags() updates Flags generic", () => {
 		const app = new Crust("test").flags(
 			{ name: "verbose", type: "boolean", short: "v" },
 			{ name: "port", type: "number", default: 3000 },
 		);
 
-		// Extract the Local type from the phantom _types property
-		type AppLocal = (typeof app)["_types"]["local"];
+		// Extract the Flags type from the phantom _types property
+		type AppFlags = (typeof app)["_types"]["flags"];
 
 		type _checkVerbose = Expect<
-			Equal<AppLocal["verbose"], { readonly type: "boolean"; readonly short: "v" }>
+			Equal<AppFlags["verbose"], { readonly type: "boolean"; readonly short: "v" }>
 		>;
 		type _checkPort = Expect<
-			Equal<AppLocal["port"], { readonly type: "number"; readonly default: 3000 }>
+			Equal<AppFlags["port"], { readonly type: "number"; readonly default: 3000 }>
 		>;
 	});
 
@@ -610,10 +610,10 @@ describe("Crust type-level tests", () => {
 			)
 			.args({ name: "file", type: "string", required: true });
 
-		// Verify flags Local generic is preserved
-		type AppLocal = (typeof app)["_types"]["local"];
+		// Verify the Flags generic is preserved
+		type AppFlags = (typeof app)["_types"]["flags"];
 		type _checkVerbose = Expect<
-			Equal<AppLocal["verbose"], { readonly type: "boolean"; readonly short: "v" }>
+			Equal<AppFlags["verbose"], { readonly type: "boolean"; readonly short: "v" }>
 		>;
 
 		// Verify args A generic is preserved

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -13,7 +13,6 @@ import { cloneFlagSpellings } from "../parsing/spellings.ts";
 import type {
 	ArgsDef,
 	CommandMeta,
-	EffectiveFlags,
 	FlagDef,
 	FlagsDef,
 	InferArgs,
@@ -105,11 +104,11 @@ type ConfigRequirements<C extends CommandConfig> = C extends {
 
 type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any>;
 
-// Child builders start at `Eff = {}`: collisions with ancestor-owned flags
-// are runtime-only, caught while the definition materializes against its
+// Child builders start without inherited flags: collisions with ancestor-owned
+// flags are runtime-only, caught while the definition materializes against its
 // parent's normalized flags.
 type CommandRecipe<R extends CommandRequirements, B extends AnyCommandDefinitionBuilder> = (
-	command: CommandDefinitionBuilder<{}, {}, [], EffectiveFlags<{}>, RequirementContext<R>>,
+	command: CommandDefinitionBuilder<{}, [], RequirementContext<R>>,
 ) => B;
 
 const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
@@ -334,13 +333,11 @@ type AddChecks<
  * accumulated by `.flags()` and `.provide()` for compile-time collision checks.
  */
 export interface CommandDefinitionBuilder<
-	Local extends FlagsDef = {},
-	Owned extends FlagsDef = {},
+	Flags extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
-	Sp extends string = SpellingsOf<Eff>,
+	Sp extends string = SpellingsOf<Flags>,
 	H extends string = never,
 > {
 	/** @internal — phantom exposing accumulated argv hints for tooling autocomplete */
@@ -349,10 +346,8 @@ export interface CommandDefinitionBuilder<
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): CommandDefinitionBuilder<
-		MergeFlags<Local, NamedFlagsRecord<Defs>>,
-		Owned,
+		MergeFlags<Flags, NamedFlagsRecord<Defs>>,
 		A,
-		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
@@ -361,15 +356,13 @@ export interface CommandDefinitionBuilder<
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H>;
+	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> & ValidateContextNames<Ctx, Cs>
 	): CommandDefinitionBuilder<
-		Local,
-		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+		MergeFlags<Flags, ContextsOwnedFlags<Cs>>,
 		A,
-		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
@@ -379,10 +372,8 @@ export interface CommandDefinitionBuilder<
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
 	): CommandDefinitionBuilder<
-		Local,
-		Owned,
+		Flags,
 		A,
-		Eff,
 		Ctx,
 		Sibs | CommandDefinitionSpellings<Ds[number]>,
 		Sp,
@@ -390,8 +381,8 @@ export interface CommandDefinitionBuilder<
 	>;
 
 	action(
-		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
+		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
+	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, H>;
 }
 
 /**
@@ -466,10 +457,8 @@ export function defineCommand(
  * Chainable builder for defining CLI commands with full type inference.
  *
  * Generic parameters:
- * - `Local` — flags defined on this command via `.flags()`
- * - `Owned` — flags installed by Contexts provided on this command path
+ * - `Flags` — flags defined locally or installed by provided Contexts
  * - `A` — positional argument definitions
- * - `Eff` — effective flags (merged local + owned flags)
  * - `Ctx` — provided Context values
  * - `Sibs` — sibling command names and aliases already registered
  * - `Sp` — accumulated flag spellings used for collision checks
@@ -486,21 +475,17 @@ export function defineCommand(
  * ```
  */
 export class Crust<
-	Local extends FlagsDef = {},
-	Owned extends FlagsDef = {},
+	Flags extends FlagsDef = {},
 	A extends ArgsDef = ArgsDef,
-	Eff extends FlagsDef = EffectiveFlags<Local, Owned>,
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
-	Sp extends string = SpellingsOf<Eff>,
+	Sp extends string = SpellingsOf<Flags>,
 	H extends string = never,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
-		local: Local;
-		owned: Owned;
+		flags: Flags;
 		args: A;
-		effective: Eff;
 		ctx: Ctx;
 		// Method syntax keeps broad/legacy Crust annotations assignable while
 		// exposing Sp to type-level tests through Parameters<>.
@@ -573,10 +558,8 @@ export class Crust<
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): Crust<
-		MergeFlags<Local, NamedFlagsRecord<Defs>>,
-		Owned,
+		MergeFlags<Flags, NamedFlagsRecord<Defs>>,
 		A,
-		EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 		Ctx,
 		Sibs,
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
@@ -606,10 +589,8 @@ export class Crust<
 		}
 
 		return this._clone({ localFlags, effectiveFlags, flagSpellings }) as unknown as Crust<
-			MergeFlags<Local, NamedFlagsRecord<Defs>>,
-			Owned,
+			MergeFlags<Flags, NamedFlagsRecord<Defs>>,
 			A,
-			EffectiveFlags<MergeFlags<Local, NamedFlagsRecord<Defs>>, Owned>,
 			Ctx,
 			Sibs,
 			Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
@@ -631,10 +612,10 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H> {
+	): Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H> {
 		return this._clone({
 			args: normalizeArgs(this._node.args, defs as ArgsDef),
-		}) as unknown as Crust<Local, Owned, AppendedArgs<A, NewA>, Eff, Ctx, Sibs, Sp, H>;
+		}) as unknown as Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -654,10 +635,8 @@ export class Crust<
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> & ValidateContextNames<Ctx, Cs>
 	): Crust<
-		Local,
-		MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+		MergeFlags<Flags, ContextsOwnedFlags<Cs>>,
 		A,
-		EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
@@ -675,10 +654,8 @@ export class Crust<
 		);
 		for (const instance of instances) Object.assign(ownedFlags, instance.ownedFlags);
 		return this._clone({ contexts, ownedFlags, effectiveFlags, flagSpellings }) as unknown as Crust<
-			Local,
-			MergeFlags<Owned, ContextsOwnedFlags<Cs>>,
+			MergeFlags<Flags, ContextsOwnedFlags<Cs>>,
 			A,
-			EffectiveFlags<Local, MergeFlags<Owned, ContextsOwnedFlags<Cs>>>,
 			MergeContext<Ctx, ContextsOutput<Cs>>,
 			Sibs,
 			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
@@ -691,7 +668,7 @@ export class Crust<
 	 * command's behavior after its inputs and Contexts are ready.
 	 *
 	 * The action receives a {@link CrustCommandContext} with `args` typed from
-	 * `.args()` and `flags` typed as `EffectiveFlags<Local, Owned>`.
+	 * `.args()` and `flags` typed from the accumulated `Flags`.
 	 *
 	 * An action is set once; calling `.action()` again throws rather than
 	 * silently replacing command behavior. The original builder is not mutated.
@@ -701,8 +678,8 @@ export class Crust<
 	 * @throws {CrustError} `DEFINITION` when this command already has an action
 	 */
 	action(
-		action: (ctx: NoInfer<CrustCommandContext<A, Eff, Ctx>>) => void | Promise<void>,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
+		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
+	): Crust<Flags, A, Ctx, Sibs, Sp, H> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
@@ -712,7 +689,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -724,7 +701,7 @@ export class Crust<
 	 *
 	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
+	extend(...extensions: readonly Extension[]): Crust<Flags, A, Ctx, Sibs, Sp, H> {
 		const names = new Set(this._node.extensions.map((extension) => extension.name));
 		for (const extension of extensions) {
 			if (names.has(extension.name)) {
@@ -738,7 +715,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
 	}
 
 	/**
@@ -751,24 +728,20 @@ export class Crust<
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
 	): Crust<
-		Local,
-		Owned,
+		Flags,
 		A,
-		Eff,
 		Ctx,
 		Sibs | CommandDefinitionSpellings<Ds[number]>,
 		Sp,
 		H | DefinitionHints<Ds[number]>
 	> {
-		let result = this as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
+		let result = this as Crust<Flags, A, Ctx, Sibs, Sp, H>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
 		return result as Crust<
-			Local,
-			Owned,
+			Flags,
 			A,
-			Eff,
 			Ctx,
 			Sibs | CommandDefinitionSpellings<Ds[number]>,
 			Sp,
@@ -776,14 +749,12 @@ export class Crust<
 		>;
 	}
 
-	private _addDefinition(
-		definition: CommandDefinition,
-	): Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H> {
+	private _addDefinition(definition: CommandDefinition): Crust<Flags, A, Ctx, Sibs, Sp, H> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -59,6 +59,7 @@ export { SNAPSHOT_PATH_ENV } from "./invocation.ts";
  * Generic parameters:
  * - `A` — positional argument definitions tuple
  * - `F` — the effective (Context-owned + local merged) flag definitions
+ * - `Ctx` — provided Context values, keyed by Context name
  */
 export interface CrustCommandContext<
 	A extends ArgsDef = ArgsDef,

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -60,7 +60,7 @@ describe("command definitions", () => {
 		// The CommandDefinitionBuilder interface mirrors Crust's Sp accumulator
 		// type-only; this pins the recipe path so the mirror cannot drift. The
 		// widened call in between proves Sp retains earlier literals instead of
-		// recomputing from the (now-widened) Eff.
+		// recomputing from the (now-widened) Flags.
 		const dynamicDefs: { name: string; type: "boolean" }[] = [{ name: "dynamic", type: "boolean" }];
 		const definition = defineCommand("serve", (command) =>
 			command

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, it } from "bun:test";
 
 import type { StandardSchema } from "@crustjs/utils/schema";
 
-import type { Simplify } from "./api/context.ts";
 import type {
 	ArgDef,
 	ArgsDef,
 	CommandMeta,
-	EffectiveFlags,
 	FlagDef,
 	FlagsDef,
 	InferArgs,
@@ -692,37 +690,6 @@ describe("CommandMeta interface", () => {
 // been removed as part of the old API cleanup. Tests for the new builder API
 // live in crust.test.ts. CrustCommandContext (the replacement for
 // CommandContext) is tested there as well.
-
-// ────────────────────────────────────────────────────────────────────────────
-// EffectiveFlags type-level tests
-// ────────────────────────────────────────────────────────────────────────────
-
-describe("EffectiveFlags type inference", () => {
-	it("merges local and current Context-owned flags", () => {
-		type Result = EffectiveFlags<
-			{ output: { type: "string" } },
-			{ apiKey: { type: "string"; short: "k" } }
-		>;
-		// Simplify flattens the intersection: assert the merged keys and value
-		// types, not the representation.
-		type _check = Expect<
-			Equal<
-				Simplify<Result>,
-				{
-					output: { type: "string" };
-					apiKey: { type: "string"; short: "k" };
-				}
-			>
-		>;
-		expect(true).toBe(true);
-	});
-
-	it("returns empty when all inputs are empty", () => {
-		type Result = EffectiveFlags<{}>;
-		type _check = Expect<Equal<Result, {}>>;
-		expect(true).toBe(true);
-	});
-});
 
 // ────────────────────────────────────────────────────────────────────────────
 // InferFlags — url/path/json types

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -516,7 +516,7 @@ export type NamedFlagsRecord<Defs extends readonly NamedFlagDef[]> = {
 	: never;
 
 // ────────────────────────────────────────────────────────────────────────────
-// Effective flag utility types
+// Flag merge utility type
 // ────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -531,9 +531,6 @@ export type NamedFlagsRecord<Defs extends readonly NamedFlagDef[]> = {
  * `Simplify<Omit & …>`) nested and hit TS2589 at ~47 / ~31 chained calls.
  */
 export type MergeFlags<Base extends FlagsDef, Override extends FlagsDef> = Base & Override;
-
-/** Computes a command's action-visible flags from local and Context-owned definitions. */
-export type EffectiveFlags<Local extends FlagsDef, Owned extends FlagsDef = {}> = Local & Owned;
 
 // ────────────────────────────────────────────────────────────────────────────
 // InferArgs / InferFlags — Type inference utilities

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -47,7 +47,7 @@ type DuplicateNameBrand<F, Dups extends string> =
  * so collisions, `no-` prefixes, and async parsers error on the offending argument.
  *
  * Bounded-generic wrappers (e.g. `<F extends FlagsDef>(app: Crust<F, A, C>)`)
- * keep the default `Sp = SpellingsOf<E>` deferred and will not typecheck against
+ * keep the default `Sp = SpellingsOf<F>` deferred and will not typecheck against
  * `Existing`; type wrapper parameters as `Crust<any, ...>` instead, whose default
  * `SpellingsOf<any>` is `never` (see tests/helpers.ts).
  */

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -46,7 +46,7 @@ type DuplicateNameBrand<F, Dups extends string> =
  * each branded record value back onto the tuple element that declared it —
  * so collisions, `no-` prefixes, and async parsers error on the offending argument.
  *
- * Bounded-generic wrappers (e.g. `<E extends FlagsDef>(app: Crust<L, O, A, E, C>)`)
+ * Bounded-generic wrappers (e.g. `<F extends FlagsDef>(app: Crust<F, A, C>)`)
  * keep the default `Sp = SpellingsOf<E>` deferred and will not typecheck against
  * `Existing`; type wrapper parameters as `Crust<any, ...>` instead, whose default
  * `SpellingsOf<any>` is `never` (see tests/helpers.ts).

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -43,7 +43,7 @@ export const deploy = defineCommand("deploy", { requires: [auth] }, (cmd) =>
 	}),
 );
 
-// Inferred builder type references EffectiveFlags / Context-owned flag shapes
+// Inferred builder type references accumulated Context-owned flag shapes
 export const app = new Crust("consumer-cli")
 	.flags(...flags)
 	.provide(auth())

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -24,7 +24,7 @@ export interface RunResult {
  *   expect(result.exitCode).toBe(0);
  */
 export async function executeCrust(
-	builder: Crust<any, any, any, any, any>,
+	builder: Crust<any, any, any, any, any, any>,
 	argv?: string[],
 ): Promise<RunResult> {
 	const stdoutChunks: string[] = [];

--- a/packages/skills/src/annotations.ts
+++ b/packages/skills/src/annotations.ts
@@ -23,7 +23,7 @@ export interface SkillCommandAnnotations {
 	instructions?: string[];
 }
 
-type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any>;
+type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any, any>;
 
 const SKILL_COMMAND_ANNOTATIONS = Symbol("crust.skill.commandAnnotations");
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #230 (`feat/testing-argv-hints`). Merge that first; this PR's diff is the last commit only.

## What

`Crust` and `CommandDefinitionBuilder` go from eight generic parameters to six:

```ts
// before
Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>
// after
Crust<Flags, A, Ctx, Sibs, Sp, H>
```

**Breaking** for explicit positional generic annotations (prefer inference or migrate to the six-param form). The `_types.local/owned/effective` phantoms collapse into `_types.flags`. Zero runtime change — the emitted JS chunk is byte-identical.

## Why

A parameter audit (probe-verified against the workspace) showed only six independent state channels:

- `Eff` was an exact cache of `Local & Owned` — `EffectiveFlags` was a plain intersection, so the cache bought nothing. Deleted.
- `Local`/`Owned` had no type-level consumer of the split: no validator reads them separately (`ValidateNamedFlagDefs` reads `Sp`); only test phantoms distinguished them. Merged into `Flags`. The runtime `localFlags`/`ownedFlags`/`effectiveFlags` node records are untouched.

Every future channel (like `H` in #230) now threads through 25% fewer positions.

## Deliberately kept

- **`Sp` stays a materialized accumulator** — deriving `SpellingsOf<Flags>` on demand measured +64% instantiations at 60 chained flags (the accumulator win was originally measured in #189).
- **`Sibs` stays separate from `H`** — merging them false-positives sibling collision brands for nested command names (probe-verified).
- **`_types.spellings`/`_types.hints` shapes unchanged** — `@crustjs/testing` extracts them structurally; the testing package needs no changes and gets no bump.
- A single-state-object redesign (`Crust<S extends CommandState>`) was prototyped and rejected: the naive form hits TS2589 at ~50 chained calls, and the safe `infer`-destructure form costs +6–39% instantiations. Prior art agrees — tRPC v11 threads 8 positional params through its procedure builder.

## Measured

| | base (#230) | this PR |
|---|---|---|
| core instantiations | 625,808 | 612,293 (**−2.2%**) |
| core check time | ~0.56s | ~0.58s (noise) |
| emitted core d.ts | 75,651 B | 74,739 B (−1.2%) |
| emitted JS chunk | — | **md5-identical** |

## Verification

- `turbo check:types` 21/21, `turbo test` all green, `oxlint` + `oxfmt --check` clean
- Type tests pin the six-param explicit annotation, spelling-accumulator behavior, collision brand texts, and `@ts-expect-error` twins; deleted `EffectiveFlags` tests removed with the code
- Independent adversarial reviews (type-correctness; simplicity/docs/changeset) found only a stale comment and a docs signature default, both fixed
- Changeset: `minor` for `@crustjs/core`, matching repo precedent for breaking pre-1.0 changes