### PR TITLE
feat(man): render subcommand sections on the root man page

### DIFF
--- a/.changeset/tidy-dingos-document.md
+++ b/.changeset/tidy-dingos-document.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/man": minor
+---
+
+Render documentation sections from visible subcommands in generated man pages.

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -53,7 +53,7 @@ Extension contributions are applied in `.extend()` registration order. Extension
 
 ## Command sections
 
-Sections are named documentation blocks — like man-page sections — that render into `--help`, man pages, and generated agent skills from a single declaration. Commands can declare plain-text documentation sections in their metadata. Help renders them after Options, and man-page generation emits one mdoc section per root-level entry (subcommand sections appear in help only):
+Sections are named documentation blocks — like man-page sections — that render into `--help`, man pages, and generated agent skills from a single declaration. Commands can declare plain-text documentation sections in their metadata. Help renders them after Options. Man-page generation emits root entries as mdoc sections and groups visible subcommand entries under subsections for their canonical command paths:
 
 ```ts
 const deploy = defineCommand(

--- a/apps/docs/content/docs/modules/man.mdx
+++ b/apps/docs/content/docs/modules/man.mdx
@@ -76,7 +76,7 @@ const source = renderManPageMdoc({
 });
 ```
 
-The renderer uses semantic mdoc(7) flag and argument macros. It intentionally summarizes only the root command's immediate visible subcommands; nested commands remain available in the shared full-tree documentation model. Root `meta.sections` visible to the `man.id` (`crust:man`) consumer are appended after the built-in sections as mdoc `.Sh` sections.
+The renderer uses semantic mdoc(7) flag and argument macros. Its subcommand summary lists only the root command's immediate visible children. Root `meta.sections` visible to the `man.id` (`crust:man`) consumer are appended after the built-in sections as mdoc `.Sh` sections. Sections on visible subcommands are collected recursively under `.Sh COMMANDS`, with one `.Ss` subsection per canonical command path.
 
 Target a section to man pages with `only: [man.id]`, or exclude it with `except: [man.id]`:
 

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -45,9 +45,9 @@ describe("renderManPageMdoc", () => {
 
 		expect(output).toContain(".Sh COMMANDS");
 		expect(output).toContain(
-			".Ss config\n.Pp\n.Sy OVERVIEW\nconfig body\n.Pp\n.Sy DETAILS\nconfig details",
+			".Ss config\n.Sy OVERVIEW\nconfig body\n.Pp\n.Sy DETAILS\nconfig details",
 		);
-		expect(output).toContain(".Ss config set\n.Pp\n.Sy EXAMPLES\nconfig set body");
+		expect(output).toContain(".Ss config set\n.Sy EXAMPLES\nconfig set body");
 		const paths = ["alpha", "config", "config set", "zeta"].map((path) =>
 			output.indexOf(`.Ss ${path}\n`),
 		);
@@ -84,7 +84,7 @@ describe("renderManPageMdoc", () => {
 
 		expect(output).toContain(".Sh COMMANDS");
 		expect(output).not.toContain(".Ss config\n");
-		expect(output).toContain(".Ss config set\n.Pp\n.Sy EXAMPLES\nconfig set body");
+		expect(output).toContain(".Ss config set\n.Sy EXAMPLES\nconfig set body");
 	});
 
 	it("filters subcommand sections by audience and omits hidden commands", async () => {
@@ -111,7 +111,7 @@ describe("renderManPageMdoc", () => {
 
 		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
 
-		expect(output).toContain(".Ss publish\n.Pp\n.Sy MAN NOTES\nman body");
+		expect(output).toContain(".Ss publish\n.Sy MAN NOTES\nman body");
 		expect(output).not.toContain("other body");
 		expect(output).not.toContain("hidden body");
 		expect(output).not.toContain(".Ss internal");

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -7,6 +7,73 @@ import { man } from "./extension.ts";
 import { renderManPageMdoc } from "./mdoc.ts";
 
 describe("renderManPageMdoc", () => {
+	it("renders visible subcommand sections in canonical path order", async () => {
+		const app = new Crust("demo")
+			.add(
+				defineCommand("zeta", { sections: [{ title: "Notes", body: "zeta body" }] }, (cmd) =>
+					cmd.action(() => {}),
+				),
+			)
+			.add(
+				defineCommand("config", { sections: [{ title: "Overview", body: "config body" }] }, (cmd) =>
+					cmd
+						.add(
+							defineCommand(
+								"set",
+								{ sections: [{ title: "Examples", body: "config set body" }] },
+								(subcommand) => subcommand.action(() => {}),
+							),
+						)
+						.action(() => {}),
+				),
+			)
+			.add(
+				defineCommand("alpha", { sections: [{ title: "Notes", body: "alpha body" }] }, (cmd) =>
+					cmd.action(() => {}),
+				),
+			);
+
+		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
+
+		expect(output).toContain(".Sh COMMANDS");
+		expect(output).toContain(".Ss config set\n.Sy EXAMPLES\nconfig set body");
+		const paths = ["alpha", "config", "config set", "zeta"].map((path) =>
+			output.indexOf(`.Ss ${path}\n`),
+		);
+		expect(paths.every((index) => index >= 0)).toBe(true);
+		expect(paths).toEqual([...paths].sort((a, b) => a - b));
+	});
+
+	it("filters subcommand sections by audience and omits hidden commands", async () => {
+		const app = new Crust("demo")
+			.add(
+				defineCommand(
+					"publish",
+					{
+						sections: [
+							{ title: "Man notes", body: "man body", only: [man.id] },
+							{ title: "Other notes", body: "other body", except: [man.id] },
+						],
+					},
+					(cmd) => cmd.action(() => {}),
+				),
+			)
+			.add(
+				defineCommand(
+					"internal",
+					{ hidden: true, sections: [{ title: "Secrets", body: "hidden body" }] },
+					(cmd) => cmd.action(() => {}),
+				),
+			);
+
+		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
+
+		expect(output).toContain(".Ss publish\n.Sy MAN NOTES\nman body");
+		expect(output).not.toContain("other body");
+		expect(output).not.toContain("hidden body");
+		expect(output).not.toContain(".Ss internal");
+	});
+
 	it("honors only and except audiences", async () => {
 		const other = defineExtensionId("acme:other");
 		const snapshot = await new Crust("demo", {

--- a/packages/man/src/mdoc.test.ts
+++ b/packages/man/src/mdoc.test.ts
@@ -15,16 +15,24 @@ describe("renderManPageMdoc", () => {
 				),
 			)
 			.add(
-				defineCommand("config", { sections: [{ title: "Overview", body: "config body" }] }, (cmd) =>
-					cmd
-						.add(
-							defineCommand(
-								"set",
-								{ sections: [{ title: "Examples", body: "config set body" }] },
-								(subcommand) => subcommand.action(() => {}),
-							),
-						)
-						.action(() => {}),
+				defineCommand(
+					"config",
+					{
+						sections: [
+							{ title: "Overview", body: "config body" },
+							{ title: "Details", body: "config details" },
+						],
+					},
+					(cmd) =>
+						cmd
+							.add(
+								defineCommand(
+									"set",
+									{ sections: [{ title: "Examples", body: "config set body" }] },
+									(subcommand) => subcommand.action(() => {}),
+								),
+							)
+							.action(() => {}),
 				),
 			)
 			.add(
@@ -36,12 +44,47 @@ describe("renderManPageMdoc", () => {
 		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
 
 		expect(output).toContain(".Sh COMMANDS");
-		expect(output).toContain(".Ss config set\n.Sy EXAMPLES\nconfig set body");
+		expect(output).toContain(
+			".Ss config\n.Pp\n.Sy OVERVIEW\nconfig body\n.Pp\n.Sy DETAILS\nconfig details",
+		);
+		expect(output).toContain(".Ss config set\n.Pp\n.Sy EXAMPLES\nconfig set body");
 		const paths = ["alpha", "config", "config set", "zeta"].map((path) =>
 			output.indexOf(`.Ss ${path}\n`),
 		);
 		expect(paths.every((index) => index >= 0)).toBe(true);
 		expect(paths).toEqual([...paths].sort((a, b) => a - b));
+	});
+
+	it("omits COMMANDS when subcommands have no sections", async () => {
+		const app = new Crust("demo").add(
+			defineCommand("config", {}, (cmd) =>
+				cmd.add(defineCommand("set", {}, (subcommand) => subcommand.action(() => {}))),
+			),
+		);
+
+		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
+
+		expect(output).not.toContain(".Sh COMMANDS");
+	});
+
+	it("renders a section-bearing grandchild without a heading for its section-less parent", async () => {
+		const app = new Crust("demo").add(
+			defineCommand("config", {}, (cmd) =>
+				cmd.add(
+					defineCommand(
+						"set",
+						{ sections: [{ title: "Examples", body: "config set body" }] },
+						(subcommand) => subcommand.action(() => {}),
+					),
+				),
+			),
+		);
+
+		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
+
+		expect(output).toContain(".Sh COMMANDS");
+		expect(output).not.toContain(".Ss config\n");
+		expect(output).toContain(".Ss config set\n.Pp\n.Sy EXAMPLES\nconfig set body");
 	});
 
 	it("filters subcommand sections by audience and omits hidden commands", async () => {
@@ -68,7 +111,7 @@ describe("renderManPageMdoc", () => {
 
 		const output = renderManPageMdoc({ root: await app.snapshot(), name: "demo" });
 
-		expect(output).toContain(".Ss publish\n.Sy MAN NOTES\nman body");
+		expect(output).toContain(".Ss publish\n.Pp\n.Sy MAN NOTES\nman body");
 		expect(output).not.toContain("other body");
 		expect(output).not.toContain("hidden body");
 		expect(output).not.toContain(".Ss internal");

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -17,9 +17,12 @@ function escapeMdocBodyLine(line: string): string {
 	// Both `.` and `'` start roff control lines.
 	return /^[.']/.test(line) ? `\\&${line}` : line;
 }
+function macroArgument(text: string): string {
+	// Backslashes would otherwise start roff escape sequences inside heading macros.
+	return text.replace(/\\/g, "\\e");
+}
 function shTitle(title: string): string {
-	// Backslashes would otherwise start roff escape sequences inside `.Sh`.
-	return title.toUpperCase().replace(/\\/g, "\\e");
+	return macroArgument(title.toUpperCase());
 }
 function dtTitle(name: string): string {
 	const upper = name.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
@@ -59,6 +62,28 @@ function resolveDdLine(explicit?: string): string {
 		year: "numeric",
 		timeZone: fromEpoch ? "UTC" : undefined,
 	});
+}
+
+interface CommandSectionGroup {
+	path: readonly string[];
+	sections: ReturnType<typeof sectionsFor>;
+}
+
+function subcommandSectionGroups(
+	command: CommandSnapshot,
+	path: readonly string[] = [],
+): CommandSectionGroup[] {
+	const groups: CommandSectionGroup[] = [];
+	const children = Object.entries(command.subCommands)
+		.filter(([, child]) => !child.meta.hidden)
+		.sort(([a], [b]) => a.localeCompare(b));
+	for (const [name, child] of children) {
+		const childPath = [...path, name];
+		const sections = sectionsFor(child.meta.sections, MAN);
+		if (sections.length > 0) groups.push({ path: childPath, sections });
+		groups.push(...subcommandSectionGroups(child, childPath));
+	}
+	return groups;
 }
 
 export interface RenderManPageMdocOptions {
@@ -120,6 +145,17 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 	for (const metadataSection of sectionsFor(root.meta.sections, MAN)) {
 		lines.push(`.Sh ${shTitle(metadataSection.title)}`);
 		for (const line of metadataSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
+	}
+	const commandSections = subcommandSectionGroups(root);
+	if (commandSections.length > 0) {
+		lines.push(".Sh COMMANDS");
+		for (const group of commandSections) {
+			lines.push(`.Ss ${macroArgument(group.path.join(" "))}`);
+			for (const commandSection of group.sections) {
+				lines.push(`.Sy ${shTitle(commandSection.title)}`);
+				for (const line of commandSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
+			}
+		}
 	}
 	lines.push("");
 	return lines.join("\n");

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -144,10 +144,12 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		lines.push(".Sh COMMANDS");
 		for (const group of commandSections) {
 			lines.push(`.Ss ${macroArgument(group.path.join(" "))}`);
-			for (const commandSection of group.sections) {
-				lines.push(".Pp", `.Sy ${shTitle(commandSection.title)}`);
+			group.sections.forEach((commandSection, index) => {
+				// mandoc -Tlint warns on .Pp directly after .Ss; only separate consecutive sections.
+				if (index > 0) lines.push(".Pp");
+				lines.push(`.Sy ${shTitle(commandSection.title)}`);
 				for (const line of commandSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
-			}
+			});
 		}
 	}
 	lines.push("");

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,5 +1,4 @@
 import {
-	type CommandSection,
 	type CommandSnapshot,
 	type ExtensionId,
 	defineExtensionId,
@@ -65,26 +64,19 @@ function resolveDdLine(explicit?: string): string {
 	});
 }
 
-interface CommandSectionGroup {
-	path: readonly string[];
-	sections: readonly CommandSection[];
-}
-
 function subcommandSectionGroups(
 	command: CommandSnapshot,
 	path: readonly string[] = [],
-): CommandSectionGroup[] {
-	const groups: CommandSectionGroup[] = [];
-	const children = Object.entries(command.subCommands)
+): { path: string[]; sections: ReturnType<typeof sectionsFor> }[] {
+	return Object.entries(command.subCommands)
 		.filter(([, child]) => !child.meta.hidden)
-		.sort(([a], [b]) => a.localeCompare(b));
-	for (const [name, child] of children) {
-		const childPath = [...path, name];
-		const sections = sectionsFor(child.meta.sections, MAN);
-		if (sections.length > 0) groups.push({ path: childPath, sections });
-		groups.push(...subcommandSectionGroups(child, childPath));
-	}
-	return groups;
+		.sort(([a], [b]) => a.localeCompare(b))
+		.flatMap(([name, child]) => {
+			const childPath = [...path, name];
+			const sections = sectionsFor(child.meta.sections, MAN);
+			const descendants = subcommandSectionGroups(child, childPath);
+			return sections.length > 0 ? [{ path: childPath, sections }, ...descendants] : descendants;
+		});
 }
 
 export interface RenderManPageMdocOptions {

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,4 +1,5 @@
 import {
+	type CommandSection,
 	type CommandSnapshot,
 	type ExtensionId,
 	defineExtensionId,
@@ -66,7 +67,7 @@ function resolveDdLine(explicit?: string): string {
 
 interface CommandSectionGroup {
 	path: readonly string[];
-	sections: ReturnType<typeof sectionsFor>;
+	sections: readonly CommandSection[];
 }
 
 function subcommandSectionGroups(
@@ -152,7 +153,7 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		for (const group of commandSections) {
 			lines.push(`.Ss ${macroArgument(group.path.join(" "))}`);
 			for (const commandSection of group.sections) {
-				lines.push(`.Sy ${shTitle(commandSection.title)}`);
+				lines.push(".Pp", `.Sy ${shTitle(commandSection.title)}`);
 				for (const line of commandSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
 			}
 		}


### PR DESCRIPTION
## Summary

Implements #251: subcommand-targeted `meta.sections` (and extension-contributed sections) now render on the generated man page instead of being silently dropped. Help and generated skills already rendered them; man was the one surface that didn't.

**Design (research-backed):** keep the single root man page and render command documentation under one `.Sh COMMANDS` heading with one `.Ss` per canonical command path (`config set` style), matching the systemctl(1) single-page convention. Per-command pages (git-style `tool-verb(1)`) stay a future option once per-command reference material warrants it — the research brief with sources is summarized in the PR discussion if needed.

**Behavior:**
- Depth-first, alphabetically-ordered walk of visible `subCommands`; hidden commands (and their descendants) excluded.
- `only`/`except` audience filtering by `man.id` preserved via the existing `sectionsFor` path.
- Section titles render as `.Pp`-separated `.Sy` run-in headings so consecutive sections don't merge into one paragraph.
- Root-targeted sections keep their existing placement; the `COMMANDS` heading is omitted when no subcommand has sections.
- No `CommandDocumentation` model change; existing roff escaping reused.

## Tests
- Canonical-path ordering incl. nesting; audience filtering; hidden exclusion; `.Pp` separation of consecutive sections; no-sections omission; section-bearing grandchild under a section-less parent.

## Validation
- `bun test packages/man` — 22 pass, 0 fail
- `bun run --cwd packages/man check:types`, `bun run lint packages`, `bun run format packages` — pass
- Two independent review passes; the one rendering finding (`.Sy` inline-macro paragraph merge) fixed in the follow-up commit.

**Known deferred:** `localeCompare` without an explicit locale is host-locale-dependent (pre-existing pattern across this file's sorts); pinning it everywhere is a separate cleanup.

## Stack
PR 2/6 of the v0.2 stack, based on #282 (`fix/252-build-snapshot-ordering`). Retarget to `main` after #282 merges; hosted CI triggers only on `main`-based PRs, so this relies on the local gates above until then.

Fixes #251
