### PR TITLE
feat(crust): runtime build targets (bun, deno, node)

### DIFF
--- a/.changeset/runtime-build-targets.md
+++ b/.changeset/runtime-build-targets.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/crust": minor
+---
+
+Add first-class Bun, Deno, and Node build runtimes to `crust build`. Projects can persist `crust.runtime` in package.json or override it with `--runtime`; Deno produces standalone executables and Node produces executable bundled JavaScript.

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -87,11 +87,11 @@ Node produces a single portable JavaScript artifact, so it rejects `--target` an
 | `x86_64-pc-windows-msvc`    | Windows x86_64      |
 | `aarch64-pc-windows-msvc`   | Windows ARM64       |
 
-<Callout type="warn">
-  Deno executables enforce Deno's permission model at runtime. Crust bakes no `--allow-*` flags
-  into the binary, so a CLI that reads env vars (including `NO_COLOR`), touches the filesystem, or
-  spawns subprocesses will prompt for permissions — or fail non-interactively — unless users grant
-  them. Document the flags your CLI needs, or compile with a wrapper that passes them explicitly.
+<Callout type="info">
+  Deno binaries are compiled with `-A` (all permissions granted). Crust core reads environment
+  variables before dispatch, so a sandboxed binary would crash on startup — and Bun- and
+  Node-built CLIs have no sandbox either, so this matches the other runtimes. A permission
+  passthrough flag for narrower grants is planned follow-up scope.
 </Callout>
 
 ## Multi-Target Build (Bun and Deno)

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -1,18 +1,20 @@
 ---
 title: Building & Distribution
-description: Compile your CLI to standalone executables with crust build.
+description: Build your CLI for Bun, Deno, or Node with crust build.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
-The `crust build` command compiles your CLI entry file into standalone Bun executables by running `bun build --compile` in a subprocess. It prefers the real `bun` binary when available and falls back to the current executable in Bun mode when needed. It also supports cross-platform compilation and generates a platform-detecting shell resolver for multi-target distribution — no runtime (Node.js or Bun) required on the end user's machine.
+The `crust build` command builds CLIs for Bun, Deno, or Node. Bun (the default) and Deno produce standalone executables; Node produces one bundled, executable JavaScript file. Select the runtime with `--runtime` or persist it in `package.json`:
 
-<Callout type="info">
-  Standalone binaries are the recommended distribution strategy for most CLIs. If you intentionally
-  ship a Bun runtime package instead, use a JS build output like `dist/cli.js` and point `bin` to
-  that file.
-</Callout>
+```json title="package.json"
+{
+  "crust": { "runtime": "deno" }
+}
+```
+
+The CLI flag overrides project configuration. Existing projects without `crust.runtime` continue to use Bun. Bun compilation prefers a `bun` executable on `PATH` and otherwise uses the runtime embedded in the packaged Crust executable. Deno builds require `deno` on `PATH`. Node builds use Crust's embedded Bun bundler, so users do not need Bun installed.
 
 ## Basic Usage
 
@@ -23,10 +25,16 @@ crust build
 # Build with a custom entry point
 crust build --entry src/main.ts
 
-# Build for a specific platform
+# Build for a specific Bun platform
 crust build --target bun-darwin-arm64
 
-# Build with explicit env files for build-time constants
+# Build a Deno standalone executable
+crust build --runtime deno --target aarch64-apple-darwin
+
+# Build an executable Node.js bundle at dist/my-cli.js
+crust build --runtime node --name my-cli
+
+# Build with explicit env files
 crust build --env-file .env.production
 ```
 
@@ -37,29 +45,58 @@ crust build --env-file .env.production
 | `--entry`                      | `-e`  | `"string"`              | `src/cli.ts`  | Entry file path                                                                |
 | `--outfile`                    | `-o`  | `"string"`              | —             | Output file path (single-target only)                                          |
 | `--name`                       | `-n`  | `"string"`              | auto-detected | Binary name                                                                    |
-| `--minify`                     | —     | `"boolean"`             | `true`        | Minify the output                                                              |
-| `--target`                     | `-t`  | `"string"` (repeatable) | all platforms | Canonical Bun target(s), e.g. `bun-darwin-arm64`                               |
+| `--minify`                     | —     | `"boolean"`             | `true` (Bun/Node) | Minify Bun and Node output; not applicable to Deno (`deno compile` has no minifier) |
+| `--runtime`                    | —     | `"string"`              | `bun`         | `bun`, `deno`, or `node`; overrides `package.json`                             |
+| `--target`                     | `-t`  | `"string"` (repeatable) | all platforms | Canonical Bun or Deno compiler target; unsupported for Node                    |
 | `--outdir`                     | `-d`  | `"string"`              | `dist`        | Output directory for compiled binaries                                         |
 | `--resolver`                   | `-r`  | `"string"`              | `cli`         | Resolver script filename (multi-target only, no extension)                     |
-| `--env-file`                   | —     | `"string"` (repeatable) | —             | Explicit env file(s) used for build-time constants                             |
+| `--env-file`                   | —     | `"string"` (repeatable) | —             | Explicit env file(s) used for build-time constants (Bun and Node only)         |
 | `--validate` / `--no-validate` | —     | `"boolean"`             | `true`        | Materialize command definitions and run Extension build hooks before compiling |
 | `--package`                    | —     | `"boolean"`             | `false`       | Stage npm packages in `dist/npm` instead of raw binaries                       |
 | `--stage-dir`                  | —     | `"string"`              | `dist/npm`    | Package staging directory; only used with `--package`                          |
 
-## Supported Targets
+## Runtime Outputs
 
-| Canonical Bun Target       | Platform            | Package/dir suffix |
-| -------------------------- | ------------------- | ------------------ |
-| `bun-linux-x64-baseline`   | Linux x86_64        | `linux-x64`        |
-| `bun-linux-arm64`          | Linux ARM64         | `linux-arm64`      |
-| `bun-darwin-x64`           | macOS Intel         | `darwin-x64`       |
-| `bun-darwin-arm64`         | macOS Apple Silicon | `darwin-arm64`     |
-| `bun-windows-x64-baseline` | Windows x86_64      | `windows-x64`      |
-| `bun-windows-arm64`        | Windows ARM64       | `windows-arm64`    |
+| Runtime | Compiler                  | Output                                       | Requirements                   |
+| ------- | ------------------------- | -------------------------------------------- | ------------------------------ |
+| Bun     | `bun build --compile`     | Standalone executable(s)                     | None when using packaged Crust |
+| Deno    | `deno compile`            | Standalone executable(s)                     | Deno on `PATH` while building  |
+| Node    | `bun build --target node` | Bundled `dist/<name>.js` with a Node shebang | Node on the end user's machine |
 
-## Multi-Target Build (Default)
+Node produces a single portable JavaScript artifact, so it rejects `--target` and `--package`; resolver settings do not apply. Publish it as a normal npm package with its output path in `bin`.
 
-When no `--target` is specified (or multiple targets are given), `crust build` produces:
+### Supported Bun targets
+
+| Canonical target           | Platform            |
+| -------------------------- | ------------------- |
+| `bun-linux-x64-baseline`   | Linux x86_64        |
+| `bun-linux-arm64`          | Linux ARM64         |
+| `bun-darwin-x64`           | macOS Intel         |
+| `bun-darwin-arm64`         | macOS Apple Silicon |
+| `bun-windows-x64-baseline` | Windows x86_64      |
+| `bun-windows-arm64`        | Windows ARM64       |
+
+### Supported Deno targets
+
+| Canonical target            | Platform            |
+| --------------------------- | ------------------- |
+| `x86_64-unknown-linux-gnu`  | Linux x86_64        |
+| `aarch64-unknown-linux-gnu` | Linux ARM64         |
+| `x86_64-apple-darwin`       | macOS Intel         |
+| `aarch64-apple-darwin`      | macOS Apple Silicon |
+| `x86_64-pc-windows-msvc`    | Windows x86_64      |
+| `aarch64-pc-windows-msvc`   | Windows ARM64       |
+
+<Callout type="warn">
+  Deno executables enforce Deno's permission model at runtime. Crust bakes no `--allow-*` flags
+  into the binary, so a CLI that reads env vars (including `NO_COLOR`), touches the filesystem, or
+  spawns subprocesses will prompt for permissions — or fail non-interactively — unless users grant
+  them. Document the flags your CLI needs, or compile with a wrapper that passes them explicitly.
+</Callout>
+
+## Multi-Target Build (Bun and Deno)
+
+For Bun or Deno, when no `--target` is specified (or multiple targets are given), `crust build` produces:
 
 1. **A binary for each platform** — named `dist/<name>-<target>` (e.g., `dist/my-cli-bun-darwin-arm64`)
 2. **A shell resolver** — `dist/cli` (customizable via `--resolver`) that detects the host platform and executes the correct binary, plus a `dist/cli.cmd` companion for Windows
@@ -144,7 +181,7 @@ crust build --entry src/main.ts  # Uses "main" as the name
 
 ## Disabling Minification
 
-Minification is enabled by default. Disable it with:
+Minification is enabled by default for Bun and Node. Deno builds never minify (`deno compile` has no minification step), and passing `--minify` explicitly with `--runtime deno` is an error. Disable it for Bun and Node with:
 
 ```sh
 crust build --no-minify
@@ -152,7 +189,7 @@ crust build --no-minify
 
 ## Environment Variables
 
-Only `PUBLIC_*` values are embedded as build-time constants; `--env-file` (repeatable, also with `--package`) selects explicit env files.
+Bun and Node builds embed only `PUBLIC_*` values as build-time constants. `--env-file` is repeatable and uses the same Bun bundler semantics for both runtimes. Deno builds reject `--env-file`: `deno compile` embeds every variable from the file into the binary — secrets included — with no `PUBLIC_*` filter, so Crust refuses rather than leak. Load configuration at runtime instead.
 
 ```sh
 crust build --env-file .env.production
@@ -203,7 +240,7 @@ Use this escape hatch for entries with unavoidable import-time side effects. It 
 
 ## Per-OS Distribution with `--package`
 
-For distributing your CLI via npm with platform-specific packages, use the `--package` flag. This creates a root package with optional dependencies on per-platform packages, enabling npm to install only the binary for the user's platform.
+`--package` currently supports Bun builds only. Deno and Node builds fail with guidance to publish their generated artifact directly. For distributing a Bun CLI via npm with platform-specific packages, use the `--package` flag. This creates a root package with optional dependencies on per-platform packages, enabling npm to install only the binary for the user's platform.
 
 ```sh
 # Build and stage npm distribution packages
@@ -305,8 +342,8 @@ Per-platform packages are named by appending the platform suffix (see [Supported
 
 ## package.json Setup
 
-<Tabs items={["Standalone binaries (recommended)", "Per-OS npm distribution", "Bun runtime package"]}>
-<Tab value="Standalone binaries (recommended)">
+<Tabs items={["Bun standalone", "Deno standalone", "Node runtime package"]}>
+<Tab value="Bun standalone">
 
 ```json title="package.json"
 {
@@ -322,52 +359,43 @@ Per-platform packages are named by appending the platform suffix (see [Supported
 }
 ```
 
-The `bin` field points to the resolver script, which handles platform detection and runs the correct compiled binary.
+The `bin` field points to the resolver script, which handles platform detection and runs the correct compiled binary. Use `crust build --package` when publishing per-OS Bun packages.
 
 </Tab>
-<Tab value="Per-OS npm distribution">
+<Tab value="Deno standalone">
 
 ```json title="package.json"
 {
   "name": "my-cli",
-  "private": true,
-  "scripts": {
-    "package": "crust build --package",
-    "publish": "crust publish --stage-dir dist/npm"
-  }
-}
-```
-
-In this mode the package users install is the **staged root package** (`dist/npm/root/package.json`), which `crust build --package` generates with its own `bin` entry and platform `optionalDependencies` — your local `package.json` needs no `bin`, `files`, or `prepack` wiring. After building and staging, publish all platform packages:
-
-```sh
-# Stage npm packages
-bun run package
-
-# Publish all packages
-crust publish
-```
-
-Users install your CLI normally with `bun add -g my-cli` or `npm install -g my-cli`, and npm automatically installs only the binary for their platform.
-
-</Tab>
-<Tab value="Bun runtime package">
-
-```json title="package.json"
-{
-  "name": "my-cli",
+  "crust": { "runtime": "deno" },
   "files": ["dist"],
-  "bin": {
-    "my-cli": "dist/cli.js"
-  },
+  "bin": { "my-cli": "dist/cli" },
   "scripts": {
-    "build": "bun build src/cli.ts --target bun --outfile dist/cli.js",
-    "prepack": "bun run build"
+    "build": "crust build --target x86_64-unknown-linux-gnu --outfile dist/cli"
   }
 }
 ```
 
-This mode still requires Bun on the end user's machine.
+The generated executable embeds Deno. Building requires Deno on `PATH`; running it does not.
+
+</Tab>
+<Tab value="Node runtime package">
+
+```json title="package.json"
+{
+  "name": "my-cli",
+  "crust": { "runtime": "node" },
+  "type": "module",
+  "files": ["dist"],
+  "bin": { "my-cli": "dist/cli.js" },
+  "scripts": {
+    "build": "crust build --name cli",
+    "prepack": "npm run build"
+  }
+}
+```
+
+The generated JavaScript file has a Node shebang and executable permissions. End users need Node, but not Bun. The bundle is ESM, so set `"type": "module"` in the published package (or rename the artifact to `.mjs`).
 
 </Tab>
 </Tabs>

--- a/apps/docs/content/docs/modules/crust.mdx
+++ b/apps/docs/content/docs/modules/crust.mdx
@@ -15,12 +15,12 @@ bun add -d @crustjs/crust
 
 | Command                                                            | Description                                                    |
 | ------------------------------------------------------------------ | -------------------------------------------------------------- |
-| [`crust build`](/docs/guide/build)                                 | Validate and compile a CLI to standalone executables           |
+| [`crust build`](/docs/guide/build)                                 | Validate and build a CLI: Bun/Deno standalone executables or a Node JS bundle (`--runtime`, `crust.runtime`) |
 | [`crust publish`](/docs/guide/build#publishing-with-crust-publish) | Publish staged npm packages created by `crust build --package` |
 
 `crust build` runs the entry point in a snapshot subprocess before compiling it. It uses the lockstep `SNAPSHOT_PATH_ENV` and `BUILD_OUT_DIR_ENV` tooling constants internally; `.execute()` writes the validated Command Snapshot, runs registered Extension build hooks in order, and exits before dispatch. Application code should not set these internal environment variables.
 
-The build command can embed `PUBLIC_*` constants from Bun's current-directory environment or explicit `--env-file` inputs. See [Environment variables](/docs/guide/environment).
+The build command can embed `PUBLIC_*` constants from Bun's current-directory environment or explicit `--env-file` inputs (Bun and Node runtimes; Deno builds reject `--env-file`). See [Environment variables](/docs/guide/environment).
 
 ## Distribution modes
 

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -82,7 +82,7 @@ describe("crust CLI entry point", () => {
 			expect(output).toContain("Commands:");
 			expect(output).toContain("build");
 			expect(output).toContain("publish");
-			expect(output).toContain("Compile your CLI to a standalone executable");
+			expect(output).toContain("Build your CLI for Bun, Deno, or Node");
 			expect(output).toContain("Publish staged npm packages created by crust build --package");
 		});
 

--- a/packages/crust/src/commands/build.integration.test.ts
+++ b/packages/crust/src/commands/build.integration.test.ts
@@ -1,11 +1,16 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { Crust } from "@crustjs/core";
 
 import { buildCommand } from "../../src/commands/build.ts";
-import { SUPPORTED_TARGETS, TARGET_INFO } from "../../src/utils/build-helpers.ts";
+import {
+	DENO_TARGET_INFO,
+	SUPPORTED_DENO_TARGETS,
+	SUPPORTED_TARGETS,
+	TARGET_INFO,
+} from "../../src/utils/build-helpers.ts";
 
 function getHostTarget(): string | null {
 	if (process.platform === "darwin" && process.arch === "arm64") {
@@ -38,6 +43,13 @@ function getHostTarget(): string | null {
 function getHostBunTarget(): string | null {
 	const hostTarget = getHostTarget();
 	return SUPPORTED_TARGETS.find((target) => TARGET_INFO[target].alias === hostTarget) ?? null;
+}
+
+function getHostDenoTarget(): string | null {
+	const hostTarget = getHostTarget();
+	return (
+		SUPPORTED_DENO_TARGETS.find((target) => DENO_TARGET_INFO[target].alias === hostTarget) ?? null
+	);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -333,6 +345,66 @@ await app.execute();
 				process.cwd = prevCwd;
 			}
 		},
+	);
+
+	it.skipIf(Bun.which("node") === null)(
+		"builds an executable Node artifact from package.json runtime config",
+		async () => {
+		process.cwd = () => tmpDir;
+		writeFileSync(
+			join(tmpDir, "package.json"),
+			JSON.stringify({ name: "test-build-cli", version: "0.1.0", crust: { runtime: "node" } }),
+		);
+		const outPath = join(tmpDir, "dist", "node-cli.js");
+		try {
+			await new Crust("test").add(buildCommand).execute({
+				argv: ["build", "--entry", "src/cli.ts", "--outfile", outPath, "--no-validate"],
+			});
+			expect(readFileSync(outPath, "utf8").startsWith("#!/usr/bin/env node\n")).toBe(true);
+			if (process.platform !== "win32") expect(statSync(outPath).mode & 0o111).not.toBe(0);
+
+			const proc = Bun.spawn([Bun.which("node")!, outPath], {
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+			expect(exitCode).toBe(0);
+			expect(stdout.trim()).toBe("hello from crust build test");
+		} finally {
+			writeFileSync(
+				join(tmpDir, "package.json"),
+				JSON.stringify({ name: "test-build-cli", version: "0.1.0" }),
+			);
+		}
+	}, 30_000);
+
+	it.skipIf(Bun.which("deno") === null || getHostDenoTarget() === null)(
+		"builds and runs a Deno standalone executable for the host target",
+		async () => {
+			const hostTarget = getHostDenoTarget();
+			if (!hostTarget) return;
+			process.cwd = () => tmpDir;
+			const outPath = join(tmpDir, "dist", "deno-cli");
+			await new Crust("test").add(buildCommand).execute({
+				argv: [
+					"build",
+					"--runtime",
+					"deno",
+					"--entry",
+					"src/cli.ts",
+					"--target",
+					hostTarget,
+					"--outfile",
+					outPath,
+					"--no-validate",
+				],
+			});
+			const proc = Bun.spawn([outPath], { stdout: "pipe", stderr: "pipe" });
+			const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+			expect(exitCode).toBe(0);
+			expect(stdout.trim()).toBe("hello from crust build test");
+		},
+		60_000,
 	);
 
 	it.skipIf(getHostBunTarget() === null)(

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -124,6 +124,7 @@ describe("build argument construction", () => {
 	it("constructs a Deno compile with its canonical target", () => {
 		expect(createDenoCompileArgs("/src/cli.ts", "/dist/cli", "x86_64-unknown-linux-gnu")).toEqual([
 			"compile",
+			"-A",
 			"--output",
 			"/dist/cli",
 			"--target",

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -7,16 +7,28 @@ import { Crust } from "@crustjs/core";
 import {
 	buildCommand,
 	generateCmdResolver,
+	generateDenoCmdResolver,
+	generateDenoResolver,
 	generateResolver,
+	resolveBuildRuntime,
 	resolveEnvFilePaths,
+	resolveNodeOutfile,
 	resolveOutfile,
 } from "../../src/commands/build.ts";
 import type { BunTarget } from "../../src/utils/build-helpers.ts";
 import {
+	createBunCompileArgs,
+	createDenoCompileArgs,
+	createNodeBuildArgs,
+	DENO_TARGET_INFO,
 	getBinaryFilename,
+	getDenoBinaryFilename,
 	resolveBaseName,
 	resolveBunBuildRunner,
+	resolveDenoTarget,
+	resolveDenoTargets,
 	resolveTarget,
+	SUPPORTED_DENO_TARGETS,
 	SUPPORTED_TARGETS,
 	TARGET_INFO,
 } from "../../src/utils/build-helpers.ts";
@@ -44,6 +56,80 @@ describe("env file helpers", () => {
 
 	it("throws when an env-file is missing", () => {
 		expect(() => resolveEnvFilePaths(tmpDir, [".env.missing"])).toThrow(/Env file not found/);
+	});
+});
+
+describe("runtime build configuration", () => {
+	const tmpDir = join(import.meta.dir, ".tmp-runtime-config");
+
+	beforeAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+		mkdirSync(tmpDir, { recursive: true });
+	});
+
+	afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+	it("defaults to Bun without project configuration", () => {
+		expect(resolveBuildRuntime(tmpDir)).toBe("bun");
+	});
+
+	it("reads package.json crust.runtime and lets --runtime override it", () => {
+		writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ crust: { runtime: "deno" } }));
+		expect(resolveBuildRuntime(tmpDir)).toBe("deno");
+		expect(resolveBuildRuntime(tmpDir, "node")).toBe("node");
+	});
+
+	it("rejects an invalid configured runtime", () => {
+		writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ crust: { runtime: "python" } }));
+		expect(() => resolveBuildRuntime(tmpDir)).toThrow(/Invalid package.json crust.runtime/);
+	});
+});
+
+describe("build argument construction", () => {
+	it("constructs a Node bundle with portable env embedding", () => {
+		expect(createNodeBuildArgs("/src/cli.ts", "/dist/cli.js", true, ["/src/.env"])).toEqual([
+			"build",
+			"--env-file",
+			"/src/.env",
+			"--env=PUBLIC_*",
+			"--target",
+			"node",
+			"--format",
+			"esm",
+			"--outfile",
+			"/dist/cli.js",
+			"--minify",
+			"/src/cli.ts",
+		]);
+	});
+
+	it("constructs a Bun compile with the legacy argument sequence", () => {
+		expect(
+			createBunCompileArgs("/src/cli.ts", "/dist/cli", true, "bun-linux-x64-baseline", ["/src/.env"]),
+		).toEqual([
+			"build",
+			"--compile",
+			"--env-file",
+			"/src/.env",
+			"--env=PUBLIC_*",
+			"--outfile",
+			"/dist/cli",
+			"--minify",
+			"--target",
+			"bun-linux-x64-baseline",
+			"/src/cli.ts",
+		]);
+	});
+
+	it("constructs a Deno compile with its canonical target", () => {
+		expect(createDenoCompileArgs("/src/cli.ts", "/dist/cli", "x86_64-unknown-linux-gnu")).toEqual([
+			"compile",
+			"--output",
+			"/dist/cli",
+			"--target",
+			"x86_64-unknown-linux-gnu",
+			"/src/cli.ts",
+		]);
 	});
 });
 
@@ -90,6 +176,30 @@ describe("resolveTarget", () => {
 
 	it("throws on unknown target", () => {
 		expect(() => resolveTarget("linux-arm32")).toThrow(/Unknown target/);
+	});
+});
+
+describe("resolveDenoTarget", () => {
+	it("accepts exactly the targets supported by deno compile", () => {
+		for (const target of SUPPORTED_DENO_TARGETS) expect(resolveDenoTarget(target)).toBe(target);
+		expect(resolveDenoTargets(undefined)).toEqual([...SUPPORTED_DENO_TARGETS]);
+	});
+
+	it("guides aliases to canonical Deno target names", () => {
+		for (const target of SUPPORTED_DENO_TARGETS) {
+			expect(() => resolveDenoTarget(DENO_TARGET_INFO[target].alias)).toThrow(
+				`Did you mean "${target}"?`,
+			);
+		}
+	});
+
+	it("uses Deno target names and the Windows executable extension", () => {
+		expect(getDenoBinaryFilename("cli", "x86_64-unknown-linux-gnu")).toBe(
+			"cli-x86_64-unknown-linux-gnu",
+		);
+		expect(getDenoBinaryFilename("cli", "aarch64-pc-windows-msvc")).toBe(
+			"cli-aarch64-pc-windows-msvc.exe",
+		);
 	});
 });
 
@@ -162,6 +272,15 @@ describe("resolveOutfile", () => {
 		const result = resolveOutfile(undefined, "my-tool", entry, cwd, "out");
 		expect(result).toBe(resolve(cwd, "out", "my-tool"));
 	});
+
+	it("adds .js to implicit Node outputs but respects explicit outfile", () => {
+		expect(resolveNodeOutfile(undefined, "my-tool", entry, cwd, "dist")).toBe(
+			resolve(cwd, "dist", "my-tool.js"),
+		);
+		expect(resolveNodeOutfile("bin/custom.mjs", undefined, entry, cwd, "dist")).toBe(
+			resolve(cwd, "bin/custom.mjs"),
+		);
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -231,6 +350,18 @@ describe("generateResolver", () => {
 // Unit tests for generateCmdResolver (Windows batch)
 // ────────────────────────────────────────────────────────────────────────────
 
+describe("Deno resolvers", () => {
+	it("maps Deno targets to their platform-specific filenames", () => {
+		const shell = generateDenoResolver("my-cli", SUPPORTED_DENO_TARGETS);
+		expect(shell).toContain('Linux-x86_64) bin="my-cli-x86_64-unknown-linux-gnu"');
+		expect(shell).not.toContain("pc-windows-msvc");
+
+		const cmd = generateDenoCmdResolver("my-cli", SUPPORTED_DENO_TARGETS);
+		expect(cmd).toContain("my-cli-x86_64-pc-windows-msvc.exe");
+		expect(cmd).toContain("my-cli-aarch64-pc-windows-msvc.exe");
+	});
+});
+
 describe("generateCmdResolver", () => {
 	it("references the correct Windows binary filename", () => {
 		const content = generateCmdResolver("my-cli", SUPPORTED_TARGETS);
@@ -259,7 +390,72 @@ describe("generateCmdResolver", () => {
 // Error handling tests
 // ────────────────────────────────────────────────────────────────────────────
 
+async function executeBuildError(name: string, argv: string[]): Promise<string> {
+	const originalCwd = process.cwd;
+	const originalLog = console.log;
+	const originalError = console.error;
+	const tmpDir = join(import.meta.dir, `.tmp-${name}`);
+	const errors: string[] = [];
+	rmSync(tmpDir, { recursive: true, force: true });
+	mkdirSync(join(tmpDir, "src"), { recursive: true });
+	writeFileSync(join(tmpDir, "src", "cli.ts"), "console.log('hi');");
+	process.cwd = () => tmpDir;
+	console.log = () => {};
+	console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
+	try {
+		process.exitCode = 0;
+		await new Crust("test").add(buildCommand).execute({ argv: ["build", ...argv] });
+		return errors.join("\n");
+	} finally {
+		process.exitCode = 0;
+		process.cwd = originalCwd;
+		console.log = originalLog;
+		console.error = originalError;
+		rmSync(tmpDir, { recursive: true, force: true });
+	}
+}
+
 describe("buildCommand error handling", () => {
+	it("rejects unsupported runtime and flag combinations before compiling", async () => {
+		expect(
+			await executeBuildError("node-target", [
+				"--runtime",
+				"node",
+				"--target",
+				"bun-linux-x64-baseline",
+				"--no-validate",
+			]),
+		).toContain("--target cannot be used with --runtime node");
+		expect(
+			await executeBuildError("node-package", ["--runtime", "node", "--package", "--no-validate"]),
+		).toContain("--package does not apply to Node builds");
+		expect(
+			await executeBuildError("deno-package", [
+				"--runtime",
+				"deno",
+				"--package",
+				"--no-validate",
+			]),
+		).toContain("Deno per-platform npm staging is reserved for a follow-up");
+		expect(
+			await executeBuildError("deno-minify", ["--runtime", "deno", "--minify", "--no-validate"]),
+		).toContain("--minify is not supported with --runtime deno");
+		const envFile = join(import.meta.dir, ".tmp-deno-env-file.env");
+		writeFileSync(envFile, "SECRET=x\n");
+		try {
+			expect(
+				await executeBuildError("deno-env-file", [
+					"--runtime",
+					"deno",
+					"--env-file",
+					envFile,
+					"--no-validate",
+				]),
+			).toContain("--env-file is not supported with --runtime deno");
+		} finally {
+			rmSync(envFile, { force: true });
+		}
+	});
 	it("sets exitCode and logs error when entry file is missing", async () => {
 		const originalCwd = process.cwd;
 		const tmpDir = join(import.meta.dir, ".tmp-missing-entry");

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -1,17 +1,26 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import { defineCommand } from "@crustjs/core";
 import { bold, cyan, dim, green } from "@crustjs/style";
 
 import {
+	BUILD_RUNTIMES,
+	type BuildRuntime,
 	type BunTarget,
+	DENO_TARGET_INFO,
+	type DenoTarget,
 	execBuild,
+	execDenoBuild,
+	execNodeBuild,
 	getBinaryFilename,
+	getDenoBinaryFilename,
 	resolveBaseName,
+	resolveDenoTargets,
 	resolveTargets,
 	TARGET_INFO,
 	buildEntrypoint,
+	type TargetInfo,
 } from "../utils/build-helpers.ts";
 
 /**
@@ -42,6 +51,49 @@ export function resolveOutfile(
 	return resolve(cwd, outdir, baseName);
 }
 
+export function resolveNodeOutfile(
+	outfile: string | undefined,
+	name: string | undefined,
+	entry: string,
+	cwd: string,
+	outdir: string,
+): string {
+	if (outfile) return resolve(cwd, outfile);
+	const baseName = resolveBaseName(name, entry, cwd);
+	return resolve(cwd, outdir, baseName.endsWith(".js") ? baseName : `${baseName}.js`);
+}
+
+export function resolveBuildRuntime(cwd: string, override?: string): BuildRuntime {
+	if (override !== undefined) {
+		if ((BUILD_RUNTIMES as readonly string[]).includes(override)) return override as BuildRuntime;
+		throw new Error(`Unknown runtime "${override}". Valid runtimes: ${BUILD_RUNTIMES.join(", ")}`);
+	}
+
+	const packagePath = resolve(cwd, "package.json");
+	if (!existsSync(packagePath)) return "bun";
+	let pkg: { crust?: { runtime?: unknown } };
+	try {
+		pkg = JSON.parse(readFileSync(packagePath, "utf8")) as { crust?: { runtime?: unknown } };
+	} catch {
+		// Malformed package.json: legacy builds tolerated this (resolveBaseName falls
+		// through), so keep default-bun builds working — but say so, since a
+		// configured crust.runtime in that file would be silently ignored.
+		console.warn(`Warning: could not parse ${packagePath}; defaulting to the bun runtime.`);
+		return "bun";
+	}
+	const configured = pkg.crust?.runtime;
+	if (configured === undefined) return "bun";
+	if (
+		typeof configured === "string" &&
+		(BUILD_RUNTIMES as readonly string[]).includes(configured)
+	) {
+		return configured as BuildRuntime;
+	}
+	throw new Error(
+		`Invalid package.json crust.runtime ${JSON.stringify(configured)}. Valid runtimes: ${BUILD_RUNTIMES.join(", ")}`,
+	);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Shell resolver generator (Unix + Windows)
 // ────────────────────────────────────────────────────────────────────────────
@@ -57,14 +109,17 @@ export function resolveOutfile(
  * @param targets - The list of targets that were built
  * @returns The shell resolver script as a string
  */
-export function generateResolver(baseName: string, targets: readonly BunTarget[]): string {
-	// Build case entries for only the targets that were built (excluding Windows)
+function generateResolverFor<T extends string>(
+	baseName: string,
+	targets: readonly T[],
+	targetInfo: Record<T, TargetInfo>,
+	getFilename: (baseName: string, target: T) => string,
+): string {
 	const caseEntries: string[] = [];
 	for (const target of targets) {
-		if (target.startsWith("bun-windows")) continue;
-		const unameKey = TARGET_INFO[target].unameKey;
-		const filename = getBinaryFilename(baseName, target);
-		caseEntries.push(`\t${unameKey}) bin="${filename}" ;;`);
+		const info = targetInfo[target];
+		if (info.os === "win32") continue;
+		caseEntries.push(`\t${info.unameKey}) bin="${getFilename(baseName, target)}" ;;`);
 	}
 	const caseBody = caseEntries.join("\n");
 
@@ -109,6 +164,14 @@ exec "$bin_path" "$@"
 `;
 }
 
+export function generateResolver(baseName: string, targets: readonly BunTarget[]): string {
+	return generateResolverFor(baseName, targets, TARGET_INFO, getBinaryFilename);
+}
+
+export function generateDenoResolver(baseName: string, targets: readonly DenoTarget[]): string {
+	return generateResolverFor(baseName, targets, DENO_TARGET_INFO, getDenoBinaryFilename);
+}
+
 /**
  * Generate the Windows batch resolver script content (.cmd).
  *
@@ -119,21 +182,23 @@ exec "$bin_path" "$@"
  * @param targets - The list of targets that were built
  * @returns The .cmd resolver script as a string
  */
-export function generateCmdResolver(baseName: string, targets: readonly BunTarget[]): string {
-	const windowsTargets = targets.filter((t) => t.startsWith("bun-windows"));
+function generateCmdResolverFor<T extends string>(
+	baseName: string,
+	targets: readonly T[],
+	targetInfo: Record<T, TargetInfo>,
+	getFilename: (baseName: string, target: T) => string,
+): string {
+	const windowsTargets = targets.filter((target) => targetInfo[target].os === "win32");
 
-	// If no Windows targets were built, generate a stub that tells the user
 	if (windowsTargets.length === 0) {
 		return `@echo off\r\necho [${baseName}] No Windows binary was built for this package. >&2\r\nexit /b 1\r\n`;
 	}
 
-	const windowsX64Target = windowsTargets.find(
-		(t): t is BunTarget => t === "bun-windows-x64-baseline",
-	);
-	const windowsArm64Target = windowsTargets.find((t): t is BunTarget => t === "bun-windows-arm64");
+	const windowsX64Target = windowsTargets.find((target) => targetInfo[target].cpu === "x64");
+	const windowsArm64Target = windowsTargets.find((target) => targetInfo[target].cpu === "arm64");
 
-	const x64Filename = windowsX64Target ? getBinaryFilename(baseName, windowsX64Target) : "";
-	const arm64Filename = windowsArm64Target ? getBinaryFilename(baseName, windowsArm64Target) : "";
+	const x64Filename = windowsX64Target ? getFilename(baseName, windowsX64Target) : "";
+	const arm64Filename = windowsArm64Target ? getFilename(baseName, windowsArm64Target) : "";
 
 	// Build architecture dispatch lines.
 	// CMD expands %var% at parse-time, so we cannot test a variable
@@ -184,6 +249,14 @@ if not exist "%bin_path%" (\r
 `;
 }
 
+export function generateCmdResolver(baseName: string, targets: readonly BunTarget[]): string {
+	return generateCmdResolverFor(baseName, targets, TARGET_INFO, getBinaryFilename);
+}
+
+export function generateDenoCmdResolver(baseName: string, targets: readonly DenoTarget[]): string {
+	return generateCmdResolverFor(baseName, targets, DENO_TARGET_INFO, getDenoBinaryFilename);
+}
+
 /**
  * Write the resolver scripts to disk.
  *
@@ -199,11 +272,74 @@ function writeResolver(
 	baseName: string,
 	targets: readonly BunTarget[],
 ): void {
-	const shellContent = generateResolver(baseName, targets);
-	writeFileSync(resolverPath, shellContent, { mode: 0o755 });
+	writeFileSync(resolverPath, generateResolver(baseName, targets), { mode: 0o755 });
+	writeFileSync(`${resolverPath}.cmd`, generateCmdResolver(baseName, targets));
+}
 
-	const cmdContent = generateCmdResolver(baseName, targets);
-	writeFileSync(`${resolverPath}.cmd`, cmdContent);
+function writeDenoResolver(
+	resolverPath: string,
+	baseName: string,
+	targets: readonly DenoTarget[],
+): void {
+	writeFileSync(resolverPath, generateDenoResolver(baseName, targets), { mode: 0o755 });
+	writeFileSync(`${resolverPath}.cmd`, generateDenoCmdResolver(baseName, targets));
+}
+
+type BinaryBuildOptions<T extends string> = {
+	entryPath: string;
+	outfile?: string;
+	name?: string;
+	cwd: string;
+	outdir: string;
+	resolver: string;
+	targets: readonly T[];
+	envFiles: readonly string[];
+	getFilename: (baseName: string, target: T) => string;
+	execute: (
+		entry: string,
+		outfile: string,
+		target: T,
+		envFiles: readonly string[],
+	) => Promise<void>;
+	writeResolver: (path: string, baseName: string, targets: readonly T[]) => void;
+};
+
+async function buildBinaryOutputs<T extends string>(options: BinaryBuildOptions<T>): Promise<void> {
+	if (options.targets.length === 1) {
+		const outfilePath = resolveOutfile(
+			options.outfile,
+			options.name,
+			options.entryPath,
+			options.cwd,
+			options.outdir,
+		);
+		console.log(`Building ${dim(options.entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
+		await options.execute(options.entryPath, outfilePath, options.targets[0]!, options.envFiles);
+		console.log(`${green("✓")} Built successfully: ${outfilePath}`);
+		return;
+	}
+
+	const baseName = resolveBaseName(options.name, options.entryPath, options.cwd);
+	console.log(
+		`Building ${dim(options.entryPath)} for ${bold(`${options.targets.length}`)} target(s)...`,
+	);
+	const results: string[] = [];
+	for (const target of options.targets) {
+		const targetOutfile = resolve(
+			options.cwd,
+			options.outdir,
+			options.getFilename(baseName, target),
+		);
+		console.log(`  ${cyan("→")} ${bold(target)}: ${dim(targetOutfile)}`);
+		await options.execute(options.entryPath, targetOutfile, target, options.envFiles);
+		results.push(targetOutfile);
+	}
+
+	const resolverPath = resolve(options.cwd, options.outdir, options.resolver);
+	options.writeResolver(resolverPath, baseName, options.targets);
+	console.log(`\n${green("✓")} Built ${bold(`${results.length}`)} target(s) successfully:`);
+	for (const result of results) console.log(`  ${result}`);
+	console.log(`\n${dim("Resolver:")} ${resolverPath} ${dim(`(+ ${resolverPath}.cmd)`)}`);
 }
 
 export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined): string[] {
@@ -229,10 +365,9 @@ export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined)
 /**
  * The `crust build` command.
  *
- * Compiles a CLI entry file to standalone Bun executable(s).
- * By default, builds for all supported platforms and generates shell/CMD
- * resolver scripts for runtime-free dispatch.
- * Use `--target` to build for specific platform(s) only.
+ * Builds a CLI entry for Bun, Deno, or Node.
+ * Bun and Deno produce standalone executables and multi-platform resolvers;
+ * Node produces one executable JavaScript bundle.
  *
  * @example
  * ```sh
@@ -243,12 +378,13 @@ export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined)
  * crust build --target bun-linux-x64-baseline              # Build only for Linux x64
  * crust build --target bun-linux-x64-baseline --target bun-darwin-arm64  # Specific platforms only
  * crust build --target bun-linux-x64-baseline --outfile ./my-cli     # Single target with custom output
- * crust build --outdir out                              # Output binaries to out/ directory
+ * crust build --runtime deno --target aarch64-apple-darwin
+ * crust build --runtime node --outdir out               # Output out/<name>.js
  * ```
  */
 export const buildCommand = defineCommand(
 	"build",
-	{ description: "Compile your CLI to a standalone executable" },
+	{ description: "Build your CLI for Bun, Deno, or Node" },
 	(command) =>
 		command
 			.flags(
@@ -274,21 +410,27 @@ export const buildCommand = defineCommand(
 				{
 					name: "minify",
 					type: "boolean",
-					description: "Minify the output",
-					default: true,
+					// No default: deno builds must distinguish an explicit --minify (error)
+					// from the implicit bun/node default (true, applied below).
+					description: "Minify the output (default for bun and node; unsupported for deno)",
+				},
+				{
+					name: "runtime",
+					type: "string",
+					choices: BUILD_RUNTIMES,
+					description: "Build runtime (overrides package.json crust.runtime; defaults to bun)",
 				},
 				{
 					name: "target",
 					type: "string",
 					multiple: true,
-					description:
-						"Canonical Bun target(s) to compile for (e.g. bun-linux-x64-baseline, bun-darwin-arm64). Omit to build all.",
+					description: "Canonical compiler target(s). Omit to build all platforms for Bun or Deno.",
 					short: "t",
 				},
 				{
 					name: "outdir",
 					type: "string",
-					description: "Output directory for compiled binaries",
+					description: "Output directory for build artifacts",
 					default: "dist",
 					short: "d",
 				},
@@ -315,7 +457,7 @@ export const buildCommand = defineCommand(
 				{
 					name: "package",
 					type: "boolean",
-					description: "Stage npm packages in dist/npm instead of raw binaries",
+					description: "Stage per-platform Bun npm packages in dist/npm",
 					default: false,
 				},
 				{
@@ -327,34 +469,60 @@ export const buildCommand = defineCommand(
 			)
 			.action(async ({ flags }) => {
 				const cwd = process.cwd();
-
-				// Resolve entry file path relative to cwd
+				const runtime = resolveBuildRuntime(cwd, flags.runtime);
 				const entryPath = resolve(cwd, flags.entry);
 				const envFiles = resolveEnvFilePaths(cwd, flags["env-file"]);
 
-				// Verify entry file exists
 				if (!existsSync(entryPath)) {
 					throw new Error(
 						`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
 					);
 				}
 
+				if (flags.package && runtime === "deno") {
+					throw new Error(
+						"--package does not yet support Deno builds.\n  Deno per-platform npm staging is reserved for a follow-up; build a specific target without --package for now.",
+					);
+				}
+				if (flags.package && runtime === "node") {
+					throw new Error(
+						"--package does not apply to Node builds.\n  Publish the generated JavaScript artifact as a normal npm package.",
+					);
+				}
 				if (flags.package && flags.outfile) {
 					throw new Error(
 						"--outfile cannot be used with --package.\n  Use --stage-dir to control the staged npm output directory.",
 					);
 				}
-				const targets = resolveTargets(flags.target);
-				if (!flags.package && flags.outfile && targets.length > 1) {
+				if (runtime === "node" && flags.target?.length) {
+					throw new Error(
+						"--target cannot be used with --runtime node.\n  Node builds produce one portable JavaScript artifact.",
+					);
+				}
+				if (runtime === "deno" && flags.minify) {
+					throw new Error(
+						"--minify is not supported with --runtime deno.\n  deno compile has no minification step; drop the flag.",
+					);
+				}
+				if (runtime === "deno" && envFiles.length > 0) {
+					throw new Error(
+						"--env-file is not supported with --runtime deno.\n" +
+							"  deno compile embeds every variable from the file into the binary — secrets included —\n" +
+							"  with no PUBLIC_* filter. Load configuration at runtime instead (e.g. deno run --env-file).",
+					);
+				}
+				// deno compile has no minifier; bun/node bundling minifies unless --no-minify.
+				const minify = runtime === "deno" ? false : (flags.minify ?? true);
+
+				const bunTargets = runtime === "bun" ? resolveTargets(flags.target) : undefined;
+				const denoTargets = runtime === "deno" ? resolveDenoTargets(flags.target) : undefined;
+				const targetCount = bunTargets?.length ?? denoTargets?.length ?? 0;
+				if (!flags.package && flags.outfile && targetCount > 1) {
 					throw new Error(
 						"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
 					);
 				}
 
-				// An explicit --outfile relocates the binary, so hook artifacts must
-				// land beside it for executable-relative source resolution to work at
-				// runtime. The guards above make --outfile imply a single-target,
-				// non-package build.
 				const outDir = flags.outfile
 					? dirname(resolve(cwd, flags.outfile))
 					: resolve(cwd, flags.outdir);
@@ -368,7 +536,7 @@ export const buildCommand = defineCommand(
 						cwd,
 						entry: flags.entry,
 						name: flags.name,
-						minify: flags.minify,
+						minify,
 						target: flags.target,
 						stageDir: flags["stage-dir"],
 						envFiles,
@@ -377,43 +545,52 @@ export const buildCommand = defineCommand(
 					return;
 				}
 
-				if (targets.length === 1) {
-					// Single-target build: one binary, no resolver
-					const outfilePath = resolveOutfile(
+				if (runtime === "node") {
+					const outfilePath = resolveNodeOutfile(
 						flags.outfile,
 						flags.name,
 						entryPath,
 						cwd,
 						flags.outdir,
 					);
-
 					console.log(`Building ${dim(entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
-					await execBuild(entryPath, outfilePath, flags.minify, targets[0], envFiles);
+					await execNodeBuild(entryPath, outfilePath, minify, envFiles);
 					console.log(`${green("✓")} Built successfully: ${outfilePath}`);
-				} else {
-					// Multi-target build: multiple binaries + shell/CMD resolvers
-					const baseName = resolveBaseName(flags.name, entryPath, cwd);
+					return;
+				}
 
-					console.log(`Building ${dim(entryPath)} for ${bold(`${targets.length}`)} target(s)...`);
+				if (bunTargets) {
+					await buildBinaryOutputs({
+						entryPath,
+						outfile: flags.outfile,
+						name: flags.name,
+						cwd,
+						outdir: flags.outdir,
+						resolver: flags.resolver,
+						targets: bunTargets,
+						envFiles,
+						getFilename: getBinaryFilename,
+						execute: (entry, outfile, target, files) =>
+							execBuild(entry, outfile, minify, target, files),
+						writeResolver,
+					});
+					return;
+				}
 
-					const results: string[] = [];
-					for (const target of targets) {
-						const targetOutfile = resolve(cwd, flags.outdir, getBinaryFilename(baseName, target));
-
-						console.log(`  ${cyan("→")} ${bold(target)}: ${dim(targetOutfile)}`);
-						await execBuild(entryPath, targetOutfile, flags.minify, target, envFiles);
-						results.push(targetOutfile);
-					}
-
-					// Generate resolver scripts
-					const resolverPath = resolve(cwd, flags.outdir, flags.resolver);
-					writeResolver(resolverPath, baseName, targets);
-
-					console.log(`\n${green("✓")} Built ${bold(`${results.length}`)} target(s) successfully:`);
-					for (const r of results) {
-						console.log(`  ${r}`);
-					}
-					console.log(`\n${dim("Resolver:")} ${resolverPath} ${dim(`(+ ${resolverPath}.cmd)`)}`);
+				if (denoTargets) {
+					await buildBinaryOutputs({
+						entryPath,
+						outfile: flags.outfile,
+						name: flags.name,
+						cwd,
+						outdir: flags.outdir,
+						resolver: flags.resolver,
+						targets: denoTargets,
+						envFiles,
+						getFilename: getDenoBinaryFilename,
+						execute: (entry, outfile, target) => execDenoBuild(entry, outfile, target),
+						writeResolver: writeDenoResolver,
+					});
 				}
 			}),
 );

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -20,7 +20,7 @@ import {
 	resolveTargets,
 	TARGET_INFO,
 	buildEntrypoint,
-	type TargetInfo,
+	type ResolverTargetInfo,
 } from "../utils/build-helpers.ts";
 
 /**
@@ -112,7 +112,7 @@ export function resolveBuildRuntime(cwd: string, override?: string): BuildRuntim
 function generateResolverFor<T extends string>(
 	baseName: string,
 	targets: readonly T[],
-	targetInfo: Record<T, TargetInfo>,
+	targetInfo: Record<T, ResolverTargetInfo>,
 	getFilename: (baseName: string, target: T) => string,
 ): string {
 	const caseEntries: string[] = [];
@@ -185,7 +185,7 @@ export function generateDenoResolver(baseName: string, targets: readonly DenoTar
 function generateCmdResolverFor<T extends string>(
 	baseName: string,
 	targets: readonly T[],
-	targetInfo: Record<T, TargetInfo>,
+	targetInfo: Record<T, ResolverTargetInfo>,
 	getFilename: (baseName: string, target: T) => string,
 ): string {
 	const windowsTargets = targets.filter((target) => targetInfo[target].os === "win32");

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -113,50 +113,50 @@ export const SUPPORTED_DENO_TARGETS = [
 
 export type DenoTarget = (typeof SUPPORTED_DENO_TARGETS)[number];
 
+/** Subset of target metadata the generated resolver scripts consume. */
+export type ResolverTargetInfo = Pick<TargetInfo, "unameKey" | "os" | "cpu">;
+
+/** No platformKey: npm per-platform packaging (distribute.ts) is Bun-only. */
+type DenoTargetInfo = Omit<TargetInfo, "platformKey">;
+
 export const DENO_TARGET_INFO = {
 	"x86_64-unknown-linux-gnu": {
 		alias: "linux-x64",
-		platformKey: "linux-x64",
 		unameKey: "Linux-x86_64",
 		os: "linux",
 		cpu: "x64",
 	},
 	"aarch64-unknown-linux-gnu": {
 		alias: "linux-arm64",
-		platformKey: "linux-arm64",
 		unameKey: "Linux-aarch64",
 		os: "linux",
 		cpu: "arm64",
 	},
 	"x86_64-apple-darwin": {
 		alias: "darwin-x64",
-		platformKey: "darwin-x64",
 		unameKey: "Darwin-x86_64",
 		os: "darwin",
 		cpu: "x64",
 	},
 	"aarch64-apple-darwin": {
 		alias: "darwin-arm64",
-		platformKey: "darwin-arm64",
 		unameKey: "Darwin-arm64",
 		os: "darwin",
 		cpu: "arm64",
 	},
 	"x86_64-pc-windows-msvc": {
 		alias: "windows-x64",
-		platformKey: "win32-x64",
 		unameKey: "Windows-x64",
 		os: "win32",
 		cpu: "x64",
 	},
 	"aarch64-pc-windows-msvc": {
 		alias: "windows-arm64",
-		platformKey: "win32-arm64",
 		unameKey: "Windows-arm64",
 		os: "win32",
 		cpu: "arm64",
 	},
-} as const satisfies Record<DenoTarget, TargetInfo>;
+} as const satisfies Record<DenoTarget, DenoTargetInfo>;
 
 /**
  * Resolve a canonical Bun target string to a supported compile target.
@@ -367,6 +367,10 @@ export function createDenoCompileArgs(
 	// --env-file for the deno runtime instead of leaking secrets.
 	return [
 		"compile",
+		// -A: Crust core reads process.env before dispatch, so a sandboxed binary
+		// crashes with NotCapable on startup. Full grants also match Bun compile,
+		// which has no sandbox. A permission passthrough flag can narrow this later.
+		"-A",
 		"--output",
 		outfilePath,
 		"--target",

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { text } from "node:stream/consumers";
@@ -11,8 +11,11 @@ import { yellow } from "@crustjs/style";
 import { which } from "@crustjs/utils/process";
 
 // ────────────────────────────────────────────────────────────────────────────
-// Supported Bun compile targets
+// Build runtimes and compile targets
 // ────────────────────────────────────────────────────────────────────────────
+
+export const BUILD_RUNTIMES = ["bun", "deno", "node"] as const;
+export type BuildRuntime = (typeof BUILD_RUNTIMES)[number];
 
 /**
  * All Bun compile targets supported by `crust build`.
@@ -95,6 +98,67 @@ export const TARGET_INFO = {
 } as const satisfies Record<BunTarget, TargetInfo>;
 
 /**
+ * Deno 2.9 compile targets, verified against `deno compile --help`.
+ * Keep this table separate from Bun's target namespace: the compilers use
+ * different canonical strings even when they describe the same platform.
+ */
+export const SUPPORTED_DENO_TARGETS = [
+	"x86_64-unknown-linux-gnu",
+	"aarch64-unknown-linux-gnu",
+	"x86_64-apple-darwin",
+	"aarch64-apple-darwin",
+	"x86_64-pc-windows-msvc",
+	"aarch64-pc-windows-msvc",
+] as const;
+
+export type DenoTarget = (typeof SUPPORTED_DENO_TARGETS)[number];
+
+export const DENO_TARGET_INFO = {
+	"x86_64-unknown-linux-gnu": {
+		alias: "linux-x64",
+		platformKey: "linux-x64",
+		unameKey: "Linux-x86_64",
+		os: "linux",
+		cpu: "x64",
+	},
+	"aarch64-unknown-linux-gnu": {
+		alias: "linux-arm64",
+		platformKey: "linux-arm64",
+		unameKey: "Linux-aarch64",
+		os: "linux",
+		cpu: "arm64",
+	},
+	"x86_64-apple-darwin": {
+		alias: "darwin-x64",
+		platformKey: "darwin-x64",
+		unameKey: "Darwin-x86_64",
+		os: "darwin",
+		cpu: "x64",
+	},
+	"aarch64-apple-darwin": {
+		alias: "darwin-arm64",
+		platformKey: "darwin-arm64",
+		unameKey: "Darwin-arm64",
+		os: "darwin",
+		cpu: "arm64",
+	},
+	"x86_64-pc-windows-msvc": {
+		alias: "windows-x64",
+		platformKey: "win32-x64",
+		unameKey: "Windows-x64",
+		os: "win32",
+		cpu: "x64",
+	},
+	"aarch64-pc-windows-msvc": {
+		alias: "windows-arm64",
+		platformKey: "win32-arm64",
+		unameKey: "Windows-arm64",
+		os: "win32",
+		cpu: "arm64",
+	},
+} as const satisfies Record<DenoTarget, TargetInfo>;
+
+/**
  * Resolve a canonical Bun target string to a supported compile target.
  *
  * @param input - User-provided canonical Bun target string
@@ -132,6 +196,24 @@ export function resolveTargets(targetFlags: string[] | undefined): BunTarget[] {
 	return targetFlags.map(resolveTarget);
 }
 
+export function resolveDenoTarget(input: string): DenoTarget {
+	if ((SUPPORTED_DENO_TARGETS as readonly string[]).includes(input)) {
+		return input as DenoTarget;
+	}
+
+	const canonical = SUPPORTED_DENO_TARGETS.find(
+		(target) => DENO_TARGET_INFO[target].alias === input,
+	);
+	const hint = canonical ? ` Did you mean "${canonical}"?` : "";
+	throw new Error(
+		`Unknown Deno target "${input}". Targets must use canonical Deno names.${hint}\n  Valid targets: ${SUPPORTED_DENO_TARGETS.join(", ")}`,
+	);
+}
+
+export function resolveDenoTargets(targetFlags: string[] | undefined): DenoTarget[] {
+	return targetFlags?.length ? targetFlags.map(resolveDenoTarget) : [...SUPPORTED_DENO_TARGETS];
+}
+
 /**
  * Get the binary filename (basename only) for a given target.
  *
@@ -142,6 +224,11 @@ export function resolveTargets(targetFlags: string[] | undefined): BunTarget[] {
 export function getBinaryFilename(baseName: string, target: BunTarget): string {
 	const isWindows = target.startsWith("bun-windows");
 	const ext = isWindows ? ".exe" : "";
+	return `${baseName}-${target}${ext}`;
+}
+
+export function getDenoBinaryFilename(baseName: string, target: DenoTarget): string {
+	const ext = DENO_TARGET_INFO[target].os === "win32" ? ".exe" : "";
 	return `${baseName}-${target}${ext}`;
 }
 
@@ -166,10 +253,12 @@ function toBunEnvFileArgs(envFiles: readonly string[]): string[] {
 	return envFiles.flatMap((envFile) => ["--env-file", envFile]);
 }
 
-export type BunBuildRunner = {
+export type BuildRunner = {
 	command: string;
 	env: Record<string, string | undefined>;
 };
+
+export type BunBuildRunner = BuildRunner;
 
 /**
  * Resolve the safest executable to run `bun build`.
@@ -222,8 +311,18 @@ export async function execBuild(
 	envFiles: readonly string[] = [],
 ): Promise<void> {
 	const runner = resolveBunBuildRunner();
-	const args = [
-		runner.command,
+	const args = createBunCompileArgs(entryPath, outfilePath, minify, target, envFiles);
+	await runBuildProcess(runner, args, outfilePath);
+}
+
+export function createBunCompileArgs(
+	entryPath: string,
+	outfilePath: string,
+	minify: boolean,
+	target?: BunTarget,
+	envFiles: readonly string[] = [],
+): string[] {
+	return [
 		"build",
 		"--compile",
 		...toBunEnvFileArgs(envFiles),
@@ -234,8 +333,54 @@ export async function execBuild(
 		...(target ? ["--target", target] : []),
 		entryPath,
 	];
+}
 
-	const proc = spawn(args[0]!, args.slice(1), {
+export function createNodeBuildArgs(
+	entryPath: string,
+	outfilePath: string,
+	minify: boolean,
+	envFiles: readonly string[] = [],
+): string[] {
+	return [
+		"build",
+		...toBunEnvFileArgs(envFiles),
+		"--env=PUBLIC_*",
+		"--target",
+		"node",
+		"--format",
+		"esm",
+		"--outfile",
+		outfilePath,
+		...(minify ? ["--minify"] : []),
+		entryPath,
+	];
+}
+
+export function createDenoCompileArgs(
+	entryPath: string,
+	outfilePath: string,
+	target: DenoTarget,
+): string[] {
+	// No --env-file: `deno compile` embeds EVERY variable from the file into the
+	// binary (verified empirically on Deno 2.9 — secrets included), with no
+	// equivalent of bun's --env=PUBLIC_* filter. The build command rejects
+	// --env-file for the deno runtime instead of leaking secrets.
+	return [
+		"compile",
+		"--output",
+		outfilePath,
+		"--target",
+		target,
+		entryPath,
+	];
+}
+
+async function runBuildProcess(
+	runner: BuildRunner,
+	args: readonly string[],
+	outfilePath: string,
+): Promise<void> {
+	const proc = spawn(runner.command, args, {
 		env: runner.env as NodeJS.ProcessEnv,
 		cwd: process.cwd(),
 		stdio: ["ignore", "pipe", "pipe"],
@@ -251,6 +396,43 @@ export async function execBuild(
 		const output = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
 		throw new Error(`Build failed for ${outfilePath}${output ? `:\n${output}` : ""}`);
 	}
+}
+
+export async function execNodeBuild(
+	entryPath: string,
+	outfilePath: string,
+	minify: boolean,
+	envFiles: readonly string[] = [],
+): Promise<void> {
+	const runner = resolveBunBuildRunner();
+	await runBuildProcess(
+		runner,
+		createNodeBuildArgs(entryPath, outfilePath, minify, envFiles),
+		outfilePath,
+	);
+
+	const output = await readFile(outfilePath, "utf8");
+	const shebang = "#!/usr/bin/env node\n";
+	await writeFile(outfilePath, shebang + output.replace(/^#![^\n]*(?:\n|$)/, ""));
+	if (process.platform !== "win32") await chmod(outfilePath, 0o755);
+}
+
+export async function execDenoBuild(
+	entryPath: string,
+	outfilePath: string,
+	target: DenoTarget,
+): Promise<void> {
+	const denoPath = which("deno");
+	if (!denoPath) {
+		throw new Error(
+			"Deno is required for --runtime deno but was not found on PATH.\n  Install Deno from https://deno.com/ and try again.",
+		);
+	}
+	await runBuildProcess(
+		{ command: denoPath, env: { ...process.env } },
+		createDenoCompileArgs(entryPath, outfilePath, target),
+		outfilePath,
+	);
 }
 
 /**


### PR DESCRIPTION
Stacked on #270 (ws4-runtime-portability). Merge that first; this PR's base is its branch.

## What

`crust build` gains a runtime target concept:

| Runtime | Output | Toolchain |
|---|---|---|
| `bun` (default) | standalone binaries (unchanged legacy path, byte-identical args) | embedded Bun / PATH bun |
| `deno` | standalone binaries via spawned `deno compile`, own 6-target mapping table | `deno` on PATH (actionable error otherwise) |
| `node` | single bundled+minified ESM artifact, `#!/usr/bin/env node` shebang, chmod +x | embedded Bun bundler — end users need Node only |

Selection: `package.json` → `"crust": { "runtime": "..." }`, overridden by `--runtime`. Existing projects are untouched (default `bun`).

## Deliberate rejections (fail-loud, not silent)

- `--package` with deno/node — per-platform npm staging for deno is follow-up scope; node artifacts publish directly.
- `--minify` with deno — `deno compile` has no minifier; default deno builds succeed (minify computed per runtime).
- `--env-file` with deno — **verified empirically**: `deno compile --env-file` embeds *every* variable into the binary (secrets included, `strings` confirms) with no `PUBLIC_*` filter. Crust refuses rather than leak.

## Validation

- 90/90 `packages/crust` tests (incl. new no-compile arg-construction, config precedence, rejection-path, and tool-gated integration tests that run real `deno compile` / node artifacts)
- typecheck, oxfmt, live smoke builds executed on all three runtimes
- Docs: build guide rewritten for runtimes (targets tables, permissions callout, env semantics, `"type": "module"` note), `modules/crust.mdx` synced

## Follow-ups (intentionally out of scope)

- Deno `--allow-*` permission passthrough at compile time
- Deno per-platform npm staging (`--package`)
- PR ③: scaffolder runtime picker writing `crust.runtime`