### PR TITLE
refactor(skills)!: rename SkillOptions.source to packagedDir

### DIFF
--- a/.changeset/rename-skill-packaged-dir.md
+++ b/.changeset/rename-skill-packaged-dir.md
@@ -1,0 +1,13 @@
+---
+"@crustjs/skills": minor
+---
+
+Rename the skills Extension's `source` option to `packagedDir` to make its purpose explicit. This is a breaking change with no compatibility alias:
+
+```ts
+// Before
+skill({ source: new URL("../skills", import.meta.url) });
+
+// After
+skill({ packagedDir: new URL("../skills", import.meta.url) });
+```

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -11,14 +11,14 @@ description: Package and install agent skills for AI coding assistants.
 bun add @crustjs/skills
 ```
 
-## Package-as-source workflow
+## Packaged skills workflow
 
-A **skill source** is the `skills/` directory shipped in your npm package. It is the single source of truth and contains both:
+The **packaged skills directory** is the `skills/` directory shipped in your npm package. It is the single source of truth and contains both:
 
 - A **generated skill**, rendered from the command tree and its `meta.sections`.
 - Any **authored skills**, included from hand-written skill directories via `extras`.
 
-The `skill()` Extension owns its build output. During `crust build`, configured `extras` are built alongside the generated skill from the prepared Command Snapshot. Without `extras`, the Extension copies an available packaged source wholesale to `<outdir>/skills`, falling back to the generated skill when the source is unavailable. `crust build --package` includes the resulting directory in the staged root package. No `--skills` build flag is needed; `--no-validate` skips all Extension build hooks.
+The `skill()` Extension owns its build output. During `crust build`, configured `extras` are built alongside the generated skill from the prepared Command Snapshot. Without `extras`, the Extension copies the available packaged skills directory wholesale to `<outdir>/skills`, falling back to the generated skill when that directory is unavailable. `crust build --package` includes the resulting directory in the staged root package. No `--skills` build flag is needed; `--no-validate` skips all Extension build hooks.
 
 ```ts
 import { writeSkills } from "@crustjs/skills";
@@ -34,7 +34,7 @@ await writeSkills(app, {
 
 For a custom pipeline with a prepared Command Snapshot instead of a live app, call `writeSkillsFromSnapshot(snapshot, options)`. `outDir` must be named `skills`. Each skill gets its own `skills/<name>/` directory containing `SKILL.md` and any supporting files. `writeSkills()` and `writeSkillsFromSnapshot()` replace `outDir` on every build and never write to an agent directory.
 
-Include the source in the published package:
+Include the directory in the published package:
 
 ```json
 {
@@ -46,7 +46,7 @@ Include the source in the published package:
 
 ## Enable discovery and installation
 
-Point the extension at the packaged source with a package-relative file URL:
+Point the extension at the packaged skills directory with a package-relative file URL:
 
 ```ts
 import { Crust } from "@crustjs/core";
@@ -55,18 +55,18 @@ import { skill } from "@crustjs/skills";
 export const app = new Crust("my-cli", { description: "My CLI" })
   .extend(
     skill({
-      source: new URL("../skills", import.meta.url),
+      packagedDir: new URL("../skills", import.meta.url),
       extras: [new URL("../skills-src/deployment-guide", import.meta.url)],
     }),
   )
   .action(() => {});
 ```
 
-When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying an existing source. `source` remains the packaged directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
+When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. `packagedDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
 
-The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the source is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the skill source to keep absolute build-machine paths out of generated artifacts.
+The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the packaged directory is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the packaged skills directory to keep absolute build-machine paths out of generated artifacts.
 
-The management command reads every skill in the source and creates links in selected agent directories. `--scope project|global` selects project or user locations; `--all` installs for universal and detected agents without prompting.
+The management command reads every skill in `packagedDir` and creates links in selected agent directories. `--scope project|global` selects project or user locations; `--all` installs for universal and detected agents without prompting.
 
 ```sh
 my-cli skill
@@ -74,7 +74,7 @@ my-cli skill --all --scope project
 my-cli skill update
 ```
 
-If the package-relative source cannot be found, Crust also checks next to `process.execPath` — for the source's basename when the source is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the source resolves but a packaged skill is invalid (for example a `SKILL.md` without a description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the source as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
+If `packagedDir` cannot be found relative to the package, Crust also checks next to `process.execPath` — for the directory's basename when it is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the directory resolves but a packaged skill is invalid (for example a `SKILL.md` without a description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the packaged directory as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
 
 <auto-type-table path="../../../../../packages/skills/src/types.ts" name="SkillOptions" />
 

--- a/packages/crust/src/utils/build-helpers.test.ts
+++ b/packages/crust/src/utils/build-helpers.test.ts
@@ -72,7 +72,7 @@ describe("buildEntrypoint", () => {
 			`import { Crust } from ${JSON.stringify(coreUrl)};\n` +
 				`import { skill } from ${JSON.stringify(skillsUrl)};\n` +
 				`import { man } from ${JSON.stringify(manUrl)};\n` +
-				`await new Crust("demo", { description: "Demo" }).extend(skill({ source: ${JSON.stringify(source)} }), man()).execute();\n`,
+				`await new Crust("demo", { description: "Demo" }).extend(skill({ packagedDir: ${JSON.stringify(source)} }), man()).execute();\n`,
 		);
 
 		// crust build runs from the project root; the entry subprocess inherits

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -51,7 +51,7 @@ async function writeSource(name: string, content = name, description = name): Pr
 
 function createApp(source: string | URL, autoUpdate = true) {
 	return new Crust("demo", { description: "Demo" })
-		.extend(skill({ source, defaultScope: "project", autoUpdate }))
+		.extend(skill({ packagedDir: source, defaultScope: "project", autoUpdate }))
 		.action(() => {});
 }
 
@@ -59,7 +59,7 @@ function target(name = "demo") {
 	return join(tempRoot, ".agents", "skills", name);
 }
 
-describe("skill extension package sources", () => {
+describe("skill extension packaged directory", () => {
 	it("advertises every packaged skill in help with its resolved source path", async () => {
 		const source = await writeSource("demo", "demo", "Run demo workflows");
 		await writeSource("guide", "guide", "Explain deployment choices");
@@ -75,22 +75,22 @@ describe("skill extension package sources", () => {
 		);
 	});
 
-	it("keeps help usable when the packaged skill source cannot be resolved", async () => {
+	it("keeps help usable when the packaged skills directory cannot be resolved", async () => {
 		const source = join(tempRoot, "missing-skills");
 		const app = new Crust("demo", { description: "Demo" })
-			.extend(skill({ source, command: "agents" }))
+			.extend(skill({ packagedDir: source, command: "agents" }))
 			.action(() => {});
 		const output = renderHelp(await app.snapshot());
 
 		expect(output).toContain("Agent skills:");
-		expect(output).toContain("The skill source path is unavailable.");
+		expect(output).toContain("The packaged skills directory is unavailable.");
 		expect(output).toContain("Run `demo agents`");
 		expect(output).not.toContain(source);
 	});
 
 	it("copies packaged sources from its build hook", async () => {
 		const source = await writeSource("demo", "packaged");
-		const extension = skill({ source });
+		const extension = skill({ packagedDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 
@@ -108,7 +108,7 @@ describe("skill extension package sources", () => {
 			"---\nname: guide\ndescription: Deployment guide\n---\n",
 		);
 		await writeFile(join(authored, "content.md"), "authored\n");
-		const extension = skill({ source, extras: [authored] });
+		const extension = skill({ packagedDir: source, extras: [authored] });
 		const snapshot = await new Crust("demo", {
 			description: "Demo",
 			sections: [{ title: "Agent skills", body: "Application-authored agent guidance." }],
@@ -131,7 +131,7 @@ describe("skill extension package sources", () => {
 		);
 		expect(rootReference).toContain("# `demo`");
 		expect(rootReference).toContain("## Agent skills\nApplication-authored agent guidance.");
-		// The extension's Agent skills section advertises the input source path; it
+		// The extension's Agent skills section advertises the packaged directory; it
 		// must not leak build-machine paths into the regenerated command reference.
 		expect(rootReference).not.toContain(tempRoot);
 		expect(await readFile(join(outDir, "skills", "guide", "content.md"), "utf8")).toBe(
@@ -142,7 +142,7 @@ describe("skill extension package sources", () => {
 
 	it("copies packaged sources when extras is empty", async () => {
 		const source = await writeSource("demo", "packaged");
-		const extension = skill({ source, extras: [] });
+		const extension = skill({ packagedDir: source, extras: [] });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 
@@ -153,7 +153,7 @@ describe("skill extension package sources", () => {
 
 	it("renders from the snapshot without requiring a package version", async () => {
 		const source = join(tempRoot, "missing-skills");
-		const extension = skill({ source });
+		const extension = skill({ packagedDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 		await writeFile(join(tempRoot, "package.json"), "{}");
@@ -166,7 +166,7 @@ describe("skill extension package sources", () => {
 		expect(generated).toContain("name: demo");
 		expect(generated).not.toContain("version:");
 		expect(generated).not.toContain(tempRoot);
-		// The snapshot was prepared while the source was missing; the emitted
+		// The snapshot was prepared while the packaged directory was missing; the
 		// skill must not embed that stale warning in its command reference.
 		const rootReference = await readFile(
 			join(outDir, "skills", "demo", "commands", "demo.md"),
@@ -262,7 +262,7 @@ describe("skill extension package sources", () => {
 
 		let ran = false;
 		const app = new Crust("demo", { description: "Demo" })
-			.extend(skill({ source, defaultScope: "project" }))
+			.extend(skill({ packagedDir: source, defaultScope: "project" }))
 			.action(() => {
 				ran = true;
 			});
@@ -273,20 +273,20 @@ describe("skill extension package sources", () => {
 		expect(output).toContain("demo — Run demo workflows");
 	});
 
-	it("reports unreadable packaged skills without claiming the source path is unavailable", async () => {
+	it("reports unreadable packaged skills without claiming the directory is unavailable", async () => {
 		const source = await writeSource("demo");
 		await writeFile(join(source, "demo", "SKILL.md"), "---\nname: demo\n---\n");
 
 		const output = renderHelp(await createApp(source).snapshot());
 		expect(output).toContain("Agent skills:");
 		expect(output).toContain("Packaged skills could not be read.");
-		expect(output).not.toContain("The skill source path is unavailable.");
+		expect(output).not.toContain("The packaged skills directory is unavailable.");
 	});
 
-	it("does not break unrelated commands when the source is unavailable", async () => {
+	it("does not break unrelated commands when the packaged directory is unavailable", async () => {
 		let ran = false;
 		const app = new Crust("demo")
-			.extend(skill({ source: join(tempRoot, "missing-skills") }))
+			.extend(skill({ packagedDir: join(tempRoot, "missing-skills") }))
 			.action(() => {
 				ran = true;
 			});

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -123,7 +123,7 @@ async function repairInstalledSkill(
 async function autoRepairSkills(options: SkillOptions): Promise<void> {
 	let skills: readonly PackagedSkill[];
 	try {
-		skills = loadPackagedSkills(options.source);
+		skills = loadPackagedSkills(options.packagedDir);
 	} catch (error) {
 		// A missing or invalid packaged asset must not prevent unrelated CLI commands
 		// from running; the explicit skill command surfaces the same failure loudly.
@@ -177,7 +177,7 @@ function formatSkillDocumentation(
 		// A missing or invalid packaged asset degrades the advertisement instead of
 		// failing help, matching the auto-update hook's recovery behavior.
 		if (error instanceof SkillSourceUnavailableError) {
-			return `The skill source path is unavailable. Run \`${appName} ${commandName}\` to link packaged skills into an agent directory.`;
+			return `The packaged skills directory is unavailable. Run \`${appName} ${commandName}\` to link packaged skills into an agent directory.`;
 		}
 		// No warn here: the preRun repair hook already surfaces the underlying
 		// message once per invocation, and the explicit skill command fails loudly.
@@ -207,7 +207,7 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 	const outDir = join(context.outDir, "skills");
 	let source: string | undefined;
 	try {
-		source = resolveSkillSource(options.source);
+		source = resolveSkillSource(options.packagedDir);
 	} catch (error) {
 		if (!(error instanceof SkillSourceUnavailableError)) throw error;
 		// A missing packaged source is regenerated from the snapshot below.
@@ -222,10 +222,10 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 		return;
 	}
 
-	// rm below would destroy a source nested in (or equal to) the output it feeds.
+	// rm below would destroy a packaged directory nested in (or equal to) its output.
 	if (isWithin(outDir, source)) {
 		throw new Error(
-			`Skill source "${source}" cannot be nested inside output directory "${outDir}".`,
+			`Packaged skills directory "${source}" cannot be nested inside output directory "${outDir}".`,
 		);
 	}
 	await rm(outDir, { recursive: true, force: true });
@@ -238,12 +238,12 @@ export function skill(options: SkillOptions): Extension {
 	return defineExtension("skills", {
 		commands: [buildSkillCommand(commandName, options)],
 		// Skills are loaded when a snapshot is prepared, not at construction, so
-		// help and man pages reflect the source as it exists at render time.
+		// help and man pages reflect the packaged directory as it exists at render time.
 		sections: (snapshot) => [
 			{
 				command: [],
 				title: SKILLS_SECTION_TITLE,
-				body: formatSkillDocumentation(options.source, commandName, snapshot.meta.name),
+				body: formatSkillDocumentation(options.packagedDir, commandName, snapshot.meta.name),
 				except: [SKILLS],
 			},
 		],
@@ -432,7 +432,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 							})
 							.action(async (context) => {
 								const scope = await resolveScope(context.flags.scope, options);
-								for (const packagedSkill of loadPackagedSkills(options.source)) {
+								for (const packagedSkill of loadPackagedSkills(options.packagedDir)) {
 									await repairInstalledSkill(packagedSkill, scope, true);
 								}
 							}),
@@ -443,7 +443,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 					const scope = installAll
 						? (parseScopeFlag(context.flags.scope) ?? options.defaultScope ?? DEFAULT_SKILL_SCOPE)
 						: await resolveScope(context.flags.scope, options);
-					for (const packagedSkill of loadPackagedSkills(options.source)) {
+					for (const packagedSkill of loadPackagedSkills(options.packagedDir)) {
 						await reconcileSkill({ packagedSkill, scope, installAll });
 					}
 				}),

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -210,7 +210,7 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 		source = resolveSkillSource(options.packagedDir);
 	} catch (error) {
 		if (!(error instanceof SkillSourceUnavailableError)) throw error;
-		// A missing packaged source is regenerated from the snapshot below.
+		// A missing packaged directory is regenerated from the snapshot below.
 	}
 
 	if (source === undefined || (options.extras?.length ?? 0) > 0) {

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -184,11 +184,11 @@ export interface SkillStatusResult {
 /** Options for the skills extension. */
 export interface SkillOptions {
 	/** Read-only directory produced by writeSkills(). */
-	source: string | URL;
+	packagedDir: string | URL;
 	/**
 	 * Hand-authored skill directories (URL, absolute, or package-root-relative path).
 	 * When non-empty, the build regenerates the command skill from the snapshot and
-	 * includes only these authored skills instead of copying `source`.
+	 * includes only these authored skills instead of copying `packagedDir`.
 	 */
 	extras?: readonly (string | URL)[];
 	/** Default agent-directory scope. */


### PR DESCRIPTION
## Motivation

`source` read as the authored source of truth, but the option points at the packaged skills artifact. The authored inputs are supplied through `extras`. `packagedDir` makes that distinction explicit and aligns the Extension API with the existing `PackagedSkill` and `loadPackagedSkills` vocabulary.

## What changed

- Renamed `SkillOptions.source` to `SkillOptions.packagedDir` across discovery, build, help, installation, and update flows.
- Updated Extension and cross-package integration tests.
- Updated option-specific documentation, comments, and user-facing errors to use “packaged skills directory.”
- Added a minor changeset for `@crustjs/skills`.

## Breaking change

No compatibility alias is provided.

```ts
// Before
skill({ source: new URL("../skills", import.meta.url) });

// After
skill({ packagedDir: new URL("../skills", import.meta.url) });
```

The low-level `InstallSkillOptions.sourceDir`, source-resolution helpers, and source-related error class remain unchanged.

## Verification

- `bun --filter @crustjs/skills test` — 130 passed, 0 failed
- `bun --filter @crustjs/skills check:types` — passed
- `bun test packages/crust/src/utils/build-helpers.test.ts` — 7 passed, 0 failed
- `bun run lint` — passed
- `bun run format` — passed
- stale API/docs grep and `git diff --check` — passed
