### PR TITLE
refactor: remove backward-compat artifacts ahead of clean release

### DIFF
--- a/.changeset/drop-spellings-phantom.md
+++ b/.changeset/drop-spellings-phantom.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Remove the internal `_types.spellings` phantom method from `Crust`. The `Sp` generic and compile-time flag-collision checks are unchanged; only the `@internal` phantom entry (previously kept for a type-level test) is gone from emitted declarations.

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -120,58 +120,18 @@ new Crust("serve")
 
 A schema cannot be combined with core value options — see [Schema-backed definitions](/docs/guide/types#schema-backed-definitions) for the full rule.
 
-## Commander migration compatibility
+## Unsupported flag grammars
 
-Crust's parser is built on `node:util.parseArgs`, and three Commander grammars are intentionally **not supported**. They conflict with `parseArgs` token rules or make flag/positional boundaries ambiguous; CLIs migrating from Commander should normalize argv app-side before `execute()`.
+Crust's parser is built on `node:util.parseArgs`, and three grammars found in some other CLI libraries are intentionally **not supported**. They conflict with `parseArgs` token rules or make flag/positional boundaries ambiguous. If your app needs one of them, rewrite argv app-side before `execute()`.
 
-### Greedy multi-value flags (won't fix)
+### Greedy multi-value flags
 
-Commander's variadic options consume every following token until the next flag: `--locales en fr de`. Crust `multiple` flags require one option token per value — `--locales en --locales fr --locales de`. An unrepeated trailing value becomes an unmatched positional.
+Variadic options that consume every following token until the next flag (`--locales en fr de`) are not supported. Crust `multiple` flags require one option token per value — `--locales en --locales fr --locales de`. An unrepeated trailing value becomes an unmatched positional.
 
-### Optional-valued flags (won't fix)
+### Optional-valued flags
 
-Commander supports `--tag` (boolean) and `--tag v1.2` (string) on the same option. A Crust flag is either `boolean` or value-taking — there is no optional-value variant, because whether the next token is the flag's value or a positional would depend on runtime lookahead.
+A Crust flag is either `boolean` or value-taking — there is no option that accepts both `--tag` and `--tag v1.2`, because whether the next token is the flag's value or a positional would depend on runtime lookahead. Split it into a boolean flag plus a value-taking flag (e.g. `--tag` and `--tag-name v1.2`).
 
-### Separated dash-leading values (won't fix)
+### Separated dash-leading values
 
 `--timeout -5` is rejected by `parseArgs` as ambiguous (`-5` looks like a flag). Use the `=` form: `--timeout=-5`.
-
-### Recommended normalization pattern
-
-Rewrite argv once at the entry point, before `execute()`:
-
-```ts
-const GREEDY_FLAGS = new Set(["--locales", "--new"]);
-
-function normalizeArgv(argv: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const token = argv[i]!;
-    if (token === "--") return [...out, ...argv.slice(i)];
-
-    // Greedy multi-value: `--locales en fr` -> `--locales en --locales fr`
-    if (GREEDY_FLAGS.has(token)) {
-      if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) out.push(token);
-      while (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) {
-        out.push(token, argv[++i]!);
-      }
-      continue;
-    }
-
-    // Separated dash-leading value: `--timeout -5` -> `--timeout=-5`
-    if (token === "--timeout" && /^-\d/.test(argv[i + 1] ?? "")) {
-      out.push(`${token}=${argv[++i]}`);
-      continue;
-    }
-
-    out.push(token);
-  }
-  return out;
-}
-
-await app.execute({ argv: normalizeArgv(process.argv.slice(2)) });
-```
-
-For optional-valued flags, split them into a boolean flag plus a value-taking flag (e.g. `--tag` and `--tag-name v1.2`), or normalize `--tag <value>` to `--tag-name=<value>` in the same pass.
-
-What migrators no longer need to normalize: propagating flags before a subcommand (`app --quiet translate`) route correctly, and bare version output is covered by [`version`'s `format` option](/docs/modules/extensions/version#options).

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -258,18 +258,9 @@ describe("Crust .flags()", () => {
 			.args({ name: "file", type: "string" })
 			.extend(defineExtension("noop"));
 
-		type _Spellings = Expect<
-			Equal<Parameters<(typeof app)["_types"]["spellings"]>[0], "verbose" | "v">
-		>;
-		const explicit: Crust<
-			(typeof app)["_types"]["flags"],
-			(typeof app)["_types"]["args"],
-			(typeof app)["_types"]["ctx"],
-			never,
-			"verbose" | "v"
-		> = app;
-		void explicit;
-
+		// Sp retention is pinned by the @ts-expect-error collision checks below:
+		// if the accumulator dropped "v", they would become unused and fail the
+		// typecheck.
 		expect(() =>
 			app.flags(
 				// @ts-expect-error -- the accumulator retains "v" from before the widened call

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -687,9 +687,6 @@ export class Crust<
 		ctx: Ctx;
 		tree: Tree;
 		shape: CommandShape<A, Flags, Tree>;
-		// Method syntax keeps broad/legacy Crust annotations assignable while
-		// exposing Sp to type-level tests through Parameters<>.
-		spellings(spelling: Sp): void;
 	};
 
 	/** @internal */

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -33,6 +33,7 @@ const report = (instantiations: number, scaling: [number, number, number]): Type
 		50: metrics(scaling[1]),
 		100: metrics(scaling[2]),
 	},
+	editor: null,
 });
 
 const repoRoot = resolve(import.meta.dir, "..");
@@ -104,7 +105,7 @@ describe("type performance report", () => {
 		expect(output).toContain("TypeScript 7.0.2 · ⚠️ marks compiler-work increases above 10%.");
 	});
 
-	it("renders editor latency rows, with n/a for reports lacking them", () => {
+	it("renders editor latency rows, with n/a when measurement failed", () => {
 		const base = report(100_000, [10_000, 25_000, 50_000]);
 		const head = report(100_000, [10_000, 25_000, 50_000]);
 		head.editor = {

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -18,9 +18,8 @@ export type ScalingSize = (typeof scalingSizes)[number];
 // dist (e.g. the PR changed the public API); rendered as "n/a" instead of failing.
 export interface TypePerfReport extends TypePerfMetrics {
 	scaling: Record<ScalingSize, TypePerfMetrics | null>;
-	// Optional so reports written by older script revisions still compare;
 	// null = the LSP session failed (rendered as "n/a").
-	editor?: EditorLatencyMetrics | null;
+	editor: EditorLatencyMetrics | null;
 }
 
 const metricPatterns = {
@@ -60,8 +59,8 @@ const editorLatencyLabels: Record<keyof EditorLatencyMetrics, string> = {
 };
 
 function editorLatencyRows(
-	base: EditorLatencyMetrics | null | undefined,
-	head: EditorLatencyMetrics | null | undefined,
+	base: EditorLatencyMetrics | null,
+	head: EditorLatencyMetrics | null,
 ): string[] {
 	return (Object.entries(editorLatencyLabels) as [keyof EditorLatencyMetrics, string][]).map(
 		([key, label]) =>


### PR DESCRIPTION
## Summary

A full-repo audit for backward-compatibility artifacts found exactly three; this PR removes all of them. Everything else flagged by the sweep (CLI aliases, skills `compatibility` metadata, non-TTY fallbacks, bash completion shim, etc.) was verified as current features, not compat baggage.

### 1. core — drop the `_types.spellings` phantom (`packages/core/src/command/crust.ts`)

The bivariant phantom method existed to keep broad `Crust` annotations assignable while exposing `Sp` to one type-level test. It turns out deletable outright:

- `Sp` is already witnessed by the real `.flags()`/`.provide()` method signatures (bivariant), so broad annotations (`(app: Crust) => Crust`) and `AnyCrust` stay assignable without it. Verified empirically: contravariant/covariant alternatives each break one direction; deletion breaks neither.
- Its only consumer was one test assertion whose behavior is already pinned by the adjacent `@ts-expect-error` collision checks (unused directive = failed typecheck).
- The `Sp` generic and compile-time flag-collision detection are **unchanged**.

Changeset: patch for `@crustjs/core` (phantom entry disappears from emitted declarations).

### 2. scripts — `TypePerfReport.editor` now required

It was optional only so reports written by older script revisions still parsed. CI (`.github/workflows/type-perf.yml`) measures base and head with the head's script in a single run — no old persisted reports exist. Removed the optionality and the `undefined` handling.

### 3. docs — retitle Commander migration section (`guide/flags.mdx`)

"Commander migration compatibility" → "Unsupported flag grammars". Keeps the three parser-limit facts (current `parseArgs`-based behavior users hit regardless of origin), drops the Commander framing and the ~40-line `normalizeArgv` migration recipe. No cross-links referenced the old anchor.

## Validation

- `turbo check:types` — 21/21 packages green
- `bun test` in `packages/core` — 620 pass
- `bun test scripts/type-perf-report.test.ts` — 8 pass