### PR TITLE
refactor(skills)!: rename packagedDir to distDir

### DIFF
--- a/.changeset/rename-skill-packaged-dir.md
+++ b/.changeset/rename-skill-packaged-dir.md
@@ -2,12 +2,12 @@
 "@crustjs/skills": minor
 ---
 
-Rename the skills Extension's `source` option to `packagedDir` to make its purpose explicit. This is a breaking change with no compatibility alias:
+Rename the skills Extension's `source` option to `distDir` to make its purpose explicit. This is a breaking change with no compatibility alias:
 
 ```ts
 // Before
 skill({ source: new URL("../skills", import.meta.url) });
 
 // After
-skill({ packagedDir: new URL("../skills", import.meta.url) });
+skill({ distDir: new URL("../skills", import.meta.url) });
 ```

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -55,18 +55,18 @@ import { skill } from "@crustjs/skills";
 export const app = new Crust("my-cli", { description: "My CLI" })
   .extend(
     skill({
-      packagedDir: new URL("../skills", import.meta.url),
+      distDir: new URL("../skills", import.meta.url),
       extras: [new URL("../skills-src/deployment-guide", import.meta.url)],
     }),
   )
   .action(() => {});
 ```
 
-When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. `packagedDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
+When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. `distDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
 
 The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the packaged directory is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the packaged skills directory to keep absolute build-machine paths out of generated artifacts.
 
-The management command reads every skill in `packagedDir` and creates links in selected agent directories. `--scope project|global` selects project or user locations; `--all` installs for universal and detected agents without prompting.
+The management command reads every skill in `distDir` and creates links in selected agent directories. `--scope project|global` selects project or user locations; `--all` installs for universal and detected agents without prompting.
 
 ```sh
 my-cli skill
@@ -74,7 +74,7 @@ my-cli skill --all --scope project
 my-cli skill update
 ```
 
-If `packagedDir` cannot be found relative to the package, Crust also checks next to `process.execPath` — for the directory's basename when it is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the directory resolves but a packaged skill is invalid (for example a `SKILL.md` without a description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the packaged directory as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
+If `distDir` cannot be found relative to the package, Crust also checks next to `process.execPath` — for the directory's basename when it is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the directory resolves but a packaged skill is invalid (for example a `SKILL.md` without a description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the packaged directory as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
 
 <auto-type-table path="../../../../../packages/skills/src/types.ts" name="SkillOptions" />
 

--- a/packages/crust/src/utils/build-helpers.test.ts
+++ b/packages/crust/src/utils/build-helpers.test.ts
@@ -72,7 +72,7 @@ describe("buildEntrypoint", () => {
 			`import { Crust } from ${JSON.stringify(coreUrl)};\n` +
 				`import { skill } from ${JSON.stringify(skillsUrl)};\n` +
 				`import { man } from ${JSON.stringify(manUrl)};\n` +
-				`await new Crust("demo", { description: "Demo" }).extend(skill({ packagedDir: ${JSON.stringify(source)} }), man()).execute();\n`,
+				`await new Crust("demo", { description: "Demo" }).extend(skill({ distDir: ${JSON.stringify(source)} }), man()).execute();\n`,
 		);
 
 		// crust build runs from the project root; the entry subprocess inherits

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -62,7 +62,7 @@ function target(name = "demo") {
 describe("skill extension packaged directory", () => {
 	it("exposes the reserved identity on the factory", () => {
 		expect(String(skill.id)).toBe("crust:skills");
-		expect(skill({ packagedDir: "." }).id).toBe(skill.id);
+		expect(skill({ distDir: "." }).id).toBe(skill.id);
 	});
 
 	it("advertises every packaged skill in help with its resolved source path", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -51,7 +51,7 @@ async function writeSource(name: string, content = name, description = name): Pr
 
 function createApp(source: string | URL, autoUpdate = true) {
 	return new Crust("demo", { description: "Demo" })
-		.extend(skill({ packagedDir: source, defaultScope: "project", autoUpdate }))
+		.extend(skill({ distDir: source, defaultScope: "project", autoUpdate }))
 		.action(() => {});
 }
 
@@ -83,7 +83,7 @@ describe("skill extension packaged directory", () => {
 	it("keeps help usable when the packaged skills directory cannot be resolved", async () => {
 		const source = join(tempRoot, "missing-skills");
 		const app = new Crust("demo", { description: "Demo" })
-			.extend(skill({ packagedDir: source, command: "agents" }))
+			.extend(skill({ distDir: source, command: "agents" }))
 			.action(() => {});
 		const output = renderHelp(await app.snapshot());
 
@@ -95,7 +95,7 @@ describe("skill extension packaged directory", () => {
 
 	it("copies packaged sources from its build hook", async () => {
 		const source = await writeSource("demo", "packaged");
-		const extension = skill({ packagedDir: source });
+		const extension = skill({ distDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 
@@ -113,7 +113,7 @@ describe("skill extension packaged directory", () => {
 			"---\nname: guide\ndescription: Deployment guide\n---\n",
 		);
 		await writeFile(join(authored, "content.md"), "authored\n");
-		const extension = skill({ packagedDir: source, extras: [authored] });
+		const extension = skill({ distDir: source, extras: [authored] });
 		const snapshot = await new Crust("demo", {
 			description: "Demo",
 			sections: [{ title: "Agent skills", body: "Application-authored agent guidance." }],
@@ -147,7 +147,7 @@ describe("skill extension packaged directory", () => {
 
 	it("copies packaged sources when extras is empty", async () => {
 		const source = await writeSource("demo", "packaged");
-		const extension = skill({ packagedDir: source, extras: [] });
+		const extension = skill({ distDir: source, extras: [] });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 
@@ -158,7 +158,7 @@ describe("skill extension packaged directory", () => {
 
 	it("renders from the snapshot without requiring a package version", async () => {
 		const source = join(tempRoot, "missing-skills");
-		const extension = skill({ packagedDir: source });
+		const extension = skill({ distDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 		await writeFile(join(tempRoot, "package.json"), "{}");
@@ -267,7 +267,7 @@ describe("skill extension packaged directory", () => {
 
 		let ran = false;
 		const app = new Crust("demo", { description: "Demo" })
-			.extend(skill({ packagedDir: source, defaultScope: "project" }))
+			.extend(skill({ distDir: source, defaultScope: "project" }))
 			.action(() => {
 				ran = true;
 			});
@@ -291,7 +291,7 @@ describe("skill extension packaged directory", () => {
 	it("does not break unrelated commands when the packaged directory is unavailable", async () => {
 		let ran = false;
 		const app = new Crust("demo")
-			.extend(skill({ packagedDir: join(tempRoot, "missing-skills") }))
+			.extend(skill({ distDir: join(tempRoot, "missing-skills") }))
 			.action(() => {
 				ran = true;
 			});

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -124,7 +124,7 @@ async function repairInstalledSkill(
 async function autoRepairSkills(options: SkillOptions): Promise<void> {
 	let skills: readonly PackagedSkill[];
 	try {
-		skills = loadPackagedSkills(options.packagedDir);
+		skills = loadPackagedSkills(options.distDir);
 	} catch (error) {
 		// A missing or invalid packaged asset must not prevent unrelated CLI commands
 		// from running; the explicit skill command surfaces the same failure loudly.
@@ -208,7 +208,7 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 	const outDir = join(context.outDir, "skills");
 	let source: string | undefined;
 	try {
-		source = resolveSkillSource(options.packagedDir);
+		source = resolveSkillSource(options.distDir);
 	} catch (error) {
 		if (!(error instanceof SkillSourceUnavailableError)) throw error;
 		// A missing packaged directory is regenerated from the snapshot below.
@@ -244,7 +244,7 @@ function skillFactory(options: SkillOptions): Extension {
 			{
 				command: [],
 				title: SKILLS_SECTION_TITLE,
-				body: formatSkillDocumentation(options.packagedDir, commandName, snapshot.meta.name),
+				body: formatSkillDocumentation(options.distDir, commandName, snapshot.meta.name),
 				except: [SKILLS],
 			},
 		],
@@ -438,7 +438,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 							})
 							.action(async (context) => {
 								const scope = await resolveScope(context.flags.scope, options);
-								for (const packagedSkill of loadPackagedSkills(options.packagedDir)) {
+								for (const packagedSkill of loadPackagedSkills(options.distDir)) {
 									await repairInstalledSkill(packagedSkill, scope, true);
 								}
 							}),
@@ -449,7 +449,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 					const scope = installAll
 						? (parseScopeFlag(context.flags.scope) ?? options.defaultScope ?? DEFAULT_SKILL_SCOPE)
 						: await resolveScope(context.flags.scope, options);
-					for (const packagedSkill of loadPackagedSkills(options.packagedDir)) {
+					for (const packagedSkill of loadPackagedSkills(options.distDir)) {
 						await reconcileSkill({ packagedSkill, scope, installAll });
 					}
 				}),

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -184,11 +184,11 @@ export interface SkillStatusResult {
 /** Options for the skills extension. */
 export interface SkillOptions {
 	/** Read-only directory produced by writeSkills(). */
-	packagedDir: string | URL;
+	distDir: string | URL;
 	/**
 	 * Hand-authored skill directories (URL, absolute, or package-root-relative path).
 	 * When non-empty, the build regenerates the command skill from the snapshot and
-	 * includes only these authored skills instead of copying `packagedDir`.
+	 * includes only these authored skills instead of copying `distDir`.
 	 */
 	extras?: readonly (string | URL)[];
 	/** Default agent-directory scope. */


### PR DESCRIPTION
## Summary

- rename the prerelease `SkillOptions.packagedDir` option to `distDir`
- update every runtime caller, test fixture, and public docs reference
- keep the rename breaking and alias-free while preserving existing path/build behavior
- update the pending changeset so released users migrate directly from `source` to `distDir`

## Verification

- `bun run check:types` — 21/21 tasks passed
- `bun run lint`
- `bun run format` — 389 files checked
- `bun run test` — 25/25 tasks passed; `@crustjs/skills` 132/132 tests passed
- `git diff --check origin/main...HEAD`
- exact tracked-file search confirms zero `packagedDir` references
- independent standards, spec, validation, and post-rebase reviews: no blockers

## Breaking change

`SkillOptions.packagedDir` is now `SkillOptions.distDir`. No compatibility alias is included because this API is still prerelease.
