### PR TITLE
ci: order each package's tests after its own build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
 		"//#format": {},
 		"//#format:fix": { "cache": false },
 		"test": {
-			"dependsOn": ["^build"]
+			"dependsOn": ["build", "^build"]
 		},
 		"check:types": {
 			"dependsOn": ["^build"]


### PR DESCRIPTION
## What

One line in `turbo.json`: `test` now depends on `["build", "^build"]` instead of only `^build`.

## Why

A package's own `test` and `build` ran concurrently — nothing ordered them. Several suites assert against their own `dist/` (`skills`/`extensions` exports tests, `core` declaration-emission, `crust` package integration), and bunup emits JS milliseconds before d.ts, leaving a window where `dist/index.js` exists but declarations don't.

PR #230's CI hit exactly that window: the `@crustjs/skills` exports test reported all six `(types)` targets missing even though the build log shows them emitted — turbo replays grouped task logs on completion, so the log order hides the overlap. The comment in `exports.test.ts` ("In turbo runs build precedes test") was a false premise; this change makes it true.

## Notes

- The in-test "build if dist missing" fallbacks stay — they serve direct `bun test` runs outside turbo.
- No changeset: repo tooling only, no published package changes.

## Verification

Full `turbo test` green locally (21/21 tasks) with the new dependency edge.