### PR TITLE
refactor(exports)!: root-only exports for extensions and skills

### DIFF
--- a/.changeset/calm-beans-travel.md
+++ b/.changeset/calm-beans-travel.md
@@ -3,4 +3,13 @@
 "@crustjs/skills": minor
 ---
 
-Remove per-module subpath exports; all public APIs are now imported from the package root.
+Remove per-module subpath exports (`@crustjs/extensions/{completion,did-you-mean,help,no-color,update-notifier,version}`, `@crustjs/skills/{agents,bundle,extension,generate}`). Import from the package root instead:
+
+```ts
+// Before
+import { help } from "@crustjs/extensions/help";
+// After
+import { help } from "@crustjs/extensions";
+```
+
+Internal helpers that were only reachable via subpaths are no longer exported and have no root-export replacement: `isNewerVersion`, `fetchLatestVersion`, and the `UpdateNotifierState` type from `@crustjs/extensions/update-notifier`; `resolveEffectiveScope`, `ALL_AGENTS`, `AGENT_LABELS`, and `resolveAgentPath` from `@crustjs/skills/agents`; `groupAgentsByOutputDir` from `@crustjs/skills/generate`; and `probeFrontmatter`, `loadBundleFiles`, and the `LoadedBundle` type from `@crustjs/skills/bundle`.

--- a/.changeset/calm-beans-travel.md
+++ b/.changeset/calm-beans-travel.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/extensions": minor
+"@crustjs/skills": minor
+---
+
+Remove per-module subpath exports; all public APIs are now imported from the package root.

--- a/.changeset/lazy-startup-paths.md
+++ b/.changeset/lazy-startup-paths.md
@@ -5,4 +5,4 @@
 "@crustjs/store": patch
 ---
 
-Reuse Core's prepared invocation tree across repeated dispatches, defer completion renderers and skill implementation modules until first use (Store's `node:crypto` import is replaced by the runtime global), and add focused subpath exports for Extensions and Skills. As a result, Extension command recipes now materialize once per builder instance instead of on every run — recipes must stay inert, per the documented contract.
+Reuse Core's prepared invocation tree across repeated dispatches, defer completion renderers and skill implementation modules until first use (Store's `node:crypto` import is replaced by the runtime global). As a result, Extension command recipes now materialize once per builder instance instead of on every run — recipes must stay inert, per the documented contract.

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -5,7 +5,7 @@ description: Official application-wide capabilities for Crust CLIs.
 
 `@crustjs/extensions` provides the six official Extensions. Register them on the root builder with `.extend()`.
 
-The root export provides the full surface. Focused `completion`, `did-you-mean`, `help`, `no-color`, `update-notifier`, and `version` subpaths avoid loading unrelated Extensions; for example, `import { help } from "@crustjs/extensions/help"`.
+Import every Extension from the package root; for example, `import { help } from "@crustjs/extensions"`.
 
 ## Install
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,7 +97,7 @@ interface StringArgDef extends ArgDefBase {
 	 * Validated at parse time before `parse` runs. Passing a value outside
 	 * `choices` throws `CrustError("PARSE", …)` before any `parse` transform
 	 * is applied. Also consumed by shell-completion extensions
-	 * (e.g. `@crustjs/extensions/completion`) to emit value candidates.
+	 * (e.g. `@crustjs/extensions`) to emit value candidates.
 	 *
 	 * Only available on string-typed args; not supported on number/boolean.
 	 *
@@ -260,7 +260,7 @@ interface StringFlagDef extends SingleFlagBase {
 	 * Validated at parse time before `parse` runs. Passing a value outside
 	 * `choices` throws `CrustError("PARSE", …)` before any `parse` transform
 	 * is applied. Also consumed by shell-completion extensions
-	 * (e.g. `@crustjs/extensions/completion`) to emit value candidates.
+	 * (e.g. `@crustjs/extensions`) to emit value candidates.
 	 *
 	 * Only available on string-typed flags; not supported on number/boolean.
 	 *
@@ -357,7 +357,7 @@ interface StringMultiFlagDef extends MultiFlagBase {
 	 * Each element is validated at parse time before `parse` runs. Passing
 	 * a value outside `choices` throws `CrustError("PARSE", …)` before any
 	 * `parse` transform is applied. Also consumed by shell-completion
-	 * extensions (e.g. `@crustjs/extensions/completion`) to emit value candidates.
+	 * extensions (e.g. `@crustjs/extensions`) to emit value candidates.
 	 *
 	 * Only available on string-typed multi-flags; not supported on number/boolean.
 	 *

--- a/packages/extensions/bunup.config.ts
+++ b/packages/extensions/bunup.config.ts
@@ -1,15 +1,7 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-	entry: [
-		"src/index.ts",
-		"src/completion/index.ts",
-		"src/did-you-mean.ts",
-		"src/help.ts",
-		"src/no-color.ts",
-		"src/update-notifier.ts",
-		"src/version.ts",
-	],
+	entry: ["src/index.ts"],
 	format: ["esm"],
 	target: "bun",
 	dts: true,

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -31,30 +31,6 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
-		},
-		"./completion": {
-			"types": "./dist/completion/index.d.ts",
-			"import": "./dist/completion/index.js"
-		},
-		"./did-you-mean": {
-			"types": "./dist/did-you-mean.d.ts",
-			"import": "./dist/did-you-mean.js"
-		},
-		"./help": {
-			"types": "./dist/help.d.ts",
-			"import": "./dist/help.js"
-		},
-		"./no-color": {
-			"types": "./dist/no-color.d.ts",
-			"import": "./dist/no-color.js"
-		},
-		"./update-notifier": {
-			"types": "./dist/update-notifier.d.ts",
-			"import": "./dist/update-notifier.js"
-		},
-		"./version": {
-			"types": "./dist/version.d.ts",
-			"import": "./dist/version.js"
 		}
 	},
 	"publishConfig": {

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -170,7 +170,11 @@ const DEFAULT_REGISTRY_URL = "https://registry.npmjs.org";
 // Internal utilities — version comparison
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Returns whether `latest` is newer, or false when either version is invalid. */
+/**
+ * Returns whether `latest` is newer, or false when either version is invalid.
+ *
+ * @internal
+ */
 export function isNewerVersion(current: string, latest: string): boolean {
 	try {
 		return Bun.semver.order(latest, current) === 1;

--- a/packages/extensions/tests/exports.test.ts
+++ b/packages/extensions/tests/exports.test.ts
@@ -3,8 +3,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 // The bunup entry list and the package.json exports map are maintained by
-// hand; this guards against adding a subpath to one but not the other and
-// shipping an export that resolves to a missing dist file.
+// hand; this guards the root-only surface and verifies its dist targets.
 
 const pkgDir = resolve(import.meta.dir, "..");
 
@@ -21,11 +20,11 @@ beforeAll(() => {
 });
 
 describe("package exports", () => {
-	it("every exports map target exists in dist", async () => {
+	it("exports only the root with targets that exist in dist", async () => {
 		const pkg = await Bun.file(join(pkgDir, "package.json")).json();
 		const exportsMap = pkg.exports as Record<string, Record<string, string>>;
 
-		expect(Object.keys(exportsMap).length).toBeGreaterThan(1);
+		expect(Object.keys(exportsMap)).toEqual(["."]);
 
 		const missing: string[] = [];
 		for (const [subpath, conditions] of Object.entries(exportsMap)) {

--- a/packages/extensions/tests/exports.test.ts
+++ b/packages/extensions/tests/exports.test.ts
@@ -22,7 +22,7 @@ beforeAll(() => {
 describe("package exports", () => {
 	it("exports only the root with targets that exist in dist", async () => {
 		const pkg = await Bun.file(join(pkgDir, "package.json")).json();
-		const exportsMap = pkg.exports as Record<string, Record<string, string>>;
+		const exportsMap = pkg.exports as Record<".", Record<string, string>>;
 
 		expect(Object.keys(exportsMap)).toEqual(["."]);
 

--- a/packages/extensions/tests/exports.test.ts
+++ b/packages/extensions/tests/exports.test.ts
@@ -26,14 +26,8 @@ describe("package exports", () => {
 
 		expect(Object.keys(exportsMap)).toEqual(["."]);
 
-		const missing: string[] = [];
-		for (const [subpath, conditions] of Object.entries(exportsMap)) {
-			for (const [condition, target] of Object.entries(conditions)) {
-				if (!existsSync(join(pkgDir, target))) {
-					missing.push(`${subpath} (${condition}) → ${target}`);
-				}
-			}
+		for (const target of Object.values(exportsMap["."])) {
+			expect(existsSync(join(pkgDir, target))).toBe(true);
 		}
-		expect(missing).toEqual([]);
 	});
 });

--- a/packages/skills/bunup.config.ts
+++ b/packages/skills/bunup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "bunup";
 
 export default defineConfig({
-	entry: ["src/index.ts", "src/agents.ts", "src/bundle.ts", "src/extension.ts", "src/generate.ts"],
+	entry: ["src/index.ts"],
 	format: ["esm"],
 	target: "bun",
 	dts: true,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -30,22 +30,6 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
-		},
-		"./agents": {
-			"types": "./dist/agents.d.ts",
-			"import": "./dist/agents.js"
-		},
-		"./bundle": {
-			"types": "./dist/bundle.d.ts",
-			"import": "./dist/bundle.js"
-		},
-		"./extension": {
-			"types": "./dist/extension.d.ts",
-			"import": "./dist/extension.js"
-		},
-		"./generate": {
-			"types": "./dist/generate.d.ts",
-			"import": "./dist/generate.js"
 		}
 	},
 	"publishConfig": {

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -30,6 +30,7 @@ function universalGlobalSkillsDir(home: string): string {
 	return join(home, ".agents", "skills");
 }
 
+/** @internal */
 export function resolveEffectiveScope(scope: Scope): Scope {
 	return scope === "project" && process.cwd() === homedir() ? "global" : scope;
 }
@@ -320,10 +321,18 @@ const AGENTS: Record<AgentTarget, AgentConfig> = {
 	},
 };
 
-/** All agent targets supported by `@crustjs/skills`. */
+/**
+ * All agent targets supported by `@crustjs/skills`.
+ *
+ * @internal
+ */
 export const ALL_AGENTS = Object.keys(AGENTS) as AgentTarget[];
 
-/** Human-readable labels for each agent target. */
+/**
+ * Human-readable labels for each agent target.
+ *
+ * @internal
+ */
 export const AGENT_LABELS: Record<AgentTarget, string> = Object.fromEntries(
 	ALL_AGENTS.map((agent) => [agent, AGENTS[agent].label]),
 ) as Record<AgentTarget, string>;
@@ -373,6 +382,8 @@ export async function detectInstalledAgents(): Promise<AgentTarget[]> {
 
 /**
  * Resolves the filesystem path for a skill installation.
+ *
+ * @internal
  */
 export function resolveAgentPath(agent: AgentTarget, scope: Scope, name: string): string {
 	const effectiveScope = resolveEffectiveScope(scope);

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -27,6 +27,7 @@ import type {
 
 export { isValidSkillName } from "./skill-name.ts";
 
+/** @internal */
 export function groupAgentsByOutputDir(
 	agents: readonly AgentTarget[],
 	scope: Scope,

--- a/packages/skills/tests/exports.test.ts
+++ b/packages/skills/tests/exports.test.ts
@@ -3,8 +3,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 // The bunup entry list and the package.json exports map are maintained by
-// hand; this guards against adding a subpath to one but not the other and
-// shipping an export that resolves to a missing dist file.
+// hand; this guards the root-only surface and verifies its dist targets.
 
 const pkgDir = resolve(import.meta.dir, "..");
 
@@ -21,11 +20,11 @@ beforeAll(() => {
 });
 
 describe("package exports", () => {
-	it("every exports map target exists in dist", async () => {
+	it("exports only the root with targets that exist in dist", async () => {
 		const pkg = await Bun.file(join(pkgDir, "package.json")).json();
 		const exportsMap = pkg.exports as Record<string, Record<string, string>>;
 
-		expect(Object.keys(exportsMap).length).toBeGreaterThan(1);
+		expect(Object.keys(exportsMap)).toEqual(["."]);
 
 		const missing: string[] = [];
 		for (const [subpath, conditions] of Object.entries(exportsMap)) {

--- a/packages/skills/tests/exports.test.ts
+++ b/packages/skills/tests/exports.test.ts
@@ -22,7 +22,7 @@ beforeAll(() => {
 describe("package exports", () => {
 	it("exports only the root with targets that exist in dist", async () => {
 		const pkg = await Bun.file(join(pkgDir, "package.json")).json();
-		const exportsMap = pkg.exports as Record<string, Record<string, string>>;
+		const exportsMap = pkg.exports as Record<".", Record<string, string>>;
 
 		expect(Object.keys(exportsMap)).toEqual(["."]);
 

--- a/packages/skills/tests/exports.test.ts
+++ b/packages/skills/tests/exports.test.ts
@@ -26,14 +26,8 @@ describe("package exports", () => {
 
 		expect(Object.keys(exportsMap)).toEqual(["."]);
 
-		const missing: string[] = [];
-		for (const [subpath, conditions] of Object.entries(exportsMap)) {
-			for (const [condition, target] of Object.entries(conditions)) {
-				if (!existsSync(join(pkgDir, target))) {
-					missing.push(`${subpath} (${condition}) → ${target}`);
-				}
-			}
+		for (const target of Object.values(exportsMap["."])) {
+			expect(existsSync(join(pkgDir, target))).toBe(true);
 		}
-		expect(missing).toEqual([]);
 	});
 });


### PR DESCRIPTION
Stacked PR 1/5 (base: `main`). Implements WS1 of the export-surface / tsdown / runtime-portability plan.

## What

Convert `@crustjs/extensions` and `@crustjs/skills` from a dual export surface (root barrel + per-module subpaths) to **root-only exports**:

- `exports` maps reduced to `"."` only; bunup entries reduced to `src/index.ts`
- skills `./bundle` helpers (`probeFrontmatter`, `loadBundleFiles`, `LoadedBundle`) become internal (no external consumers)
- Export-map tests updated to assert root-only
- Docs/JSDoc stragglers fixed (`modules/extensions/index.mdx`, `core/src/types.ts`)
- Changeset: minor bump for both packages

`sideEffects: false` is intentionally **not** added here — it breaks bunup builds on Bun 1.3.14 (oven-sh/bun#27709); it lands with the tsdown migration in the next PR of this stack.

## Verification

- `bun run check` ✅ (all package builds + lint + format)
- `bun run check:types` ✅ (20 tasks)
- `packages/extensions` tests: 233 pass ✅; `packages/skills`: 130 pass ✅
- Repo-wide grep: no remaining subpath imports/mentions outside CHANGELOGs ✅
- Independent fresh-context review: 7/7 checks pass, no blockers; import-time side-effect audit confirms both packages are safe for a future `sideEffects: false`
