### PR TITLE
feat(core): consumer-targeted documentation sections

### DIFF
--- a/.changeset/section-consumers.md
+++ b/.changeset/section-consumers.md
@@ -1,8 +1,8 @@
 ---
 "@crustjs/core": minor
-"@crustjs/extensions": patch
-"@crustjs/man": patch
-"@crustjs/skills": patch
+"@crustjs/extensions": minor
+"@crustjs/man": minor
+"@crustjs/skills": minor
 ---
 
-Add typed section consumer tokens and audience filtering for help, man pages, and generated agent skills.
+Add typed section consumer tokens and audience filtering for help, man pages, and generated agent skills. Application-authored sections titled "Agent skills" are now preserved in generated skills.

--- a/.changeset/section-consumers.md
+++ b/.changeset/section-consumers.md
@@ -1,0 +1,8 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": patch
+"@crustjs/man": patch
+"@crustjs/skills": patch
+---
+
+Add typed section consumer tokens and audience filtering for help, man pages, and generated agent skills.

--- a/.changeset/section-consumers.md
+++ b/.changeset/section-consumers.md
@@ -5,4 +5,4 @@
 "@crustjs/skills": minor
 ---
 
-Add typed section consumer tokens and audience filtering for help, man pages, and generated agent skills. Application-authored sections titled "Agent skills" are now preserved in generated skills.
+Add section consumer ids and audience filtering for help, man pages, and generated agent skills. Application-authored sections titled "Agent skills" are now preserved in generated skills.

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -80,7 +80,7 @@ const guidance = defineExtension("guidance", {
 
 Titles must be non-empty single lines, and bodies are non-empty plain text so the same content is safe for terminal help and mdoc output.
 
-Sections are visible to every renderer by default. Renderer packages export consumer tokens that let authors narrow a section with mutually exclusive `only` or `except` fields:
+Sections are visible to every renderer by default. Renderer packages export consumer ids that let authors narrow a section with mutually exclusive `only` or `except` fields:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
@@ -100,7 +100,7 @@ const deploy = defineCommand(
 );
 ```
 
-A renderer defines its own token with `defineSectionConsumer()` and selects its sections with `sectionsFor()`. Core does not maintain a fixed list of consumers. Passing several tokens to `sectionsFor()` uses any-of semantics.
+A renderer exports its own consumer id and selects its sections with `sectionsFor()`. Core does not maintain a fixed list of consumers.
 
 ## Build hooks
 

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -80,6 +80,28 @@ const guidance = defineExtension("guidance", {
 
 Titles must be non-empty single lines, and bodies are non-empty plain text so the same content is safe for terminal help and mdoc output.
 
+Sections are visible to every renderer by default. Renderer packages export consumer tokens that let authors narrow a section with mutually exclusive `only` or `except` fields:
+
+```ts
+import { defineCommand } from "@crustjs/core";
+import { HELP } from "@crustjs/extensions";
+import { SKILLS } from "@crustjs/skills";
+
+const deploy = defineCommand(
+  "deploy",
+  {
+    sections: [
+      { title: "Safety", body: "Use preview mode first." },
+      { title: "Agent notes", body: "Inspect the plan before deploying.", only: [SKILLS] },
+      { title: "Examples", body: "deploy production", only: [HELP, SKILLS] },
+    ],
+  },
+  (command) => command.action(() => {}),
+);
+```
+
+A renderer defines its own token with `defineSectionConsumer()` and selects its sections with `sectionsFor()`. Core does not maintain a fixed list of consumers. Passing several tokens to `sectionsFor()` uses any-of semantics.
+
 ## Build hooks
 
 `build(ctx)` generates artifacts when invoked by build tooling such as `crust build`; it does not run during ordinary `run()` or `execute()` dispatch. The snapshot subprocess invokes registered hooks in Extension registration order, so Extension presence is the source of intent. The context contains the frozen root Command Snapshot and a resolved absolute `outDir`. Build hooks may be async; errors propagate with the Extension name. `crust build --no-validate` skips entry preparation and all build hooks.

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -60,6 +60,8 @@ Downstream commands call `await ctx.use(api)`. Other Contexts can list `api` in 
 | `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                   |
 | `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                            |
 | `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                             |
+| `defineSectionConsumer(id)`           | Define a typed token for a renderer that consumes command sections                                                                                  |
+| `sectionsFor(sections, ...consumers)` | Select sections visible to any of the supplied consumer tokens                                                                                      |
 | [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                           |
 
 ## Definition types
@@ -72,6 +74,8 @@ Downstream commands call `await ctx.use(api)`. Other Contexts can list `api` in 
 | [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                               |
 | [`CommandConfig`](/docs/api/crust)            | Static metadata for a reusable definition                                        |
 | `CommandMeta`                                 | Name, description, usage, sections, aliases, and visibility                      |
+| `CommandSection`                              | A titled documentation block with an optional consumer audience                  |
+| `SectionConsumer`                             | Branded renderer token returned by `defineSectionConsumer()`                     |
 | `ContextResolver` / `FactoryValueOf`          | Pull-based Context resolver and factory-value helper types                       |
 | [`RootCommandMeta`](/docs/api/crust)          | Root description, usage, and sections accepted by the `Crust` constructor        |
 | `FlagDef`                                     | Core-value or Standard Schema flag definition                                    |
@@ -148,6 +152,25 @@ These types back [`run(path, input?, io?)`](/docs/api/crust) and the [`@crustjs/
 | `ParseErrorDetails`           | Flag, argument, value, and reason                                        |
 | `ValidationErrorDetails`      | Aggregated `{ message, path }` issues                                    |
 | `CommandNotFoundErrorDetails` | Input, siblings, path, and parent Command Snapshot                       |
+
+## Section consumers
+
+A command section without an audience is available to every renderer. Use `only` or `except` with consumer tokens exported by renderer packages to narrow it; the two fields are mutually exclusive:
+
+```ts
+import { sectionsFor, defineSectionConsumer, type CommandSection } from "@crustjs/core";
+
+export const WEB_DOCS = defineSectionConsumer("acme:web-docs");
+
+const sections: readonly CommandSection[] = [
+  { title: "Overview", body: "Visible everywhere." },
+  { title: "Web example", body: "Visible in web docs.", only: [WEB_DOCS] },
+];
+
+const webSections = sectionsFor(sections, WEB_DOCS);
+```
+
+`sectionsFor(sections, HELP, WEB_DOCS)` includes a section when at least one requested consumer may see it. Consumers match by `id`, so targeting remains stable when snapshots are cloned or serialized. Consumer packages own and export their tokens; core has no built-in consumer registry. Namespace third-party IDs to avoid collisions.
 
 ## Tooling subpath
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -60,8 +60,7 @@ Downstream commands call `await ctx.use(api)`. Other Contexts can list `api` in 
 | `defineExtension(name, config)`       | Define a frozen, application-wide Extension value                                                                                                   |
 | `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                            |
 | `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                             |
-| `defineSectionConsumer(id)`           | Define a typed token for a renderer that consumes command sections                                                                                  |
-| `sectionsFor(sections, ...consumers)` | Select sections visible to any of the supplied consumer tokens                                                                                      |
+| `sectionsFor(sections, consumer)`     | Select sections visible to the given consumer id                                                                                                    |
 | [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                           |
 
 ## Definition types
@@ -75,7 +74,7 @@ Downstream commands call `await ctx.use(api)`. Other Contexts can list `api` in 
 | [`CommandConfig`](/docs/api/crust)            | Static metadata for a reusable definition                                        |
 | `CommandMeta`                                 | Name, description, usage, sections, aliases, and visibility                      |
 | `CommandSection`                              | A titled documentation block with an optional consumer audience                  |
-| `SectionConsumer`                             | Branded renderer token returned by `defineSectionConsumer()`                     |
+| `SectionConsumer`                             | String id of a renderer that consumes command sections                           |
 | `ContextResolver` / `FactoryValueOf`          | Pull-based Context resolver and factory-value helper types                       |
 | [`RootCommandMeta`](/docs/api/crust)          | Root description, usage, and sections accepted by the `Crust` constructor        |
 | `FlagDef`                                     | Core-value or Standard Schema flag definition                                    |
@@ -155,12 +154,12 @@ These types back [`run(path, input?, io?)`](/docs/api/crust) and the [`@crustjs/
 
 ## Section consumers
 
-A command section without an audience is available to every renderer. Use `only` or `except` with consumer tokens exported by renderer packages to narrow it; the two fields are mutually exclusive:
+A command section without an audience is available to every renderer. Use `only` or `except` with consumer ids exported by renderer packages to narrow it; the two fields are mutually exclusive:
 
 ```ts
-import { sectionsFor, defineSectionConsumer, type CommandSection } from "@crustjs/core";
+import { sectionsFor, type CommandSection, type SectionConsumer } from "@crustjs/core";
 
-export const WEB_DOCS = defineSectionConsumer("acme:web-docs");
+export const WEB_DOCS: SectionConsumer = "acme:web-docs";
 
 const sections: readonly CommandSection[] = [
   { title: "Overview", body: "Visible everywhere." },
@@ -170,7 +169,7 @@ const sections: readonly CommandSection[] = [
 const webSections = sectionsFor(sections, WEB_DOCS);
 ```
 
-`sectionsFor(sections, HELP, WEB_DOCS)` includes a section when at least one requested consumer may see it. Consumers match by `id`, so targeting remains stable when snapshots are cloned or serialized. Consumer packages own and export their tokens; core has no built-in consumer registry. Namespace third-party IDs to avoid collisions.
+Consumers match by string id, so targeting remains stable when snapshots are cloned or serialized. Consumer packages own and export their ids; core has no built-in consumer registry. Namespace third-party ids to avoid collisions.
 
 ## Tooling subpath
 

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -26,7 +26,20 @@ function help(): Extension;
 
 `help()` owns a recursive boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Action also displays help.
 
-The renderer includes usage, visible subcommands, positional arguments, effective flags, aliases, defaults, choices, and `meta.sections`. Commands with `meta.hidden: true` stay routable but are omitted from listings.
+The renderer includes usage, visible subcommands, positional arguments, effective flags, aliases, defaults, choices, and the `meta.sections` visible to its `HELP` consumer. Commands with `meta.hidden: true` stay routable but are omitted from listings.
+
+## Section consumer
+
+The package exports `HELP`, the consumer token used by the help renderer. Sections render everywhere by default; target help specifically with `only: [HELP]`, or omit a section from help with `except: [HELP]`:
+
+```ts
+import { Crust } from "@crustjs/core";
+import { HELP } from "@crustjs/extensions";
+
+const documentedApp = new Crust("my-cli", {
+  sections: [{ title: "Terminal example", body: "my-cli deploy", only: [HELP] }],
+});
+```
 
 ## `renderHelp`
 

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -30,7 +30,7 @@ The renderer includes usage, visible subcommands, positional arguments, effectiv
 
 ## Section consumer
 
-The package exports `HELP`, the consumer token used by the help renderer. Sections render everywhere by default; target help specifically with `only: [HELP]`, or omit a section from help with `except: [HELP]`:
+The package exports `HELP`, the consumer id used by the help renderer. Sections render everywhere by default; target help specifically with `only: [HELP]`, or omit a section from help with `except: [HELP]`:
 
 ```ts
 import { Crust } from "@crustjs/core";

--- a/apps/docs/content/docs/modules/man.mdx
+++ b/apps/docs/content/docs/modules/man.mdx
@@ -76,7 +76,18 @@ const source = renderManPageMdoc({
 });
 ```
 
-The renderer uses semantic mdoc(7) flag and argument macros. It intentionally summarizes only the root command's immediate visible subcommands; nested commands remain available in the shared full-tree documentation model. The root command's `meta.sections` are appended after the built-in sections as mdoc `.Sh` sections.
+The renderer uses semantic mdoc(7) flag and argument macros. It intentionally summarizes only the root command's immediate visible subcommands; nested commands remain available in the shared full-tree documentation model. Root `meta.sections` visible to the exported `MAN` consumer are appended after the built-in sections as mdoc `.Sh` sections.
+
+Target a section to man pages with `only: [MAN]`, or exclude it with `except: [MAN]`:
+
+```ts
+import { Crust } from "@crustjs/core";
+import { MAN } from "@crustjs/man";
+
+const documentedApp = new Crust("my-cli", {
+  sections: [{ title: "FILES", body: "~/.config/my-cli.json", only: [MAN] }],
+});
+```
 
 Prepare the command tree through the supported `app.snapshot()` method before calling either API. The package uses `buildCommandDocumentation()` from `@crustjs/core/tooling` internally for its lockstep first-party rendering model.
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -126,7 +126,7 @@ await uninstallSkill({ name: "my-cli" });
 
 ## Command sections
 
-Add agent-facing guidance to a command's metadata. Each section is rendered as a Markdown heading and body in that command's generated documentation. Sections are shared with every renderer by default; use the exported `SKILLS` consumer token for agent-only guidance:
+Add agent-facing guidance to a command's metadata. Each section is rendered as a Markdown heading and body in that command's generated documentation. Sections are shared with every renderer by default; use the exported `SKILLS` consumer id for agent-only guidance:
 
 ```ts
 import { defineCommand } from "@crustjs/core";

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -126,16 +126,20 @@ await uninstallSkill({ name: "my-cli" });
 
 ## Command sections
 
-Add agent-facing guidance to a command's metadata. Each section is rendered as a Markdown heading and body in that command's generated documentation:
+Add agent-facing guidance to a command's metadata. Each section is rendered as a Markdown heading and body in that command's generated documentation. Sections are shared with every renderer by default; use the exported `SKILLS` consumer token for agent-only guidance:
 
 ```ts
 import { defineCommand } from "@crustjs/core";
+import { SKILLS } from "@crustjs/skills";
 
 const deploy = defineCommand(
   "deploy",
   {
     description: "Deploy",
-    sections: [{ title: "Safety", body: "Use preview mode first." }],
+    sections: [
+      { title: "Safety", body: "Use preview mode first." },
+      { title: "Agent procedure", body: "Inspect the preview output.", only: [SKILLS] },
+    ],
   },
   (command) => command.action(() => {}),
 );

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -162,23 +162,10 @@ function validateSectionConsumers(
 	consumers: unknown,
 	owner: SectionOwner,
 ): readonly SectionConsumer[] {
-	if (
-		!Array.isArray(consumers) ||
-		consumers.length === 0 ||
-		!consumers.every(
-			(consumer) =>
-				typeof consumer === "object" &&
-				consumer !== null &&
-				isText((consumer as { id?: unknown }).id),
-		)
-	) {
+	if (!Array.isArray(consumers) || consumers.length === 0 || !consumers.every(isText)) {
 		throw invalidSections(owner);
 	}
-	return Object.freeze(
-		consumers.map(
-			(consumer) => Object.freeze({ id: (consumer as { id: string }).id }) as SectionConsumer,
-		),
-	);
+	return Object.freeze([...consumers]);
 }
 
 function validateSection(section: unknown, owner: SectionOwner): CommandSection {
@@ -196,13 +183,13 @@ function validateSection(section: unknown, owner: SectionOwner): CommandSection 
 	) {
 		throw invalidSections(owner);
 	}
-	if (only !== undefined) {
-		return Object.freeze({ title, body, only: validateSectionConsumers(only, owner) });
-	}
-	if (except !== undefined) {
-		return Object.freeze({ title, body, except: validateSectionConsumers(except, owner) });
-	}
-	return Object.freeze({ title, body });
+	// Cast: the only/except mutual-exclusion check above enforces SectionAudience.
+	return Object.freeze({
+		title,
+		body,
+		...(only !== undefined && { only: validateSectionConsumers(only, owner) }),
+		...(except !== undefined && { except: validateSectionConsumers(except, owner) }),
+	}) as CommandSection;
 }
 
 function validateAuthoredSections(node: CommandNode): void {

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -10,7 +10,7 @@ import { CrustError } from "../errors.ts";
 import { parseArgs, validateParsed } from "../parsing/parser.ts";
 import { applySchemas } from "../parsing/schema.ts";
 import { cloneFlagSpellings } from "../parsing/spellings.ts";
-import type { CommandSection, FlagDef, FlagsDef, InvocationIO } from "../types.ts";
+import type { CommandSection, FlagDef, FlagsDef, InvocationIO, SectionConsumer } from "../types.ts";
 import { normalizeFlag } from "../validation/normalize.ts";
 import type { CommandDefinition } from "./crust.ts";
 import type { CommandNode } from "./node.ts";
@@ -159,10 +159,48 @@ function invalidSections({ subject, name }: SectionOwner): CrustError {
 
 const isText = (value: unknown): value is string => typeof value === "string" && !!value.trim();
 
-function validateSection(section: unknown, owner: SectionOwner): CommandSection {
-	const { title, body } = (section ?? {}) as Partial<CommandSection>;
-	if (!isText(title) || /[\r\n]/.test(title) || !isText(body)) {
+function validateSectionConsumers(
+	consumers: unknown,
+	owner: SectionOwner,
+): readonly SectionConsumer[] {
+	if (
+		!Array.isArray(consumers) ||
+		!consumers.every(
+			(consumer) =>
+				typeof consumer === "object" &&
+				consumer !== null &&
+				typeof (consumer as { id?: unknown }).id === "string",
+		)
+	) {
 		throw invalidSections(owner);
+	}
+	return Object.freeze(
+		consumers.map(
+			(consumer) => Object.freeze({ id: (consumer as { id: string }).id }) as SectionConsumer,
+		),
+	);
+}
+
+function validateSection(section: unknown, owner: SectionOwner): CommandSection {
+	const { title, body, only, except } = (section ?? {}) as {
+		title?: unknown;
+		body?: unknown;
+		only?: unknown;
+		except?: unknown;
+	};
+	if (
+		!isText(title) ||
+		/[\r\n]/.test(title) ||
+		!isText(body) ||
+		(only !== undefined && except !== undefined)
+	) {
+		throw invalidSections(owner);
+	}
+	if (only !== undefined) {
+		return Object.freeze({ title, body, only: validateSectionConsumers(only, owner) });
+	}
+	if (except !== undefined) {
+		return Object.freeze({ title, body, except: validateSectionConsumers(except, owner) });
 	}
 	return Object.freeze({ title, body });
 }

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -10,6 +10,7 @@ import { CrustError } from "../errors.ts";
 import { parseArgs, validateParsed } from "../parsing/parser.ts";
 import { applySchemas } from "../parsing/schema.ts";
 import { cloneFlagSpellings } from "../parsing/spellings.ts";
+import { isText } from "../sections.ts";
 import type { CommandSection, FlagDef, FlagsDef, InvocationIO, SectionConsumer } from "../types.ts";
 import { normalizeFlag } from "../validation/normalize.ts";
 import type { CommandDefinition } from "./crust.ts";
@@ -157,19 +158,18 @@ function invalidSections({ subject, name }: SectionOwner): CrustError {
 	);
 }
 
-const isText = (value: unknown): value is string => typeof value === "string" && !!value.trim();
-
 function validateSectionConsumers(
 	consumers: unknown,
 	owner: SectionOwner,
 ): readonly SectionConsumer[] {
 	if (
 		!Array.isArray(consumers) ||
+		consumers.length === 0 ||
 		!consumers.every(
 			(consumer) =>
 				typeof consumer === "object" &&
 				consumer !== null &&
-				typeof (consumer as { id?: unknown }).id === "string",
+				isText((consumer as { id?: unknown }).id),
 		)
 	) {
 		throw invalidSections(owner);

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -4,6 +4,7 @@ import { defineContext } from "../api/context.ts";
 import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
+import { defineSectionConsumer } from "../sections.ts";
 import { Crust, defineCommand } from "./crust.ts";
 import { createCommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
@@ -151,6 +152,32 @@ describe("command metadata sections", () => {
 		expect(() => structuredClone(snapshot)).not.toThrow();
 	});
 
+	it("preserves authored and contributed section audiences", async () => {
+		const help = defineSectionConsumer("help");
+		const skills = defineSectionConsumer("skills");
+		const app = new Crust("cli", {
+			sections: [{ title: "Agent notes", body: "Agent body", only: [skills] }],
+		}).extend(
+			defineExtension("docs", {
+				sections: () => [
+					{ command: [], title: "Human notes", body: "Human body", except: [skills, help] },
+				],
+			}),
+		);
+
+		const snapshot = await app.snapshot();
+
+		expect(snapshot.meta.sections).toEqual([
+			{ title: "Agent notes", body: "Agent body", only: [skills] },
+			{ title: "Human notes", body: "Human body", except: [skills, help] },
+		]);
+		expect(Object.isFrozen(snapshot.meta.sections?.[0]?.only)).toBe(true);
+		expect(Object.isFrozen(snapshot.meta.sections?.[0]?.only?.[0])).toBe(true);
+		const clonedSections = structuredClone(snapshot).meta.sections;
+		expect(clonedSections?.[0]?.only?.[0]?.id).toBe("skills");
+		expect(clonedSections?.[1]?.except?.map(({ id }) => id)).toEqual(["skills", "help"]);
+	});
+
 	it("rejects unknown and aliased contribution paths", async () => {
 		for (const command of [["missing"], ["b"], ["constructor"], ["__proto__"], ["toString"]]) {
 			const app = new Crust("cli")
@@ -179,6 +206,13 @@ describe("command metadata sections", () => {
 			[{ title: "Notes", body: "" }],
 			[{ title: 1, body: "Body" }],
 			[{ title: "Notes", body: null }],
+			[{ title: "Notes", body: "Body", only: [], except: [{ id: "help" }] }],
+			[{ title: "Notes", body: "Body", only: "help" }],
+			[{ title: "Notes", body: "Body", only: [] }],
+			[{ title: "Notes", body: "Body", except: [] }],
+			[{ title: "Notes", body: "Body", only: [{}] }],
+			[{ title: "Notes", body: "Body", except: [{ id: 1 }] }],
+			[{ title: "Notes", body: "Body", only: [{ id: "   " }] }],
 			[null],
 		];
 		for (const sections of badSections) {
@@ -202,6 +236,10 @@ describe("command metadata sections", () => {
 			[{ command: [1], title: "Notes", body: "Body" }],
 			[{ command: [], title: "", body: "Body" }],
 			[{ command: [], title: "Notes", body: "   " }],
+			[{ command: [], title: "Notes", body: "Body", only: [], except: [] }],
+			[{ command: [], title: "Notes", body: "Body", only: "help" }],
+			[{ command: [], title: "Notes", body: "Body", only: [] }],
+			[{ command: [], title: "Notes", body: "Body", only: [{ id: null }] }],
 		];
 		for (const contributions of badReturns) {
 			const app = new Crust("cli").extend(

--- a/packages/core/src/command/snapshot.test.ts
+++ b/packages/core/src/command/snapshot.test.ts
@@ -4,7 +4,6 @@ import { defineContext } from "../api/context.ts";
 import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import { CrustError } from "../errors.ts";
-import { defineSectionConsumer } from "../sections.ts";
 import { Crust, defineCommand } from "./crust.ts";
 import { createCommandNode } from "./node.ts";
 import { snapshotCommand } from "./snapshot.ts";
@@ -153,14 +152,12 @@ describe("command metadata sections", () => {
 	});
 
 	it("preserves authored and contributed section audiences", async () => {
-		const help = defineSectionConsumer("help");
-		const skills = defineSectionConsumer("skills");
 		const app = new Crust("cli", {
-			sections: [{ title: "Agent notes", body: "Agent body", only: [skills] }],
+			sections: [{ title: "Agent notes", body: "Agent body", only: ["skills"] }],
 		}).extend(
 			defineExtension("docs", {
 				sections: () => [
-					{ command: [], title: "Human notes", body: "Human body", except: [skills, help] },
+					{ command: [], title: "Human notes", body: "Human body", except: ["skills", "help"] },
 				],
 			}),
 		);
@@ -168,14 +165,13 @@ describe("command metadata sections", () => {
 		const snapshot = await app.snapshot();
 
 		expect(snapshot.meta.sections).toEqual([
-			{ title: "Agent notes", body: "Agent body", only: [skills] },
-			{ title: "Human notes", body: "Human body", except: [skills, help] },
+			{ title: "Agent notes", body: "Agent body", only: ["skills"] },
+			{ title: "Human notes", body: "Human body", except: ["skills", "help"] },
 		]);
 		expect(Object.isFrozen(snapshot.meta.sections?.[0]?.only)).toBe(true);
-		expect(Object.isFrozen(snapshot.meta.sections?.[0]?.only?.[0])).toBe(true);
 		const clonedSections = structuredClone(snapshot).meta.sections;
-		expect(clonedSections?.[0]?.only?.[0]?.id).toBe("skills");
-		expect(clonedSections?.[1]?.except?.map(({ id }) => id)).toEqual(["skills", "help"]);
+		expect(clonedSections?.[0]?.only).toEqual(["skills"]);
+		expect(clonedSections?.[1]?.except).toEqual(["skills", "help"]);
 	});
 
 	it("rejects unknown and aliased contribution paths", async () => {
@@ -206,13 +202,13 @@ describe("command metadata sections", () => {
 			[{ title: "Notes", body: "" }],
 			[{ title: 1, body: "Body" }],
 			[{ title: "Notes", body: null }],
-			[{ title: "Notes", body: "Body", only: [], except: [{ id: "help" }] }],
+			[{ title: "Notes", body: "Body", only: [], except: ["help"] }],
 			[{ title: "Notes", body: "Body", only: "help" }],
 			[{ title: "Notes", body: "Body", only: [] }],
 			[{ title: "Notes", body: "Body", except: [] }],
-			[{ title: "Notes", body: "Body", only: [{}] }],
-			[{ title: "Notes", body: "Body", except: [{ id: 1 }] }],
-			[{ title: "Notes", body: "Body", only: [{ id: "   " }] }],
+			[{ title: "Notes", body: "Body", only: [{ id: "help" }] }],
+			[{ title: "Notes", body: "Body", except: [1] }],
+			[{ title: "Notes", body: "Body", only: ["   "] }],
 			[null],
 		];
 		for (const sections of badSections) {
@@ -239,7 +235,7 @@ describe("command metadata sections", () => {
 			[{ command: [], title: "Notes", body: "Body", only: [], except: [] }],
 			[{ command: [], title: "Notes", body: "Body", only: "help" }],
 			[{ command: [], title: "Notes", body: "Body", only: [] }],
-			[{ command: [], title: "Notes", body: "Body", only: [{ id: null }] }],
+			[{ command: [], title: "Notes", body: "Body", only: [null] }],
 		];
 		for (const contributions of badReturns) {
 			const app = new Crust("cli").extend(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,7 +49,7 @@ export type {
 } from "./command/crust.ts";
 export { Crust, defineCommand } from "./command/crust.ts";
 // Documentation sections
-export { defineSectionConsumer, sectionsFor } from "./sections.ts";
+export { sectionsFor } from "./sections.ts";
 // Errors
 export type {
 	CommandNotFoundErrorDetails,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,8 @@ export type {
 	RunInputArguments,
 } from "./command/crust.ts";
 export { Crust, defineCommand } from "./command/crust.ts";
+// Documentation sections
+export { defineSectionConsumer, sectionsFor } from "./sections.ts";
 // Errors
 export type {
 	CommandNotFoundErrorDetails,
@@ -65,6 +67,8 @@ export type {
 	ArgsDef,
 	CommandMeta,
 	CommandSection,
+	SectionAudience,
+	SectionConsumer,
 	FlagDef,
 	FlagsDef,
 	InputArgs,

--- a/packages/core/src/sections.test.ts
+++ b/packages/core/src/sections.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+
+import { defineSectionConsumer, sectionsFor } from "./sections.ts";
+import type { CommandSection } from "./types.ts";
+
+const help = defineSectionConsumer("help");
+const man = defineSectionConsumer("man");
+const skills = defineSectionConsumer("skills");
+
+const universal = { title: "Universal", body: "Everywhere" } as const;
+
+describe("sectionsFor", () => {
+	it("includes untargeted sections for every consumer", () => {
+		expect(sectionsFor([universal], help)).toEqual([universal]);
+	});
+
+	it("includes only sections addressed to a requested consumer", () => {
+		const section = { title: "Agent notes", body: "For agents", only: [skills] } as const;
+		expect(sectionsFor([section], skills)).toEqual([section]);
+		expect(sectionsFor([section], help)).toEqual([]);
+	});
+
+	it("excludes sections from an excepted consumer", () => {
+		const section = { title: "Human notes", body: "For humans", except: [skills] } as const;
+		expect(sectionsFor([section], help)).toEqual([section]);
+		expect(sectionsFor([section], skills)).toEqual([]);
+	});
+
+	it("uses any-of semantics for multiple consumers", () => {
+		const skillOnly = { title: "Agent notes", body: "For agents", only: [skills] } as const;
+		const exceptHelp = { title: "Not help", body: "Other output", except: [help] } as const;
+		expect(sectionsFor([skillOnly, exceptHelp], help, man, skills)).toEqual([
+			skillOnly,
+			exceptHelp,
+		]);
+	});
+
+	it("matches consumer ids after structured cloning", () => {
+		const sections = structuredClone([
+			{ title: "Agent notes", body: "For agents", only: [skills] },
+		]) as CommandSection[];
+		expect(sectionsFor(sections, defineSectionConsumer("skills"))).toEqual(sections);
+	});
+});

--- a/packages/core/src/sections.test.ts
+++ b/packages/core/src/sections.test.ts
@@ -9,6 +9,13 @@ const skills = defineSectionConsumer("skills");
 
 const universal = { title: "Universal", body: "Everywhere" } as const;
 
+describe("defineSectionConsumer", () => {
+	it("rejects empty consumer ids", () => {
+		expect(() => defineSectionConsumer("")).toThrow("non-empty id");
+		expect(() => defineSectionConsumer("   ")).toThrow("non-empty id");
+	});
+});
+
 describe("sectionsFor", () => {
 	it("includes untargeted sections for every consumer", () => {
 		expect(sectionsFor([universal], help)).toEqual([universal]);

--- a/packages/core/src/sections.test.ts
+++ b/packages/core/src/sections.test.ts
@@ -1,51 +1,31 @@
 import { describe, expect, it } from "bun:test";
 
-import { defineSectionConsumer, sectionsFor } from "./sections.ts";
+import { sectionsFor } from "./sections.ts";
 import type { CommandSection } from "./types.ts";
-
-const help = defineSectionConsumer("help");
-const man = defineSectionConsumer("man");
-const skills = defineSectionConsumer("skills");
 
 const universal = { title: "Universal", body: "Everywhere" } as const;
 
-describe("defineSectionConsumer", () => {
-	it("rejects empty consumer ids", () => {
-		expect(() => defineSectionConsumer("")).toThrow("non-empty id");
-		expect(() => defineSectionConsumer("   ")).toThrow("non-empty id");
-	});
-});
-
 describe("sectionsFor", () => {
 	it("includes untargeted sections for every consumer", () => {
-		expect(sectionsFor([universal], help)).toEqual([universal]);
+		expect(sectionsFor([universal], "help")).toEqual([universal]);
 	});
 
-	it("includes only sections addressed to a requested consumer", () => {
-		const section = { title: "Agent notes", body: "For agents", only: [skills] } as const;
-		expect(sectionsFor([section], skills)).toEqual([section]);
-		expect(sectionsFor([section], help)).toEqual([]);
+	it("includes only sections addressed to the requested consumer", () => {
+		const section = { title: "Agent notes", body: "For agents", only: ["skills"] } as const;
+		expect(sectionsFor([section], "skills")).toEqual([section]);
+		expect(sectionsFor([section], "help")).toEqual([]);
 	});
 
 	it("excludes sections from an excepted consumer", () => {
-		const section = { title: "Human notes", body: "For humans", except: [skills] } as const;
-		expect(sectionsFor([section], help)).toEqual([section]);
-		expect(sectionsFor([section], skills)).toEqual([]);
-	});
-
-	it("uses any-of semantics for multiple consumers", () => {
-		const skillOnly = { title: "Agent notes", body: "For agents", only: [skills] } as const;
-		const exceptHelp = { title: "Not help", body: "Other output", except: [help] } as const;
-		expect(sectionsFor([skillOnly, exceptHelp], help, man, skills)).toEqual([
-			skillOnly,
-			exceptHelp,
-		]);
+		const section = { title: "Human notes", body: "For humans", except: ["skills"] } as const;
+		expect(sectionsFor([section], "help")).toEqual([section]);
+		expect(sectionsFor([section], "skills")).toEqual([]);
 	});
 
 	it("matches consumer ids after structured cloning", () => {
 		const sections = structuredClone([
-			{ title: "Agent notes", body: "For agents", only: [skills] },
+			{ title: "Agent notes", body: "For agents", only: ["skills"] },
 		]) as CommandSection[];
-		expect(sectionsFor(sections, defineSectionConsumer("skills"))).toEqual(sections);
+		expect(sectionsFor(sections, "skills")).toEqual(sections);
 	});
 });

--- a/packages/core/src/sections.ts
+++ b/packages/core/src/sections.ts
@@ -1,7 +1,12 @@
 import type { CommandSection, SectionConsumer } from "./types.ts";
 
+export function isText(value: unknown): value is string {
+	return typeof value === "string" && !!value.trim();
+}
+
 /** Define a token for a command-section renderer. */
 export function defineSectionConsumer(id: string): SectionConsumer {
+	if (!isText(id)) throw new Error("Section consumer requires a non-empty id.");
 	return Object.freeze({ id }) as SectionConsumer;
 }
 
@@ -11,11 +16,12 @@ export function sectionsFor(
 	...consumers: readonly [SectionConsumer, ...SectionConsumer[]]
 ): readonly CommandSection[] {
 	return (sections ?? []).filter((section) => {
-		if (section.only) {
-			return consumers.some((consumer) => section.only?.some(({ id }) => id === consumer.id));
+		const { only, except } = section;
+		if (only) {
+			return consumers.some((consumer) => only.some(({ id }) => id === consumer.id));
 		}
-		if (section.except) {
-			return consumers.some((consumer) => !section.except?.some(({ id }) => id === consumer.id));
+		if (except) {
+			return consumers.some((consumer) => !except.some(({ id }) => id === consumer.id));
 		}
 		return true;
 	});

--- a/packages/core/src/sections.ts
+++ b/packages/core/src/sections.ts
@@ -4,25 +4,14 @@ export function isText(value: unknown): value is string {
 	return typeof value === "string" && !!value.trim();
 }
 
-/** Define a token for a command-section renderer. */
-export function defineSectionConsumer(id: string): SectionConsumer {
-	if (!isText(id)) throw new Error("Section consumer requires a non-empty id.");
-	return Object.freeze({ id }) as SectionConsumer;
-}
-
-/** Select sections visible to any of the requested consumers. */
+/** Select sections visible to the given consumer. */
 export function sectionsFor(
 	sections: readonly CommandSection[] | undefined,
-	...consumers: readonly [SectionConsumer, ...SectionConsumer[]]
+	consumer: SectionConsumer,
 ): readonly CommandSection[] {
 	return (sections ?? []).filter((section) => {
-		const { only, except } = section;
-		if (only) {
-			return consumers.some((consumer) => only.some(({ id }) => id === consumer.id));
-		}
-		if (except) {
-			return consumers.some((consumer) => !except.some(({ id }) => id === consumer.id));
-		}
+		if (section.only) return section.only.includes(consumer);
+		if (section.except) return !section.except.includes(consumer);
 		return true;
 	});
 }

--- a/packages/core/src/sections.ts
+++ b/packages/core/src/sections.ts
@@ -1,0 +1,22 @@
+import type { CommandSection, SectionConsumer } from "./types.ts";
+
+/** Define a token for a command-section renderer. */
+export function defineSectionConsumer(id: string): SectionConsumer {
+	return Object.freeze({ id }) as SectionConsumer;
+}
+
+/** Select sections visible to any of the requested consumers. */
+export function sectionsFor(
+	sections: readonly CommandSection[] | undefined,
+	...consumers: readonly [SectionConsumer, ...SectionConsumer[]]
+): readonly CommandSection[] {
+	return (sections ?? []).filter((section) => {
+		if (section.only) {
+			return consumers.some((consumer) => section.only?.some(({ id }) => id === consumer.id));
+		}
+		if (section.except) {
+			return consumers.some((consumer) => !section.except?.some(({ id }) => id === consumer.id));
+		}
+		return true;
+	});
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -721,11 +721,24 @@ export type InputFlags<F extends FlagsDef> = Simplify<
 // CommandMeta — Command metadata
 // ────────────────────────────────────────────────────────────────────────────
 
+declare const sectionConsumerBrand: unique symbol;
+
+/** A renderer that consumes command documentation sections. */
+export interface SectionConsumer {
+	readonly id: string;
+	readonly [sectionConsumerBrand]: true;
+}
+
+export type SectionAudience =
+	| { readonly only: readonly SectionConsumer[]; readonly except?: never }
+	| { readonly except: readonly SectionConsumer[]; readonly only?: never }
+	| { readonly only?: never; readonly except?: never };
+
 /** A plain-text documentation section rendered after built-in command documentation. */
-export interface CommandSection {
+export type CommandSection = {
 	readonly title: string;
 	readonly body: string;
-}
+} & SectionAudience;
 
 /** Metadata describing a CLI command */
 export interface CommandMeta {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -721,13 +721,8 @@ export type InputFlags<F extends FlagsDef> = Simplify<
 // CommandMeta — Command metadata
 // ────────────────────────────────────────────────────────────────────────────
 
-declare const sectionConsumerBrand: unique symbol;
-
-/** A renderer that consumes command documentation sections. */
-export interface SectionConsumer {
-	readonly id: string;
-	readonly [sectionConsumerBrand]: true;
-}
+/** Identifier of a renderer that consumes command documentation sections. */
+export type SectionConsumer = string;
 
 export type SectionAudience =
 	| { readonly only: readonly SectionConsumer[]; readonly except?: never }

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -1,4 +1,11 @@
-import { type CommandSnapshot, type Extension, defineExtension } from "@crustjs/core";
+import {
+	type CommandSnapshot,
+	type Extension,
+	type SectionConsumer,
+	defineExtension,
+	defineSectionConsumer,
+	sectionsFor,
+} from "@crustjs/core";
 import {
 	buildCommandDocumentation,
 	formatDescription,
@@ -12,6 +19,8 @@ import { bold, cyan, dim, green, padEnd, yellow } from "@crustjs/style";
 const FLAG_COLUMN_WIDTH = 28;
 const ARG_COLUMN_WIDTH = 18;
 const COMMAND_COLUMN_WIDTH = 10;
+
+export const HELP: SectionConsumer = defineSectionConsumer("help");
 
 function formatArgToken(arg: DocumentationArg): string {
 	return arg.required ? yellow(arg.token) : dim(yellow(arg.token));
@@ -85,7 +94,7 @@ export function renderHelp(command: CommandSnapshot, path?: readonly string[]): 
 	]) {
 		if (section.length > 0) lines.push("", ...section);
 	}
-	for (const section of command.meta.sections ?? []) {
+	for (const section of sectionsFor(command.meta.sections, HELP)) {
 		lines.push(
 			"",
 			bold(cyan(`${section.title}:`)),

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -3,7 +3,6 @@ import {
 	type Extension,
 	type SectionConsumer,
 	defineExtension,
-	defineSectionConsumer,
 	sectionsFor,
 } from "@crustjs/core";
 import {
@@ -20,7 +19,7 @@ const FLAG_COLUMN_WIDTH = 28;
 const ARG_COLUMN_WIDTH = 18;
 const COMMAND_COLUMN_WIDTH = 10;
 
-export const HELP: SectionConsumer = defineSectionConsumer("help");
+export const HELP: SectionConsumer = "help";
 
 function formatArgToken(arg: DocumentationArg): string {
 	return arg.required ? yellow(arg.token) : dim(yellow(arg.token));

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -2,7 +2,7 @@ export { completion } from "./completion/index.ts";
 export type { CompletionOptions, CompletionShell } from "./completion/index.ts";
 export { didYouMean } from "./did-you-mean.ts";
 export type { DidYouMeanOptions } from "./did-you-mean.ts";
-export { help, renderHelp } from "./help.ts";
+export { HELP, help, renderHelp } from "./help.ts";
 export { noColor } from "./no-color.ts";
 export { updateNotifier } from "./update-notifier.ts";
 export type {

--- a/packages/man/src/index.ts
+++ b/packages/man/src/index.ts
@@ -1,6 +1,6 @@
 export type { ManOptions } from "./extension.ts";
 export { man } from "./extension.ts";
 export type { RenderManPageMdocOptions } from "./mdoc.ts";
-export { renderManPageMdoc } from "./mdoc.ts";
+export { MAN, renderManPageMdoc } from "./mdoc.ts";
 export type { WriteManPageOptions } from "./write-man-page.ts";
 export { writeManPage } from "./write-man-page.ts";

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,10 +1,17 @@
-import type { CommandSnapshot } from "@crustjs/core";
+import {
+	type CommandSnapshot,
+	type SectionConsumer,
+	defineSectionConsumer,
+	sectionsFor,
+} from "@crustjs/core";
 import {
 	buildCommandDocumentation,
 	formatDescription,
 	type CommandDocumentation,
 	type DocumentationFlag,
 } from "@crustjs/core/tooling";
+
+export const MAN: SectionConsumer = defineSectionConsumer("man");
 
 function escapeMdocBodyLine(line: string): string {
 	// Both `.` and `'` start roff control lines.
@@ -110,7 +117,7 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		}
 		lines.push(".El");
 	}
-	for (const metadataSection of root.meta.sections ?? []) {
+	for (const metadataSection of sectionsFor(root.meta.sections, MAN)) {
 		lines.push(`.Sh ${shTitle(metadataSection.title)}`);
 		for (const line of metadataSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
 	}

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,9 +1,4 @@
-import {
-	type CommandSnapshot,
-	type SectionConsumer,
-	defineSectionConsumer,
-	sectionsFor,
-} from "@crustjs/core";
+import { type CommandSnapshot, type SectionConsumer, sectionsFor } from "@crustjs/core";
 import {
 	buildCommandDocumentation,
 	formatDescription,
@@ -11,7 +6,7 @@ import {
 	type DocumentationFlag,
 } from "@crustjs/core/tooling";
 
-export const MAN: SectionConsumer = defineSectionConsumer("man");
+export const MAN: SectionConsumer = "man";
 
 function escapeMdocBodyLine(line: string): string {
 	// Both `.` and `'` start roff control lines.

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -109,7 +109,12 @@ describe("skill extension package sources", () => {
 		);
 		await writeFile(join(authored, "content.md"), "authored\n");
 		const extension = skill({ source, extras: [authored] });
-		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
+		const snapshot = await new Crust("demo", {
+			description: "Demo",
+			sections: [{ title: "Agent skills", body: "Application-authored agent guidance." }],
+		})
+			.extend(extension)
+			.snapshot();
 		const outDir = join(tempRoot, "dist");
 		await writeFile(join(tempRoot, "package.json"), '{"version":"9.9.9"}');
 
@@ -125,8 +130,9 @@ describe("skill extension package sources", () => {
 			"utf8",
 		);
 		expect(rootReference).toContain("# `demo`");
-		// The Agent skills section advertises the input source path; it must not
-		// leak build-machine paths into the regenerated command reference.
+		expect(rootReference).toContain("## Agent skills\nApplication-authored agent guidance.");
+		// The extension's Agent skills section advertises the input source path; it
+		// must not leak build-machine paths into the regenerated command reference.
 		expect(rootReference).not.toContain(tempRoot);
 		expect(await readFile(join(outDir, "skills", "guide", "content.md"), "utf8")).toBe(
 			"authored\n",

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -26,6 +26,7 @@ import {
 	installSkill,
 	uninstallSkill,
 } from "./generate.ts";
+import { SKILLS } from "./manifest.ts";
 import {
 	SkillSourceUnavailableError,
 	loadPackagedSkills,
@@ -213,17 +214,11 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 	}
 
 	if (source === undefined || (options.extras?.length ?? 0) > 0) {
-		// The Agent skills section describes the input source, not the output being generated here.
-		const meta = {
-			...context.snapshot.meta,
-			sections: context.snapshot.meta.sections?.filter(
-				(section) => section.title !== SKILLS_SECTION_TITLE,
-			),
-		};
-		await writeSkillsFromSnapshot(
-			{ ...context.snapshot, meta },
-			{ outDir, version: await readPackageVersion(), extras: options.extras },
-		);
+		await writeSkillsFromSnapshot(context.snapshot, {
+			outDir,
+			version: await readPackageVersion(),
+			extras: options.extras,
+		});
 		return;
 	}
 
@@ -249,6 +244,7 @@ export function skill(options: SkillOptions): Extension {
 				command: [],
 				title: SKILLS_SECTION_TITLE,
 				body: formatSkillDocumentation(options.source, commandName, snapshot.meta.name),
+				except: [SKILLS],
 			},
 		],
 		build: (context) => buildSkills(options, context),

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -13,6 +13,7 @@ export {
 export { SkillConflictError, SkillSourceConflictError } from "./errors.ts";
 export { skill } from "./extension.ts";
 export { getSkillStatus, installSkill, uninstallSkill } from "./generate.ts";
+export { SKILLS } from "./manifest.ts";
 export { isValidSkillName } from "./skill-name.ts";
 export { loadPackagedSkills, resolveSkillSource, SkillSourceUnavailableError } from "./source.ts";
 export type { PackagedSkill } from "./source.ts";

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -1,4 +1,9 @@
-import type { CommandSnapshot } from "@crustjs/core";
+import {
+	type CommandSnapshot,
+	type SectionConsumer,
+	defineSectionConsumer,
+	sectionsFor,
+} from "@crustjs/core";
 import {
 	buildCommandDocumentation,
 	type CommandDocumentation,
@@ -7,6 +12,8 @@ import {
 } from "@crustjs/core/tooling";
 
 import type { ManifestArg, ManifestFlag, ManifestNode } from "./types.ts";
+
+export const SKILLS: SectionConsumer = defineSectionConsumer("skills");
 
 export function buildManifest(command: CommandSnapshot): ManifestNode {
 	return buildNode(buildCommandDocumentation(command), command);
@@ -17,7 +24,10 @@ function buildNode(model: CommandDocumentation, source: CommandSnapshot): Manife
 		path: model.path.map(normalizeName),
 		description: model.description,
 		usage: model.usage,
-		sections: source.meta.sections,
+		sections: sectionsFor(source.meta.sections, SKILLS).map(({ title, body }) => ({
+			title,
+			body,
+		})),
 		runnable: model.hasAction,
 		args: model.args.map(normalizeArg),
 		flags: [...model.flags].sort((a, b) => a.name.localeCompare(b.name)).map(normalizeFlag),

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -1,9 +1,4 @@
-import {
-	type CommandSnapshot,
-	type SectionConsumer,
-	defineSectionConsumer,
-	sectionsFor,
-} from "@crustjs/core";
+import { type CommandSnapshot, type SectionConsumer, sectionsFor } from "@crustjs/core";
 import {
 	buildCommandDocumentation,
 	type CommandDocumentation,
@@ -13,7 +8,7 @@ import {
 
 import type { ManifestArg, ManifestFlag, ManifestNode } from "./types.ts";
 
-export const SKILLS: SectionConsumer = defineSectionConsumer("skills");
+export const SKILLS: SectionConsumer = "skills";
 
 export function buildManifest(command: CommandSnapshot): ManifestNode {
 	return buildNode(buildCommandDocumentation(command), command);

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -1,5 +1,3 @@
-import type { CommandSnapshot } from "@crustjs/core";
-
 /** Metadata used to render a generated skill. */
 export interface SkillMeta {
 	name: string;
@@ -114,7 +112,7 @@ export interface ManifestNode {
 	description?: string;
 	usage: string;
 	/** Plain-text command sections rendered into the command's markdown file. */
-	sections?: CommandSnapshot["meta"]["sections"];
+	sections?: readonly { readonly title: string; readonly body: string }[];
 	runnable: boolean;
 	args: ManifestArg[];
 	flags: ManifestFlag[];


### PR DESCRIPTION
Stacked on #258 (`feat/skills-extension-extras`).

## Why

The extras build in #258 filtered snapshot sections by the literal title "Agent skills" to keep the skills extension's self-advertisement out of generated `SKILL.md` files — which silently dropped app-authored sections with the same title (flagged in #258 review). Sections had no way to express *who* a section is for.

## What

Sections gain **consumer targeting** via core factory tokens. Core hardcodes no consumer names; each consumer package is self-contained.

### `@crustjs/core`
- `SectionConsumer` — branded token type (phantom `unique symbol`, factory-only construction, plain serializable `{ id }` at runtime)
- `defineSectionConsumer(id)` — factory; rejects blank ids
- `sectionsFor(sections, ...consumers)` — variadic any-of filter
- `CommandSection` gains `only` / `except` audience fields, mutually exclusive at the type level (XOR union); plain `{ title, body }` stays valid → visible to all consumers (backward compatible)
- Snapshot pipeline validates and preserves audience metadata; JSON/`structuredClone` safety unchanged

### Consumers (one token + one `sectionsFor` call each)
- `@crustjs/extensions` exports `HELP`
- `@crustjs/man` exports `MAN`
- `@crustjs/skills` exports `SKILLS`; manifest strips audience fields from generated output

### Payoff
The skills extension marks its self-ad section `except: [SKILLS]` and the title-based filter in `buildSkills` is **deleted** — app-authored "Agent skills" sections now survive extras builds (regression-tested).

```ts
sections: [
  { title: "Safety", body: "Use preview mode first." },            // everywhere
  { title: "Agent notes", body: "...", only: [SKILLS] },           // skill only
  { title: "Support", body: "...", except: [SKILLS] },             // humans only
]
```

## Verification

- `bun run check:types`, `bun run lint`, `bun run format`, `bun run test` (1,680 tests) — all green, independently re-run after review fixes
- Two independent reviews (spec: all requirements MET; standards: findings addressed in 4b4ca87c — validator/snapshot-preservation tests, minor changesets for consumer packages, help/man token docs, empty-audience rejection)

Changesets: minor for core/extensions/man/skills.
