### PR TITLE
feat(core): reject literal empty names at direct definition sites

### DIFF
--- a/.changeset/empty-definition-names.md
+++ b/.changeset/empty-definition-names.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Reject statically known empty names at `defineFlag`, `defineArg`, `defineCommand`, and command definition `.as()` calls.

--- a/.changeset/empty-definition-names.md
+++ b/.changeset/empty-definition-names.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/core": minor
+"@crustjs/core": patch
 ---
 
 Reject statically known empty names at `defineFlag`, `defineArg`, `defineCommand`, and command definition `.as()` calls.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -61,7 +61,7 @@ interface CommandDefinition<
   Aliases extends readonly string[] = readonly string[],
 > {
   readonly name: Name;
-  as<const N extends string>(name: N): CommandDefinition<N, Aliases>;
+  as<const N extends string>(name: N & EmptyNameBrand<N>): CommandDefinition<N, Aliases>;
 }
 ```
 
@@ -71,7 +71,7 @@ A `CommandDefinition` is a frozen value carrying its name, static config, and co
 
 ```ts
 defineCommand<const Name extends string>(
-  name: Name,
+  name: Name & EmptyNameBrand<Name>,
   recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
 ): CommandDefinition<Name>;
 
@@ -80,7 +80,7 @@ interface CommandConfig extends Omit<CommandMeta, "name"> {
 }
 
 defineCommand<const Name extends string, const C extends CommandConfig>(
-  name: Name,
+  name: Name & EmptyNameBrand<Name>,
   config: C & ValidateCommandConfig<Name, C>,
   recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
 ): CommandDefinition<Name, AliasesOf<C>>;
@@ -109,7 +109,7 @@ const deploy = defineCommand(
 );
 ```
 
-The recipe does not execute when the definition is created. It executes once for each `.add()`, so keep configuration side-effect-free. TypeScript validates the definition shape; materialization checks at runtime that the recipe returns the seeded builder and does not register nested Extensions, because those behaviors are not type-expressible.
+The recipe does not execute when the definition is created. It executes once for each `.add()`, so keep configuration side-effect-free. Statically known empty names passed to `defineCommand()` or `.as()` fail typecheck with `FIX_EMPTY_NAME`; widened and dynamically assembled names retain runtime validation at composition. TypeScript validates the definition shape; materialization checks at runtime that the recipe returns the seeded builder and does not register nested Extensions, because those behaviors are not type-expressible.
 
 ## Constructor
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -103,7 +103,7 @@ const verbose = defineFlag("verbose", { type: "boolean", short: "v" });
 const target = defineArg("target", { type: "string", required: true });
 ```
 
-`defineFlag(name, def)` returns a `NamedFlagDef`; `defineArg(name, def)` returns an `ArgDef`. `UnnamedArgDef` is the `defineArg` input shape — an `ArgDef` without its `name`.
+`defineFlag(name, def)` returns a `NamedFlagDef`; `defineArg(name, def)` returns an `ArgDef`. Statically known empty names fail typecheck with `FIX_EMPTY_SPELLING` for flags and `FIX_EMPTY_NAME` for arguments; widened strings remain accepted for dynamic definitions. `UnnamedArgDef` is the `defineArg` input shape — an `ArgDef` without its `name`.
 
 ### `CommandMeta`
 

--- a/packages/core/src/api/flags.ts
+++ b/packages/core/src/api/flags.ts
@@ -1,4 +1,6 @@
 import type { ArgDef, FlagDef } from "../types.ts";
+import type { EmptyArgNameBrand } from "../validation/args.brands.ts";
+import type { EmptyFlagSpellingBrand } from "../validation/flags.brands.ts";
 import type { Simplify } from "./context.ts";
 
 /** Distribute `Omit<_, "name">` over the {@link ArgDef} union. */
@@ -14,7 +16,7 @@ export type UnnamedArgDef = OmitName<ArgDef>;
  * `.flags(...defs)` or owned by a Context.
  */
 export function defineFlag<const N extends string, const D extends FlagDef>(
-	name: N,
+	name: N & EmptyFlagSpellingBrand<N>,
 	def: D,
 ): Simplify<{ readonly name: N } & D> {
 	return { ...def, name } as Simplify<{ readonly name: N } & D>;
@@ -25,7 +27,7 @@ export function defineFlag<const N extends string, const D extends FlagDef>(
  * definition type. Attach with the variadic `.args(...defs)`.
  */
 export function defineArg<const N extends string, const D extends UnnamedArgDef>(
-	name: N,
+	name: N & EmptyArgNameBrand<N>,
 	def: D,
 ): Simplify<{ readonly name: N } & D> {
 	return { ...def, name } as Simplify<{ readonly name: N } & D>;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -30,6 +30,7 @@ import type { AppendArgsChecks } from "../validation/args.brands.ts";
 import type {
 	AliasesOf,
 	CommandDefinitionSpellings,
+	EmptyNameBrand,
 	ValidateCommandConfig,
 	ValidateCommandDefinitions,
 } from "../validation/commands.brands.ts";
@@ -215,7 +216,9 @@ export interface CommandDefinition<
 	/** The subcommand name this definition is added under */
 	readonly name: Name;
 	/** The same definition under a different name; configured aliases travel with it. */
-	as<const N extends string>(name: N): CommandDefinition<N, Aliases, Shape, Deps>;
+	as<const N extends string>(
+		name: N & EmptyNameBrand<N>,
+	): CommandDefinition<N, Aliases, Shape, Deps>;
 	/** @internal */
 	readonly [commandDefinitionInternal]: CommandDefinitionInternal;
 	/** @internal — phantom carrying configured alias literals for add-time checks */
@@ -415,7 +418,7 @@ export function defineCommand<
 	const Name extends string,
 	Builder extends AnyCommandDefinitionBuilder,
 >(
-	name: Name,
+	name: Name & EmptyNameBrand<Name>,
 	recipe: CommandRecipe<{}, Builder>,
 ): CommandDefinition<Name, readonly [], ShapeOfBuilder<Builder>>;
 export function defineCommand<
@@ -423,7 +426,7 @@ export function defineCommand<
 	const C extends CommandConfig,
 	Builder extends AnyCommandDefinitionBuilder,
 >(
-	name: Name,
+	name: Name & EmptyNameBrand<Name>,
 	config: C & ValidateCommandConfig<Name, C>,
 	recipe: CommandRecipe<CommandDeps<C>, Builder>,
 ): CommandDefinition<Name, AliasesOf<C>, ShapeOfBuilder<Builder>, CommandDeps<C>>;

--- a/packages/core/src/validation/args.brands.ts
+++ b/packages/core/src/validation/args.brands.ts
@@ -1,5 +1,11 @@
 import type { ArgsDef } from "../types.ts";
-import type { AsyncParseBrand, DefaultWithinChoicesBrand, DefName, Overlap } from "./shared.ts";
+import type {
+	AsyncParseBrand,
+	DefaultWithinChoicesBrand,
+	DefName,
+	EmptyLiteralNameBrand,
+	Overlap,
+} from "./shared.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Compile-time validation
@@ -19,9 +25,7 @@ type DuplicateArgBrand<A, Existing extends string> =
 type EmptyArgNameError = { readonly FIX_EMPTY_NAME: "Argument names must be non-empty" };
 
 /** Brand a statically known empty argument name while allowing widened and generic names. */
-export type EmptyArgNameBrand<Name extends string> = ({
-	readonly "": EmptyArgNameError;
-} & Record<string, unknown>)[Name];
+export type EmptyArgNameBrand<Name extends string> = EmptyLiteralNameBrand<Name, EmptyArgNameError>;
 
 // An empty name renders as "<>" in help/snapshot labels and validation messages.
 type EmptyArgDefinitionNameBrand<A> = "" extends DefName<A> ? EmptyArgNameError : {};

--- a/packages/core/src/validation/args.brands.ts
+++ b/packages/core/src/validation/args.brands.ts
@@ -16,15 +16,21 @@ type DuplicateArgBrand<A, Existing extends string> =
 				}
 		: never;
 
+type EmptyArgNameError = { readonly FIX_EMPTY_NAME: "Argument names must be non-empty" };
+
+/** Brand a statically known empty argument name while allowing widened and generic names. */
+export type EmptyArgNameBrand<Name extends string> = ({
+	readonly "": EmptyArgNameError;
+} & Record<string, unknown>)[Name];
+
 // An empty name renders as "<>" in help/snapshot labels and validation messages.
-type EmptyArgNameBrand<A> =
-	"" extends DefName<A> ? { readonly FIX_EMPTY_NAME: "Argument names must be non-empty" } : {};
+type EmptyArgDefinitionNameBrand<A> = "" extends DefName<A> ? EmptyArgNameError : {};
 
 type ArgChecks<A, Existing extends string> = A &
 	DuplicateArgBrand<A, Existing> &
 	AsyncParseBrand<A> &
 	DefaultWithinChoicesBrand<A> &
-	EmptyArgNameBrand<A>;
+	EmptyArgDefinitionNameBrand<A>;
 
 /**
  * Per-arg validation tuple type. Resolves to `A` when the constraints are

--- a/packages/core/src/validation/commands.brands.ts
+++ b/packages/core/src/validation/commands.brands.ts
@@ -1,4 +1,4 @@
-import type { DefName, Overlap } from "./shared.ts";
+import type { DefName, EmptyLiteralNameBrand, Overlap } from "./shared.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Compile-time validation
@@ -44,9 +44,7 @@ export type ValidateCommandConfig<Name extends string, C> = string extends Name
 type EmptyNameError = { readonly FIX_EMPTY_NAME: "Command name must be a non-empty string" };
 
 /** Brand a statically known empty command name while allowing widened and generic names. */
-export type EmptyNameBrand<Name extends string> = ({
-	readonly "": EmptyNameError;
-} & Record<string, unknown>)[Name];
+export type EmptyNameBrand<Name extends string> = EmptyLiteralNameBrand<Name, EmptyNameError>;
 
 /**
  * Brand a statically known empty command name at the composition site:

--- a/packages/core/src/validation/commands.brands.ts
+++ b/packages/core/src/validation/commands.brands.ts
@@ -41,15 +41,19 @@ export type ValidateCommandConfig<Name extends string, C> = string extends Name
 		? {}
 		: { readonly FIX_ALIAS_SHAPE: AliasShapeErrors<Name, C> };
 
+type EmptyNameError = { readonly FIX_EMPTY_NAME: "Command name must be a non-empty string" };
+
+/** Brand a statically known empty command name while allowing widened and generic names. */
+export type EmptyNameBrand<Name extends string> = ({
+	readonly "": EmptyNameError;
+} & Record<string, unknown>)[Name];
+
 /**
  * Brand a statically known empty command name at the composition site:
  * routing stops at empty argv tokens, so such a command can never dispatch.
  * Widened names opt out (`DefName` yields `never`, which `""` does not extend).
  */
-type EmptyNameBrand<D> =
-	"" extends DefName<D>
-		? { readonly FIX_EMPTY_NAME: "Command name must be a non-empty string" }
-		: {};
+type EmptyDefinitionNameBrand<D> = "" extends DefName<D> ? EmptyNameError : {};
 
 type DefinitionAliases<D> = D extends {
 	readonly _aliases?: infer A extends readonly string[];
@@ -97,7 +101,10 @@ export type ValidateCommandDefinitions<
 	Existing extends string = never,
 > = Ds extends readonly [infer Head, ...infer Tail]
 	? readonly [
-			Head & CommandCollisionBrand<Head, Existing> & EmptyNameBrand<Head> & SelfAliasBrand<Head>,
+			Head &
+				CommandCollisionBrand<Head, Existing> &
+				EmptyDefinitionNameBrand<Head> &
+				SelfAliasBrand<Head>,
 			...ValidateCommandDefinitions<Tail, Existing | CommandDefinitionSpellings<Head>>,
 		]
 	: Ds;

--- a/packages/core/src/validation/direct-names.brands.test.ts
+++ b/packages/core/src/validation/direct-names.brands.test.ts
@@ -35,6 +35,8 @@ describe("direct definition name brands", () => {
 		}
 
 		const dynamicName = "dynamic" as string;
+		// Direct widened calls take the eager indexed-access path, not the deferred generic one.
+		expect(defineFlag(dynamicName, { type: "string" }).name).toBe("dynamic");
 		expect(myFlag(dynamicName).name).toBe("dynamic");
 		expect(myArg(dynamicName).name).toBe("dynamic");
 		expect(myCommand(dynamicName).name).toBe("dynamic");

--- a/packages/core/src/validation/direct-names.brands.test.ts
+++ b/packages/core/src/validation/direct-names.brands.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+
+import { defineArg, defineFlag } from "../api/flags.ts";
+import { defineCommand } from "../command/crust.ts";
+
+describe("direct definition name brands", () => {
+	it("rejects statically known empty names at every direct definition API", () => {
+		const command = defineCommand("valid", (builder) => builder);
+		const typecheck = () => {
+			// @ts-expect-error -- flag names must be non-empty
+			defineFlag("", { type: "string" });
+			// @ts-expect-error -- argument names must be non-empty
+			defineArg("", { type: "string" });
+			// @ts-expect-error -- command names must be non-empty
+			defineCommand("", (builder) => builder);
+			// @ts-expect-error -- renamed command names must be non-empty
+			command.as("");
+		};
+
+		expect(typecheck).toBeInstanceOf(Function);
+	});
+
+	it("keeps generic wrappers and widened string names accepted", () => {
+		function myFlag<Name extends string>(name: Name) {
+			return defineFlag(name, { type: "string" });
+		}
+		function myArg<Name extends string>(name: Name) {
+			return defineArg(name, { type: "string" });
+		}
+		function myCommand<Name extends string>(name: Name) {
+			return defineCommand(name, (builder) => builder);
+		}
+		function renameCommand<Name extends string>(name: Name) {
+			return myCommand("source").as(name);
+		}
+
+		const dynamicName = "dynamic" as string;
+		expect(myFlag(dynamicName).name).toBe("dynamic");
+		expect(myArg(dynamicName).name).toBe("dynamic");
+		expect(myCommand(dynamicName).name).toBe("dynamic");
+		expect(renameCommand(dynamicName).name).toBe("dynamic");
+	});
+});

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -1,5 +1,11 @@
 import type { FlagsDef, NamedFlagDef, NamedFlagsRecord } from "../types.ts";
-import type { AsyncParseBrand, DefaultWithinChoicesBrand, DefName, Overlap } from "./shared.ts";
+import type {
+	AsyncParseBrand,
+	DefaultWithinChoicesBrand,
+	DefName,
+	EmptyLiteralNameBrand,
+	Overlap,
+} from "./shared.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Compile-time validation
@@ -32,9 +38,10 @@ type EmptySpellingError = {
 };
 
 /** Brand a statically known empty flag name while allowing widened and generic names. */
-export type EmptyFlagSpellingBrand<Name extends string> = ({
-	readonly "": EmptySpellingError;
-} & Record<string, unknown>)[Name];
+export type EmptyFlagSpellingBrand<Name extends string> = EmptyLiteralNameBrand<
+	Name,
+	EmptySpellingError
+>;
 
 /** Reject empty spellings: their CLI tokens (`--`, `-`) are unparseable, so the flag can never be supplied. */
 type EmptySpellingBrand<F> = "" extends DefName<F> | ExtractAllAliases<F> ? EmptySpellingError : {};

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -27,12 +27,17 @@ type ReservedSpellingBrand<F> = "__proto__" extends DefName<F> | ExtractAllAlias
 		}
 	: {};
 
+type EmptySpellingError = {
+	readonly FIX_EMPTY_SPELLING: "Flag names and aliases must be non-empty strings";
+};
+
+/** Brand a statically known empty flag name while allowing widened and generic names. */
+export type EmptyFlagSpellingBrand<Name extends string> = ({
+	readonly "": EmptySpellingError;
+} & Record<string, unknown>)[Name];
+
 /** Reject empty spellings: their CLI tokens (`--`, `-`) are unparseable, so the flag can never be supplied. */
-type EmptySpellingBrand<F> = "" extends DefName<F> | ExtractAllAliases<F>
-	? {
-			readonly FIX_EMPTY_SPELLING: "Flag names and aliases must be non-empty strings";
-		}
-	: {};
+type EmptySpellingBrand<F> = "" extends DefName<F> | ExtractAllAliases<F> ? EmptySpellingError : {};
 
 /** Canonical names claimed by more than one definition in the same call. */
 type DuplicateNames<

--- a/packages/core/src/validation/shared.ts
+++ b/packages/core/src/validation/shared.ts
@@ -21,6 +21,11 @@ export type DefName<T> = T extends { name: infer N extends string }
  */
 export type Overlap<S, Existing extends string> = S & Existing;
 
+/** Brand a statically known empty literal while allowing widened and generic names. */
+export type EmptyLiteralNameBrand<Name extends string, Err> = ({
+	readonly "": Err;
+} & Record<string, unknown>)[Name];
+
 /**
  * Brand a definition whose custom parser can return a Promise — parse results
  * are consumed synchronously during argv parsing. `Extract` keeps the check


### PR DESCRIPTION
## Summary

Implements #279: literal empty names now fail typecheck at the four direct definition sites — `defineFlag("")`, `defineArg("")`, `defineCommand("")` (both overloads), and definition `.as("")` — closing the gap left when PR #277 removed the runtime `nonEmptyName` rule. Composition-site brands (`.flags()`/`.args()`/`.add()`) already existed; this covers definitions created but not yet attached.

**Mechanism:** parameter intersection `Name & ({ "": Error } & Record<string, unknown>)[Name]` — literal `""` resolves to the error brand (fails assignability), while deferred generics and widened `string` resolve through the index signature to `unknown` (compile untouched). Error types are shared with the existing composition-site brands, so `FIX_EMPTY_SPELLING` / `FIX_EMPTY_NAME` keys and messages have a single source.

**Explicitly preserved:**
- Generic wrappers keep compiling — regression-tested with real `<Name extends string>` wrapper functions over all four APIs (the exact break called out in the issue).
- Widened/dynamic names stay accepted at compile time and keep their runtime guards (`new Crust("")` constructor check, flag spelling validation).

## Tests
`packages/core/src/validation/direct-names.brands.test.ts`: `@ts-expect-error` on all four literal sites (enforced via `check:types` unused-directive errors), generic wrappers for all four, direct widened calls and wrapper-widened calls.

## Validation
- `bun test packages/core/src/validation` — 44 pass / `bun test` core command suites — 130 pass, 0 fail
- `bun run --cwd packages/core check:types`, declaration-emission test, lint, format — pass
- Type-perf vs main baseline: core **−2.01%** instantiations, consumers +0.05–0.10% — no regression
- Two independent review passes: no blockers; both nits addressed in the follow-up commit

## Stack
PR 3/6 of the v0.2 stack, based on #283. Retarget to `main` after #283 merges (hosted CI triggers only on `main`-based PRs; local gates above stand in until then).

Fixes #279
