### PR TITLE
fix(core): preserve command aliases in mixed .add() batches; remove argv-hints machinery

### DIFF
--- a/.changeset/mixed-add-alias-hints.md
+++ b/.changeset/mixed-add-alias-hints.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Command hint extraction now distributes over command-definition unions, so aliases survive when definitions with and without aliases are added in the same `.add()` batch.

--- a/.changeset/mixed-add-alias-hints.md
+++ b/.changeset/mixed-add-alias-hints.md
@@ -2,4 +2,4 @@
 "@crustjs/core": patch
 ---
 
-Command hint extraction now distributes over command-definition unions, so aliases survive when definitions with and without aliases are added in the same `.add()` batch.
+Command spelling extraction now distributes over command-definition unions, so alias collision checks see aliases when definitions with and without aliases are added in the same `.add()` batch.

--- a/.changeset/six-crust-params.md
+++ b/.changeset/six-crust-params.md
@@ -2,4 +2,4 @@
 "@crustjs/core": minor
 ---
 
-Replace the eight generic parameters on `Crust` and `CommandDefinitionBuilder` with six by unifying local and Context-owned flags into one `Flags` parameter and removing the redundant effective-flags cache. This is a breaking change for explicit positional generic annotations; prefer inference or migrate positionally: `Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp, H>` becomes `Crust<Flags, A, Ctx, Sibs, Sp, H>` with `Flags = Local & Owned` and `Eff` dropped.
+Replace the seven generic parameters on `Crust` and `CommandDefinitionBuilder` with five by unifying local and Context-owned flags into one `Flags` parameter and removing the redundant effective-flags cache. This is a breaking change for explicit positional generic annotations; prefer inference or migrate positionally: `Crust<Local, Owned, A, Eff, Ctx, Sibs, Sp>` becomes `Crust<Flags, A, Ctx, Sibs, Sp>` with `Flags = Local & Owned` and `Eff` dropped.

--- a/.changeset/strict-testing-argv.md
+++ b/.changeset/strict-testing-argv.md
@@ -1,6 +1,0 @@
----
-"@crustjs/core": patch
-"@crustjs/testing": minor
----
-
-Preserve command aliases in argv hints when aliased and alias-free definitions are added in one batch. Testing helpers now reject statically unknown command and flag literals while keeping positionals, values, widened argv arrays, and structural applications flexible.

--- a/.changeset/strict-testing-argv.md
+++ b/.changeset/strict-testing-argv.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/core": patch
+"@crustjs/testing": minor
+---
+
+Preserve command aliases in argv hints when aliased and alias-free definitions are added in one batch. Testing helpers now reject statically unknown command and flag literals while keeping positionals, values, widened argv arrays, and structural applications flexible.

--- a/.changeset/testing-argv-hints.md
+++ b/.changeset/testing-argv-hints.md
@@ -1,8 +1,0 @@
----
-"@crustjs/core": minor
-"@crustjs/testing": minor
----
-
-Testing helpers now autocomplete argv. `captureRun()`, `captureExecute()`, and `runInteractive()` are generic over the app, and their `argv` parameter suggests the command names, aliases, and dashed flag spellings the application statically declares — including flags and subcommands defined inside `defineCommand` recipes — while continuing to accept arbitrary strings for positionals and flag values. The hint union is exported as `ArgvHints<App>`.
-
-To support this, `@crustjs/core` threads a new trailing `Hints` type parameter through `Crust`, `CommandDefinitionBuilder`, and `CommandDefinition`: `defineCommand()` captures the recipe's statically known nested spellings, and `.add()` folds them into the parent. All new parameters are trailing and defaulted, so existing annotations keep working. Widened (non-literal) definitions and Extension-contributed commands or flags contribute no hints.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -65,7 +65,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` typed argv](/docs/modules/testing#typed-argv)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -65,7 +65,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. Both are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -74,40 +74,30 @@ interface CommandDefinition<
   R extends CommandRequirements = {},
   Name extends string = string,
   Aliases extends readonly string[] = readonly string[],
-  Hints extends string = string,
 > {
   readonly name: Name;
-  as<const N extends string>(name: N): CommandDefinition<R, N, Aliases, Hints>;
+  as<const N extends string>(name: N): CommandDefinition<R, N, Aliases>;
 }
 ```
 
-A `CommandDefinition<R>` is a frozen value carrying its name, static config, and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. Configured aliases travel with the renamed definition and must remain unique among siblings. It has no command node or execution methods. `Hints` carries the recipe's statically known nested command and flag spellings; `.add()` folds them into the parent's `H` parameter for tooling autocomplete.
+A `CommandDefinition<R>` is a frozen value carrying its name, static config, and configure recipe. `.as(name)` returns the same definition under a different name, so one definition can be added twice. Configured aliases travel with the renamed definition and must remain unique among siblings. It has no command node or execution methods.
 
 ### `defineCommand(name, config?, recipe)`
 
 ```ts
-defineCommand<
-  const Name extends string,
-  B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
->(
+defineCommand<const Name extends string>(
   name: Name,
-  recipe: (command: CommandDefinitionBuilder) => B,
-): CommandDefinition<{}, Name, readonly string[], BuilderHints<B>>;
+  recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
+): CommandDefinition<{}, Name>;
 
 interface CommandConfig extends Omit<CommandMeta, "name">, CommandRequirements {}
 
-defineCommand<
-  const Name extends string,
-  const C extends CommandConfig,
-  B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
->(
+defineCommand<const Name extends string, const C extends CommandConfig>(
   name: Name,
   config: C & ValidateCommandConfig<Name, C>,
-  recipe: (command: CommandDefinitionBuilder) => B,
-): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>, BuilderHints<B>>;
+  recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
+): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>>;
 ```
-
-`B` captures the recipe's returned builder, so the nested command and flag spellings it accumulated feed the definition's `Hints` parameter.
 
 Creates an inert reusable definition under a required name. Static `description`, `usage`, `aliases`, `hidden`, and Context `requires` belong in `config`. The recipe builder is typed from the requirement values:
 
@@ -205,7 +195,7 @@ const app = new Crust("serve").flags(
 );
 ```
 
-Repeated `.flags()` calls accumulate local flags and cache their statically known spellings — the union of flag names and aliases that `SpellingsOf` computes — in the `Sp` parameter. Because `Sp` accumulates per call, spellings registered before a widened (dynamically typed) `.flags()` call stay collision-checked at compile time; previously any widened call deferred all subsequent collision checks to runtime. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<F extends FlagsDef>(app: Crust<F, A, Ctx>)`) defer the default `Sp = SpellingsOf<F>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any, any>` instead — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
+Repeated `.flags()` calls accumulate local flags and cache their statically known spellings — the union of flag names and aliases that `SpellingsOf` computes — in the `Sp` parameter. Because `Sp` accumulates per call, spellings registered before a widened (dynamically typed) `.flags()` call stay collision-checked at compile time; previously any widened call deferred all subsequent collision checks to runtime. For TypeScript consumers, statically known spelling collisions fail typecheck with `FIX_ALIAS_COLLISION`; runtime validation throws `DEFINITION` for collisions from plain-JS consumers or dynamically built definitions. Generic wrapper functions that keep the flag parameter bounded (e.g. `<F extends FlagsDef>(app: Crust<F, A, Ctx>)`) defer the default `Sp = SpellingsOf<F>` and will not typecheck further `.flags()` calls; type wrapper parameters as `Crust<any, any, any, any, any>` instead — runtime validation still applies. A spelling typed as a union of literals (e.g. `short: cond ? "a" : "b"`) is conservatively rejected when any member collides, even though the runtime value might not; widen it to `string` to defer the check to runtime. Promise-returning custom `parse` functions similarly fail with `FIX_ASYNC_PARSE` because parsing consumes their result synchronously; runtime validation rejects declared `async` functions for plain-JS consumers.
 
 Flags declared here are local to this command. Context-owned flags are the propagation mechanism for descendant parsers; downstream code receives their derived Context capability. Boolean flags support generated `--no-<spelling>` negation for the canonical name and every long alias; `noNegate: true` rejects negation with a `PARSE` error and hides the generated label from help, completion, and man output. Names and aliases beginning with `no-` are reserved.
 
@@ -307,8 +297,7 @@ add<const Ds extends readonly CommandDefinition<any>[]>(
   A,
   Ctx,
   Sibs | CommandDefinitionSpellings<Ds[number]>,
-  Sp,
-  H | DefinitionHints<Ds[number]>
+  Sp
 >
 ```
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -47,7 +47,6 @@ interface CommandDefinitionBuilder<
   Ctx,
   Sibs extends string = never,
   Sp extends string = SpellingsOf<Flags>,
-  H extends string = never,
 > {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
@@ -133,7 +132,6 @@ class Crust<
   Ctx,
   Sibs extends string = never,
   Sp extends string = SpellingsOf<Flags>,
-  H extends string = never,
 >
 
 new Crust(name: string, meta?: RootCommandMeta)
@@ -219,8 +217,7 @@ provide<const Cs extends readonly ContextInstance[]>(
   A,
   MergeContext<Ctx, ContextsOutput<Cs>>,
   Sibs,
-  Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
-  H
+  Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 >
 ```
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -65,7 +65,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` typed argv](/docs/modules/testing#typed-argv)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and Context types; required capabilities seed `Ctx`. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`, and `H` accumulates argv hint literals carried by added definitions (consumed by [`@crustjs/testing` argv autocomplete](/docs/modules/testing#argv-autocomplete)). All three are trailing defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -37,16 +37,16 @@ interface ExecutableApp {
 
 Any application that implements the required shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` implements neither contract and must first be added to an application.
 
-## Typed argv
+## Argv autocomplete
 
-When `app` is a `Crust` builder, every helper autocompletes the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes. Unknown command and flag literals are compile-time errors, while positionals and flag values remain free text:
+When `app` is a `Crust` builder, the `argv` parameter of every helper suggests the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes — while still accepting any string for positionals and flag values:
 
 ```ts
 await captureRun(app, ["deploy", "api", "--env", "staging"]);
-//                     ^ "deploy" and "--env" are checked; "api" and "staging" are free text
+//                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
 ```
 
-`--help`, `-h`, and `--version` are always accepted, as are negated long flags, long `--flag=value` forms, short bundles/inline values, and every token after `--`. When the root command declares positional args via `.args()`, a first non-command token is accepted as a root positional instead of being rejected as an unknown command. Other Extension-contributed commands and flags are not visible in the static hints; use a widened array (`argv as string[]`) as an escape hatch for those dynamic tokens. Structural apps that don't extend `Crust` accept any argv. The hint union is exported as `ArgvHints<App>`.
+Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear, and `--no-<flag>` negation forms are not emitted. The union is also flat — every spelling is suggested at every position; parsing still validates ordering at runtime. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
 
 ## `captureRun(app, argv)`
 
@@ -72,8 +72,7 @@ Drive the terminal `execute()` path in-process. Unlike `captureRun()`, this exer
 ```ts
 import { captureExecute } from "@crustjs/testing";
 
-const argv: string[] = ["deploy", "--bad-flag"];
-const result = await captureExecute(app, argv);
+const result = await captureExecute(app, ["deploy", "--bad-flag"]);
 
 expect(result.exitCode).toBe(1);
 expect(result.stderr).toContain("Unknown flag");

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -37,16 +37,16 @@ interface ExecutableApp {
 
 Any application that implements the required shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` implements neither contract and must first be added to an application.
 
-## Argv autocomplete
+## Typed argv
 
-When `app` is a `Crust` builder, the `argv` parameter of every helper suggests the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes — while still accepting any string for positionals and flag values:
+When `app` is a `Crust` builder, every helper autocompletes the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes. Unknown command and flag literals are compile-time errors, while positionals and flag values remain free text:
 
 ```ts
 await captureRun(app, ["deploy", "api", "--env", "staging"]);
-//                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
+//                     ^ "deploy" and "--env" are checked; "api" and "staging" are free text
 ```
 
-Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear, and `--no-<flag>` negation forms are not emitted. The union is also flat — every spelling is suggested at every position; parsing still validates ordering at runtime. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
+`--help`, `-h`, and `--version` are always accepted, as are negated long flags, long `--flag=value` forms, short bundles/inline values, and every token after `--`. Other Extension-contributed commands and flags are not visible in the static hints; use a widened array (`argv as string[]`) as an escape hatch for those dynamic tokens. Structural apps that don't extend `Crust` accept any argv. The hint union is exported as `ArgvHints<App>`.
 
 ## `captureRun(app, argv)`
 
@@ -72,7 +72,8 @@ Drive the terminal `execute()` path in-process. Unlike `captureRun()`, this exer
 ```ts
 import { captureExecute } from "@crustjs/testing";
 
-const result = await captureExecute(app, ["deploy", "--bad-flag"]);
+const argv: string[] = ["deploy", "--bad-flag"];
+const result = await captureExecute(app, argv);
 
 expect(result.exitCode).toBe(1);
 expect(result.stderr).toContain("Unknown flag");

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -37,17 +37,6 @@ interface ExecutableApp {
 
 Any application that implements the required shape is accepted; it does not need to extend `Crust`. An inert `CommandDefinition` implements neither contract and must first be added to an application.
 
-## Argv autocomplete
-
-When `app` is a `Crust` builder, the `argv` parameter of every helper suggests the command and flag spellings the application declares — including flags and subcommands defined inside `defineCommand` recipes — while still accepting any string for positionals and flag values:
-
-```ts
-await captureRun(app, ["deploy", "api", "--env", "staging"]);
-//                     ^ "deploy" and "--env" autocomplete; "api" and "staging" are free text
-```
-
-Hints cover statically known spellings only: commands added with widened (non-literal) names and Extension-contributed commands or flags (such as `--help`) do not appear, and `--no-<flag>` negation forms are not emitted. The union is also flat — every spelling is suggested at every position; parsing still validates ordering at runtime. Structural apps that don't extend `Crust` get no hints. The hint union is exported as `ArgvHints<App>`.
-
 ## `captureRun(app, argv)`
 
 Run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. If the application throws, `error` contains that value and output written before the failure is retained.

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -46,7 +46,7 @@ await captureRun(app, ["deploy", "api", "--env", "staging"]);
 //                     ^ "deploy" and "--env" are checked; "api" and "staging" are free text
 ```
 
-`--help`, `-h`, and `--version` are always accepted, as are negated long flags, long `--flag=value` forms, short bundles/inline values, and every token after `--`. Other Extension-contributed commands and flags are not visible in the static hints; use a widened array (`argv as string[]`) as an escape hatch for those dynamic tokens. Structural apps that don't extend `Crust` accept any argv. The hint union is exported as `ArgvHints<App>`.
+`--help`, `-h`, and `--version` are always accepted, as are negated long flags, long `--flag=value` forms, short bundles/inline values, and every token after `--`. When the root command declares positional args via `.args()`, a first non-command token is accepted as a root positional instead of being rejected as an unknown command. Other Extension-contributed commands and flags are not visible in the static hints; use a widened array (`argv as string[]`) as an escape hatch for those dynamic tokens. Structural apps that don't extend `Crust` accept any argv. The hint union is exported as `ArgvHints<App>`.
 
 ## `captureRun(app, argv)`
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -11,7 +11,6 @@ import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
 import type { FlagsDef } from "../types.ts";
 import {
-	type CommandDefinition,
 	type CommandDefinitionBuilder,
 	Crust,
 	defineCommand,
@@ -267,9 +266,7 @@ describe("Crust .flags()", () => {
 			(typeof app)["_types"]["args"],
 			(typeof app)["_types"]["ctx"],
 			never,
-			"verbose" | "v",
-			// oxlint-disable-next-line typescript/no-unnecessary-type-arguments -- pins all six parameters
-			never
+			"verbose" | "v"
 		> = app;
 		void explicit;
 
@@ -814,65 +811,6 @@ describe("Crust .add() type-level tests", () => {
 			defineCommand("issue", { aliases: ["issue"] }, (command) => command);
 		};
 		void typecheckAliasShapes;
-
-		expect(true).toBe(true);
-	});
-
-	it("accumulates argv hints from flags and nested command definitions", () => {
-		const login = defineCommand("login", { aliases: ["l"] }, (command) =>
-			command
-				.flags({ name: "token", type: "string", short: "t", aliases: ["tok"] })
-				.action(() => {}),
-		);
-		const auth = defineCommand("auth", (command) => command.add(login));
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(auth);
-
-		type Hints = Parameters<(typeof app)["_types"]["hints"]>[0];
-		type _Hints = Expect<
-			Equal<Hints, "auth" | "--verbose" | "-v" | "login" | "l" | "--token" | "-t" | "--tok">
-		>;
-
-		// .as() renames the definition but keeps its nested hints
-		const renamed = new Crust("cli").add(auth.as("account"));
-		type RenamedHints = Parameters<(typeof renamed)["_types"]["hints"]>[0];
-		type _RenamedHints = Expect<
-			Equal<RenamedHints, "account" | "login" | "l" | "--token" | "-t" | "--tok">
-		>;
-
-		// widened definitions opt out of hints without collapsing the union
-		const widened: CommandDefinition = defineCommand("static", (command) => command);
-		const mixed = new Crust("cli").add(login).add(widened);
-		type MixedHints = Parameters<(typeof mixed)["_types"]["hints"]>[0];
-		type _MixedHints = Expect<Equal<MixedHints, "login" | "l" | "--token" | "-t" | "--tok">>;
-
-		// aliases survive unions formed by a mixed single-batch add
-		const mixedBatch = new Crust("cli").add(
-			login,
-			defineCommand("plain", (command) => command),
-		);
-		type MixedBatchHints = Parameters<(typeof mixedBatch)["_types"]["hints"]>[0];
-		type _MixedBatchHints = Expect<
-			Equal<MixedBatchHints, "login" | "l" | "--token" | "-t" | "--tok" | "plain">
-		>;
-
-		// explicit type arguments still work — trailing builder param is defaulted
-		const explicit = defineCommand<"deploy">("deploy", (command) => command.action(() => {}));
-		type _ExplicitName = Expect<Equal<(typeof explicit)["name"], "deploy">>;
-
-		// hints flow through deep nesting and .provide()-owned flags
-		const leaf = defineCommand("leaf", (command) =>
-			command.flags({ name: "deep", type: "boolean" }).action(() => {}),
-		);
-		const mid = defineCommand("mid", (command) =>
-			command
-				.provide(
-					defineContext("log", { flags: [{ name: "trace", type: "boolean" }] }, () => ({}))(),
-				)
-				.add(leaf),
-		);
-		const deep = new Crust("cli").add(defineCommand("top", (command) => command.add(mid)));
-		type DeepHints = Parameters<(typeof deep)["_types"]["hints"]>[0];
-		type _DeepHints = Expect<Equal<DeepHints, "top" | "mid" | "leaf" | "--trace" | "--deep">>;
 
 		expect(true).toBe(true);
 	});

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -845,6 +845,16 @@ describe("Crust .add() type-level tests", () => {
 		type MixedHints = Parameters<(typeof mixed)["_types"]["hints"]>[0];
 		type _MixedHints = Expect<Equal<MixedHints, "login" | "l" | "--token" | "-t" | "--tok">>;
 
+		// aliases survive unions formed by a mixed single-batch add
+		const mixedBatch = new Crust("cli").add(
+			login,
+			defineCommand("plain", (command) => command),
+		);
+		type MixedBatchHints = Parameters<(typeof mixedBatch)["_types"]["hints"]>[0];
+		type _MixedBatchHints = Expect<
+			Equal<MixedBatchHints, "login" | "l" | "--token" | "-t" | "--tok" | "plain">
+		>;
+
 		// explicit type arguments still work — trailing builder param is defaulted
 		const explicit = defineCommand<"deploy">("deploy", (command) => command.action(() => {}));
 		type _ExplicitName = Expect<Equal<(typeof explicit)["name"], "deploy">>;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -103,14 +103,14 @@ type ConfigRequirements<C extends CommandConfig> = C extends {
 	? { readonly requires: R }
 	: {};
 
-type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any>;
+type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any>;
 
 // Child builders start without inherited flags: collisions with ancestor-owned
 // flags are runtime-only, caught while the definition materializes against its
 // parent's normalized flags.
-type CommandRecipe<R extends CommandRequirements, B extends AnyCommandDefinitionBuilder> = (
+type CommandRecipe<R extends CommandRequirements> = (
 	command: CommandDefinitionBuilder<{}, [], RequirementContext<R>>,
-) => B;
+) => AnyCommandDefinitionBuilder;
 
 const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
 
@@ -121,60 +121,21 @@ interface CommandDefinitionInternal {
 	readonly requiredCtxNames: readonly string[];
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Argv hints — static command/flag spellings for tooling autocomplete
-// ────────────────────────────────────────────────────────────────────────────
-
-/** Dashed argv form of a flag spelling: `-x` for one character, `--name` otherwise. */
-type DashSpelling<S extends string> = S extends `${infer First}${infer Rest}`
-	? Rest extends ""
-		? `-${First}`
-		: `--${S}`
-	: never;
-
-/**
- * Every argv literal a command's static type knows about: sibling command
- * spellings, dashed flag spellings, and hints carried by added definitions.
- * Exposed through the `_types.hints` phantom so tooling (e.g.
- * `@crustjs/testing` argv autocomplete) can extract it structurally.
- */
-type HintUnion<Sibs extends string, Sp extends string, H extends string> =
-	| Sibs
-	| DashSpelling<Sp>
-	| H;
-
-/** Hints carried by a definition; widened definitions (`Hints = string`) opt out. */
-type DefinitionHints<D> = D extends { readonly _hints?: infer H extends string }
-	? string extends H
-		? never
-		: H
-	: never;
-
-/** Extract the accumulated argv hints from a recipe's returned builder. */
-type BuilderHints<B> = B extends {
-	readonly _types?: { hints(hint: infer H): void } | undefined;
-}
-	? H & string
-	: never;
-
 export interface CommandDefinition<
 	R extends CommandRequirements = {},
 	Name extends string = string,
 	Aliases extends readonly string[] = readonly string[],
-	Hints extends string = string,
 > {
 	/** The subcommand name this definition is added under */
 	readonly name: Name;
 	/** The same definition under a different name; configured aliases travel with it. */
-	as<const N extends string>(name: N): CommandDefinition<R, N, Aliases, Hints>;
+	as<const N extends string>(name: N): CommandDefinition<R, N, Aliases>;
 	/** @internal */
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
 	/** @internal — phantom carrying the requirements for add-time checks */
 	readonly _requirements?: R;
 	/** @internal — phantom carrying configured alias literals for add-time checks */
 	readonly _aliases?: Aliases;
-	/** @internal — phantom carrying nested command and flag argv spellings for tooling hints */
-	readonly _hints?: Hints;
 }
 
 /**
@@ -339,11 +300,7 @@ export interface CommandDefinitionBuilder<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Flags>,
-	H extends string = never,
 > {
-	/** @internal — phantom exposing accumulated argv hints for tooling autocomplete */
-	readonly _types?: { hints(hint: HintUnion<Sibs, Sp, H>): void };
-
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
 	): CommandDefinitionBuilder<
@@ -351,13 +308,12 @@ export interface CommandDefinitionBuilder<
 		A,
 		Ctx,
 		Sibs,
-		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
-		H
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H>;
+	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> & ValidateContextNames<Ctx, Cs>
@@ -366,24 +322,16 @@ export interface CommandDefinitionBuilder<
 		A,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
-		H
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	>;
 
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
-	): CommandDefinitionBuilder<
-		Flags,
-		A,
-		Ctx,
-		Sibs | CommandDefinitionSpellings<Ds[number]>,
-		Sp,
-		H | DefinitionHints<Ds[number]>
-	>;
+	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Sp>;
 
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, H>;
+	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp>;
 }
 
 /**
@@ -395,26 +343,19 @@ export interface CommandDefinitionBuilder<
  * Static metadata and Context requirements belong in `config`. Use `.as(name)`
  * to add one definition under a different name; configured aliases travel with it.
  */
-export function defineCommand<
-	const Name extends string,
-	B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
->(
+export function defineCommand<const Name extends string>(
 	name: Name,
-	recipe: CommandRecipe<{}, B>,
-): CommandDefinition<{}, Name, readonly string[], BuilderHints<B>>;
-export function defineCommand<
-	const Name extends string,
-	const C extends CommandConfig,
-	B extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
->(
+	recipe: CommandRecipe<{}>,
+): CommandDefinition<{}, Name>;
+export function defineCommand<const Name extends string, const C extends CommandConfig>(
 	name: Name,
 	config: C & ValidateCommandConfig<Name, C>,
-	recipe: CommandRecipe<ConfigRequirements<C>, B>,
-): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>, BuilderHints<B>>;
+	recipe: CommandRecipe<ConfigRequirements<C>>,
+): CommandDefinition<ConfigRequirements<C>, Name, AliasesOf<C>>;
 export function defineCommand(
 	name: string,
-	configOrRecipe: CommandConfig | CommandRecipe<CommandRequirements, AnyCommandDefinitionBuilder>,
-	maybeRecipe?: CommandRecipe<CommandRequirements, AnyCommandDefinitionBuilder>,
+	configOrRecipe: CommandConfig | CommandRecipe<CommandRequirements>,
+	maybeRecipe?: CommandRecipe<CommandRequirements>,
 ): CommandDefinition<CommandRequirements> {
 	const hasConfig = typeof configOrRecipe !== "function";
 	const config: CommandConfig = hasConfig ? configOrRecipe : {};
@@ -481,7 +422,6 @@ export class Crust<
 	Ctx extends ContextMap = {},
 	Sibs extends string = never,
 	Sp extends string = SpellingsOf<Flags>,
-	H extends string = never,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
@@ -491,9 +431,6 @@ export class Crust<
 		// Method syntax keeps broad/legacy Crust annotations assignable while
 		// exposing Sp to type-level tests through Parameters<>.
 		spellings(spelling: Sp): void;
-		// Argv literals for tooling autocomplete (command spellings, dashed
-		// flag spellings, and hints from added definitions).
-		hints(hint: HintUnion<Sibs, Sp, H>): void;
 	};
 
 	/** @internal */
@@ -563,8 +500,7 @@ export class Crust<
 		A,
 		Ctx,
 		Sibs,
-		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
-		H
+		Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 	> {
 		const localFlags: FlagsDef = { ...this._node.localFlags };
 		const effectiveFlags: FlagsDef = { ...this._node.effectiveFlags };
@@ -594,8 +530,7 @@ export class Crust<
 			A,
 			Ctx,
 			Sibs,
-			Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
-			H
+			Sp | SpellingsOf<NamedFlagsRecord<Defs>>
 		>;
 	}
 
@@ -613,10 +548,10 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H> {
+	): Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp> {
 		return this._clone({
 			args: normalizeArgs(this._node.args, defs as ArgsDef),
-		}) as unknown as Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, H>;
+		}) as unknown as Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp>;
 	}
 
 	/**
@@ -640,8 +575,7 @@ export class Crust<
 		A,
 		MergeContext<Ctx, ContextsOutput<Cs>>,
 		Sibs,
-		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
-		H
+		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 	> {
 		const ownedFlags = { ...this._node.ownedFlags };
 		const effectiveFlags = { ...this._node.effectiveFlags };
@@ -659,8 +593,7 @@ export class Crust<
 			A,
 			MergeContext<Ctx, ContextsOutput<Cs>>,
 			Sibs,
-			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
-			H
+			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>
 		>;
 	}
 
@@ -680,7 +613,7 @@ export class Crust<
 	 */
 	action(
 		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
-	): Crust<Flags, A, Ctx, Sibs, Sp, H> {
+	): Crust<Flags, A, Ctx, Sibs, Sp> {
 		if (this._node.run) {
 			throw new CrustError(
 				"DEFINITION",
@@ -690,7 +623,7 @@ export class Crust<
 		}
 		return this._clone({
 			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp>;
 	}
 
 	/**
@@ -702,7 +635,7 @@ export class Crust<
 	 *
 	 * @throws {CrustError} `DEFINITION` when an Extension name is already registered
 	 */
-	extend(...extensions: readonly Extension[]): Crust<Flags, A, Ctx, Sibs, Sp, H> {
+	extend(...extensions: readonly Extension[]): Crust<Flags, A, Ctx, Sibs, Sp> {
 		const names = new Set(this._node.extensions.map((extension) => extension.name));
 		for (const extension of extensions) {
 			if (names.has(extension.name)) {
@@ -716,7 +649,7 @@ export class Crust<
 		}
 		return this._clone({
 			extensions: [...this._node.extensions, ...extensions],
-		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp>;
 	}
 
 	/**
@@ -728,34 +661,20 @@ export class Crust<
 	 */
 	add<const Ds extends readonly CommandDefinition<any>[]>(
 		...definitions: Ds & AddChecks<Ctx, Sibs, Ds>
-	): Crust<
-		Flags,
-		A,
-		Ctx,
-		Sibs | CommandDefinitionSpellings<Ds[number]>,
-		Sp,
-		H | DefinitionHints<Ds[number]>
-	> {
-		let result = this as Crust<Flags, A, Ctx, Sibs, Sp, H>;
+	): Crust<Flags, A, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Sp> {
+		let result = this as Crust<Flags, A, Ctx, Sibs, Sp>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
-		return result as Crust<
-			Flags,
-			A,
-			Ctx,
-			Sibs | CommandDefinitionSpellings<Ds[number]>,
-			Sp,
-			H | DefinitionHints<Ds[number]>
-		>;
+		return result as Crust<Flags, A, Ctx, Sibs | CommandDefinitionSpellings<Ds[number]>, Sp>;
 	}
 
-	private _addDefinition(definition: CommandDefinition): Crust<Flags, A, Ctx, Sibs, Sp, H> {
+	private _addDefinition(definition: CommandDefinition): Crust<Flags, A, Ctx, Sibs, Sp> {
 		const childNode = materializeCommandDefinition(definition, this._node);
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Flags, A, Ctx, Sibs, Sp, H>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -404,7 +404,6 @@ export function defineCommand(
  * - `Ctx` — provided Context values
  * - `Sibs` — sibling command names and aliases already registered
  * - `Sp` — accumulated flag spellings used for collision checks
- * - `H` — argv hint literals accumulated from added command definitions
  *
  * @example
  * ```ts

--- a/packages/core/src/validation/commands.brands.test.ts
+++ b/packages/core/src/validation/commands.brands.test.ts
@@ -23,6 +23,12 @@ describe("compile-time command validation", () => {
 			>
 		>;
 		type _widened = Expect<Equal<CommandDefinitionSpellings<Def<string, readonly ["i"]>>, never>>;
+		type _mixedUnion = Expect<
+			Equal<
+				CommandDefinitionSpellings<Def<"logs", readonly ["log"]> | Def<"init">>,
+				"logs" | "log" | "init"
+			>
+		>;
 
 		expect(true).toBe(true);
 	});

--- a/packages/core/src/validation/commands.brands.ts
+++ b/packages/core/src/validation/commands.brands.ts
@@ -42,12 +42,13 @@ type DefinitionAliases<D> = D extends {
 	: readonly string[];
 
 /** All statically known canonical and alias spellings carried by a command definition. */
-export type CommandDefinitionSpellings<D> =
-	DefName<D> extends infer Name extends string
+export type CommandDefinitionSpellings<D> = D extends unknown
+	? DefName<D> extends infer Name extends string
 		? [Name] extends [never]
 			? never
 			: Name | NarrowAliases<DefinitionAliases<D>>
-		: never;
+		: never
+	: never;
 
 type CommandCollisionBrand<D, Existing extends string> =
 	Overlap<CommandDefinitionSpellings<D>, Existing> extends infer Collision extends string

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -24,7 +24,7 @@ export interface RunResult {
  *   expect(result.exitCode).toBe(0);
  */
 export async function executeCrust(
-	builder: Crust<any, any, any, any, any, any>,
+	builder: Crust<any, any, any, any, any>,
 	argv?: string[],
 ): Promise<RunResult> {
 	const stdoutChunks: string[] = [];

--- a/packages/skills/src/annotations.ts
+++ b/packages/skills/src/annotations.ts
@@ -23,7 +23,7 @@ export interface SkillCommandAnnotations {
 	instructions?: string[];
 }
 
-type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any, any>;
+type SkillCommandTarget = CommandNode | Crust<any, any, any, any, any>;
 
 const SKILL_COMMAND_ANNOTATIONS = Symbol("crust.skill.commandAnnotations");
 

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,48 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { Crust, defineCommand, defineExtension } from "@crustjs/core";
+import { Crust, defineExtension } from "@crustjs/core";
 import { progress, spinner } from "@crustjs/progress";
 import { input } from "@crustjs/prompts";
 
-import {
-	type ArgvHints,
-	captureExecute,
-	captureRun,
-	runInteractive,
-	type RunnableApp,
-} from "./index.ts";
-
-type Expect<T extends true> = T;
-type Equal<A, B> =
-	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
-
-describe("argv hints", () => {
-	it("derives command and flag spellings from the app type while accepting any string", async () => {
-		const login = defineCommand("login", (command) =>
-			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
-		);
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(login);
-
-		type _Hints = Expect<
-			Equal<ArgvHints<typeof app>, "login" | "--verbose" | "-v" | "--token" | "-t">
-		>;
-		// structural apps without the phantom fall back to no hints
-		type _None = Expect<Equal<ArgvHints<RunnableApp>, never>>;
-
-		// arbitrary strings (positionals, flag values) remain accepted by every helper,
-		// including widened string[] arrays — the common consumer pattern
-		const typecheckLooseArgv = () => {
-			const widened: string[] = ["login", "free-text"];
-			void captureRun(app, widened);
-			void captureExecute(app, ["login", "free-text"]);
-			void runInteractive(app, ["login", "free-text"]);
-		};
-		void typecheckLooseArgv;
-
-		const result = await captureRun(app, ["login", "--token", "abc"]);
-		expect(result.error).toBeUndefined();
-	});
-});
+import { captureExecute, captureRun, runInteractive, type RunnableApp } from "./index.ts";
 
 describe("captureRun", () => {
 	it("captures output from a structural runnable as lines", async () => {

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -17,60 +17,29 @@ type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 describe("argv hints", () => {
-	it("derives and validates statically known command and flag spellings", async () => {
-		const deploy = defineCommand("deploy", (command) =>
+	it("derives command and flag spellings from the app type while accepting any string", async () => {
+		const login = defineCommand("login", (command) =>
 			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
 		);
-		const app = new Crust("cli")
-			.flags({ name: "verbose", type: "boolean", short: "v" }, { name: "port", type: "string" })
-			.add(deploy);
+		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(login);
 
 		type _Hints = Expect<
-			Equal<ArgvHints<typeof app>, "deploy" | "--verbose" | "-v" | "--port" | "--token" | "-t">
+			Equal<ArgvHints<typeof app>, "login" | "--verbose" | "-v" | "--token" | "-t">
 		>;
-		// structural apps without the phantom fall back to no validation
+		// structural apps without the phantom fall back to no hints
 		type _None = Expect<Equal<ArgvHints<RunnableApp>, never>>;
 
-		const typecheckArgv = () => {
-			// @ts-expect-error -- statically unknown command
-			void captureRun(app, ["deply"]);
-			// @ts-expect-error -- statically unknown flag
-			void captureExecute(app, ["deploy", "--tokn"]);
-			// @ts-expect-error -- all helpers validate literal argv
-			void runInteractive(app, ["deploy", "--tokn"]);
-
-			void captureRun(app, ["deploy", "anything-free-text"]);
-			void captureRun(app, ["--verbose", "deploy"]);
-			void captureRun(app, ["--port=123"]);
-			void captureRun(app, ["-vt", "-tsecret"]);
-			void captureRun(app, ["--help"]);
-			void captureRun(app, ["-h"]);
-			void captureRun(app, ["--version"]);
-			void captureRun(app, ["--", "whatever", "--unknown"]);
-
-			// Widened argv is the escape hatch for dynamic and Extension-contributed tokens.
-			const widened: string[] = ["deploy", "--extension-flag"];
+		// arbitrary strings (positionals, flag values) remain accepted by every helper,
+		// including widened string[] arrays — the common consumer pattern
+		const typecheckLooseArgv = () => {
+			const widened: string[] = ["login", "free-text"];
 			void captureRun(app, widened);
-			void captureExecute(app, widened);
-			void runInteractive(app, widened);
-
-			// Root positionals: a first non-dash token routes to the root action
-			// when the root declares args, so it must not be an unknown command.
-			const withRootArgs = new Crust("cli")
-				.args({ name: "file", type: "string" })
-				.action(() => {})
-				.add(deploy);
-			void captureRun(withRootArgs, ["input.txt"]);
-			void captureRun(withRootArgs, ["deploy"]);
-			// @ts-expect-error -- flags are still validated when root args exist
-			void captureRun(withRootArgs, ["input.txt", "--tokn"]);
-
-			const structural: RunnableApp = { async run() {} };
-			void captureRun(structural, ["anything", "--unknown"]);
+			void captureExecute(app, ["login", "free-text"]);
+			void runInteractive(app, ["login", "free-text"]);
 		};
-		void typecheckArgv;
+		void typecheckLooseArgv;
 
-		const result = await captureRun(app, ["deploy", "--token", "abc"]);
+		const result = await captureRun(app, ["login", "--token", "abc"]);
 		expect(result.error).toBeUndefined();
 	});
 });

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -17,29 +17,49 @@ type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 describe("argv hints", () => {
-	it("derives command and flag spellings from the app type while accepting any string", async () => {
-		const login = defineCommand("login", (command) =>
+	it("derives and validates statically known command and flag spellings", async () => {
+		const deploy = defineCommand("deploy", (command) =>
 			command.flags({ name: "token", type: "string", short: "t" }).action(() => {}),
 		);
-		const app = new Crust("cli").flags({ name: "verbose", type: "boolean", short: "v" }).add(login);
+		const app = new Crust("cli")
+			.flags({ name: "verbose", type: "boolean", short: "v" }, { name: "port", type: "string" })
+			.add(deploy);
 
 		type _Hints = Expect<
-			Equal<ArgvHints<typeof app>, "login" | "--verbose" | "-v" | "--token" | "-t">
+			Equal<ArgvHints<typeof app>, "deploy" | "--verbose" | "-v" | "--port" | "--token" | "-t">
 		>;
-		// structural apps without the phantom fall back to no hints
+		// structural apps without the phantom fall back to no validation
 		type _None = Expect<Equal<ArgvHints<RunnableApp>, never>>;
 
-		// arbitrary strings (positionals, flag values) remain accepted by every helper,
-		// including widened string[] arrays — the common consumer pattern
-		const typecheckLooseArgv = () => {
-			const widened: string[] = ["login", "free-text"];
-			void captureRun(app, widened);
-			void captureExecute(app, ["login", "free-text"]);
-			void runInteractive(app, ["login", "free-text"]);
-		};
-		void typecheckLooseArgv;
+		const typecheckArgv = () => {
+			// @ts-expect-error -- statically unknown command
+			void captureRun(app, ["deply"]);
+			// @ts-expect-error -- statically unknown flag
+			void captureExecute(app, ["deploy", "--tokn"]);
+			// @ts-expect-error -- all helpers validate literal argv
+			void runInteractive(app, ["deploy", "--tokn"]);
 
-		const result = await captureRun(app, ["login", "--token", "abc"]);
+			void captureRun(app, ["deploy", "anything-free-text"]);
+			void captureRun(app, ["--verbose", "deploy"]);
+			void captureRun(app, ["--port=123"]);
+			void captureRun(app, ["-vt", "-tsecret"]);
+			void captureRun(app, ["--help"]);
+			void captureRun(app, ["-h"]);
+			void captureRun(app, ["--version"]);
+			void captureRun(app, ["--", "whatever", "--unknown"]);
+
+			// Widened argv is the escape hatch for dynamic and Extension-contributed tokens.
+			const widened: string[] = ["deploy", "--extension-flag"];
+			void captureRun(app, widened);
+			void captureExecute(app, widened);
+			void runInteractive(app, widened);
+
+			const structural: RunnableApp = { async run() {} };
+			void captureRun(structural, ["anything", "--unknown"]);
+		};
+		void typecheckArgv;
+
+		const result = await captureRun(app, ["deploy", "--token", "abc"]);
 		expect(result.error).toBeUndefined();
 	});
 });

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -54,6 +54,17 @@ describe("argv hints", () => {
 			void captureExecute(app, widened);
 			void runInteractive(app, widened);
 
+			// Root positionals: a first non-dash token routes to the root action
+			// when the root declares args, so it must not be an unknown command.
+			const withRootArgs = new Crust("cli")
+				.args({ name: "file", type: "string" })
+				.action(() => {})
+				.add(deploy);
+			void captureRun(withRootArgs, ["input.txt"]);
+			void captureRun(withRootArgs, ["deploy"]);
+			// @ts-expect-error -- flags are still validated when root args exist
+			void captureRun(withRootArgs, ["input.txt", "--tokn"]);
+
 			const structural: RunnableApp = { async run() {} };
 			void captureRun(structural, ["anything", "--unknown"]);
 		};

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -38,12 +38,21 @@ type LegalDashToken<H extends string> =
 	| "-h"
 	| "--version";
 
+/**
+ * Compile-time-only brand carrying an argv validation message. An invalid
+ * token's expected type is `Token & ArgvError<...>`: intersecting the string
+ * literal with an object (rather than another string literal) keeps the
+ * intersection from collapsing to `never`, so tsc prints the message instead
+ * of `Type 'string' is not assignable to type 'never'`.
+ */
+type ArgvError<Message extends string> = { readonly [Brand in Message]: never };
+
 type ValidateToken<T extends string, H extends string> = string extends T
 	? T
 	: T extends `-${string}`
 		? T extends LegalDashToken<H>
 			? T
-			: `Unknown flag "${T}"`
+			: ArgvError<`Unknown flag "${T}"`>
 		: T;
 
 /**
@@ -89,7 +98,7 @@ type ValidateArgv<
 										? Token
 										: RootPositional extends true
 											? Token
-											: `Unknown command "${Token}"`
+											: ArgvError<`Unknown command "${Token}"`>
 							: ValidateToken<Token, H>,
 						...ValidateArgv<Rest, H, RootPositional, false>,
 					]

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -46,9 +46,33 @@ type ValidateToken<T extends string, H extends string> = string extends T
 			: `Unknown flag "${T}"`
 		: T;
 
-type ValidateArgv<A extends readonly string[], H extends string, First extends boolean = true> = [
-	H,
-] extends [never]
+/**
+ * Whether the root command declares positional args (`.args()` narrows
+ * `_types.args` to a non-empty tuple). When it does, Core routes an unmatched
+ * first token to the root action as a positional, so it must not be rejected
+ * as an unknown command.
+ *
+ * This is a deliberate proxy for Core's actual routing rule ("root has
+ * `run()`"), which is invisible in types — `.action()` does not change
+ * `Crust`'s type parameters. The proxy is stricter than runtime in one case:
+ * a root action *without* declared args silently ignores extra positionals,
+ * and we still reject those — passing a positional such a root never reads
+ * is almost certainly a test bug.
+ */
+type RootHasPositionals<App> = App extends {
+	readonly _types: { args: infer RA extends readonly unknown[] };
+}
+	? RA extends readonly [unknown, ...unknown[]]
+		? true
+		: false
+	: false;
+
+type ValidateArgv<
+	A extends readonly string[],
+	H extends string,
+	RootPositional extends boolean,
+	First extends boolean = true,
+> = [H] extends [never]
 	? A
 	: number extends A["length"]
 		? A
@@ -63,9 +87,11 @@ type ValidateArgv<A extends readonly string[], H extends string, First extends b
 									? Token
 									: Token extends CommandHints<H>
 										? Token
-										: `Unknown command "${Token}"`
+										: RootPositional extends true
+											? Token
+											: `Unknown command "${Token}"`
 							: ValidateToken<Token, H>,
-						...ValidateArgv<Rest, H, false>,
+						...ValidateArgv<Rest, H, RootPositional, false>,
 					]
 			: A;
 
@@ -78,7 +104,7 @@ export interface CapturedRun {
 /** Run an application and capture its text output without throwing invocation errors. */
 export async function captureRun<App extends RunnableApp, const A extends readonly string[]>(
 	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>>,
+	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
 ): Promise<CapturedRun> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
@@ -133,7 +159,7 @@ let captureExecuteChain: Promise<unknown> = Promise.resolve();
  */
 export function captureExecute<App extends ExecutableApp, const A extends readonly string[]>(
 	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>>,
+	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
 ): Promise<CapturedExecute> {
 	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
 	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
@@ -184,7 +210,7 @@ export interface InteractiveRun {
 /** Run an application with fake terminal streams for its prompts and stderr output. */
 export function runInteractive<App extends RunnableApp, const A extends readonly string[]>(
 	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>>,
+	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
 ): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -23,12 +23,51 @@ export type ArgvHints<App> = App extends {
 	? H
 	: never;
 
-/**
- * argv for the testing helpers: any strings are accepted (positionals and
- * flag values are free text), while known command and flag spellings
- * autocomplete in the editor.
- */
-type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
+type FlagHints<H extends string> = Extract<H, `-${string}`>;
+type LongFlags<H extends string> = Extract<H, `--${string}`>;
+type ShortFlags<H extends string> = Exclude<FlagHints<H>, `--${string}`>;
+type CommandHints<H extends string> = Exclude<H, `-${string}`>;
+
+type LegalDashToken<H extends string> =
+	| "-"
+	| FlagHints<H>
+	| `${LongFlags<H>}=${string}`
+	| (LongFlags<H> extends `--${infer Name}` ? `--no-${Name}` : never)
+	| `${ShortFlags<H>}${string}`
+	| "--help"
+	| "-h"
+	| "--version";
+
+type ValidateToken<T extends string, H extends string> = string extends T
+	? T
+	: T extends `-${string}`
+		? T extends LegalDashToken<H>
+			? T
+			: `Unknown flag "${T}"`
+		: T;
+
+type ValidateArgv<A extends readonly string[], H extends string, First extends boolean = true> = [
+	H,
+] extends [never]
+	? A
+	: number extends A["length"]
+		? A
+		: A extends readonly [infer Token extends string, ...infer Rest extends readonly string[]]
+			? Token extends "--"
+				? A
+				: readonly [
+						First extends true
+							? Token extends `-${string}`
+								? ValidateToken<Token, H>
+								: [CommandHints<H>] extends [never]
+									? Token
+									: Token extends CommandHints<H>
+										? Token
+										: `Unknown command "${Token}"`
+							: ValidateToken<Token, H>,
+						...ValidateArgv<Rest, H, false>,
+					]
+			: A;
 
 export interface CapturedRun {
 	readonly stdout: string;
@@ -37,9 +76,9 @@ export interface CapturedRun {
 }
 
 /** Run an application and capture its text output without throwing invocation errors. */
-export async function captureRun<App extends RunnableApp>(
+export async function captureRun<App extends RunnableApp, const A extends readonly string[]>(
 	app: App,
-	argv: Argv<App>,
+	argv: A & ValidateArgv<A, ArgvHints<App>>,
 ): Promise<CapturedRun> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
@@ -92,9 +131,9 @@ let captureExecuteChain: Promise<unknown> = Promise.resolve();
  * Concurrent calls are serialized because the exit-code protocol is
  * process-global.
  */
-export function captureExecute<App extends ExecutableApp>(
+export function captureExecute<App extends ExecutableApp, const A extends readonly string[]>(
 	app: App,
-	argv: Argv<App>,
+	argv: A & ValidateArgv<A, ArgvHints<App>>,
 ): Promise<CapturedExecute> {
 	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
 	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
@@ -143,7 +182,10 @@ export interface InteractiveRun {
 }
 
 /** Run an application with fake terminal streams for its prompts and stderr output. */
-export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
+export function runInteractive<App extends RunnableApp, const A extends readonly string[]>(
+	app: App,
+	argv: A & ValidateArgv<A, ArgvHints<App>>,
+): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output;
 	// Spinners and progress indicators render onto the same fake terminal as

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -11,25 +11,6 @@ export interface RunnableApp {
 	run(argv: readonly string[], io?: CaptureIO): Promise<void>;
 }
 
-/**
- * Argv literals a Crust app's static type knows about — command spellings and
- * dashed flag spellings, including those defined inside `defineCommand`
- * recipes — extracted from the `_types.hints` phantom. Apps without the
- * phantom resolve to `never`.
- */
-export type ArgvHints<App> = App extends {
-	readonly _types: { hints(hint: infer H extends string): void };
-}
-	? H
-	: never;
-
-/**
- * argv for the testing helpers: any strings are accepted (positionals and
- * flag values are free text), while known command and flag spellings
- * autocomplete in the editor.
- */
-type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
-
 export interface CapturedRun {
 	readonly stdout: string;
 	readonly stderr: string;
@@ -37,10 +18,7 @@ export interface CapturedRun {
 }
 
 /** Run an application and capture its text output without throwing invocation errors. */
-export async function captureRun<App extends RunnableApp>(
-	app: App,
-	argv: Argv<App>,
-): Promise<CapturedRun> {
+export async function captureRun(app: RunnableApp, argv: readonly string[]): Promise<CapturedRun> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
 	const stdoutLines: string[] = [];
@@ -92,9 +70,9 @@ let captureExecuteChain: Promise<unknown> = Promise.resolve();
  * Concurrent calls are serialized because the exit-code protocol is
  * process-global.
  */
-export function captureExecute<App extends ExecutableApp>(
-	app: App,
-	argv: Argv<App>,
+export function captureExecute(
+	app: ExecutableApp,
+	argv: readonly string[],
 ): Promise<CapturedExecute> {
 	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
 	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
@@ -143,7 +121,7 @@ export interface InteractiveRun {
 }
 
 /** Run an application with fake terminal streams for its prompts and stderr output. */
-export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
+export function runInteractive(app: RunnableApp, argv: readonly string[]): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output;
 	// Spinners and progress indicators render onto the same fake terminal as

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -23,86 +23,12 @@ export type ArgvHints<App> = App extends {
 	? H
 	: never;
 
-type FlagHints<H extends string> = Extract<H, `-${string}`>;
-type LongFlags<H extends string> = Extract<H, `--${string}`>;
-type ShortFlags<H extends string> = Exclude<FlagHints<H>, `--${string}`>;
-type CommandHints<H extends string> = Exclude<H, `-${string}`>;
-
-type LegalDashToken<H extends string> =
-	| "-"
-	| FlagHints<H>
-	| `${LongFlags<H>}=${string}`
-	| (LongFlags<H> extends `--${infer Name}` ? `--no-${Name}` : never)
-	| `${ShortFlags<H>}${string}`
-	| "--help"
-	| "-h"
-	| "--version";
-
 /**
- * Compile-time-only brand carrying an argv validation message. An invalid
- * token's expected type is `Token & ArgvError<...>`: intersecting the string
- * literal with an object (rather than another string literal) keeps the
- * intersection from collapsing to `never`, so tsc prints the message instead
- * of `Type 'string' is not assignable to type 'never'`.
+ * argv for the testing helpers: any strings are accepted (positionals and
+ * flag values are free text), while known command and flag spellings
+ * autocomplete in the editor.
  */
-type ArgvError<Message extends string> = { readonly [Brand in Message]: never };
-
-type ValidateToken<T extends string, H extends string> = string extends T
-	? T
-	: T extends `-${string}`
-		? T extends LegalDashToken<H>
-			? T
-			: ArgvError<`Unknown flag "${T}"`>
-		: T;
-
-/**
- * Whether the root command declares positional args (`.args()` narrows
- * `_types.args` to a non-empty tuple). When it does, Core routes an unmatched
- * first token to the root action as a positional, so it must not be rejected
- * as an unknown command.
- *
- * This is a deliberate proxy for Core's actual routing rule ("root has
- * `run()`"), which is invisible in types — `.action()` does not change
- * `Crust`'s type parameters. The proxy is stricter than runtime in one case:
- * a root action *without* declared args silently ignores extra positionals,
- * and we still reject those — passing a positional such a root never reads
- * is almost certainly a test bug.
- */
-type RootHasPositionals<App> = App extends {
-	readonly _types: { args: infer RA extends readonly unknown[] };
-}
-	? RA extends readonly [unknown, ...unknown[]]
-		? true
-		: false
-	: false;
-
-type ValidateArgv<
-	A extends readonly string[],
-	H extends string,
-	RootPositional extends boolean,
-	First extends boolean = true,
-> = [H] extends [never]
-	? A
-	: number extends A["length"]
-		? A
-		: A extends readonly [infer Token extends string, ...infer Rest extends readonly string[]]
-			? Token extends "--"
-				? A
-				: readonly [
-						First extends true
-							? Token extends `-${string}`
-								? ValidateToken<Token, H>
-								: [CommandHints<H>] extends [never]
-									? Token
-									: Token extends CommandHints<H>
-										? Token
-										: RootPositional extends true
-											? Token
-											: ArgvError<`Unknown command "${Token}"`>
-							: ValidateToken<Token, H>,
-						...ValidateArgv<Rest, H, RootPositional, false>,
-					]
-			: A;
+type Argv<App> = readonly (ArgvHints<App> | (string & {}))[];
 
 export interface CapturedRun {
 	readonly stdout: string;
@@ -111,9 +37,9 @@ export interface CapturedRun {
 }
 
 /** Run an application and capture its text output without throwing invocation errors. */
-export async function captureRun<App extends RunnableApp, const A extends readonly string[]>(
+export async function captureRun<App extends RunnableApp>(
 	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
+	argv: Argv<App>,
 ): Promise<CapturedRun> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
@@ -166,9 +92,9 @@ let captureExecuteChain: Promise<unknown> = Promise.resolve();
  * Concurrent calls are serialized because the exit-code protocol is
  * process-global.
  */
-export function captureExecute<App extends ExecutableApp, const A extends readonly string[]>(
+export function captureExecute<App extends ExecutableApp>(
 	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
+	argv: Argv<App>,
 ): Promise<CapturedExecute> {
 	const run = captureExecuteChain.then(() => captureExecuteExclusive(app, argv));
 	// A rejected capture (e.g. `throwOnError`) must not poison later captures.
@@ -217,10 +143,7 @@ export interface InteractiveRun {
 }
 
 /** Run an application with fake terminal streams for its prompts and stderr output. */
-export function runInteractive<App extends RunnableApp, const A extends readonly string[]>(
-	app: App,
-	argv: A & ValidateArgv<A, ArgvHints<App>, RootHasPositionals<App>>,
-): InteractiveRun {
+export function runInteractive<App extends RunnableApp>(app: App, argv: Argv<App>): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output;
 	// Spinners and progress indicators render onto the same fake terminal as


### PR DESCRIPTION
Fixes command hint inference when commands with aliases are added in a mixed `.add()` batch: `CommandDefinitionSpellings` now distributes over command-definition unions, so add-time alias collision checks preserve canonical names and aliases instead of dropping aliases.

Also **removes the argv-hints machinery entirely**:

- Reverts the strict typed-argv validation originally shipped in this PR (e9dfa898).
- Reverts the soft argv autocomplete from #230 (e9bf7e45): drops `ArgvHints`/`Argv` from `@crustjs/testing` (helpers take plain `readonly string[]` again) and removes the trailing `H`/`Hints` generic, `_types.hints` phantom, and hint-union types from `@crustjs/core`. `Crust`/`CommandDefinitionBuilder` are now 5 generic params, `CommandDefinition` 3. Since #230 was unreleased, its changeset is deleted; the pending generics-migration changeset now describes the released seven-to-five change.

Includes compile-time regression coverage for the kept collision fix (`commands.brands.test.ts`) and a `@crustjs/core` patch changeset.
