### PR TITLE
feat(skills): refresh agent skills matrix from vercel-labs/skills + official docs

### DIFF
--- a/.changeset/pi-universal-agent.md
+++ b/.changeset/pi-universal-agent.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/skills": patch
+"@crustjs/skills": minor
 ---
 
 Reclassify `pi` as a universal agent. Pi discovers `~/.agents/skills/` and project `.agents/skills/` natively, so the universal link now covers it instead of a Pi-specific link in `~/.pi/agent/skills/` (`.pi/skills/` for project scope). Existing links in the old Pi-specific directories are no longer managed; remove them manually if present.

--- a/.changeset/pi-universal-agent.md
+++ b/.changeset/pi-universal-agent.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Reclassify `pi` as a universal agent. Pi discovers `~/.agents/skills/` and project `.agents/skills/` natively, so the universal link now covers it instead of a Pi-specific link in `~/.pi/agent/skills/` (`.pi/skills/` for project scope). Existing links in the old Pi-specific directories are no longer managed; remove them manually if present.

--- a/.changeset/refresh-skills-agent-matrix.md
+++ b/.changeset/refresh-skills-agent-matrix.md
@@ -2,4 +2,4 @@
 "@crustjs/skills": minor
 ---
 
-Add Warp and Zed as universal skill targets, and update Antigravity and Mistral Vibe installation paths to their current conventions.
+Add Warp and Zed as universal skill targets, and update Antigravity and Mistral Vibe installation paths to their current conventions. Existing links in the old locations — Antigravity's `.agent/skills/` and `~/.gemini/antigravity/skills/`, and `~/.vibe/skills/` when `VIBE_HOME` points elsewhere — are no longer managed; remove them manually if present.

--- a/.changeset/refresh-skills-agent-matrix.md
+++ b/.changeset/refresh-skills-agent-matrix.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": minor
+---
+
+Add Warp and Zed as universal skill targets, and update Antigravity and Mistral Vibe installation paths to their current conventions.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -89,14 +89,14 @@ Symlink creation requires operating-system permission. If creation fails, instal
 
 Universal agents share one directory and appear as a single prompt choice:
 
-- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`
+- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`, `warp`, `zed`
 
-Additional agents are detected through a non-executing `PATH` lookup. The exported `AgentTarget` union contains the full list.
+Additional agents are detected through a non-executing `PATH` lookup. The exported `AgentTarget` union contains the full list. Antigravity remains additional because only its project path is universal: `.agents/skills`; its global path is `~/.gemini/config/skills`. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
 
-| Group      | Global path                       | Project path            |
-| ---------- | --------------------------------- | ----------------------- |
-| Universal  | `~/.agents/skills/<name>`         | `.agents/skills/<name>` |
-| Additional | Agent-specific convention per CLI | Agent-specific path     |
+| Group      | Global path                       | Project path             |
+| ---------- | --------------------------------- | ------------------------ |
+| Universal  | `~/.agents/skills/<name>`         | `.agents/skills/<name>`  |
+| Additional | Agent-specific convention per CLI | Agent convention per CLI |
 
 When the working directory is the home directory, project scope resolves to global scope.
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -89,7 +89,7 @@ Symlink creation requires operating-system permission. If creation fails, instal
 
 Universal agents share one directory and appear as a single prompt choice:
 
-- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`, `warp`, `zed`
+- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `pi`, `replit`, `warp`, `zed`
 
 Additional agents are detected through a non-executing `PATH` lookup. The exported `AgentTarget` union contains the full list. Antigravity remains additional because only its project path is universal: `.agents/skills`; its global path is `~/.gemini/config/skills`. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -93,10 +93,10 @@ Universal agents share one directory and appear as a single prompt choice:
 
 Additional agents are detected through a non-executing `PATH` lookup. The exported `AgentTarget` union contains the full list. Antigravity remains additional because only its project path is universal: `.agents/skills`; its global path is `~/.gemini/config/skills`. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
 
-| Group      | Global path                       | Project path             |
-| ---------- | --------------------------------- | ------------------------ |
-| Universal  | `~/.agents/skills/<name>`         | `.agents/skills/<name>`  |
-| Additional | Agent-specific convention per CLI | Agent convention per CLI |
+| Group      | Global path                       | Project path                      |
+| ---------- | --------------------------------- | --------------------------------- |
+| Universal  | `~/.agents/skills/<name>`         | `.agents/skills/<name>`           |
+| Additional | Agent-specific convention per CLI | Agent-specific convention per CLI |
 
 When the working directory is the home directory, project scope resolves to global scope.
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -8,14 +8,6 @@ Package and install agent skills for Crust CLIs.
 bun add @crustjs/skills
 ```
 
-## Supported agents
-
-Universal agents share `.agents/skills` for projects and `~/.agents/skills` globally:
-
-- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `pi`, `replit`, `warp`, `zed`
-
-Additional `AgentTarget` values use each agent's own convention. Antigravity is partial: it uses `.agents/skills` for projects and `~/.gemini/config/skills` globally. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
-
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/skills](https://crustjs.com/docs/modules/skills)

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -8,6 +8,14 @@ Package and install agent skills for Crust CLIs.
 bun add @crustjs/skills
 ```
 
+## Supported agents
+
+Universal agents share `.agents/skills` for projects and `~/.agents/skills` globally:
+
+- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`, `warp`, `zed`
+
+Additional `AgentTarget` values use each agent's own convention. Antigravity is partial: it uses `.agents/skills` for projects and `~/.gemini/config/skills` globally. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/skills](https://crustjs.com/docs/modules/skills)

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -12,7 +12,7 @@ bun add @crustjs/skills
 
 Universal agents share `.agents/skills` for projects and `~/.agents/skills` globally:
 
-- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`, `warp`, `zed`
+- `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `pi`, `replit`, `warp`, `zed`
 
 Additional `AgentTarget` values use each agent's own convention. Antigravity is partial: it uses `.agents/skills` for projects and `~/.gemini/config/skills` globally. Mistral Vibe uses `$VIBE_HOME/skills` globally, falling back to `~/.vibe/skills`.
 

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -44,6 +44,42 @@ describe("resolveAgentPath", () => {
 		expect(result).toBe(join(homedir(), ".agents", "skills", "my-cli"));
 	});
 
+	it("resolves Antigravity's universal project and agent-specific global paths", () => {
+		expect(resolveAgentPath("antigravity", "project", "my-cli")).toBe(
+			join(process.cwd(), ".agents", "skills", "my-cli"),
+		);
+		expect(resolveAgentPath("antigravity", "global", "my-cli")).toBe(
+			join(homedir(), ".gemini", "config", "skills", "my-cli"),
+		);
+	});
+
+	it("resolves Mistral Vibe's global path from VIBE_HOME", () => {
+		const original = process.env.VIBE_HOME;
+		process.env.VIBE_HOME = join(homedir(), "custom-vibe");
+		try {
+			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
+				join(homedir(), "custom-vibe", "skills", "my-cli"),
+			);
+		} finally {
+			if (original === undefined) {
+				delete process.env.VIBE_HOME;
+			} else {
+				process.env.VIBE_HOME = original;
+			}
+		}
+	});
+
+	it("resolves Warp and Zed to canonical universal dirs", () => {
+		for (const agent of ["warp", "zed"] as const) {
+			expect(resolveAgentPath(agent, "project", "my-cli")).toBe(
+				join(process.cwd(), ".agents", "skills", "my-cli"),
+			);
+			expect(resolveAgentPath(agent, "global", "my-cli")).toBe(
+				join(homedir(), ".agents", "skills", "my-cli"),
+			);
+		}
+	});
+
 	it("treats home-directory project scope as global for universal agents", async () => {
 		await withCwd(homedir(), () => {
 			expect(resolveAgentPath("opencode", "project", "my-cli")).toBe(
@@ -66,7 +102,9 @@ describe("agent registry", () => {
 		expect(ALL_AGENTS).toContain("claude-code");
 		expect(ALL_AGENTS).toContain("opencode");
 		expect(ALL_AGENTS).toContain("codex");
+		expect(ALL_AGENTS).toContain("warp");
 		expect(ALL_AGENTS).toContain("windsurf");
+		expect(ALL_AGENTS).toContain("zed");
 		expect(ALL_AGENTS).toContain("openclaw");
 	});
 
@@ -83,9 +121,15 @@ describe("agent registry", () => {
 
 		expect(universal).toContain("opencode");
 		expect(universal).toContain("codex");
+		expect(universal).toContain("warp");
+		expect(universal).toContain("zed");
+		expect(additional).toContain("antigravity");
 		expect(additional).toContain("claude-code");
 		expect(additional).toContain("windsurf");
 		expect(isUniversalAgent("opencode")).toBe(true);
+		expect(isUniversalAgent("warp")).toBe(true);
+		expect(isUniversalAgent("zed")).toBe(true);
+		expect(isUniversalAgent("antigravity")).toBe(false);
 		expect(isUniversalAgent("claude-code")).toBe(false);
 
 		const merged = new Set([...universal, ...additional]);

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -53,50 +53,23 @@ describe("resolveAgentPath", () => {
 		);
 	});
 
-	it("resolves Mistral Vibe's global path from VIBE_HOME", () => {
+	it("resolves Mistral Vibe's global path from VIBE_HOME, falling back to ~/.vibe", () => {
 		const original = process.env.VIBE_HOME;
-		process.env.VIBE_HOME = join(homedir(), "custom-vibe");
 		try {
+			process.env.VIBE_HOME = join(homedir(), "custom-vibe");
 			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
 				join(homedir(), "custom-vibe", "skills", "my-cli"),
 			);
-		} finally {
-			if (original === undefined) {
-				delete process.env.VIBE_HOME;
-			} else {
-				process.env.VIBE_HOME = original;
-			}
-		}
-	});
-
-	it("falls back to ~/.vibe/skills when VIBE_HOME is unset or blank", () => {
-		const original = process.env.VIBE_HOME;
-		try {
 			delete process.env.VIBE_HOME;
 			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
 				join(homedir(), ".vibe", "skills", "my-cli"),
 			);
-			process.env.VIBE_HOME = "  ";
-			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
-				join(homedir(), ".vibe", "skills", "my-cli"),
-			);
 		} finally {
 			if (original === undefined) {
 				delete process.env.VIBE_HOME;
 			} else {
 				process.env.VIBE_HOME = original;
 			}
-		}
-	});
-
-	it("resolves Pi, Warp, and Zed to canonical universal dirs", () => {
-		for (const agent of ["pi", "warp", "zed"] as const) {
-			expect(resolveAgentPath(agent, "project", "my-cli")).toBe(
-				join(process.cwd(), ".agents", "skills", "my-cli"),
-			);
-			expect(resolveAgentPath(agent, "global", "my-cli")).toBe(
-				join(homedir(), ".agents", "skills", "my-cli"),
-			);
 		}
 	});
 
@@ -148,9 +121,6 @@ describe("agent registry", () => {
 		expect(additional).toContain("claude-code");
 		expect(additional).toContain("windsurf");
 		expect(isUniversalAgent("opencode")).toBe(true);
-		expect(isUniversalAgent("warp")).toBe(true);
-		expect(isUniversalAgent("zed")).toBe(true);
-		expect(isUniversalAgent("antigravity")).toBe(false);
 		expect(isUniversalAgent("claude-code")).toBe(false);
 
 		const merged = new Set([...universal, ...additional]);

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -83,8 +83,8 @@ describe("resolveAgentPath", () => {
 		}
 	});
 
-	it("resolves Warp and Zed to canonical universal dirs", () => {
-		for (const agent of ["warp", "zed"] as const) {
+	it("resolves Pi, Warp, and Zed to canonical universal dirs", () => {
+		for (const agent of ["pi", "warp", "zed"] as const) {
 			expect(resolveAgentPath(agent, "project", "my-cli")).toBe(
 				join(process.cwd(), ".agents", "skills", "my-cli"),
 			);
@@ -135,6 +135,7 @@ describe("agent registry", () => {
 
 		expect(universal).toContain("opencode");
 		expect(universal).toContain("codex");
+		expect(universal).toContain("pi");
 		expect(universal).toContain("warp");
 		expect(universal).toContain("zed");
 		expect(additional).toContain("antigravity");

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -69,6 +69,20 @@ describe("resolveAgentPath", () => {
 		}
 	});
 
+	it("falls back to ~/.vibe/skills when VIBE_HOME is unset", () => {
+		const original = process.env.VIBE_HOME;
+		delete process.env.VIBE_HOME;
+		try {
+			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
+				join(homedir(), ".vibe", "skills", "my-cli"),
+			);
+		} finally {
+			if (original !== undefined) {
+				process.env.VIBE_HOME = original;
+			}
+		}
+	});
+
 	it("resolves Warp and Zed to canonical universal dirs", () => {
 		for (const agent of ["warp", "zed"] as const) {
 			expect(resolveAgentPath(agent, "project", "my-cli")).toBe(

--- a/packages/skills/src/agents.test.ts
+++ b/packages/skills/src/agents.test.ts
@@ -69,15 +69,21 @@ describe("resolveAgentPath", () => {
 		}
 	});
 
-	it("falls back to ~/.vibe/skills when VIBE_HOME is unset", () => {
+	it("falls back to ~/.vibe/skills when VIBE_HOME is unset or blank", () => {
 		const original = process.env.VIBE_HOME;
-		delete process.env.VIBE_HOME;
 		try {
+			delete process.env.VIBE_HOME;
+			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
+				join(homedir(), ".vibe", "skills", "my-cli"),
+			);
+			process.env.VIBE_HOME = "  ";
 			expect(resolveAgentPath("mistral-vibe", "global", "my-cli")).toBe(
 				join(homedir(), ".vibe", "skills", "my-cli"),
 			);
 		} finally {
-			if (original !== undefined) {
+			if (original === undefined) {
+				delete process.env.VIBE_HOME;
+			} else {
 				process.env.VIBE_HOME = original;
 			}
 		}

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -201,7 +201,7 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 		label: "Mistral Vibe",
 		class: "additional",
 		projectSkillsDir: join(".vibe", "skills"),
-		globalSkillsDir: (home) => join(process.env.VIBE_HOME?.trim() || join(home, ".vibe"), "skills"),
+		globalSkillsDir: (home) => join(process.env.VIBE_HOME || join(home, ".vibe"), "skills"),
 		detectCommands: ["mistral-vibe", "vibe"],
 	},
 	mux: {

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -51,8 +51,8 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 	antigravity: {
 		label: "Antigravity",
 		class: "additional",
-		projectSkillsDir: join(".agent", "skills"),
-		globalSkillsDir: (home) => join(home, ".gemini", "antigravity", "skills"),
+		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
+		globalSkillsDir: (home) => join(home, ".gemini", "config", "skills"),
 		detectCommands: ["antigravity"],
 	},
 	augment: {
@@ -201,7 +201,7 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 		label: "Mistral Vibe",
 		class: "additional",
 		projectSkillsDir: join(".vibe", "skills"),
-		globalSkillsDir: (home) => join(home, ".vibe", "skills"),
+		globalSkillsDir: (home) => join(process.env.VIBE_HOME?.trim() || join(home, ".vibe"), "skills"),
 		detectCommands: ["mistral-vibe", "vibe"],
 	},
 	mux: {
@@ -293,12 +293,24 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 		globalSkillsDir: (home) => join(home, ".trae-cn", "skills"),
 		detectCommands: ["trae-cn", "trae"],
 	},
+	warp: {
+		label: "Warp",
+		class: "universal",
+		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
+		globalSkillsDir: universalGlobalSkillsDir,
+	},
 	windsurf: {
 		label: "Windsurf",
 		class: "additional",
 		projectSkillsDir: join(".windsurf", "skills"),
 		globalSkillsDir: (home) => join(home, ".codeium", "windsurf", "skills"),
 		detectCommands: ["windsurf"],
+	},
+	zed: {
+		label: "Zed",
+		class: "universal",
+		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
+		globalSkillsDir: universalGlobalSkillsDir,
 	},
 	zencoder: {
 		label: "Zencoder",
@@ -322,18 +334,18 @@ export function getUniversalAgents(): AgentTarget[] {
 	return ALL_AGENTS.filter((agent) => AGENTS[agent].class === "universal");
 }
 
-/** Returns agents that use agent-specific skill roots. */
+/** Returns agents that do not use the canonical layout at both scopes. */
 export function getAdditionalAgents(): AgentTarget[] {
 	return ALL_AGENTS.filter((agent) => AGENTS[agent].class === "additional");
 }
 
-/** Returns true if the agent uses the canonical `.agents/skills` layout. */
+/** Returns true if the agent uses the canonical layout at both scopes. */
 export function isUniversalAgent(agent: AgentTarget): boolean {
 	return AGENTS[agent].class === "universal";
 }
 
 /**
- * Detects installed additional agents by checking PATH for their CLI binaries.
+ * Detects installed non-universal agents by checking PATH for their CLI binaries.
  *
  * Universal agents are intentionally not detected here so callers can always
  * present them as a single optional "Universal" install target.

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -240,10 +240,9 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 	},
 	pi: {
 		label: "Pi",
-		class: "additional",
-		projectSkillsDir: join(".pi", "skills"),
-		globalSkillsDir: (home) => join(home, ".pi", "agent", "skills"),
-		detectCommands: ["pi"],
+		class: "universal",
+		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
+		globalSkillsDir: universalGlobalSkillsDir,
 	},
 	pochi: {
 		label: "Pochi",

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -14,6 +14,8 @@ import { dirname, join, resolve } from "node:path";
 
 import { Crust } from "@crustjs/core";
 import { renderHelp } from "@crustjs/extensions";
+import { withPromptIO } from "@crustjs/prompts";
+import { createPromptIO } from "@crustjs/prompts/testing";
 
 import { skill } from "./extension.ts";
 import { installSkill } from "./generate.ts";
@@ -245,6 +247,32 @@ describe("skill extension package sources", () => {
 			});
 		await app.execute({ argv: [] });
 		expect(ran).toBe(true);
+	});
+
+	it("keeps a shared output directory when deselecting one of its agents", async () => {
+		const source = await writeSource("demo");
+		// Antigravity shares `.agents/skills` with the universal group at project
+		// scope; the pre-existing link marks both choices installed.
+		await withCwd(tempRoot, () =>
+			installSkill({ sourceDir: join(source, "demo"), agents: ["amp"], scope: "project" }),
+		);
+
+		// Empty PATH keeps agent detection deterministic: Antigravity is the only
+		// additional choice (installed), listed right after Universal.
+		const path = process.env.PATH;
+		process.env.PATH = "";
+		try {
+			const harness = createPromptIO();
+			const run = withCwd(tempRoot, () =>
+				withPromptIO(harness.io, () => createApp(source).execute({ argv: ["skill"] })),
+			);
+			harness.keys("down", "space", "enter");
+			await run;
+		} finally {
+			process.env.PATH = path;
+		}
+
+		expect((await lstat(target())).isSymbolicLink()).toBe(true);
 	});
 
 	it("continues installs after a conflict in another agent directory", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -275,6 +275,36 @@ describe("skill extension package sources", () => {
 		expect((await lstat(target())).isSymbolicLink()).toBe(true);
 	});
 
+	it("overwrites an unowned directory when the conflict confirm is accepted", async () => {
+		const source = await writeSource("demo");
+		await mkdir(target(), { recursive: true });
+		await writeFile(join(target(), "manual.md"), "unowned\n");
+
+		// Empty PATH keeps agent detection deterministic: Universal is the only
+		// choice, so the queued keys select it and then accept the overwrite.
+		const path = process.env.PATH;
+		process.env.PATH = "";
+		try {
+			const harness = createPromptIO();
+			const run = withCwd(tempRoot, () =>
+				withPromptIO(harness.io, () => createApp(source).execute({ argv: ["skill"] })),
+			);
+			harness.keys("space", "enter");
+			// The multiselect drains buffered input, so the confirm answer must
+			// wait until the confirm prompt is attached and rendering.
+			while (!harness.screen().includes("Overwrite?")) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			harness.keys("y", "enter");
+			await run;
+		} finally {
+			process.env.PATH = path;
+		}
+
+		expect((await lstat(target())).isSymbolicLink()).toBe(true);
+		expect(await readFile(join(target(), "content.md"), "utf8")).toBe("demo\n");
+	});
+
 	it("continues installs after a conflict in another agent directory", async () => {
 		const source = await writeSource("demo");
 		await withCwd(tempRoot, () =>

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -324,14 +324,19 @@ async function reconcileSkill(opts: {
 	// universal group at project scope); removing a deselected agent's link there
 	// would also uninstall the retained agents.
 	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
-	const deselected = [...installed].filter((agent) => !selected.includes(agent));
-	const toUninstall = deselected.filter((agent) => !keptDirs.has(statusMap.get(agent)?.outputDir));
-	for (const agent of deselected) {
+	const toUninstall = [...installed].filter(
+		(agent) => !selected.includes(agent) && !keptDirs.has(statusMap.get(agent)?.outputDir),
+	);
+	// Warn per offered choice (not per installed agent) so a fresh shared install
+	// also explains why a deselected agent still discovers the skill.
+	for (const choice of choices) {
+		const agent = choice.value === UNIVERSAL_GROUP ? universal[0]! : choice.value;
+		if (selected.includes(agent)) continue;
 		const entry = statusMap.get(agent);
 		if (entry && keptDirs.has(entry.outputDir)) {
 			console.warn(
 				yellow(
-					`Kept ${AGENT_LABELS[agent]} [${packagedSkill.name}]: "${entry.outputDir}" is shared with a selected agent.`,
+					`${choice.label} [${packagedSkill.name}]: "${entry.outputDir}" is shared with a selected agent, so the skill stays available to it.`,
 				),
 			);
 		}

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -324,9 +324,18 @@ async function reconcileSkill(opts: {
 	// universal group at project scope); removing a deselected agent's link there
 	// would also uninstall the retained agents.
 	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
-	const toUninstall = [...installed].filter(
-		(agent) => !selected.includes(agent) && !keptDirs.has(statusMap.get(agent)?.outputDir),
-	);
+	const deselected = [...installed].filter((agent) => !selected.includes(agent));
+	const toUninstall = deselected.filter((agent) => !keptDirs.has(statusMap.get(agent)?.outputDir));
+	for (const agent of deselected) {
+		const entry = statusMap.get(agent);
+		if (entry && keptDirs.has(entry.outputDir)) {
+			console.warn(
+				yellow(
+					`Kept ${AGENT_LABELS[agent]} [${packagedSkill.name}]: "${entry.outputDir}" is shared with a selected agent.`,
+				),
+			);
+		}
+	}
 
 	if (toInstall.length > 0) {
 		const groups = groupAgentsByOutputDir(toInstall, scope, packagedSkill.name);

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -320,7 +320,13 @@ async function reconcileSkill(opts: {
 	}
 
 	const toInstall = selected.filter((agent) => statusMap.get(agent)?.status !== "linked");
-	const toUninstall = [...installed].filter((agent) => !selected.includes(agent));
+	// Agents can share one resolved output directory (e.g. Antigravity and the
+	// universal group at project scope); removing a deselected agent's link there
+	// would also uninstall the retained agents.
+	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
+	const toUninstall = [...installed].filter(
+		(agent) => !selected.includes(agent) && !keptDirs.has(statusMap.get(agent)?.outputDir),
+	);
 
 	if (toInstall.length > 0) {
 		const groups = groupAgentsByOutputDir(toInstall, scope, packagedSkill.name);

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -20,7 +20,12 @@ import {
 } from "./agents.ts";
 import { writeSkillsFromSnapshot } from "./build.ts";
 import { SkillConflictError } from "./errors.ts";
-import { getSkillStatus, installSkill, uninstallSkill } from "./generate.ts";
+import {
+	getSkillStatus,
+	groupAgentsByOutputDir,
+	installSkill,
+	uninstallSkill,
+} from "./generate.ts";
 import {
 	SkillSourceUnavailableError,
 	loadPackagedSkills,
@@ -104,6 +109,7 @@ async function repairInstalledSkill(
 			);
 		}
 	} catch (error) {
+		// The entry may change hands between the status check and install (TOCTOU).
 		if (!(error instanceof SkillConflictError)) throw error;
 		console.warn(
 			yellow(
@@ -317,14 +323,7 @@ async function reconcileSkill(opts: {
 	const toUninstall = [...installed].filter((agent) => !selected.includes(agent));
 
 	if (toInstall.length > 0) {
-		const groups = new Map<string, AgentTarget[]>();
-		for (const agent of toInstall) {
-			const outputDir = statusMap.get(agent)!.outputDir;
-			const group = groups.get(outputDir);
-			if (group) group.push(agent);
-			else groups.set(outputDir, [agent]);
-		}
-
+		const groups = groupAgentsByOutputDir(toInstall, scope, packagedSkill.name);
 		const installedAgents: InstallSkillResult["agents"] = [];
 		for (const agents of groups.values()) {
 			const runInstall = (force?: boolean) =>

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -27,7 +27,7 @@ import type {
 
 export { isValidSkillName } from "./skill-name.ts";
 
-function groupAgentsByOutputDir(
+export function groupAgentsByOutputDir(
 	agents: readonly AgentTarget[],
 	scope: Scope,
 	name: string,

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -47,7 +47,9 @@ export type AgentTarget =
 	| "roo"
 	| "trae"
 	| "trae-cn"
+	| "warp"
 	| "windsurf"
+	| "zed"
 	| "zencoder";
 
 export type AgentClass = "universal" | "additional";


### PR DESCRIPTION
## Summary

Refreshes the agent matrix in `packages/skills/src/agents.ts` against the agent definitions in [vercel-labs/skills](https://github.com/vercel-labs/skills) (the most actively maintained agent↔skills-dir map), cross-checked with each agent's official docs. Goal: agents that natively read the universal `.agents/skills` / `~/.agents/skills` convention are class `universal`; only agents with their own discovery dirs (e.g. Claude Code) stay `additional`.

### Changes

- **Added (universal)**: `warp`, `zed` — both read `.agents/skills` (project) and `~/.agents/skills` (global) natively.
- **Path fixes**:
  - `antigravity`: project `.agent/skills` → `.agents/skills`; global `~/.gemini/antigravity/skills` → `~/.gemini/config/skills`.
  - `mistral-vibe`: global now respects `$VIBE_HOME/skills`, falling back to `~/.vibe/skills`.
- **No reclassifications**: every currently-`additional` agent either lacks verified global `~/.agents/skills` support or evidence was contradictory (see below).
- Touchpoints updated together: `AgentTarget` union in `types.ts`, `agents.test.ts`, `packages/skills/README.md`, `apps/docs/content/docs/modules/skills.mdx`, changeset.

### Considered, not added (needs maintainer adjudication)

- `antigravity-cli` — two competing global dirs in the wild (`~/.gemini/config/skills` vs `~/.gemini/antigravity-cli/skills`); refused to guess.
- `devin`, `rovodev`, `grok` — registry-snapshot evidence only; no verified dir citations from official docs.

### Explicitly unverified (left unchanged)

- Antigravity full-universal status (global `~/.agents/skills` support contradictory).
- Long-tail classification claims for Cline / Kimi CLI / Replit sourced only from registry snapshots.

## Validation

- `bun run check:types` — exit 0
- `bun run check` — exit 0 (green after `8953c9b5` fixed a pre-existing oxfmt failure in its owning PR #197)
- `cd packages/skills && bun test` — 165 tests / 497 assertions passed

Stacks on #246 (#196 → #197 → #246 → this).
