### PR TITLE
feat(progress): injectable output sinks and hardened SIGINT handling

### DIFF
--- a/.changeset/progress-sink-injection.md
+++ b/.changeset/progress-sink-injection.md
@@ -3,4 +3,6 @@
 "@crustjs/testing": minor
 ---
 
-`@crustjs/progress` output is now injectable: the `SpinnerSink` contract (`{ isTTY, write, exit }`) is a public export, `spinner()` and `progress()` accept a per-call `sink` option, and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator in `fn`'s async scope (mirroring `withPromptIO` in `@crustjs/prompts`). Resolution order: per-call `sink` → ambient sink → `process.stderr`. `runInteractive()` in `@crustjs/testing` uses the ambient sink so spinners and progress indicators render onto its fake terminal — `waitFor()` and `screen()` now observe them.
+`@crustjs/progress` output is now injectable: the `ProgressSink` contract (`{ isTTY, write, exit }`) is a public export, `spinner()` and `progress()` accept a per-call `sink` option, and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator in `fn`'s async scope (mirroring `withPromptIO` in `@crustjs/prompts`). Resolution order: per-call `sink` → ambient sink → `process.stderr`. `runInteractive()` in `@crustjs/testing` uses the ambient sink so spinners and progress indicators render onto its fake terminal — `waitFor()` and `screen()` now observe them.
+
+`@crustjs/testing` now requires `@crustjs/progress` as a peer dependency (it is imported at module top level), so add it alongside `@crustjs/testing` when upgrading.

--- a/.changeset/progress-sink-injection.md
+++ b/.changeset/progress-sink-injection.md
@@ -3,6 +3,6 @@
 "@crustjs/testing": minor
 ---
 
-`@crustjs/progress` output is now injectable: the `ProgressSink` contract (`{ isTTY, write, exit }`) is a public export, `spinner()` and `progress()` accept a per-call `sink` option, and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator in `fn`'s async scope (mirroring `withPromptIO` in `@crustjs/prompts`). Resolution order: per-call `sink` → ambient sink → `process.stderr`. `runInteractive()` in `@crustjs/testing` uses the ambient sink so spinners and progress indicators render onto its fake terminal — `waitFor()` and `screen()` now observe them.
+`@crustjs/progress` output is now injectable: the `ProgressSink` contract (`{ isTTY, write }`) is a public export, `spinner()` and `progress()` accept a per-call `sink` option, and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator in `fn`'s async scope (mirroring `withPromptIO` in `@crustjs/prompts`). Resolution order: per-call `sink` → ambient sink → `process.stderr`. `runInteractive()` in `@crustjs/testing` uses the ambient sink so spinners and progress indicators render onto its fake terminal — `waitFor()` and `screen()` now observe them.
 
 `@crustjs/testing` now requires `@crustjs/progress` as a peer dependency (it is imported at module top level), so add it alongside `@crustjs/testing` when upgrading.

--- a/.changeset/progress-sink-injection.md
+++ b/.changeset/progress-sink-injection.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/progress": minor
+"@crustjs/testing": minor
+---
+
+`@crustjs/progress` output is now injectable: the `SpinnerSink` contract (`{ isTTY, write, exit }`) is a public export, `spinner()` and `progress()` accept a per-call `sink` option, and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator in `fn`'s async scope (mirroring `withPromptIO` in `@crustjs/prompts`). Resolution order: per-call `sink` → ambient sink → `process.stderr`. `runInteractive()` in `@crustjs/testing` uses the ambient sink so spinners and progress indicators render onto its fake terminal — `waitFor()` and `screen()` now observe them.

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -104,7 +104,7 @@ bar.stop("success", "All files translated");
 
 ### SIGINT policy
 
-`SpinnerSigintPolicy` is `"exit" | false`. By default an interactive spinner uses `"exit"`: it installs a `SIGINT` handler that restores the cursor and exits with code 130. Applications that own SIGINT (cleanup, log flushing) can opt out with `sigint: false` — the spinner then installs no handler, and the application's cleanup should call `stop()` to restore the cursor:
+`SpinnerSigintPolicy` is `"exit" | false`. By default an interactive spinner uses `"exit"`: it installs a `SIGINT` handler that restores the cursor and re-raises `SIGINT`, so the process terminates with normal signal semantics (shells observe exit status 130). Applications that own SIGINT (cleanup, log flushing) can opt out with `sigint: false` — the spinner then installs no handler, and the application's cleanup should call `stop()` to restore the cursor:
 
 ```ts
 const handle = spinner({ message: "Working...", sigint: false });
@@ -182,7 +182,7 @@ The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `def
 
 ## Output sinks
 
-Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `ProgressSink` (`{ isTTY, write, exit }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → `process.stderr`.
+Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `ProgressSink` (`{ isTTY, write }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → `process.stderr`.
 
 ```ts
 import { type ProgressSink, spinner, withProgressSink } from "@crustjs/progress";
@@ -190,13 +190,12 @@ import { type ProgressSink, spinner, withProgressSink } from "@crustjs/progress"
 const sink: ProgressSink = {
   isTTY: false,
   write: (text) => transcript.push(text),
-  exit: (code) => process.exit(code),
 };
 
 await withProgressSink(sink, () => deploy()); // spinners inside write their final lines to `sink` (no frames: isTTY is false)
 ```
 
-The default `"exit"` SIGINT policy calls `sink.exit(130)`, so custom sinks own exit behavior too. `runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses this ambient sink to render spinners onto its fake terminal screen.
+`runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses this ambient sink to render spinners onto its fake terminal screen.
 
 ## Non-interactive behavior
 

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -104,7 +104,7 @@ bar.stop("success", "All files translated");
 
 ### SIGINT policy
 
-`SpinnerSigintPolicy` is `"exit" | false`. By default an interactive spinner uses `"exit"`: it installs a `SIGINT` handler that restores the cursor and re-raises `SIGINT`, so the process terminates with normal signal semantics (shells observe exit status 130). Applications that own SIGINT (cleanup, log flushing) can opt out with `sigint: false` — the spinner then installs no handler, and the application's cleanup should call `stop()` to restore the cursor:
+`SpinnerSigintPolicy` is `"exit" | false`. By default an interactive spinner uses `"exit"`: it installs a `SIGINT` handler that restores the cursor and, when no other `SIGINT` listeners remain, re-raises `SIGINT` so the process terminates with normal signal semantics (shells observe exit status 130). If the application keeps its own persistent `SIGINT` listener, the spinner only restores the cursor and leaves termination to that listener. Applications that own SIGINT (cleanup, log flushing) can opt out with `sigint: false` — the spinner then installs no handler, and the application's cleanup should call `stop()` to restore the cursor:
 
 ```ts
 const handle = spinner({ message: "Working...", sigint: false });

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -182,18 +182,18 @@ The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `def
 
 ## Output sinks
 
-Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `SpinnerSink` (`{ isTTY, write, exit }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → `process.stderr`.
+Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `ProgressSink` (`{ isTTY, write, exit }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → `process.stderr`.
 
 ```ts
-import { type SpinnerSink, spinner, withProgressSink } from "@crustjs/progress";
+import { type ProgressSink, spinner, withProgressSink } from "@crustjs/progress";
 
-const sink: SpinnerSink = {
+const sink: ProgressSink = {
   isTTY: false,
   write: (text) => transcript.push(text),
   exit: (code) => process.exit(code),
 };
 
-await withProgressSink(sink, () => deploy()); // every spinner inside renders to `sink`
+await withProgressSink(sink, () => deploy()); // spinners inside write their final lines to `sink` (no frames: isTTY is false)
 ```
 
 The default `"exit"` SIGINT policy calls `sink.exit(130)`, so custom sinks own exit behavior too. `runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses this ambient sink to render spinners onto its fake terminal screen.

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -180,6 +180,24 @@ await spinner({
 
 The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `defaultTheme` ← per-call `theme` option. The public theme exports are `defaultTheme`, `ProgressTheme`, and `PartialProgressTheme`.
 
+## Output sinks
+
+Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `SpinnerSink` (`{ isTTY, write, exit }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → `process.stderr`.
+
+```ts
+import { type SpinnerSink, spinner, withProgressSink } from "@crustjs/progress";
+
+const sink: SpinnerSink = {
+  isTTY: false,
+  write: (text) => transcript.push(text),
+  exit: (code) => process.exit(code),
+};
+
+await withProgressSink(sink, () => deploy()); // every spinner inside renders to `sink`
+```
+
+The default `"exit"` SIGINT policy calls `sink.exit(130)`, so custom sinks own exit behavior too. `runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses this ambient sink to render spinners onto its fake terminal screen.
+
 ## Non-interactive behavior
 
 When `stderr` is not a TTY, `spinner()` does not animate and does not emit cursor-control ANSI sequences. `updateMessage()` still works and updates the message used in the final success or error line.

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -98,7 +98,7 @@ run.keys("return");
 await run.done;
 ```
 
-`screen()` returns the ANSI-stripped terminal screen. Prompt frames and `ctx.stderr()` output share that screen and the transcript scanned by `waitFor()`.
+`screen()` returns the ANSI-stripped terminal screen. Prompt frames, `ctx.stderr()` output, and `@crustjs/progress` indicators (routed via the ambient [`withProgressSink`](/docs/modules/progress#output-sinks) sink) all share that screen and the transcript scanned by `waitFor()`.
 
 The return type is `InteractiveRun`:
 

--- a/bun.lock
+++ b/bun.lock
@@ -241,11 +241,13 @@
       "devDependencies": {
         "@crustjs/config": "workspace:*",
         "@crustjs/core": "workspace:*",
+        "@crustjs/progress": "workspace:*",
         "@crustjs/prompts": "workspace:*",
         "bunup": "catalog:",
       },
       "peerDependencies": {
         "@crustjs/core": "workspace:0.x",
+        "@crustjs/progress": "workspace:0.x",
         "@crustjs/prompts": "workspace:0.x",
         "typescript": "^7.0.0",
       },

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -5,12 +5,12 @@
 export type { ProgressHandle, ProgressOptions } from "./progress.ts";
 export { progress } from "./progress.ts";
 export type {
+	ProgressSink,
 	SpinnerHandle,
 	SpinnerHandleOptions,
 	SpinnerOptions,
 	SpinnerOutcome,
 	SpinnerSigintPolicy,
-	SpinnerSink,
 	SpinnerType,
 } from "./spinner.ts";
 export { spinner, withProgressSink } from "./spinner.ts";

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -10,8 +10,9 @@ export type {
 	SpinnerOptions,
 	SpinnerOutcome,
 	SpinnerSigintPolicy,
+	SpinnerSink,
 	SpinnerType,
 } from "./spinner.ts";
-export { spinner } from "./spinner.ts";
+export { spinner, withProgressSink } from "./spinner.ts";
 export { defaultTheme } from "./theme.ts";
 export type { PartialProgressTheme, ProgressTheme } from "./theme.ts";

--- a/packages/progress/src/progress.test.ts
+++ b/packages/progress/src/progress.test.ts
@@ -75,9 +75,6 @@ describe("progress — sink resolution", () => {
 		const makeSink = (writes: string[]): ProgressSink => ({
 			isTTY: false,
 			write: (text) => writes.push(text),
-			exit: (code): never => {
-				throw new Error(`exit:${code}`);
-			},
 		});
 
 		const viaOption = createProgressBar({

--- a/packages/progress/src/progress.test.ts
+++ b/packages/progress/src/progress.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { createProgressHandle, progress as createProgressBar } from "./progress.ts";
-import { type SpinnerSink, withProgressSink } from "./spinner.ts";
+import { progress as createProgressBar } from "./progress.ts";
+import { type ProgressSink, withProgressSink } from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -31,25 +31,6 @@ afterEach(() => {
 });
 
 describe("progress — determinate", () => {
-	it("threads the internal terminal sink through the spinner handle", () => {
-		const writes: string[] = [];
-		const sink: SpinnerSink = {
-			isTTY: false,
-			write: (text) => writes.push(text),
-			exit: (code): never => {
-				throw new Error(`exit:${code}`);
-			},
-		};
-		const progress = createProgressHandle({ total: 2, message: "Files" }, sink);
-
-		progress.start();
-		progress.advance();
-		progress.stop();
-
-		expect(writes).toHaveLength(1);
-		expect(writes[0]).toContain("Files (1/2)");
-	});
-
 	it("renders current/total alongside the message", () => {
 		const progress = createProgressBar({ total: 10, message: "Translating" });
 
@@ -91,7 +72,7 @@ describe("progress — sink resolution", () => {
 	it("honors sink from options and the ambient withProgressSink sink", () => {
 		const optionWrites: string[] = [];
 		const ambientWrites: string[] = [];
-		const makeSink = (writes: string[]): SpinnerSink => ({
+		const makeSink = (writes: string[]): ProgressSink => ({
 			isTTY: false,
 			write: (text) => writes.push(text),
 			exit: (code): never => {
@@ -105,6 +86,7 @@ describe("progress — sink resolution", () => {
 			sink: makeSink(optionWrites),
 		});
 		viaOption.start();
+		viaOption.advance();
 		viaOption.stop();
 
 		withProgressSink(makeSink(ambientWrites), () => {
@@ -113,7 +95,7 @@ describe("progress — sink resolution", () => {
 			viaAmbient.stop();
 		});
 
-		expect(optionWrites[0]).toContain("✓ Upload (0/2)");
+		expect(optionWrites[0]).toContain("✓ Upload (1/2)");
 		expect(ambientWrites[0]).toContain("✓ Sync (0/2)");
 	});
 });

--- a/packages/progress/src/progress.test.ts
+++ b/packages/progress/src/progress.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { createProgressHandle, progress as createProgressBar } from "./progress.ts";
-import type { SpinnerSink } from "./spinner.ts";
+import { type SpinnerSink, withProgressSink } from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -84,5 +84,36 @@ describe("progress — determinate", () => {
 
 		expect(stderrOutput).toContain("✗");
 		expect(stderrOutput).toContain("Upload failed (2/5)");
+	});
+});
+
+describe("progress — sink resolution", () => {
+	it("honors sink from options and the ambient withProgressSink sink", () => {
+		const optionWrites: string[] = [];
+		const ambientWrites: string[] = [];
+		const makeSink = (writes: string[]): SpinnerSink => ({
+			isTTY: false,
+			write: (text) => writes.push(text),
+			exit: (code): never => {
+				throw new Error(`exit:${code}`);
+			},
+		});
+
+		const viaOption = createProgressBar({
+			message: "Upload",
+			total: 2,
+			sink: makeSink(optionWrites),
+		});
+		viaOption.start();
+		viaOption.stop();
+
+		withProgressSink(makeSink(ambientWrites), () => {
+			const viaAmbient = createProgressBar({ message: "Sync", total: 2 });
+			viaAmbient.start();
+			viaAmbient.stop();
+		});
+
+		expect(optionWrites[0]).toContain("✓ Upload (0/2)");
+		expect(ambientWrites[0]).toContain("✓ Sync (0/2)");
 	});
 });

--- a/packages/progress/src/progress.ts
+++ b/packages/progress/src/progress.ts
@@ -3,11 +3,10 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import {
+	createSpinnerHandle,
 	type SpinnerHandle,
 	type SpinnerHandleOptions,
 	type SpinnerOutcome,
-	type SpinnerSink,
-	createSpinnerHandle,
 } from "./spinner.ts";
 
 export interface ProgressOptions extends SpinnerHandleOptions {
@@ -29,21 +28,21 @@ export interface ProgressHandle {
 	stop: (outcome?: SpinnerOutcome, message?: string) => void;
 }
 
-/** Internal progress constructor that threads the spinner terminal sink through. */
-export function createProgressHandle(options: ProgressOptions, sink?: SpinnerSink): ProgressHandle {
+/**
+ * Create a determinate progress indicator rendered as
+ * `⠋ <message> (<current>/<total>)` on the spinner line.
+ */
+export function progress(options: ProgressOptions): ProgressHandle {
 	const { total } = options;
 	let current = 0;
 	let message = options.message;
 
 	const format = (msg: string): string => `${msg} (${current}/${total})`;
 
-	const handle: SpinnerHandle = createSpinnerHandle(
-		{
-			...options,
-			message: format(message),
-		},
-		sink,
-	);
+	const handle: SpinnerHandle = createSpinnerHandle({
+		...options,
+		message: format(message),
+	});
 
 	return {
 		start: handle.start,
@@ -56,12 +55,4 @@ export function createProgressHandle(options: ProgressOptions, sink?: SpinnerSin
 			handle.stop(outcome, format(finalMessage ?? message));
 		},
 	};
-}
-
-/**
- * Create a determinate progress indicator rendered as
- * `⠋ <message> (<current>/<total>)` on the spinner line.
- */
-export function progress(options: ProgressOptions): ProgressHandle {
-	return createProgressHandle(options);
 }

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -85,6 +85,31 @@ describe("spinner — terminal sink", () => {
 		expect(process.listeners("SIGINT")).not.toContain(handler);
 	});
 
+	it("does not re-raise SIGINT when the host keeps its own listener", () => {
+		const { sink, writes } = createFakeSink(true);
+		const hostListener = () => {};
+		process.on("SIGINT", hostListener);
+		const previousHandlers = new Set(process.listeners("SIGINT"));
+		const handle = spinner({ message: "Working", sink });
+		handle.start();
+		const handler = process.listeners("SIGINT").find((listener) => !previousHandlers.has(listener));
+
+		const realKill = process.kill;
+		const kills: (string | number | undefined)[] = [];
+		process.kill = ((pid: number, signal?: string | number) => {
+			kills.push(signal);
+			return true;
+		}) as typeof process.kill;
+		try {
+			handler?.("SIGINT");
+		} finally {
+			process.kill = realKill;
+			process.removeListener("SIGINT", hostListener);
+		}
+		expect(kills).toEqual([]);
+		expect(writes.at(-1)).toBe("\x1B[?25h");
+	});
+
 	it("writes only the final line in non-TTY mode", () => {
 		const { sink, writes } = createFakeSink(false);
 		const handle = spinner({ message: "Working", sink });

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -1,12 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import {
-	type SpinnerHandle,
-	type SpinnerSink,
-	createSpinnerHandle,
-	spinner,
-	withProgressSink,
-} from "./spinner.ts";
+import { type ProgressSink, type SpinnerHandle, spinner, withProgressSink } from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -46,7 +40,7 @@ function tick(ms = 10): Promise<void> {
 function createFakeSink(isTTY: boolean) {
 	const writes: string[] = [];
 	const exits: number[] = [];
-	const sink: SpinnerSink = {
+	const sink: ProgressSink = {
 		isTTY,
 		write(text) {
 			writes.push(text);
@@ -59,10 +53,10 @@ function createFakeSink(isTTY: boolean) {
 	return { sink, writes, exits };
 }
 
-describe("createSpinnerHandle — terminal sink", () => {
+describe("spinner — terminal sink", () => {
 	it("hides and restores the cursor in TTY mode", () => {
 		const { sink, writes } = createFakeSink(true);
-		const handle = createSpinnerHandle({ message: "Working" }, sink);
+		const handle = spinner({ message: "Working", sink });
 
 		handle.start();
 		handle.stop();
@@ -74,7 +68,7 @@ describe("createSpinnerHandle — terminal sink", () => {
 	it("restores the cursor and exits with 130 on SIGINT", () => {
 		const { sink, writes, exits } = createFakeSink(true);
 		const previousHandlers = new Set(process.listeners("SIGINT"));
-		const handle = createSpinnerHandle({ message: "Working" }, sink);
+		const handle = spinner({ message: "Working", sink });
 		handle.start();
 		const handler = process.listeners("SIGINT").find((listener) => !previousHandlers.has(listener));
 
@@ -87,7 +81,7 @@ describe("createSpinnerHandle — terminal sink", () => {
 
 	it("writes only the final line in non-TTY mode", () => {
 		const { sink, writes } = createFakeSink(false);
-		const handle = createSpinnerHandle({ message: "Working" }, sink);
+		const handle = spinner({ message: "Working", sink });
 
 		handle.start();
 		handle.stop();
@@ -99,10 +93,11 @@ describe("createSpinnerHandle — terminal sink", () => {
 
 	it("applies per-call theme overrides to rendered output", () => {
 		const { sink, writes } = createFakeSink(false);
-		const handle = createSpinnerHandle(
-			{ message: "Working", theme: { success: (t) => `<OK ${t}>` } },
+		const handle = spinner({
+			message: "Working",
+			theme: { success: (t) => `<OK ${t}>` },
 			sink,
-		);
+		});
 
 		handle.start();
 		handle.stop("success");
@@ -112,7 +107,7 @@ describe("createSpinnerHandle — terminal sink", () => {
 
 	it("finalizes once", () => {
 		const { sink, writes } = createFakeSink(false);
-		const handle = createSpinnerHandle({ message: "Working" }, sink);
+		const handle = spinner({ message: "Working", sink });
 
 		handle.start();
 		handle.stop("success");
@@ -125,7 +120,7 @@ describe("createSpinnerHandle — terminal sink", () => {
 	it("leaves SIGINT to the application when disabled", () => {
 		const { sink } = createFakeSink(true);
 		const previousHandlers = process.listeners("SIGINT");
-		const handle = createSpinnerHandle({ message: "Working", sigint: false }, sink);
+		const handle = spinner({ message: "Working", sigint: false, sink });
 
 		handle.start();
 		expect(process.listeners("SIGINT")).toEqual(previousHandlers);
@@ -169,6 +164,32 @@ describe("spinner — sink resolution", () => {
 
 		expect(ambient.writes).toHaveLength(0);
 		expect(explicit.writes[0]).toContain("✓ Explicit\n");
+	});
+
+	it("the nearest ambient sink wins when scopes nest", () => {
+		const outer = createFakeSink(false);
+		const inner = createFakeSink(false);
+
+		withProgressSink(outer.sink, () => {
+			withProgressSink(inner.sink, () => {
+				const handle = spinner({ message: "Nested" });
+				handle.start();
+				handle.stop();
+			});
+		});
+
+		expect(outer.writes).toHaveLength(0);
+		expect(inner.writes[0]).toContain("✓ Nested\n");
+	});
+
+	it("a handle created inside the scope keeps its sink when stopped outside", () => {
+		const { sink, writes } = createFakeSink(false);
+
+		const handle = withProgressSink(sink, () => spinner({ message: "Escaped" }));
+		handle.start();
+		handle.stop();
+
+		expect(writes[0]).toContain("✓ Escaped\n");
 	});
 
 	it("the ambient sink survives async boundaries", async () => {
@@ -246,6 +267,24 @@ describe("spinner — task error", () => {
 				},
 			}),
 		).rejects.toThrow("task failed");
+	});
+
+	it("cleans up when the task throws synchronously", async () => {
+		await expect(
+			spinner({
+				message: "Sync boom",
+				// Non-async task throwing before it returns a promise.
+				task: () => {
+					throw new Error("sync boom");
+				},
+			}),
+		).rejects.toThrow("sync boom");
+
+		expect(stderrOutput).toContain("✗");
+		expect(stderrOutput).toContain("\x1B[?25h");
+		const outputAfterError = stderrOutput;
+		await tick(200);
+		expect(stderrOutput).toBe(outputAfterError);
 	});
 
 	it("re-throws the original error object", async () => {

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import { type SpinnerHandle, type SpinnerSink, createSpinnerHandle, spinner } from "./spinner.ts";
+import {
+	type SpinnerHandle,
+	type SpinnerSink,
+	createSpinnerHandle,
+	spinner,
+	withProgressSink,
+} from "./spinner.ts";
 
 const originalStderrWrite = process.stderr.write;
 const originalStderrIsTTY = process.stderr.isTTY;
@@ -124,6 +130,61 @@ describe("createSpinnerHandle — terminal sink", () => {
 		handle.start();
 		expect(process.listeners("SIGINT")).toEqual(previousHandlers);
 		handle.stop();
+	});
+});
+
+describe("spinner — sink resolution", () => {
+	it("routes output to the per-call sink option", () => {
+		const { sink, writes } = createFakeSink(false);
+		const handle = spinner({ message: "Working", sink });
+
+		handle.start();
+		handle.stop();
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0]).toContain("✓ Working\n");
+	});
+
+	it("routes output to the ambient withProgressSink sink", () => {
+		const { sink, writes } = createFakeSink(false);
+
+		withProgressSink(sink, () => {
+			const handle = spinner({ message: "Ambient" });
+			handle.start();
+			handle.stop();
+		});
+
+		expect(writes[0]).toContain("✓ Ambient\n");
+	});
+
+	it("per-call sink option wins over the ambient sink", () => {
+		const ambient = createFakeSink(false);
+		const explicit = createFakeSink(false);
+
+		withProgressSink(ambient.sink, () => {
+			const handle = spinner({ message: "Explicit", sink: explicit.sink });
+			handle.start();
+			handle.stop();
+		});
+
+		expect(ambient.writes).toHaveLength(0);
+		expect(explicit.writes[0]).toContain("✓ Explicit\n");
+	});
+
+	it("the ambient sink survives async boundaries", async () => {
+		const { sink, writes } = createFakeSink(false);
+
+		await withProgressSink(sink, () =>
+			spinner({
+				message: "Async",
+				task: async () => {
+					await tick(10);
+					return "ok";
+				},
+			}),
+		);
+
+		expect(writes[0]).toContain("✓ Async\n");
 	});
 });
 

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -39,18 +39,13 @@ function tick(ms = 10): Promise<void> {
 
 function createFakeSink(isTTY: boolean) {
 	const writes: string[] = [];
-	const exits: number[] = [];
 	const sink: ProgressSink = {
 		isTTY,
 		write(text) {
 			writes.push(text);
 		},
-		exit(code): never {
-			exits.push(code);
-			throw new Error(`exit:${code}`);
-		},
 	};
-	return { sink, writes, exits };
+	return { sink, writes };
 }
 
 describe("spinner — terminal sink", () => {
@@ -65,17 +60,28 @@ describe("spinner — terminal sink", () => {
 		expect(writes).toContain("\x1B[?25h");
 	});
 
-	it("restores the cursor and exits with 130 on SIGINT", () => {
-		const { sink, writes, exits } = createFakeSink(true);
+	it("restores the cursor and re-raises SIGINT", () => {
+		const { sink, writes } = createFakeSink(true);
 		const previousHandlers = new Set(process.listeners("SIGINT"));
 		const handle = spinner({ message: "Working", sink });
 		handle.start();
 		const handler = process.listeners("SIGINT").find((listener) => !previousHandlers.has(listener));
 
 		expect(handler).toBeDefined();
-		expect(() => handler?.("SIGINT")).toThrow("exit:130");
+		// Stub the re-raise — a real one would terminate the test run.
+		const realKill = process.kill;
+		const kills: (string | number | undefined)[] = [];
+		process.kill = ((pid: number, signal?: string | number) => {
+			kills.push(signal);
+			return true;
+		}) as typeof process.kill;
+		try {
+			handler?.("SIGINT");
+		} finally {
+			process.kill = realKill;
+		}
+		expect(kills).toEqual(["SIGINT"]);
 		expect(writes.at(-1)).toBe("\x1B[?25h");
-		expect(exits).toEqual([130]);
 		expect(process.listeners("SIGINT")).not.toContain(handler);
 	});
 

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -207,10 +207,14 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 					cleanup();
 					finished = true;
 					sink.write(SHOW_CURSOR);
-					// Re-raise: `once` already removed this listener, so the default
-					// disposition (or the host's own handler) terminates the process
-					// with real signal semantics — shells observe exit status 130.
-					process.kill(process.pid, "SIGINT");
+					// `once` already removed this listener. With no listeners left the
+					// re-raise hits the default disposition and terminates with real
+					// signal semantics — shells observe exit status 130. A host that
+					// kept its own persistent listener already ran it for this signal;
+					// re-raising would invoke it twice, so leave termination to it.
+					if (process.listenerCount("SIGINT") === 0) {
+						process.kill(process.pid, "SIGINT");
+					}
 				};
 				process.once("SIGINT", sigintHandler);
 			}

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -54,7 +54,8 @@ export type SpinnerOutcome = "success" | "error";
  * SIGINT policy for interactive spinners.
  *
  * - `"exit"` (default): install a `SIGINT` handler that restores the cursor
- *   and exits with code 130.
+ *   and re-raises `SIGINT`, so the process terminates with normal signal
+ *   semantics (shells observe exit status 130).
  * - `false`: install no handler — the application owns SIGINT and should
  *   `stop()` the spinner (restoring the cursor) in its own cleanup.
  *
@@ -137,7 +138,6 @@ function renderFinal(
 export interface ProgressSink {
 	readonly isTTY: boolean;
 	write: (text: string) => void;
-	exit: (code: number) => never;
 }
 
 const sinkStorage = new AsyncLocalStorage<ProgressSink>();
@@ -159,9 +159,6 @@ const processSink: ProgressSink = {
 	},
 	write(text) {
 		process.stderr.write(text);
-	},
-	exit(code): never {
-		process.exit(code);
 	},
 };
 
@@ -208,11 +205,12 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 			if (sigint === "exit") {
 				sigintHandler = () => {
 					cleanup();
-					// Mark done before exit: a sink whose `exit` throws (test harnesses)
-					// must not leave a live handle behind the thrown signal handler.
 					finished = true;
 					sink.write(SHOW_CURSOR);
-					sink.exit(130);
+					// Re-raise: `once` already removed this listener, so the default
+					// disposition (or the host's own handler) terminates the process
+					// with real signal semantics — shells observe exit status 130.
+					process.kill(process.pid, "SIGINT");
 				};
 				process.once("SIGINT", sigintHandler);
 			}

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -2,6 +2,8 @@
 // Spinner — Animated progress spinner for @crustjs/progress
 // ────────────────────────────────────────────────────────────────────────────
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { resolveTheme } from "./theme.ts";
 import type { PartialProgressTheme, ProgressTheme } from "./theme.ts";
 
@@ -75,6 +77,11 @@ export interface SpinnerHandleOptions {
 	 * @default "exit"
 	 */
 	readonly sigint?: SpinnerSigintPolicy;
+	/**
+	 * Terminal sink receiving the rendered output. Resolution order:
+	 * this option → ambient {@link withProgressSink} sink → `process.stderr`.
+	 */
+	readonly sink?: SpinnerSink;
 }
 
 export interface SpinnerHandle {
@@ -123,11 +130,24 @@ function renderFinal(
 	return erase ? ERASE_LINE + CURSOR_TO_START + line : line;
 }
 
-/** Terminal operations used by the internal spinner lifecycle. */
+/** Terminal operations driven by spinners and progress indicators. */
 export interface SpinnerSink {
 	readonly isTTY: boolean;
 	write: (text: string) => void;
 	exit: (code: number) => never;
+}
+
+const sinkStorage = new AsyncLocalStorage<SpinnerSink>();
+
+/**
+ * Run a function with a sink ambiently available to every spinner or
+ * progress indicator created in its async scope (unless a per-call
+ * `sink` option overrides it). Mirrors `withPromptIO` in
+ * `@crustjs/prompts` — test harnesses and embedders redirect indicator
+ * output without touching process globals.
+ */
+export function withProgressSink<T>(sink: SpinnerSink, fn: () => T): T {
+	return sinkStorage.run(sink, fn);
 }
 
 const processSpinnerSink: SpinnerSink = {
@@ -145,8 +165,9 @@ const processSpinnerSink: SpinnerSink = {
 /** Internal handle constructor shared by both `spinner()` modes and `progress()`. */
 export function createSpinnerHandle(
 	options: SpinnerHandleOptions,
-	sink: SpinnerSink = processSpinnerSink,
+	explicitSink?: SpinnerSink,
 ): SpinnerHandle {
+	const sink = explicitSink ?? options.sink ?? sinkStorage.getStore() ?? processSpinnerSink;
 	const theme = resolveTheme(options.theme);
 	const isInteractive = sink.isTTY;
 	const { frames, interval } = resolveSpinner(options.spinner);

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -57,6 +57,9 @@ export type SpinnerOutcome = "success" | "error";
  *   and exits with code 130.
  * - `false`: install no handler — the application owns SIGINT and should
  *   `stop()` the spinner (restoring the cursor) in its own cleanup.
+ *
+ * The handler is a real `process` signal listener even when output goes to
+ * an injected sink, so prefer `false` under test harnesses.
  */
 export type SpinnerSigintPolicy = "exit" | false;
 
@@ -81,7 +84,7 @@ export interface SpinnerHandleOptions {
 	 * Terminal sink receiving the rendered output. Resolution order:
 	 * this option → ambient {@link withProgressSink} sink → `process.stderr`.
 	 */
-	readonly sink?: SpinnerSink;
+	readonly sink?: ProgressSink;
 }
 
 export interface SpinnerHandle {
@@ -131,13 +134,13 @@ function renderFinal(
 }
 
 /** Terminal operations driven by spinners and progress indicators. */
-export interface SpinnerSink {
+export interface ProgressSink {
 	readonly isTTY: boolean;
 	write: (text: string) => void;
 	exit: (code: number) => never;
 }
 
-const sinkStorage = new AsyncLocalStorage<SpinnerSink>();
+const sinkStorage = new AsyncLocalStorage<ProgressSink>();
 
 /**
  * Run a function with a sink ambiently available to every spinner or
@@ -146,11 +149,11 @@ const sinkStorage = new AsyncLocalStorage<SpinnerSink>();
  * `@crustjs/prompts` — test harnesses and embedders redirect indicator
  * output without touching process globals.
  */
-export function withProgressSink<T>(sink: SpinnerSink, fn: () => T): T {
+export function withProgressSink<T>(sink: ProgressSink, fn: () => T): T {
 	return sinkStorage.run(sink, fn);
 }
 
-const processSpinnerSink: SpinnerSink = {
+const processSink: ProgressSink = {
 	get isTTY() {
 		return process.stderr.isTTY ?? false;
 	},
@@ -163,11 +166,8 @@ const processSpinnerSink: SpinnerSink = {
 };
 
 /** Internal handle constructor shared by both `spinner()` modes and `progress()`. */
-export function createSpinnerHandle(
-	options: SpinnerHandleOptions,
-	explicitSink?: SpinnerSink,
-): SpinnerHandle {
-	const sink = explicitSink ?? options.sink ?? sinkStorage.getStore() ?? processSpinnerSink;
+export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandle {
+	const sink = options.sink ?? sinkStorage.getStore() ?? processSink;
 	const theme = resolveTheme(options.theme);
 	const isInteractive = sink.isTTY;
 	const { frames, interval } = resolveSpinner(options.spinner);
@@ -208,6 +208,9 @@ export function createSpinnerHandle(
 			if (sigint === "exit") {
 				sigintHandler = () => {
 					cleanup();
+					// Mark done before exit: a sink whose `exit` throws (test harnesses)
+					// must not leave a live handle behind the thrown signal handler.
+					finished = true;
 					sink.write(SHOW_CURSOR);
 					sink.exit(130);
 				};
@@ -257,14 +260,18 @@ export function spinner<T>(
 	if (!task) return handle;
 
 	handle.start();
-	return task(handle).then(
-		(result) => {
-			handle.stop("success");
-			return result;
-		},
-		(error) => {
-			handle.stop("error");
-			throw error;
-		},
-	);
+	// Route sync throws from `task` into the rejection path so the interval,
+	// cursor, and SIGINT listener are still cleaned up.
+	return Promise.resolve()
+		.then(() => task(handle))
+		.then(
+			(result) => {
+				handle.stop("success");
+				return result;
+			},
+			(error) => {
+				handle.stop("error");
+				throw error;
+			},
+		);
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -45,11 +45,13 @@
 	"devDependencies": {
 		"@crustjs/config": "workspace:*",
 		"@crustjs/core": "workspace:*",
+		"@crustjs/progress": "workspace:*",
 		"@crustjs/prompts": "workspace:*",
 		"bunup": "catalog:"
 	},
 	"peerDependencies": {
 		"@crustjs/core": "workspace:0.x",
+		"@crustjs/progress": "workspace:0.x",
 		"@crustjs/prompts": "workspace:0.x",
 		"typescript": "^7.0.0"
 	},

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { Crust, defineCommand, defineExtension } from "@crustjs/core";
+import { spinner } from "@crustjs/progress";
 import { input } from "@crustjs/prompts";
 
 import {
@@ -94,6 +95,20 @@ describe("runInteractive", () => {
 
 		expect(run.screen()).toContain("Starting");
 		expect(run.screen()).toContain("Hello, Ada!");
+	});
+
+	it("captures spinner output on the fake terminal screen", async () => {
+		const app: RunnableApp = {
+			async run() {
+				await spinner({ message: "Deploying", task: async () => "ok" });
+			},
+		};
+
+		const run = runInteractive(app, []);
+		await run.waitFor(/Deploying/);
+		await run.done;
+
+		expect(run.screen()).toContain("✓ Deploying");
 	});
 
 	it("waitFor rethrows the application error instead of hanging", async () => {

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { Crust, defineCommand, defineExtension } from "@crustjs/core";
-import { spinner } from "@crustjs/progress";
+import { progress, spinner } from "@crustjs/progress";
 import { input } from "@crustjs/prompts";
 
 import {
@@ -109,6 +109,22 @@ describe("runInteractive", () => {
 		await run.done;
 
 		expect(run.screen()).toContain("✓ Deploying");
+	});
+
+	it("captures progress indicator output on the fake terminal screen", async () => {
+		const app: RunnableApp = {
+			async run() {
+				const bar = progress({ message: "Copying", total: 2 });
+				bar.start();
+				bar.advance();
+				bar.stop();
+			},
+		};
+
+		const run = runInteractive(app, []);
+		await run.done;
+
+		expect(run.screen()).toContain("✓ Copying (1/2)");
 	});
 
 	it("waitFor rethrows the application error instead of hanging", async () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,5 @@
 import type { InvocationIO } from "@crustjs/core";
-import { type SpinnerSink, withProgressSink } from "@crustjs/progress";
+import { type ProgressSink, withProgressSink } from "@crustjs/progress";
 import { withPromptIO } from "@crustjs/prompts";
 import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 
@@ -145,10 +145,10 @@ export interface InteractiveRun {
 /** Run an application with fake terminal streams for its prompts and stderr output. */
 export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
 	const harness = createPromptIO();
-	const output = harness.io.output!;
+	const output = harness.io.output;
 	// Spinners and progress indicators render onto the same fake terminal as
 	// prompts, so waitFor()/screen() observe them too.
-	const sink: SpinnerSink = {
+	const sink: ProgressSink = {
 		isTTY: true,
 		write: (text) => {
 			output.write(text);

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -153,9 +153,6 @@ export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App
 		write: (text) => {
 			output.write(text);
 		},
-		exit: (code): never => {
-			throw new Error(`process.exit(${code}) requested during runInteractive`);
-		},
 	};
 	const done = withProgressSink(sink, () =>
 		withPromptIO(harness.io, () =>

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,5 @@
 import type { InvocationIO } from "@crustjs/core";
+import { type SpinnerSink, withProgressSink } from "@crustjs/progress";
 import { withPromptIO } from "@crustjs/prompts";
 import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 
@@ -145,14 +146,27 @@ export interface InteractiveRun {
 export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output!;
-	const done = withPromptIO(harness.io, () =>
-		app.run(argv, {
-			stdout: () => {},
-			stderr: (text) => {
-				// Line-oriented like core's console.error default.
-				output.write(`${text}\n`);
-			},
-		}),
+	// Spinners and progress indicators render onto the same fake terminal as
+	// prompts, so waitFor()/screen() observe them too.
+	const sink: SpinnerSink = {
+		isTTY: true,
+		write: (text) => {
+			output.write(text);
+		},
+		exit: (code): never => {
+			throw new Error(`process.exit(${code}) requested during runInteractive`);
+		},
+	};
+	const done = withProgressSink(sink, () =>
+		withPromptIO(harness.io, () =>
+			app.run(argv, {
+				stdout: () => {},
+				stderr: (text) => {
+					// Line-oriented like core's console.error default.
+					output.write(`${text}\n`);
+				},
+			}),
+		),
 	);
 
 	// Observe settlement so waitFor can stop polling; the action also keeps an


### PR DESCRIPTION
Stacked on #234.

Follow-up to #230: the argv hints were autocomplete-only — any string compiled. This makes them enforcing.

## Changes

- **fix(core):** `CommandDefinitionSpellings` now distributes over definition unions. Previously, adding an aliased and an alias-free definition in one `.add()` batch collapsed all alias literals to `never` (alias-free defs widen to `readonly string[]`, absorbing siblings), dropping aliases from argv hints and cross-batch collision brands. `.add(logs)` kept `log`; `.add(logs, init)` lost it.
- **feat(testing):** `captureRun` / `captureExecute` / `runInteractive` reject statically unknown argv literals:
  - `["deply"]` → compile error `Unknown command "deply"`
  - `["deploy", "--tokn"]` → compile error `Unknown flag "--tokn"`
  - Still legal: free positionals/values, `--flag=value`, `--no-` negations, short bundles/inline values (`-vt`, `-tsecret`), flags before subcommands, everything after `--`, and `--help`/`-h`/`--version` (Extension flags are invisible to static hints)
  - Escape hatch: widened `string[]` argv skips validation (unchanged contract); structural apps stay unchecked

## Notes

- Command-checking only applies to the leading token — later words are indistinguishable from positionals, so nested-subcommand typos still rely on runtime validation.
- Docs updated (`modules/testing.mdx` contract, stale anchor in `api/crust.mdx`); changeset: core patch, testing minor.

## Validation

- `bun run check:types` ✅
- `bun test` (core: 613, testing: 14) ✅
- `oxfmt --check`, `oxlint` ✅
