### PR TITLE
feat(core): typed action results — run() infers the action return type

### DIFF
--- a/.changeset/typed-action-results.md
+++ b/.changeset/typed-action-results.md
@@ -3,4 +3,4 @@
 "@crustjs/testing": minor
 ---
 
-Infer action return values from typed `run()` calls and expose successful results from `captureRun()`.
+Infer action return values from typed `run()` calls and expose them from `captureRun()`. `CapturedRun` is now a discriminated success/error union: the success branch always owns `result` (typed from the selected action), the failure branch owns `error` instead, and `"error" in captured` narrows between them.

--- a/.changeset/typed-action-results.md
+++ b/.changeset/typed-action-results.md
@@ -3,4 +3,11 @@
 "@crustjs/testing": minor
 ---
 
-Infer action return values from typed `run()` calls and expose them from `captureRun()`. `CapturedRun` is now a discriminated success/error union: the success branch always owns `result` (typed from the selected action), the failure branch owns `error` instead, and `"error" in captured` narrows between them.
+Infer action return values from typed `run()` calls.
+
+**BREAKING**: `run()` no longer resolves to `void`; it resolves to a `RunOutcome` discriminated union — `completed` owns the selected action's typed `result`, while `finished` owns the identity of the Extension whose `preRun` hook ended the invocation. `captureRun()` exposes the same distinction as a status-discriminated `CapturedRun`: `completed` owns `result`, `finished` owns the finishing Extension's `by` identity, and `failed` owns the thrown `error` (it previously reported output and errors through optional fields).
+
+```ts
+const outcome = await app.run(["inspect"], { args: { file: "a.txt" } });
+if (outcome.status === "completed") console.log(outcome.result);
+```

--- a/.changeset/typed-action-results.md
+++ b/.changeset/typed-action-results.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/core": minor
+"@crustjs/testing": minor
+---
+
+Infer action return values from typed `run()` calls and expose successful results from `captureRun()`.

--- a/.changeset/typed-prompt-validation-options.md
+++ b/.changeset/typed-prompt-validation-options.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/prompts": minor
+---
+
+Make `InputOptions` and `PasswordOptions` encode `schema` and `validate` as mutually exclusive, matching the existing overloads and runtime validation.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -330,14 +330,14 @@ The `CommandSnapshot` type is exported from `@crustjs/core` and re-exported from
 ## `.run(path, input?, io?)`
 
 ```ts
-run(path, input?, io?): Promise<R | undefined>
+run(path, input?, io?): Promise<RunOutcome<R>>
 ```
 
 Invokes an application programmatically with a command path and structured input inferred from the application. Editors complete command names at each path level plus the selected command's argument and flag names. Required inputs, input value types, and the selected action's awaited return type are inferred by TypeScript.
 
 ```ts
 const stdout: string[] = [];
-const result = await app.run(
+const outcome = await app.run(
   ["greet"],
   { args: { name: "Ada" }, flags: { loud: true } },
   {
@@ -345,8 +345,13 @@ const result = await app.run(
     stderr: (text) => stdout.push(text),
   },
 );
-// result is the awaited return value of the "greet" action, or undefined
-// when an Extension preRun hook finished the invocation first.
+if (outcome.status === "completed") {
+  // outcome.result is the awaited return value of the "greet" action.
+  console.log(outcome.result);
+} else {
+  // outcome.by identifies the Extension whose preRun hook finished first.
+  console.log(`Finished by ${outcome.by}`);
+}
 ```
 
 Structured values are serialized to argv and pass through the normal router, parser, schema, Context, and Command Action pipeline. When `io` contains at least one callback, the resolved callbacks are also ambient for the full invocation: progress indicators and prompt output default to the injected `stderr` callback. Progress uses non-TTY static lines, and prompt input remains a separate `PromptIO` concern.
@@ -359,7 +364,7 @@ await app.run(["exec"], { args: { command: "lint" }, raw: ["--fix", "src"] });
 
 Positional values beginning with `-`, or equal to a subcommand name or alias of the selected command, cannot be represented through `run()` and throw a `PARSE` error; use `execute({ argv })` when testing raw terminal syntax.
 
-`run()` resolves with the selected Command Action's awaited return value after successful cleanup. If an Extension `preRun` hook finishes the invocation before the action runs, `run()` resolves to `undefined` as normal control flow. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
+`run()` resolves to a `RunOutcome`: `{ status: "completed", result }` carries the selected Command Action's awaited return value after successful cleanup (including `undefined` from actionless or `void` actions), while `{ status: "finished", by }` identifies the Extension whose `preRun` hook finished the invocation first. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
 
 Extension-contributed commands and flags are runtime-dynamic and therefore do not appear in the typed command path or input: an Extension flag passed to `run()` throws a `PARSE` error. Invoke those through `execute({ argv })`.
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -39,9 +39,7 @@ interface CommandDefinitionBuilder<
   args(...defs: ArgsDef): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
   add(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
-  action(
-    action: (ctx: CrustCommandContext<A, Flags, Ctx>) => void | Promise<void>,
-  ): CommandDefinitionBuilder;
+  action<R>(action: (ctx: CrustCommandContext<A, Flags, Ctx>) => R): CommandDefinitionBuilder;
 }
 ```
 
@@ -257,12 +255,12 @@ See [Extensions](/docs/guide/extensions) for authoring custom Extensions.
 ## `.action(action)`
 
 ```ts
-action(
-  action: (ctx: CrustCommandContext<A, Flags, Ctx>) => void | Promise<void>,
+action<R>(
+  action: (ctx: CrustCommandContext<A, Flags, Ctx>) => R,
 ): Crust
 ```
 
-Defines the Command Action. A later `.action()` call replaces the action on the returned immutable builder. The action runs after routing, parsing, `preRun` hooks, and validation; Contexts construct on demand.
+Defines the Command Action. Its awaited return type is carried by the builder for typed `run()` calls. A later `.action()` call replaces both the action and its result type on the returned immutable builder. The action runs after routing, parsing, `preRun` hooks, and validation; Contexts construct on demand.
 
 ```ts
 const app = new Crust("greet")
@@ -332,14 +330,14 @@ The `CommandSnapshot` type is exported from `@crustjs/core` and re-exported from
 ## `.run(path, input?, io?)`
 
 ```ts
-run(path, input?, io?): Promise<void>
+run(path, input?, io?): Promise<R | undefined>
 ```
 
-Invokes an application programmatically with a command path and structured input inferred from the application. Editors complete command names at each path level plus the selected command's argument and flag names. Required inputs and value types are checked by TypeScript.
+Invokes an application programmatically with a command path and structured input inferred from the application. Editors complete command names at each path level plus the selected command's argument and flag names. Required inputs, input value types, and the selected action's awaited return type are inferred by TypeScript.
 
 ```ts
 const stdout: string[] = [];
-await app.run(
+const result = await app.run(
   ["greet"],
   { args: { name: "Ada" }, flags: { loud: true } },
   {
@@ -347,6 +345,8 @@ await app.run(
     stderr: (text) => stdout.push(text),
   },
 );
+// result is the awaited return value of the "greet" action, or undefined
+// when an Extension preRun hook finished the invocation first.
 ```
 
 Structured values are serialized to argv and pass through the normal router, parser, schema, Context, and Command Action pipeline. When `io` contains at least one callback, the resolved callbacks are also ambient for the full invocation: progress indicators and prompt output default to the injected `stderr` callback. Progress uses non-TTY static lines, and prompt input remains a separate `PromptIO` concern.
@@ -359,7 +359,7 @@ await app.run(["exec"], { args: { command: "lint" }, raw: ["--fix", "src"] });
 
 Positional values beginning with `-`, or equal to a subcommand name or alias of the selected command, cannot be represented through `run()` and throw a `PARSE` error; use `execute({ argv })` when testing raw terminal syntax.
 
-`run()` resolves after successful cleanup. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
+`run()` resolves with the selected Command Action's awaited return value after successful cleanup. If an Extension `preRun` hook finishes the invocation before the action runs, `run()` resolves to `undefined` as normal control flow. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
 
 Extension-contributed commands and flags are runtime-dynamic and therefore do not appear in the typed command path or input: an Extension flag passed to `run()` throws a `PARSE` error. Invoke those through `execute({ argv })`.
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -366,7 +366,7 @@ Positional values beginning with `-`, or equal to a subcommand name or alias of 
 
 `run()` resolves to a `RunOutcome`: `{ status: "completed", result }` carries the selected Command Action's awaited return value after successful cleanup (including `undefined` from actionless or `void` actions), while `{ status: "finished", by }` identifies the Extension whose `preRun` hook finished the invocation first. It does not render errors, run Extension `onError` hooks, or change `process.exitCode`. Definition, parse, Context, Command Action, and cancellation failures are thrown unchanged.
 
-Extension-contributed commands and flags are runtime-dynamic and therefore do not appear in the typed command path or input: an Extension flag passed to `run()` throws a `PARSE` error. Invoke those through `execute({ argv })`.
+Extension-contributed commands and flags are runtime-dynamic and therefore do not appear in the typed command path or input: an Extension flag passed to `run()` throws a `PARSE` error. Invoke those through `execute({ argv })`. If an Extension command reuses an authored command's canonical name, routing keeps the documented last-write-wins behavior at runtime while `run()` still types the input and result from the authored command — namespace Extension command names to avoid this mismatch.
 
 ## `.execute(options?)`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -136,7 +136,7 @@ Snapshots omit schemas and parse functions. `URL` defaults become strings, and a
 
 ## Typed invocation
 
-Types inferred from the application definition that back [`run(path, input?, io?)`](/docs/api/crust#runpath-input-io) and the [`@crustjs/testing`](/docs/modules/testing) helpers. `CommandTree` is the compile-time tree accumulated by `.add()`; `CommandPath` enumerates every valid path through it (including the root path `[]`); `CommandShapeAt` resolves the `CommandShape` a path selects; and `RunInput` is the structured `args`/`flags`/`raw` input for that shape, built from the pre-parse `InputArgs` and `InputFlags` value types. `RunInputArguments` and `RunArguments` are the tuple types that make `input` optional when the selected command requires nothing. `AnyCrust` accepts any fully-built application.
+Types inferred from the application definition that back [`run(path, input?, io?)`](/docs/api/crust#runpath-input-io) and the [`@crustjs/testing`](/docs/modules/testing) helpers. `CommandTree` is the compile-time tree accumulated by `.add()`; `CommandPath` enumerates every valid path through it (including the root path `[]`); `CommandShapeAt` resolves the `CommandShape` a path selects; and `RunInput` is the structured `args`/`flags`/`raw` input for that shape, built from the pre-parse `InputArgs` and `InputFlags` value types. `RunInputArguments` and `RunArguments` are the tuple types that make `input` optional when the selected command requires nothing; `RunOutcome` is the status-discriminated value `run()` resolves to. `AnyCrust` accepts any fully-built application.
 
 ```ts
 import type { CommandPath, CommandShapeAt, RunInput } from "@crustjs/core";

--- a/apps/docs/content/docs/guide/commands.mdx
+++ b/apps/docs/content/docs/guide/commands.mdx
@@ -82,9 +82,10 @@ await app.run(
 );
 ```
 
-`run()` throws the original error. `execute()` presents errors through Extension `onError` hooks, sets `process.exitCode`, and resolves. See [Execution Model](/docs/guide/lifecycle).
+`run()` resolves to a status-discriminated outcome: `completed` carries the action result, while `finished` names the Extension whose `preRun` hook ended the invocation. It throws the original error on failure. `execute()` presents errors through Extension `onError` hooks, sets `process.exitCode`, and resolves. See [Execution Model](/docs/guide/lifecycle).
 
 <Callout type="info">
   A command without a Command Action is valid when it owns subcommands. Invoking it directly
-  resolves without output; register the `help()` Extension to present the container's help instead.
+  resolves to `{ status: "completed", result: undefined }`; register the `help()` Extension to
+  present the container's help instead.
 </Callout>

--- a/apps/docs/content/docs/guide/lifecycle.mdx
+++ b/apps/docs/content/docs/guide/lifecycle.mdx
@@ -26,7 +26,7 @@ await app.run(
 );
 ```
 
-It requires an explicit typed command path, serializes structured input through the normal parser, honors injected writers, throws the original error, does not render it, and does not modify `process.exitCode`. Runtime-dynamic Extension commands use `execute({ argv })` instead.
+It requires an explicit typed command path, serializes structured input through the normal parser, honors injected writers, throws the original error, does not render it, and does not modify `process.exitCode`. It resolves to `{ status: "completed", result }` after an action (including actionless and `void` actions), or `{ status: "finished", by }` when an Extension `preRun` hook finishes first. Runtime-dynamic Extension commands use `execute({ argv })` instead.
 
 ## Successful invocation order
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -13,7 +13,7 @@ bun add -d @crustjs/testing
 
 ## Capture command output
 
-Use `captureRun()` for commands that write ordinary stdout or stderr or return a value. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults), and the action's awaited return value is available as the inferred `result`. `result` is `undefined` when an Extension `preRun` hook finishes first or the application throws; a thrown value is returned as `error` without discarding earlier output.
+Use `captureRun()` for commands that write ordinary stdout or stderr or return a value. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults). The capture is a union: on success it carries the action's awaited return value as the inferred `result` (`undefined` when an Extension `preRun` hook finishes first); when the application throws it carries the thrown value as `error` instead, without discarding earlier output. Narrow with `"error" in captured`.
 
 ```ts
 import { expect, test } from "bun:test";
@@ -22,11 +22,11 @@ import { captureRun } from "@crustjs/testing";
 import { app } from "./cli.ts";
 
 test("greets a name", async () => {
-  const result = await captureRun(app, [], { args: { name: "Ada" } });
+  const captured = await captureRun(app, [], { args: { name: "Ada" } });
 
-  expect(result.stdout).toBe("Hello, Ada!");
-  expect(result.stderr).toBe("");
-  expect(result.error).toBeUndefined();
+  expect(captured.stdout).toBe("Hello, Ada!");
+  expect(captured.stderr).toBe("");
+  expect("error" in captured).toBe(false);
 });
 ```
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -13,7 +13,7 @@ bun add -d @crustjs/testing
 
 ## Capture command output
 
-Use `captureRun()` for commands that write ordinary stdout or stderr or return a value. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults). The capture is a union: on success it carries the action's awaited return value as the inferred `result` (`undefined` when an Extension `preRun` hook finishes first); when the application throws it carries the thrown value as `error` instead, without discarding earlier output. Narrow with `"error" in captured`.
+Use `captureRun()` for commands that write ordinary stdout or stderr or return a value. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults). The capture is a status-discriminated union: `completed` carries the action's inferred `result`, `finished` names the Extension whose `preRun` hook ended the invocation, and `failed` carries the thrown value without discarding earlier output.
 
 ```ts
 import { expect, test } from "bun:test";
@@ -26,7 +26,7 @@ test("greets a name", async () => {
 
   expect(captured.stdout).toBe("Hello, Ada!");
   expect(captured.stderr).toBe("");
-  expect("error" in captured).toBe(false);
+  expect(captured.status).toBe("completed");
 });
 ```
 

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -13,7 +13,7 @@ bun add -d @crustjs/testing
 
 ## Capture command output
 
-Use `captureRun()` for commands that write ordinary stdout or stderr. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults), and a thrown application error is returned instead of discarding output that occurred before it.
+Use `captureRun()` for commands that write ordinary stdout or stderr or return a value. Each `ctx.stdout()`/`ctx.stderr()` call is captured as one line, joined with `"\n"` (matching the terminal defaults), and the action's awaited return value is available as the inferred `result`. `result` is `undefined` when an Extension `preRun` hook finishes first or the application throws; a thrown value is returned as `error` without discarding earlier output.
 
 ```ts
 import { expect, test } from "bun:test";

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -99,10 +99,13 @@ These types back [`run(path, input?, io?)`](/docs/api/crust) and the [`@crustjs/
 | `CommandShape`      | Argument, flag, children, and action result shape of one command              |
 | `CommandShapeAt`    | Resolve the command shape at a typed path                                     |
 | `RunInput`          | Structured `args`, `flags`, and `raw` values accepted by `run()`              |
+| `RunOutcome`        | Completed action result or the Extension that finished the invocation         |
 | `RunInputArguments` | Input tuple for a shape: optional when nothing is required                    |
 | `RunArguments`      | Full `run()` rest tuple: input plus optional invocation I/O                   |
 | `InputArgs`         | Pre-parse structured argument values for an argument definition list          |
 | `InputFlags`        | Pre-parse structured flag values for a flag definition record                 |
+
+`run()` resolves to `RunOutcome<R>`: the `completed` branch owns the selected action's typed `result`, while the `finished` branch owns the `ExtensionId` of the Extension whose `preRun` hook ended the invocation.
 
 ## Command boundary types
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -96,7 +96,7 @@ These types back [`run(path, input?, io?)`](/docs/api/crust) and the [`@crustjs/
 | `AnyCrust`          | Any fully-built application; parameter type for APIs accepting arbitrary apps |
 | `CommandTree`       | Compile-time command tree accumulated by `.add()`                             |
 | `CommandPath`       | Every valid typed path through a command tree, including the root path `[]`   |
-| `CommandShape`      | Argument, flag, and children shape of one command                             |
+| `CommandShape`      | Argument, flag, children, and action result shape of one command              |
 | `CommandShapeAt`    | Resolve the command shape at a typed path                                     |
 | `RunInput`          | Structured `args`, `flags`, and `raw` values accepted by `run()`              |
 | `RunInputArguments` | Input tuple for a shape: optional when nothing is required                    |

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -27,23 +27,27 @@ An inert `CommandDefinition` must first be added to a `Crust` application before
 
 ## `captureRun(app, path, input?)`
 
-Run an application with captured output and the selected action's inferred result. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. On success, `result` contains the action's awaited return value; it is `undefined` when an Extension `preRun` hook finished first. If the application throws, `error` contains that value, `result` is `undefined`, and output written before the failure is retained.
+Run an application with captured output and the selected action's inferred result. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. On success, the capture is the `result` branch holding the action's awaited return value; the value is `undefined` when an Extension `preRun` hook finished first. If the application throws, the capture is the `error` branch instead — it has no `result` property — and output written before the failure is retained. Narrow with `"error" in captured`; thrown values can be falsy, so property presence is the reliable discriminant.
 
 ```ts
 import { captureRun } from "@crustjs/testing";
 
-const result = await captureRun(app, ["build"], {
+const captured = await captureRun(app, ["build"], {
   args: { entry: "src/cli.ts" },
   flags: { minify: true },
 });
 
-if (result.error) throw result.error;
-console.log(result.stdout, result.result);
+if ("error" in captured) throw captured.error;
+console.log(captured.stdout, captured.result);
 ```
 
-The return type is `CapturedRun`:
+The return type is `CapturedRun`, a union of the success and failure branches:
 
-<auto-type-table path="../../../../../packages/testing/src/index.ts" name="CapturedRun" />
+```ts
+type CapturedRun<Result = unknown> =
+  | { readonly stdout: string; readonly stderr: string; readonly result: Result }
+  | { readonly stdout: string; readonly stderr: string; readonly error: unknown };
+```
 
 ## `captureExecute(app, argv)`
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -27,7 +27,7 @@ An inert `CommandDefinition` must first be added to a `Crust` application before
 
 ## `captureRun(app, path, input?)`
 
-Run an application with captured output. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. If the application throws, `error` contains that value and output written before the failure is retained.
+Run an application with captured output and the selected action's inferred result. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. On success, `result` contains the action's awaited return value; it is `undefined` when an Extension `preRun` hook finished first. If the application throws, `error` contains that value, `result` is `undefined`, and output written before the failure is retained.
 
 ```ts
 import { captureRun } from "@crustjs/testing";
@@ -38,7 +38,7 @@ const result = await captureRun(app, ["build"], {
 });
 
 if (result.error) throw result.error;
-console.log(result.stdout);
+console.log(result.stdout, result.result);
 ```
 
 The return type is `CapturedRun`:

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -27,7 +27,7 @@ An inert `CommandDefinition` must first be added to a `Crust` application before
 
 ## `captureRun(app, path, input?)`
 
-Run an application with captured output and the selected action's inferred result. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. On success, the capture is the `result` branch holding the action's awaited return value; the value is `undefined` when an Extension `preRun` hook finished first. If the application throws, the capture is the `error` branch instead — it has no `result` property — and output written before the failure is retained. Narrow with `"error" in captured`; thrown values can be falsy, so property presence is the reliable discriminant.
+Run an application with captured output and the selected action's inferred result. Each `ctx.stdout()`/`ctx.stderr()` call is one line (matching the terminal defaults), and the returned `stdout` and `stderr` fields join those lines with `"\n"`. The `completed` branch owns the action's awaited `result`, the `finished` branch owns the finishing Extension's `by` identity, and the `failed` branch owns the thrown `error`. Output written before failure is retained. Narrow with `captured.status`.
 
 ```ts
 import { captureRun } from "@crustjs/testing";
@@ -37,16 +37,25 @@ const captured = await captureRun(app, ["build"], {
   flags: { minify: true },
 });
 
-if ("error" in captured) throw captured.error;
-console.log(captured.stdout, captured.result);
+if (captured.status === "failed") throw captured.error;
+if (captured.status === "finished") {
+  console.log(`Finished by ${captured.by}`);
+} else {
+  console.log(captured.stdout, captured.result);
+}
 ```
 
-The return type is `CapturedRun`, a union of the success and failure branches:
+The return type is `CapturedRun`, a union of completed, finished, and failed branches:
 
 ```ts
-type CapturedRun<Result = unknown> =
-  | { readonly stdout: string; readonly stderr: string; readonly result: Result }
-  | { readonly stdout: string; readonly stderr: string; readonly error: unknown };
+export type CapturedRun<Result = unknown> = {
+  readonly stdout: string;
+  readonly stderr: string;
+} & (
+  | { readonly status: "completed"; readonly result: Result }
+  | { readonly status: "finished"; readonly by: ExtensionId }
+  | { readonly status: "failed"; readonly error: unknown }
+);
 ```
 
 ## `captureExecute(app, argv)`

--- a/apps/docs/examples/quick-start/invoke.ts
+++ b/apps/docs/examples/quick-start/invoke.ts
@@ -8,7 +8,7 @@ const app = new Crust("my-cli")
 //#region run
 const output: string[] = [];
 
-await app.run(
+const outcome = await app.run(
   [],
   { args: { name: "Ada" }, flags: { greet: "Hi" } },
   {
@@ -16,4 +16,8 @@ await app.run(
     stderr: (line) => output.push(line),
   },
 );
+
+if (outcome.status === "finished") {
+  throw new Error(`Invocation finished early by ${outcome.by}`);
+}
 //#endregion

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -695,7 +695,7 @@ describe("Context dependency runtime boundaries", () => {
 			details: { name: "logger", reason: "missing-context" },
 		});
 		// The root path is healthy: logger was provided before .extend().
-		await expect(app.run([])).resolves.toBeUndefined();
+		await expect(app.run([])).resolves.toEqual({ status: "completed", result: undefined });
 	});
 
 	it("keeps a child's locally provided Context over a root Extension provider", async () => {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -10,6 +10,7 @@ import type {
 } from "../api/context.ts";
 import type { Extension, ExtensionsProvidesOutput } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
+import type { ExtensionId } from "../identity.ts";
 import { addFlagSpellingEntries, cloneFlagSpellings } from "../parsing/spellings.ts";
 import type {
 	ArgDef,
@@ -109,6 +110,11 @@ export interface CommandShape<
 	readonly children: Children;
 	readonly result?: Result;
 }
+
+/** Result of a successful programmatic invocation. */
+export type RunOutcome<Result> =
+	| { readonly status: "completed"; readonly result: Result }
+	| { readonly status: "finished"; readonly by: ExtensionId };
 
 /** Compile-time command tree accumulated by `.add()`. */
 export type CommandTree = Record<string, CommandShape>;
@@ -1065,10 +1071,11 @@ export class Crust<
 	 * Unlike {@link Crust.execute}, `run()` throws the original definition,
 	 * parse, Context, or action failure without rendering it (Extension
 	 * `onError` hooks are a terminal presentation concern and never run
-	 * here) and without changing process status. It resolves with the selected
-	 * action's return value after successful cleanup. If an Extension `preRun`
-	 * hook finishes the invocation before the action runs, it resolves to
-	 * `undefined`. Prompt cancellation surfaces as a standard `AbortError`.
+	 * here) and without changing process status. It resolves to a `completed`
+	 * outcome carrying the selected action's return value after successful
+	 * cleanup, or a `finished` outcome naming the Extension whose `preRun`
+	 * hook ended the invocation first. Prompt cancellation surfaces as a
+	 * standard `AbortError`.
 	 *
 	 * @param path - Typed path to the command to invoke (`[]` selects the root)
 	 * @param input - Structured argument, flag, and raw values
@@ -1078,7 +1085,7 @@ export class Crust<
 	async run<const Path extends CommandPath<Tree>>(
 		path: Path,
 		...args: RunArguments<CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>>
-	): Promise<CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"] | undefined> {
+	): Promise<RunOutcome<CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"]>> {
 		const structuredInput = (args[0] ?? {}) as {
 			readonly args?: object;
 			readonly flags?: object;
@@ -1087,9 +1094,9 @@ export class Crust<
 		const io = args[1] as Partial<InvocationIO> | undefined;
 		const argv = serializeRunArgv(this._node, path, structuredInput);
 		// Programmatic calls preserve raw failures and never change process status.
-		return (await runInvocation(this._node, argv, io, materializeCommandDefinition)) as
-			| CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"]
-			| undefined;
+		return (await runInvocation(this._node, argv, io, materializeCommandDefinition)) as RunOutcome<
+			CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"]
+		>;
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -146,7 +146,11 @@ export type CommandShapeAt<
 		? Shape["children"][Head] extends infer Child extends CommandShape
 			? CommandShapeAt<Child, Tail>
 			: never
-		: never
+		: // A non-literal segment (e.g. a hand-annotated `[string, ...string[]]`
+			// tuple) selects a statically unknowable command, not no command.
+			string extends Head
+			? CommandShape
+			: never
 	: Path extends readonly []
 		? Shape
 		: // A tail widened past the CommandPath depth cap selects a statically

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -108,7 +108,7 @@ export interface CommandShape<
 	readonly args: A;
 	readonly flags: F;
 	readonly children: Children;
-	readonly result?: Result;
+	readonly result: Result;
 }
 
 /** Result of a successful programmatic invocation. */
@@ -147,7 +147,11 @@ export type CommandShapeAt<
 			? CommandShapeAt<Child, Tail>
 			: never
 		: never
-	: Shape;
+	: Path extends readonly []
+		? Shape
+		: // A tail widened past the CommandPath depth cap selects a statically
+			// unknowable command, so the shape (and its result) widens too.
+			CommandShape;
 
 type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends Pick<T, K> ? never : K;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -97,15 +97,17 @@ export interface CrustCommandContext<
 // Typed programmatic invocation
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Compile-time description of one command's programmatic input. */
+/** Compile-time description of one command's programmatic input and action result. */
 export interface CommandShape<
 	A extends ArgsDef = ArgsDef,
 	F extends FlagsDef = FlagsDef,
 	Children extends object = {},
+	Result = unknown,
 > {
 	readonly args: A;
 	readonly flags: F;
 	readonly children: Children;
+	readonly result?: Result;
 }
 
 /** Compile-time command tree accumulated by `.add()`. */
@@ -180,7 +182,7 @@ export interface CommandConfig extends Omit<CommandMeta, "name"> {
 /** Static metadata accepted by the root command constructor. */
 export type RootCommandMeta = Pick<CommandMeta, "description" | "usage" | "sections">;
 
-type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any, any>;
+type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any, any, any>;
 
 // Child builders start without inherited flags, so brands cannot see ancestor
 // spellings from inside a sealed recipe. Materialization seeds the child with
@@ -326,6 +328,7 @@ export interface CommandDefinitionBuilder<
 	Sp extends string = SpellingsOf<Flags>,
 	Tree extends object = {},
 	CtxFlags extends FlagsDef = {},
+	Result = void,
 > {
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
@@ -336,12 +339,13 @@ export interface CommandDefinitionBuilder<
 		Sibs,
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
 		Tree,
-		CtxFlags
+		CtxFlags,
+		Result
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags>;
+	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags, Result>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> &
@@ -354,7 +358,8 @@ export interface CommandDefinitionBuilder<
 		Sibs,
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
 		Tree,
-		MergeFlags<CtxFlags, ContextsOwnedFlags<Cs>>
+		MergeFlags<CtxFlags, ContextsOwnedFlags<Cs>>,
+		Result
 	>;
 
 	add<const Ds extends readonly CommandDefinition<any, any, any, any>[]>(
@@ -366,17 +371,27 @@ export interface CommandDefinitionBuilder<
 		Sibs | CommandDefinitionSpellings<Ds[number]>,
 		Sp,
 		Tree & DefinitionsTree<Ds, CtxFlags>,
-		CtxFlags
+		CtxFlags,
+		Result
 	>;
 
-	action(
-		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
-	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags>;
+	action<R>(
+		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => R,
+	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, Awaited<R>>;
 }
 
 type ShapeOfBuilder<B> =
-	B extends CommandDefinitionBuilder<infer Flags, infer A, any, any, any, infer Tree>
-		? CommandShape<A, Flags, Tree>
+	B extends CommandDefinitionBuilder<
+		infer Flags,
+		infer A,
+		any,
+		any,
+		any,
+		infer Tree,
+		any,
+		infer Result
+	>
+		? CommandShape<A, Flags, Tree, Result>
 		: never;
 
 type DefinitionShapeForSpelling<D, Spelling extends string> =
@@ -392,8 +407,13 @@ type DefinitionShapeForSpelling<D, Spelling extends string> =
 // same inherited flag namespace. Local parent flags never inherit and stay out.
 type ShapeWithInheritedFlags<S, CF extends FlagsDef> = {} extends CF
 	? S
-	: S extends CommandShape<infer SA, infer SF, infer SC>
-		? CommandShape<SA, MergeFlags<CF, SF>, { [K in keyof SC]: ShapeWithInheritedFlags<SC[K], CF> }>
+	: S extends CommandShape<infer SA, infer SF, infer SC, infer SR>
+		? CommandShape<
+				SA,
+				MergeFlags<CF, SF>,
+				{ [K in keyof SC]: ShapeWithInheritedFlags<SC[K], CF> },
+				SR
+			>
 		: never;
 
 type DefinitionsTree<
@@ -633,6 +653,7 @@ function serializeRunArgv(
  * - `Tree` — command shapes accumulated by `.add()` for typed `run()`
  * - `CtxFlags` — Context-owned flags accumulated by `.provide()`, inherited by
  *   the shapes of definitions added afterwards
+ * - `Result` — awaited return type of this command's action
  *
  * @example
  * ```ts
@@ -645,7 +666,7 @@ function serializeRunArgv(
  * ```
  */
 /** Broad application type for APIs that accept any fully-built Crust application. */
-export type AnyCrust = Crust<any, any, any, any, any, any, any, any>;
+export type AnyCrust = Crust<any, any, any, any, any, any, any, any, any>;
 
 export class Crust<
 	Flags extends FlagsDef = {},
@@ -656,6 +677,7 @@ export class Crust<
 	Tree extends object = {},
 	CtxFlags extends FlagsDef = {},
 	ExtSp extends string = never,
+	Result = void,
 > {
 	/** @internal — Phantom property exposing generic parameters for type-level testing */
 	declare readonly _types: {
@@ -663,7 +685,7 @@ export class Crust<
 		args: A;
 		ctx: Ctx;
 		tree: Tree;
-		shape: CommandShape<A, Flags, Tree>;
+		shape: CommandShape<A, Flags, Tree, Result>;
 	};
 
 	/** @internal */
@@ -753,7 +775,8 @@ export class Crust<
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
 		Tree,
 		CtxFlags,
-		ExtSp
+		ExtSp,
+		Result
 	> {
 		const localFlags: FlagsDef = { ...this._node.localFlags };
 		const effectiveFlags: FlagsDef = { ...this._node.effectiveFlags };
@@ -794,7 +817,8 @@ export class Crust<
 			Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
 			Tree,
 			CtxFlags,
-			ExtSp
+			ExtSp,
+			Result
 		>;
 	}
 
@@ -811,7 +835,7 @@ export class Crust<
 	 */
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp> {
+	): Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Result> {
 		const combined = [...(this._node.args ?? []), ...defs.map((definition) => ({ ...definition }))];
 		// Brands own literal tuples; this owns config-built defs, where a
 		// duplicate name silently discards a positional and a mid-tuple variadic
@@ -840,7 +864,17 @@ export class Crust<
 		}
 		return this._clone({
 			args: combined,
-		}) as unknown as Crust<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp>;
+		}) as unknown as Crust<
+			Flags,
+			AppendedArgs<A, NewA>,
+			Ctx,
+			Sibs,
+			Sp,
+			Tree,
+			CtxFlags,
+			ExtSp,
+			Result
+		>;
 	}
 
 	/**
@@ -864,7 +898,8 @@ export class Crust<
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
 		Tree,
 		MergeFlags<CtxFlags, ContextsOwnedFlags<Cs>>,
-		ExtSp
+		ExtSp,
+		Result
 	> {
 		// Positional by design: providers reach only this node and children added
 		// afterwards (flag scoping; see definition.test.ts). Extension `provides`
@@ -888,7 +923,8 @@ export class Crust<
 			Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
 			Tree,
 			MergeFlags<CtxFlags, ContextsOwnedFlags<Cs>>,
-			ExtSp
+			ExtSp,
+			Result
 		>;
 	}
 
@@ -905,12 +941,12 @@ export class Crust<
 	 * @param action - The Command Action function
 	 * @returns A new `Crust` instance with the action registered
 	 */
-	action(
-		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => void | Promise<void>,
-	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp> {
+	action<R>(
+		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => R,
+	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Awaited<R>> {
 		return this._clone({
-			run: action as (ctx: unknown) => void | Promise<void>,
-		}) as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp>;
+			run: action as (ctx: unknown) => unknown,
+		}) as unknown as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Awaited<R>>;
 	}
 
 	/**
@@ -933,7 +969,8 @@ export class Crust<
 		Sp | ExtensionsSpellings<Es>,
 		Tree,
 		CtxFlags,
-		ExtSp | ExtensionsSpellings<Es>
+		ExtSp | ExtensionsSpellings<Es>,
+		Result
 	> {
 		const provided = extensions.flatMap((extension) => extension.provides ?? []);
 		return this._clone({
@@ -947,7 +984,8 @@ export class Crust<
 			Sp | ExtensionsSpellings<Es>,
 			Tree,
 			CtxFlags,
-			ExtSp | ExtensionsSpellings<Es>
+			ExtSp | ExtensionsSpellings<Es>,
+			Result
 		>;
 	}
 
@@ -969,9 +1007,10 @@ export class Crust<
 		Sp,
 		Tree & DefinitionsTree<Ds, CtxFlags>,
 		CtxFlags,
-		ExtSp
+		ExtSp,
+		Result
 	> {
-		let result = this as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp>;
+		let result = this as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Result>;
 		for (const definition of definitions) {
 			result = result._addDefinition(definition as CommandDefinition);
 		}
@@ -983,13 +1022,14 @@ export class Crust<
 			Sp,
 			Tree & DefinitionsTree<Ds, CtxFlags>,
 			CtxFlags,
-			ExtSp
+			ExtSp,
+			Result
 		>;
 	}
 
 	private _addDefinition(
 		definition: CommandDefinition,
-	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp> {
+	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Result> {
 		// FIX_COMMAND_COLLISION owns literal names; this owns dynamic `.add()`,
 		// where a silent replacement makes the earlier command unreachable.
 		// Extension-contributed commands keep documented last-write-wins.
@@ -1004,7 +1044,7 @@ export class Crust<
 
 		return this._clone({
 			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		}) as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp>;
+		}) as Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, ExtSp, Result>;
 	}
 
 	/**
@@ -1025,9 +1065,10 @@ export class Crust<
 	 * Unlike {@link Crust.execute}, `run()` throws the original definition,
 	 * parse, Context, or action failure without rendering it (Extension
 	 * `onError` hooks are a terminal presentation concern and never run
-	 * here) and without changing process status. It resolves with no value
-	 * after successful cleanup. Prompt cancellation surfaces as a standard
-	 * `AbortError`.
+	 * here) and without changing process status. It resolves with the selected
+	 * action's return value after successful cleanup. If an Extension `preRun`
+	 * hook finishes the invocation before the action runs, it resolves to
+	 * `undefined`. Prompt cancellation surfaces as a standard `AbortError`.
 	 *
 	 * @param path - Typed path to the command to invoke (`[]` selects the root)
 	 * @param input - Structured argument, flag, and raw values
@@ -1036,8 +1077,8 @@ export class Crust<
 	 */
 	async run<const Path extends CommandPath<Tree>>(
 		path: Path,
-		...args: RunArguments<CommandShapeAt<CommandShape<A, Flags, Tree>, Path>>
-	): Promise<void> {
+		...args: RunArguments<CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>>
+	): Promise<CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"] | undefined> {
 		const structuredInput = (args[0] ?? {}) as {
 			readonly args?: object;
 			readonly flags?: object;
@@ -1046,7 +1087,9 @@ export class Crust<
 		const io = args[1] as Partial<InvocationIO> | undefined;
 		const argv = serializeRunArgv(this._node, path, structuredInput);
 		// Programmatic calls preserve raw failures and never change process status.
-		await runInvocation(this._node, argv, io, materializeCommandDefinition);
+		return (await runInvocation(this._node, argv, io, materializeCommandDefinition)) as
+			| CommandShapeAt<CommandShape<A, Flags, Tree, Result>, Path>["result"]
+			| undefined;
 	}
 
 	/**

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -326,7 +326,7 @@ async function dispatch(
 	io: InvocationIO,
 	onExtensionContext?: (context: ExtensionContext) => void,
 	onFailure?: (error: unknown, context: ExtensionContext) => Promise<ExtensionId | undefined>,
-): Promise<void> {
+): Promise<unknown> {
 	const { rootNode, extensions } = prepared;
 
 	// Routing and syntax parsing — failures flow directly to the caller.
@@ -355,7 +355,7 @@ async function dispatch(
 	});
 	onExtensionContext?.(extensionContext);
 
-	const terminal = async (): Promise<void> => {
+	const terminal = async (): Promise<unknown> => {
 		validateParsed(resolvedNode, parsed);
 
 		// Standard Schemas on arg/flag definitions own value validation and
@@ -375,9 +375,10 @@ async function dispatch(
 			stderr: io.stderr,
 		};
 
-		await resolvedNode.run(context);
+		return await resolvedNode.run(context);
 	};
 
+	let result: unknown;
 	let outcome: InvocationOutcome = { status: "completed" };
 	try {
 		try {
@@ -388,7 +389,7 @@ async function dispatch(
 				}
 			}
 			if (outcome.status !== "finished") {
-				await terminal();
+				result = await terminal();
 			}
 		} catch (error) {
 			const by = await onFailure?.(error, extensionContext);
@@ -419,6 +420,7 @@ async function dispatch(
 		// so its value registers its disposer before the disposal scope exits.
 		await resolver.settle();
 	}
+	return result;
 }
 
 /** Render one failure through Extension onError hooks, ending in Core's default renderer. */
@@ -500,11 +502,11 @@ export async function runInvocation(
 	argv: readonly string[],
 	io: Partial<InvocationIO> | undefined,
 	materializeCommandDefinition: MaterializeCommandDefinition,
-): Promise<void> {
+): Promise<unknown> {
 	const resolvedIO: InvocationIO = { ...DEFAULT_IO, ...io };
 	const prepared = prepareInvocation(node, materializeCommandDefinition);
 	const invoke = () => dispatch(argv, prepared, resolvedIO);
-	await (hasInjectedIO(io) ? withAmbientTerminalIO(resolvedIO, invoke) : invoke());
+	return await (hasInjectedIO(io) ? withAmbientTerminalIO(resolvedIO, invoke) : invoke());
 }
 
 /** Terminal CLI boundary: render failures and set the process exit status. */

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -17,7 +17,7 @@ import { applySchemas } from "../parsing/schema.ts";
 import { addFlagSpellingEntries, cloneFlagSpellings } from "../parsing/spellings.ts";
 import { isText } from "../sections.ts";
 import type { CommandSection, FlagDef, FlagsDef, InvocationIO } from "../types.ts";
-import type { CommandDefinition } from "./crust.ts";
+import type { CommandDefinition, RunOutcome } from "./crust.ts";
 import type { CommandNode } from "./node.ts";
 import { resolveCommand } from "./router.ts";
 import { type CommandSnapshot, snapshotCommand } from "./snapshot.ts";
@@ -326,7 +326,7 @@ async function dispatch(
 	io: InvocationIO,
 	onExtensionContext?: (context: ExtensionContext) => void,
 	onFailure?: (error: unknown, context: ExtensionContext) => Promise<ExtensionId | undefined>,
-): Promise<unknown> {
+): Promise<RunOutcome<unknown>> {
 	const { rootNode, extensions } = prepared;
 
 	// Routing and syntax parsing — failures flow directly to the caller.
@@ -420,7 +420,9 @@ async function dispatch(
 		// so its value registers its disposer before the disposal scope exits.
 		await resolver.settle();
 	}
-	return result;
+	return outcome.status === "finished"
+		? { status: "finished", by: outcome.by }
+		: { status: "completed", result };
 }
 
 /** Render one failure through Extension onError hooks, ending in Core's default renderer. */
@@ -502,7 +504,7 @@ export async function runInvocation(
 	argv: readonly string[],
 	io: Partial<InvocationIO> | undefined,
 	materializeCommandDefinition: MaterializeCommandDefinition,
-): Promise<unknown> {
+): Promise<RunOutcome<unknown>> {
 	const resolvedIO: InvocationIO = { ...DEFAULT_IO, ...io };
 	const prepared = prepareInvocation(node, materializeCommandDefinition);
 	const invoke = () => dispatch(argv, prepared, resolvedIO);

--- a/packages/core/src/command/node.ts
+++ b/packages/core/src/command/node.ts
@@ -35,7 +35,7 @@ export interface CommandNode {
 	/** Extensions registered via `.extend()` (root builder only) */
 	extensions: Extension[];
 	/** The Command Action */
-	run?: (ctx: unknown) => void | Promise<void>;
+	run?: (ctx: unknown) => unknown;
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -11,6 +11,25 @@ type Expect<T extends true> = T;
 type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
+// "root" plus 14 "next" segments — a path exactly at the depth-15 cap.
+type FifteenDeep = readonly [
+	"root",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+	"next",
+];
+
 describe("typed programmatic invocation", () => {
 	it("returns the selected action result with path-specific types", async () => {
 		const inspect = defineCommand("inspect", (command) =>
@@ -311,24 +330,9 @@ describe("typed programmatic invocation", () => {
 			Equal<readonly ["root", "nope"] extends Paths ? true : false, false>
 		>;
 		// Segment 16 sits past the cap, so any string is accepted there.
-		type Fifteen = readonly [
-			"root",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-		];
-		type _widenedDeep = Expect<readonly [...Fifteen, "not-a-command"] extends Paths ? true : false>;
+		type _widenedDeep = Expect<
+			readonly [...FifteenDeep, "not-a-command"] extends Paths ? true : false
+		>;
 		expect(true).toBe(true);
 	});
 
@@ -348,25 +352,7 @@ describe("typed programmatic invocation", () => {
 		type Root = { args: []; flags: {}; children: DeepTree; result?: "root-result" };
 		// The depth-15 cap only widens the CommandPath constraint; `const Path` still
 		// infers the literal tuple, and CommandShapeAt (uncapped) resolves it fully.
-		type SeventeenDeep = readonly [
-			"root",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-			"next",
-		];
+		type SeventeenDeep = readonly [...FifteenDeep, "next", "next"];
 		type _deepResult = Expect<
 			Equal<CommandShapeAt<Root, SeventeenDeep>["result"], "deep-result" | undefined>
 		>;

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -322,4 +322,45 @@ describe("typed programmatic invocation", () => {
 		type _widenedDeep = Expect<readonly [...Fifteen, "not-a-command"] extends Paths ? true : false>;
 		expect(true).toBe(true);
 	});
+
+	it("resolves action results for literal paths past the depth cap", () => {
+		type Nest<
+			Depth extends number,
+			Acc extends readonly unknown[] = [],
+		> = Acc["length"] extends Depth
+			? { args: []; flags: {}; children: {}; result?: "deep-result" }
+			: {
+					args: [];
+					flags: {};
+					children: { next: Nest<Depth, readonly [...Acc, unknown]> };
+					result?: "mid";
+				};
+		type DeepTree = { root: Nest<16> };
+		type Root = { args: []; flags: {}; children: DeepTree; result?: "root-result" };
+		// The depth-15 cap only widens the CommandPath constraint; `const Path` still
+		// infers the literal tuple, and CommandShapeAt (uncapped) resolves it fully.
+		type SeventeenDeep = readonly [
+			"root",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+			"next",
+		];
+		type _deepResult = Expect<
+			Equal<CommandShapeAt<Root, SeventeenDeep>["result"], "deep-result" | undefined>
+		>;
+		expect(true).toBe(true);
+	});
 });

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import type { StandardSchema } from "@crustjs/utils/schema";
 
+import { defineExtension } from "../api/extension.ts";
+import { defineExtensionId } from "../identity.ts";
 import type { CommandPath, CommandShapeAt, RunInput } from "./crust.ts";
 import { Crust, defineCommand } from "./crust.ts";
 
@@ -10,6 +12,42 @@ type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 describe("typed programmatic invocation", () => {
+	it("returns the selected action result with path-specific types", async () => {
+		const inspect = defineCommand("inspect", (command) =>
+			command.action(() => ({ kind: "child" as const, size: 42 })),
+		);
+		const app = new Crust("cli").action(() => ({ kind: "root" as const })).add(inspect);
+
+		const rootResult = app.run([]);
+		const childResult = app.run(["inspect"]);
+		type _root = Expect<Equal<typeof rootResult, Promise<{ kind: "root" } | undefined>>>;
+		type _child = Expect<
+			Equal<typeof childResult, Promise<{ kind: "child"; size: number } | undefined>>
+		>;
+
+		expect(await rootResult).toEqual({ kind: "root" });
+		expect(await childResult).toEqual({ kind: "child", size: 42 });
+	});
+
+	it("awaits async action results", async () => {
+		const app = new Crust("cli").action(async () => ({ ok: true as const }));
+		const pending = app.run([]);
+		type _result = Expect<Equal<typeof pending, Promise<{ ok: true } | undefined>>>;
+
+		expect(await pending).toEqual({ ok: true });
+	});
+
+	it("returns undefined when preRun finishes before the action", async () => {
+		const gate = defineExtension(defineExtensionId("gate"), {
+			hooks: { preRun: (ctx) => ctx.finish() },
+		});
+		const app = new Crust("cli").extend(gate).action(() => ({ ran: true as const }));
+		const pending = app.run([]);
+		type _result = Expect<Equal<typeof pending, Promise<{ ran: true } | undefined>>>;
+
+		expect(await pending).toBeUndefined();
+	});
+
 	it("serializes structured input through routing and the parser", async () => {
 		let received: unknown;
 		const remoteAdd = defineCommand("remote-add", (command) =>

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -39,11 +39,9 @@ describe("typed programmatic invocation", () => {
 
 		const rootResult = app.run([]);
 		const childResult = app.run(["inspect"]);
-		type _root = Expect<
-			Equal<typeof rootResult, Promise<RunOutcome<{ kind: "root" } | undefined>>>
-		>;
+		type _root = Expect<Equal<typeof rootResult, Promise<RunOutcome<{ kind: "root" }>>>>;
 		type _child = Expect<
-			Equal<typeof childResult, Promise<RunOutcome<{ kind: "child"; size: number } | undefined>>>
+			Equal<typeof childResult, Promise<RunOutcome<{ kind: "child"; size: number }>>>
 		>;
 
 		expect(await rootResult).toEqual({ status: "completed", result: { kind: "root" } });
@@ -56,7 +54,7 @@ describe("typed programmatic invocation", () => {
 	it("awaits async action results", async () => {
 		const app = new Crust("cli").action(async () => ({ ok: true as const }));
 		const pending = app.run([]);
-		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ok: true } | undefined>>>>;
+		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ok: true }>>>>;
 
 		expect(await pending).toEqual({ status: "completed", result: { ok: true } });
 	});
@@ -68,7 +66,7 @@ describe("typed programmatic invocation", () => {
 		});
 		const app = new Crust("cli").extend(gate).action(() => ({ ran: true as const }));
 		const pending = app.run([]);
-		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ran: true } | undefined>>>>;
+		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ran: true }>>>>;
 
 		expect(await pending).toEqual({ status: "finished", by: gateId });
 	});
@@ -305,7 +303,9 @@ describe("typed programmatic invocation", () => {
 			| 28
 			| 29
 			| 30;
-		type WideTree = { [K in `command-${Index}`]: { args: []; flags: {}; children: {} } };
+		type WideTree = {
+			[K in `command-${Index}`]: { args: []; flags: {}; children: {}; result: void };
+		};
 		type Paths = CommandPath<WideTree>;
 		type _includesLast = Expect<readonly ["command-30"] extends Paths ? true : false>;
 		type _rejectsUnknown = Expect<
@@ -319,8 +319,13 @@ describe("typed programmatic invocation", () => {
 			Depth extends number,
 			Acc extends readonly unknown[] = [],
 		> = Acc["length"] extends Depth
-			? { args: []; flags: {}; children: {} }
-			: { args: []; flags: {}; children: { next: Nest<Depth, readonly [...Acc, unknown]> } };
+			? { args: []; flags: {}; children: {}; result: void }
+			: {
+					args: [];
+					flags: {};
+					children: { next: Nest<Depth, readonly [...Acc, unknown]> };
+					result: void;
+				};
 		type DeepTree = { root: Nest<16> };
 		type Paths = CommandPath<DeepTree>;
 		// Below the cap, paths stay exact; at the cap the tail widens to strings
@@ -341,20 +346,23 @@ describe("typed programmatic invocation", () => {
 			Depth extends number,
 			Acc extends readonly unknown[] = [],
 		> = Acc["length"] extends Depth
-			? { args: []; flags: {}; children: {}; result?: "deep-result" }
+			? { args: []; flags: {}; children: {}; result: "deep-result" }
 			: {
 					args: [];
 					flags: {};
 					children: { next: Nest<Depth, readonly [...Acc, unknown]> };
-					result?: "mid";
+					result: "mid";
 				};
 		type DeepTree = { root: Nest<16> };
-		type Root = { args: []; flags: {}; children: DeepTree; result?: "root-result" };
+		type Root = { args: []; flags: {}; children: DeepTree; result: "root-result" };
 		// The depth-15 cap only widens the CommandPath constraint; `const Path` still
 		// infers the literal tuple, and CommandShapeAt (uncapped) resolves it fully.
 		type SeventeenDeep = readonly [...FifteenDeep, "next", "next"];
-		type _deepResult = Expect<
-			Equal<CommandShapeAt<Root, SeventeenDeep>["result"], "deep-result" | undefined>
+		type _deepResult = Expect<Equal<CommandShapeAt<Root, SeventeenDeep>["result"], "deep-result">>;
+		// A path variable widened past the cap cannot name its command statically,
+		// so the shape (and its result) widens to unknown instead of an ancestor's.
+		type _widenedResult = Expect<
+			Equal<CommandShapeAt<Root, readonly ["root", ...string[]]>["result"], unknown>
 		>;
 		expect(true).toBe(true);
 	});

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -4,7 +4,7 @@ import type { StandardSchema } from "@crustjs/utils/schema";
 
 import { defineExtension } from "../api/extension.ts";
 import { defineExtensionId } from "../identity.ts";
-import type { CommandPath, CommandShapeAt, RunInput } from "./crust.ts";
+import type { CommandPath, CommandShapeAt, RunInput, RunOutcome } from "./crust.ts";
 import { Crust, defineCommand } from "./crust.ts";
 
 type Expect<T extends true> = T;
@@ -20,32 +20,38 @@ describe("typed programmatic invocation", () => {
 
 		const rootResult = app.run([]);
 		const childResult = app.run(["inspect"]);
-		type _root = Expect<Equal<typeof rootResult, Promise<{ kind: "root" } | undefined>>>;
+		type _root = Expect<
+			Equal<typeof rootResult, Promise<RunOutcome<{ kind: "root" } | undefined>>>
+		>;
 		type _child = Expect<
-			Equal<typeof childResult, Promise<{ kind: "child"; size: number } | undefined>>
+			Equal<typeof childResult, Promise<RunOutcome<{ kind: "child"; size: number } | undefined>>>
 		>;
 
-		expect(await rootResult).toEqual({ kind: "root" });
-		expect(await childResult).toEqual({ kind: "child", size: 42 });
+		expect(await rootResult).toEqual({ status: "completed", result: { kind: "root" } });
+		expect(await childResult).toEqual({
+			status: "completed",
+			result: { kind: "child", size: 42 },
+		});
 	});
 
 	it("awaits async action results", async () => {
 		const app = new Crust("cli").action(async () => ({ ok: true as const }));
 		const pending = app.run([]);
-		type _result = Expect<Equal<typeof pending, Promise<{ ok: true } | undefined>>>;
+		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ok: true } | undefined>>>>;
 
-		expect(await pending).toEqual({ ok: true });
+		expect(await pending).toEqual({ status: "completed", result: { ok: true } });
 	});
 
-	it("returns undefined when preRun finishes before the action", async () => {
-		const gate = defineExtension(defineExtensionId("gate"), {
+	it("returns the finishing Extension when preRun finishes before the action", async () => {
+		const gateId = defineExtensionId("gate");
+		const gate = defineExtension(gateId, {
 			hooks: { preRun: (ctx) => ctx.finish() },
 		});
 		const app = new Crust("cli").extend(gate).action(() => ({ ran: true as const }));
 		const pending = app.run([]);
-		type _result = Expect<Equal<typeof pending, Promise<{ ran: true } | undefined>>>;
+		type _result = Expect<Equal<typeof pending, Promise<RunOutcome<{ ran: true } | undefined>>>>;
 
-		expect(await pending).toBeUndefined();
+		expect(await pending).toEqual({ status: "finished", by: gateId });
 	});
 
 	it("serializes structured input through routing and the parser", async () => {
@@ -143,7 +149,10 @@ describe("typed programmatic invocation", () => {
 	it("rejects unserializable JSON input values", async () => {
 		const app = new Crust("cli").flags({ name: "config", type: "json" }).action(() => {});
 
-		await expect(app.run([], { flags: { config: undefined } })).resolves.toBeUndefined();
+		await expect(app.run([], { flags: { config: undefined } })).resolves.toEqual({
+			status: "completed",
+			result: undefined,
+		});
 		await expect(app.run([], { flags: { config: (() => {}) as never } })).rejects.toMatchObject({
 			code: "PARSE",
 			details: { reason: "unserializable-json" },

--- a/packages/core/src/command/typed-run.test.ts
+++ b/packages/core/src/command/typed-run.test.ts
@@ -364,6 +364,13 @@ describe("typed programmatic invocation", () => {
 		type _widenedResult = Expect<
 			Equal<CommandShapeAt<Root, readonly ["root", ...string[]]>["result"], unknown>
 		>;
+		// A CommandPath<Tree>-typed variable (union of literal tuples and widened
+		// arrays) never resolves to never, and a widened head widens instead.
+		type _pathVariable = CommandShapeAt<Root, CommandPath<DeepTree>>["result"];
+		type _pathVariableSound = Expect<Equal<[_pathVariable] extends [never] ? true : false, false>>;
+		type _widenedHead = Expect<
+			Equal<CommandShapeAt<Root, readonly [string, ...string[]]>["result"], unknown>
+		>;
 		expect(true).toBe(true);
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export type {
 	RunArguments,
 	RunInput,
 	RunInputArguments,
+	RunOutcome,
 } from "./command/crust.ts";
 export { Crust, defineCommand } from "./command/crust.ts";
 // Documentation sections

--- a/packages/core/src/parsing/schema.test.ts
+++ b/packages/core/src/parsing/schema.test.ts
@@ -39,6 +39,17 @@ describe("Standard Schema on arg definitions", () => {
 		expect(received).toBe(8080);
 	});
 
+	it("delivers a successful schema output of literal undefined to the action", async () => {
+		let received: unknown = "untouched";
+		const toUndefined = schema<string, undefined>(() => ({ value: undefined }));
+		const app = new Crust("cli").args({ name: "port", schema: toUndefined }).action(({ args }) => {
+			received = args.port;
+		});
+
+		await app.run([], { args: { port: "8080" } });
+		expect(received).toBeUndefined();
+	});
+
 	it("schema owns requiredness: a missing arg reaches the schema as undefined", async () => {
 		const app = new Crust("cli").args({ name: "port", schema: port() }).action(() => {});
 

--- a/packages/core/src/parsing/schema.ts
+++ b/packages/core/src/parsing/schema.ts
@@ -13,7 +13,7 @@ async function runSchema(
 	raw: unknown,
 	path: readonly PropertyKey[],
 	issues: ValidationIssue[],
-): Promise<{ ok: boolean; value?: unknown }> {
+): Promise<{ readonly ok: false } | { readonly ok: true; readonly value: unknown }> {
 	let result = schema["~standard"].validate(raw);
 	if (result instanceof Promise) result = await result;
 

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -7,7 +7,7 @@
  * Uses the real .execute() pipeline from the Crust builder.
  */
 
-import type { Crust } from "../src/command/crust.ts";
+import type { AnyCrust } from "../src/command/crust.ts";
 
 export interface RunResult {
 	stdout: string;
@@ -23,10 +23,7 @@ export interface RunResult {
  *   expect(result.stdout).toContain("expected output");
  *   expect(result.exitCode).toBe(0);
  */
-export async function executeCrust(
-	builder: Crust<any, any, any, any, any>,
-	argv?: string[],
-): Promise<RunResult> {
+export async function executeCrust(builder: AnyCrust, argv?: string[]): Promise<RunResult> {
 	const stdoutChunks: string[] = [];
 	const stderrChunks: string[] = [];
 	let exitCode = 0;

--- a/packages/crust/src/utils/distribute.ts
+++ b/packages/crust/src/utils/distribute.ts
@@ -45,7 +45,7 @@ type NpmRepository = string | { type?: string; url?: string; directory?: string 
 type NpmFundingEntry = { type?: string; url?: string };
 type NpmFunding = string | NpmFundingEntry | NpmFundingEntry[];
 
-type PublishPackageJson = {
+type PublishPackageMetadata = {
 	name: string;
 	version: string;
 	type?: "module";
@@ -53,9 +53,6 @@ type PublishPackageJson = {
 	/** npm man field: paths to man pages, e.g. `./man/mycli.1` */
 	man?: string[];
 	bin?: Record<string, string>;
-	optionalDependencies?: Record<string, string>;
-	os?: [NpmOs];
-	cpu?: [NpmCpu];
 	description?: string;
 	license?: string;
 	author?: NpmPerson;
@@ -68,8 +65,23 @@ type PublishPackageJson = {
 	engines?: Record<string, string>;
 };
 
-type UserPackageJson = Omit<PublishPackageJson, "bin"> & {
+type RootPublishPackageJson = PublishPackageMetadata & {
+	optionalDependencies: Record<string, string>;
+	os?: never;
+	cpu?: never;
+};
+
+type PlatformPublishPackageJson = PublishPackageMetadata & {
+	os: [NpmOs];
+	cpu: [NpmCpu];
+	optionalDependencies?: never;
+};
+
+type UserPackageJson = Omit<PublishPackageMetadata, "bin"> & {
 	bin?: string | Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	os?: [NpmOs];
+	cpu?: [NpmCpu];
 };
 
 type DistributionMetadata = {
@@ -77,7 +89,7 @@ type DistributionMetadata = {
 	rootPackageName: string;
 	version: string;
 	baseName: string;
-	rootPackageJson: PublishPackageJson;
+	rootPackageJson: PublishPackageMetadata;
 };
 
 type DistributionTarget = {
@@ -171,10 +183,10 @@ export function buildDistributionRootPackageJson(
 	metadata: DistributionMetadata,
 	targets: readonly DistributionTarget[],
 	options?: { artifactDirs?: readonly string[]; manPages?: readonly string[] },
-): PublishPackageJson {
+): RootPublishPackageJson {
 	const artifactDirs = options?.artifactDirs ?? [];
 	const manPages = options?.manPages ?? [];
-	const rootPackageJson: PublishPackageJson = {
+	const rootPackageJson: RootPublishPackageJson = {
 		...metadata.rootPackageJson,
 		name: metadata.rootPackageName,
 		version: metadata.version,
@@ -195,7 +207,7 @@ export function buildDistributionRootPackageJson(
 export function buildDistributionPlatformPackageJson(
 	metadata: DistributionMetadata,
 	target: DistributionTarget,
-): PublishPackageJson {
+): PlatformPublishPackageJson {
 	return {
 		...metadata.rootPackageJson,
 		name: target.packageName,
@@ -209,8 +221,8 @@ export function buildDistributionPlatformPackageJson(
 	};
 }
 
-function pickRootMetadata(pkgJson: UserPackageJson): PublishPackageJson {
-	const metadata: PublishPackageJson = {
+function pickRootMetadata(pkgJson: UserPackageJson): PublishPackageMetadata {
+	const metadata: PublishPackageMetadata = {
 		name: pkgJson.name,
 		version: pkgJson.version,
 	};

--- a/packages/extensions/src/completion/spec.ts
+++ b/packages/extensions/src/completion/spec.ts
@@ -24,8 +24,8 @@
  * the package entrypoint and may change across patch releases.
  */
 
-/** Description of a single named flag attached to a command. */
-export interface CompletionFlag {
+/** Fields shared by every named flag attached to a command. */
+interface CompletionFlagBase {
 	/**
 	 * The canonical long name with **no** leading dashes — the same key used
 	 * in `CommandNode.effectiveFlags`. Templates prepend `--` when emitting.
@@ -41,56 +41,45 @@ export interface CompletionFlag {
 	 * definition declares any. Templates prepend `--` when emitting.
 	 */
 	aliases?: readonly string[];
-	/** Underlying value type — discriminator from `FlagDef.type`. */
-	type: "string" | "number" | "boolean";
 	/** Human-readable description, ANSI-stripped, ready to embed verbatim. */
 	description?: string;
-	/**
-	 * `true` when the flag consumes the next token as a value
-	 * (`string`/`number` flags). `false` for boolean toggles, which never
-	 * take a value (the parser supports `--no-flag` for negation).
-	 */
-	takesValue: boolean;
 	/**
 	 * `true` when the flag is repeatable (`multiple: true` in `FlagDef`).
 	 * Templates use this to relax mutual-exclusion or de-dup logic where
 	 * each shell supports it.
 	 */
 	multiple?: true;
-	/**
-	 * `true` when the boolean flag has explicitly opted out of `--no-`
-	 * negation (mirrors `BooleanFlagDef.noNegate` in core). Only
-	 * meaningful for `type: "boolean"` flags; absent on string/number.
-	 * Templates use this to decide whether to emit the `--no-<name>`
-	 * candidate alongside `--<name>`.
-	 */
-	noNegate?: true;
-	/**
-	 * Static enumeration of valid values, surfaced from the `choices`
-	 * field on `StringFlagDef` / `StringMultiFlagDef`. When present,
-	 * templates emit a fixed value list (`--flag=(a b c)` in zsh,
-	 * `-x -a 'a b c'` in fish, etc.). Only string-typed flags can carry
-	 * choices today; absent on number/boolean.
-	 */
-	choices?: readonly string[];
-	/**
-	 * Derived value-completion intent for `url`/`path`/`json` flags.
-	 * The spec-level `type` is normalised to `"string"` for these three
-	 * (their values are string tokens), so templates branch on this field:
-	 *  - `"files"` (`type: "path"`)  → emit file-completion candidates.
-	 *  - `"none"`  (`type: "url" | "json"`) → suppress the string fallback's
-	 *    file completion.
-	 *  - omitted: generic string — use each shell's default fallback.
-	 */
-	valueCompletion?: "files" | "none";
 }
 
-/** Description of a single positional argument attached to a command. */
-export interface CompletionArg {
+type StringCompletion =
+	| { choices: readonly string[]; valueCompletion?: never }
+	| { choices?: never; valueCompletion: "files" | "none" }
+	| { choices?: never; valueCompletion?: never };
+
+/** Description of a single named flag attached to a command. */
+export type CompletionFlag = CompletionFlagBase &
+	(
+		| {
+				type: "boolean";
+				takesValue: false;
+				noNegate?: true;
+				choices?: never;
+				valueCompletion?: never;
+		  }
+		| {
+				type: "number";
+				takesValue: true;
+				noNegate?: never;
+				choices?: never;
+				valueCompletion?: never;
+		  }
+		| ({ type: "string"; takesValue: true; noNegate?: never } & StringCompletion)
+	);
+
+/** Fields shared by every positional argument attached to a command. */
+interface CompletionArgBase {
 	/** Argument name (used as the key in the parsed result and in help). */
 	name: string;
-	/** Underlying value type — discriminator from `ArgDef.type`. */
-	type: "string" | "number" | "boolean";
 	/** Human-readable description, ANSI-stripped. */
 	description?: string;
 	/** `true` when the argument is required (per `ArgDef.required`). */
@@ -101,14 +90,18 @@ export interface CompletionArg {
 	 * candidates beyond the declared positional slot.
 	 */
 	variadic: boolean;
-	/**
-	 * Static enumeration of valid values, surfaced from the `choices`
-	 * field on `StringArgDef`. Only string-typed args can carry choices.
-	 */
-	choices?: readonly string[];
-	/** Derived value-completion intent — see {@link CompletionFlag.valueCompletion}. */
-	valueCompletion?: "files" | "none";
 }
+
+/** Description of a single positional argument attached to a command. */
+export type CompletionArg = CompletionArgBase &
+	(
+		| {
+				type: "number" | "boolean";
+				choices?: never;
+				valueCompletion?: never;
+		  }
+		| ({ type: "string" } & StringCompletion)
+	);
 
 /** Description of a single command node — recursive via `subCommands`. */
 export interface CompletionCommand {

--- a/packages/extensions/src/completion/walker.ts
+++ b/packages/extensions/src/completion/walker.ts
@@ -32,92 +32,71 @@ function walkFlag(name: string, def: FlagSnapshot): CompletionFlag {
 		assertSafeIdentifier(def.short, "flag short alias");
 	}
 
-	// url/path/json all consume a string token at the shell-completion layer.
-	// We normalise them to `"string"` and surface the original kind via a
-	// single `valueCompletion` field so templates can branch on intent
-	// ("files" / "none") rather than the source type literal.
-	const sourceType = def.type;
-	const specType: "string" | "number" | "boolean" =
-		sourceType === "url" || sourceType === "path" || sourceType === "json" ? "string" : sourceType;
-
-	const flag: CompletionFlag = {
+	const description = normaliseDescription(def.description);
+	const common = {
 		name,
-		type: specType,
-		takesValue: sourceType !== "boolean",
+		...(def.short !== undefined && def.short.length > 0 ? { short: def.short } : {}),
+		...(aliases !== undefined && aliases.length > 0 ? { aliases } : {}),
+		...(description === undefined ? {} : { description }),
+		...(def.multiple === true ? { multiple: true as const } : {}),
 	};
 
-	if (sourceType === "path") flag.valueCompletion = "files";
-	else if (sourceType === "url" || sourceType === "json") flag.valueCompletion = "none";
-
-	if (def.short !== undefined && def.short.length > 0) {
-		flag.short = def.short;
+	if (def.type === "boolean") {
+		return {
+			...common,
+			type: "boolean",
+			takesValue: false,
+			...(def.noNegate === true ? { noNegate: true as const } : {}),
+		};
 	}
-	if (aliases !== undefined && aliases.length > 0) {
-		flag.aliases = aliases;
-	}
+	if (def.type === "number") return { ...common, type: "number", takesValue: true };
 
-	const description = normaliseDescription(def.description);
-	if (description !== undefined) {
-		flag.description = description;
+	// url/path/json all consume string tokens; preserve their completion intent.
+	if (def.type === "path") {
+		return { ...common, type: "string", takesValue: true, valueCompletion: "files" };
 	}
-
-	if (def.multiple === true) {
-		flag.multiple = true;
-	}
-
-	// `noNegate` is a `boolean`-flag-only opt-out from auto `--no-<name>`
-	// rendering; it lives on both single and multi boolean variants in
-	// core's `FlagDef` discriminated union.
-	if (def.type === "boolean" && def.noNegate === true) {
-		flag.noNegate = true;
+	if (def.type === "url" || def.type === "json") {
+		return { ...common, type: "string", takesValue: true, valueCompletion: "none" };
 	}
 
-	// `choices` lives only on string-typed flags (see `types.ts`).
-	// We accept the field via discriminated narrowing rather than an `as`
-	// cast to keep the reader honest about which branches actually carry it.
-	if (def.type === "string") {
-		const choices = def.choices;
-		if (choices !== undefined && choices.length > 0) {
-			flag.choices = choices.map(assertSafeChoiceValue);
-		}
+	const choices = def.choices;
+	if (choices !== undefined && choices.length > 0) {
+		return {
+			...common,
+			type: "string",
+			takesValue: true,
+			choices: choices.map(assertSafeChoiceValue),
+		};
 	}
-
-	return flag;
+	return { ...common, type: "string", takesValue: true };
 }
 
 /** Project a single `ArgDef` onto a `CompletionArg`. */
 function walkArg(def: ArgSnapshot): CompletionArg {
 	assertSafeIdentifier(def.name, "arg name");
-	const sourceType = def.type;
-	const specType: "string" | "number" | "boolean" =
-		sourceType === "url" || sourceType === "path" || sourceType === "json"
-			? "string"
-			: (sourceType ?? "string");
-
-	const arg: CompletionArg = {
+	const description = normaliseDescription(def.description);
+	const common = {
 		name: def.name,
-		type: specType,
 		required: def.required === true,
 		variadic: def.variadic === true,
+		...(description === undefined ? {} : { description }),
 	};
 
-	if (sourceType === "path") arg.valueCompletion = "files";
-	else if (sourceType === "url" || sourceType === "json") arg.valueCompletion = "none";
-
-	const description = normaliseDescription(def.description);
-	if (description !== undefined) {
-		arg.description = description;
+	if (def.type === "number" || def.type === "boolean") {
+		return { ...common, type: def.type };
+	}
+	if (def.type === "path") {
+		return { ...common, type: "string", valueCompletion: "files" };
+	}
+	if (def.type === "url" || def.type === "json") {
+		return { ...common, type: "string", valueCompletion: "none" };
 	}
 
-	// `choices` is only present on string-typed args.
-	if (def.type === "string") {
-		const choices = def.choices;
-		if (choices !== undefined && choices.length > 0) {
-			arg.choices = choices.map(assertSafeChoiceValue);
-		}
+	const choices = def.type === "string" ? def.choices : undefined;
+	if (choices !== undefined && choices.length > 0) {
+		return { ...common, type: "string", choices: choices.map(assertSafeChoiceValue) };
 	}
-
-	return arg;
+	return { ...common, type: "string" };
 }
 
 /**

--- a/packages/prompts/src/core/types.ts
+++ b/packages/prompts/src/core/types.ts
@@ -120,6 +120,23 @@ export type ChoiceValue<C extends readonly Choice<unknown>[]> = C[number] extend
  */
 export type ValidateFn<T> = (value: T) => void | Promise<void>;
 
+/**
+ * Mutually exclusive validation options shared by text prompts: a Standard
+ * Schema, a throw-on-failure `validate` function, or neither — never both.
+ */
+export type SchemaOrValidate<Output> =
+	| {
+			/** Standard Schema that owns validation, transformation, defaults, and optionality. */
+			readonly schema: StandardSchema<unknown, Output>;
+			readonly validate?: never;
+	  }
+	| {
+			readonly schema?: never;
+			/** Throw-on-failure validation function. */
+			readonly validate: ValidateFn<string>;
+	  }
+	| { readonly schema?: never; readonly validate?: never };
+
 export async function validateSubmitValue<Output>(
 	value: string,
 	schema: StandardSchema<unknown, Output> | undefined,

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -13,6 +13,7 @@ import {
 	parseShortCircuit,
 	type PartialPromptTheme,
 	type PromptTheme,
+	type SchemaOrValidate,
 	type ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
@@ -64,20 +65,7 @@ interface InputBaseOptions {
 	readonly theme?: PartialPromptTheme;
 }
 
-type InputValidation<Output> =
-	| {
-			/** Standard Schema that owns validation, transformation, defaults, and optionality. */
-			readonly schema: StandardSchema<unknown, Output>;
-			readonly validate?: never;
-	  }
-	| {
-			readonly schema?: never;
-			/** Throw-on-failure validation function. */
-			readonly validate: ValidateFn<string>;
-	  }
-	| { readonly schema?: never; readonly validate?: never };
-
-export type InputOptions<Output = string> = InputBaseOptions & InputValidation<Output>;
+export type InputOptions<Output = string> = InputBaseOptions & SchemaOrValidate<Output>;
 
 // ────────────────────────────────────────────────────────────────────────────
 // State

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -51,7 +51,7 @@ import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
  * // typeof port === "number"
  * ```
  */
-export interface InputOptions<Output = string> {
+interface InputBaseOptions {
 	/** The prompt message displayed to the user */
 	readonly message?: string;
 	/** Placeholder text shown when the input is empty. Overrides the default value as visual placeholder when both are set. */
@@ -60,13 +60,24 @@ export interface InputOptions<Output = string> {
 	readonly default?: string;
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: string;
-	/** Standard Schema that owns validation, transformation, defaults, and optionality. */
-	readonly schema?: StandardSchema<unknown, Output>;
-	/** Throw-on-failure validation function. Cannot be combined with `schema`. */
-	readonly validate?: ValidateFn<string>;
 	/** Per-prompt theme overrides */
 	readonly theme?: PartialPromptTheme;
 }
+
+type InputValidation<Output> =
+	| {
+			/** Standard Schema that owns validation, transformation, defaults, and optionality. */
+			readonly schema: StandardSchema<unknown, Output>;
+			readonly validate?: never;
+	  }
+	| {
+			readonly schema?: never;
+			/** Throw-on-failure validation function. */
+			readonly validate: ValidateFn<string>;
+	  }
+	| { readonly schema?: never; readonly validate?: never };
+
+export type InputOptions<Output = string> = InputBaseOptions & InputValidation<Output>;
 
 // ────────────────────────────────────────────────────────────────────────────
 // State
@@ -170,14 +181,17 @@ function renderSubmitted<Output>(
  * ```
  */
 export function input<Output>(
-	options: Omit<InputOptions<Output>, "schema" | "validate"> & {
+	options: InputBaseOptions & {
 		readonly schema: StandardSchema<unknown, Output>;
 		readonly validate?: never;
 	},
 	io?: PromptIO,
 ): Promise<Output>;
 export function input(
-	options?: Omit<InputOptions, "schema"> & { readonly schema?: never },
+	options?: InputBaseOptions & {
+		readonly schema?: never;
+		readonly validate?: ValidateFn<string>;
+	},
 	io?: PromptIO,
 ): Promise<string>;
 export async function input<Output>(

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -37,7 +37,7 @@ import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
  * });
  * ```
  */
-export interface PasswordOptions<Output = string> {
+interface PasswordBaseOptions {
 	/** The prompt message displayed to the user */
 	readonly message?: string;
 	/**
@@ -46,15 +46,26 @@ export interface PasswordOptions<Output = string> {
 	 * @default "*"
 	 */
 	readonly mask?: string;
-	/** Standard Schema that owns validation, transformation, defaults, and optionality. */
-	readonly schema?: StandardSchema<unknown, Output>;
-	/** Throw-on-failure validation function. Cannot be combined with `schema`. */
-	readonly validate?: ValidateFn<string>;
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: string;
 	/** Per-prompt theme overrides */
 	readonly theme?: PartialPromptTheme;
 }
+
+type PasswordValidation<Output> =
+	| {
+			/** Standard Schema that owns validation, transformation, defaults, and optionality. */
+			readonly schema: StandardSchema<unknown, Output>;
+			readonly validate?: never;
+	  }
+	| {
+			readonly schema?: never;
+			/** Throw-on-failure validation function. */
+			readonly validate: ValidateFn<string>;
+	  }
+	| { readonly schema?: never; readonly validate?: never };
+
+export type PasswordOptions<Output = string> = PasswordBaseOptions & PasswordValidation<Output>;
 
 // ────────────────────────────────────────────────────────────────────────────
 // State (same shape as input)
@@ -161,14 +172,17 @@ function renderSubmitted<Output>(
  * ```
  */
 export function password<Output>(
-	options: Omit<PasswordOptions<Output>, "schema" | "validate"> & {
+	options: PasswordBaseOptions & {
 		readonly schema: StandardSchema<unknown, Output>;
 		readonly validate?: never;
 	},
 	io?: PromptIO,
 ): Promise<Output>;
 export function password(
-	options?: Omit<PasswordOptions, "schema"> & { readonly schema?: never },
+	options?: PasswordBaseOptions & {
+		readonly schema?: never;
+		readonly validate?: ValidateFn<string>;
+	},
 	io?: PromptIO,
 ): Promise<string>;
 export async function password<Output>(

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -13,6 +13,7 @@ import {
 	parseShortCircuit,
 	type PartialPromptTheme,
 	type PromptTheme,
+	type SchemaOrValidate,
 	type ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
@@ -52,20 +53,7 @@ interface PasswordBaseOptions {
 	readonly theme?: PartialPromptTheme;
 }
 
-type PasswordValidation<Output> =
-	| {
-			/** Standard Schema that owns validation, transformation, defaults, and optionality. */
-			readonly schema: StandardSchema<unknown, Output>;
-			readonly validate?: never;
-	  }
-	| {
-			readonly schema?: never;
-			/** Throw-on-failure validation function. */
-			readonly validate: ValidateFn<string>;
-	  }
-	| { readonly schema?: never; readonly validate?: never };
-
-export type PasswordOptions<Output = string> = PasswordBaseOptions & PasswordValidation<Output>;
+export type PasswordOptions<Output = string> = PasswordBaseOptions & SchemaOrValidate<Output>;
 
 // ────────────────────────────────────────────────────────────────────────────
 // State (same shape as input)

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -69,7 +69,10 @@ describe("captureRun", () => {
 		});
 		const app = new Crust("test-cli").extend(gate).action(() => ({ ran: true }));
 
-		expect(await captureRun(app, [])).toEqual({ stdout: "", stderr: "", result: undefined });
+		const captured = await captureRun(app, []);
+		expect(captured).toEqual({ stdout: "", stderr: "", result: undefined });
+		// toEqual cannot distinguish a missing key from present-undefined; pin the success-branch contract.
+		expect("result" in captured).toBe(true);
 	});
 });
 

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -41,7 +41,7 @@ describe("captureRun", () => {
 		const captured = await captureRun(app, []);
 		if (captured.status !== "completed") throw new Error("expected a completed run");
 		// Compile-time check: the captured result carries the action's type.
-		const _result: { status: "ok" } | undefined = captured.result;
+		const _result: { status: "ok" } = captured.result;
 		expect(captured).toEqual({
 			stdout: "first\nsecond",
 			stderr: "warning",

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -39,12 +39,13 @@ describe("captureRun", () => {
 		});
 
 		const captured = await captureRun(app, []);
-		if ("error" in captured) throw captured.error;
+		if (captured.status !== "completed") throw new Error("expected a completed run");
 		const result: { status: "ok" } | undefined = captured.result;
 		expect(result).toEqual({ status: "ok" });
 		expect(captured).toEqual({
 			stdout: "first\nsecond",
 			stderr: "warning",
+			status: "completed",
 			result: { status: "ok" },
 		});
 	});
@@ -60,32 +61,29 @@ describe("captureRun", () => {
 		const captured = await captureRun(app, []);
 		expect(captured.stdout).toBe("before");
 		expect(captured.stderr).toBe("problem");
-		if (!("error" in captured)) throw new Error("expected the failure branch");
+		if (captured.status !== "failed") throw new Error("expected the failed branch");
 		expect(captured.error).toBe(error);
-		expect("result" in captured).toBe(false);
 	});
 
 	it("discriminates a falsy thrown value as the failure branch", async () => {
 		const app = new Crust("test-cli").action(() => {
-			// Deliberately falsy: the union's `"error" in` discriminant must survive it.
 			throw undefined;
 		});
 
 		const captured = await captureRun(app, []);
-		expect("error" in captured).toBe(true);
-		expect("result" in captured).toBe(false);
+		expect(captured.status).toBe("failed");
+		if (captured.status === "failed") expect(captured.error).toBeUndefined();
 	});
 
-	it("captures undefined when preRun finishes the invocation", async () => {
-		const gate = defineExtension(defineExtensionId("gate"), {
+	it("captures the Extension that finishes the invocation", async () => {
+		const gateId = defineExtensionId("gate");
+		const gate = defineExtension(gateId, {
 			hooks: { preRun: (ctx) => ctx.finish() },
 		});
 		const app = new Crust("test-cli").extend(gate).action(() => ({ ran: true }));
 
 		const captured = await captureRun(app, []);
-		expect(captured).toEqual({ stdout: "", stderr: "", result: undefined });
-		// toEqual cannot distinguish a missing key from present-undefined; pin the success-branch contract.
-		expect("result" in captured).toBe(true);
+		expect(captured).toEqual({ stdout: "", stderr: "", status: "finished", by: gateId });
 	});
 });
 

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -30,16 +30,21 @@ describe("captureRun", () => {
 		expect(true).toBe(true);
 	});
 
-	it("captures output as lines", async () => {
+	it("captures output and the typed action result", async () => {
 		const app = new Crust("test-cli").action(({ stdout, stderr }) => {
 			stdout("first");
 			stdout("second");
 			stderr("warning");
+			return { status: "ok" as const };
 		});
 
-		expect(await captureRun(app, [])).toEqual({
+		const captured = await captureRun(app, []);
+		const result: { status: "ok" } | undefined = captured.result;
+		expect(result).toEqual({ status: "ok" });
+		expect(captured).toEqual({
 			stdout: "first\nsecond",
 			stderr: "warning",
+			result: { status: "ok" },
 		});
 	});
 
@@ -55,6 +60,16 @@ describe("captureRun", () => {
 		expect(result.stdout).toBe("before");
 		expect(result.stderr).toBe("problem");
 		expect(result.error).toBe(error);
+		expect(result.result).toBeUndefined();
+	});
+
+	it("captures undefined when preRun finishes the invocation", async () => {
+		const gate = defineExtension(defineExtensionId("gate"), {
+			hooks: { preRun: (ctx) => ctx.finish() },
+		});
+		const app = new Crust("test-cli").extend(gate).action(() => ({ ran: true }));
+
+		expect(await captureRun(app, [])).toEqual({ stdout: "", stderr: "", result: undefined });
 	});
 });
 

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -39,6 +39,7 @@ describe("captureRun", () => {
 		});
 
 		const captured = await captureRun(app, []);
+		if ("error" in captured) throw captured.error;
 		const result: { status: "ok" } | undefined = captured.result;
 		expect(result).toEqual({ status: "ok" });
 		expect(captured).toEqual({
@@ -56,11 +57,23 @@ describe("captureRun", () => {
 			throw error;
 		});
 
-		const result = await captureRun(app, []);
-		expect(result.stdout).toBe("before");
-		expect(result.stderr).toBe("problem");
-		expect(result.error).toBe(error);
-		expect(result.result).toBeUndefined();
+		const captured = await captureRun(app, []);
+		expect(captured.stdout).toBe("before");
+		expect(captured.stderr).toBe("problem");
+		if (!("error" in captured)) throw new Error("expected the failure branch");
+		expect(captured.error).toBe(error);
+		expect("result" in captured).toBe(false);
+	});
+
+	it("discriminates a falsy thrown value as the failure branch", async () => {
+		const app = new Crust("test-cli").action(() => {
+			// Deliberately falsy: the union's `"error" in` discriminant must survive it.
+			throw undefined;
+		});
+
+		const captured = await captureRun(app, []);
+		expect("error" in captured).toBe(true);
+		expect("result" in captured).toBe(false);
 	});
 
 	it("captures undefined when preRun finishes the invocation", async () => {

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -40,8 +40,8 @@ describe("captureRun", () => {
 
 		const captured = await captureRun(app, []);
 		if (captured.status !== "completed") throw new Error("expected a completed run");
-		const result: { status: "ok" } | undefined = captured.result;
-		expect(result).toEqual({ status: "ok" });
+		// Compile-time check: the captured result carries the action's type.
+		const _result: { status: "ok" } | undefined = captured.result;
 		expect(captured).toEqual({
 			stdout: "first\nsecond",
 			stderr: "warning",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -17,8 +17,8 @@ import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 export type CaptureIO = Partial<InvocationIO>;
 
 type AppTypes<App extends AnyCrust> =
-	App extends Crust<infer Flags, infer Args, any, any, any, infer Tree>
-		? { shape: CommandShape<Args, Flags, Tree>; tree: Tree }
+	App extends Crust<infer Flags, infer Args, any, any, any, infer Tree, any, any, infer Result>
+		? { shape: CommandShape<Args, Flags, Tree, Result>; tree: Tree }
 		: never;
 type AppTree<App extends AnyCrust> = AppTypes<App>["tree"];
 type ShapeAtPath<App extends AnyCrust, Path extends CommandPath<AppTree<App>>> = CommandShapeAt<
@@ -26,9 +26,10 @@ type ShapeAtPath<App extends AnyCrust, Path extends CommandPath<AppTree<App>>> =
 	Path
 >;
 
-export interface CapturedRun {
+export interface CapturedRun<Result = unknown> {
 	readonly stdout: string;
 	readonly stderr: string;
+	readonly result?: Result;
 	readonly error?: unknown;
 }
 
@@ -36,17 +37,22 @@ export interface CapturedRun {
 export async function captureRun<
 	App extends AnyCrust,
 	const Path extends CommandPath<AppTree<App>>,
->(app: App, path: Path, ...args: RunInputArguments<ShapeAtPath<App, Path>>): Promise<CapturedRun> {
+>(
+	app: App,
+	path: Path,
+	...args: RunInputArguments<ShapeAtPath<App, Path>>
+): Promise<CapturedRun<ShapeAtPath<App, Path>["result"]>> {
 	// Each io callback invocation is one line in a real terminal (core's
 	// defaults are console.log/console.error), so join captured calls with "\n".
 	const stdoutLines: string[] = [];
 	const stderrLines: string[] = [];
 	let failed = false;
+	let result: unknown;
 	let error: unknown;
 
 	try {
 		const [input] = args;
-		await app.run(path as never, input as never, {
+		result = await app.run(path as never, input as never, {
 			stdout: (text) => {
 				stdoutLines.push(text);
 			},
@@ -61,7 +67,7 @@ export async function captureRun<
 
 	const stdout = stdoutLines.join("\n");
 	const stderr = stderrLines.join("\n");
-	return failed ? { stdout, stderr, error } : { stdout, stderr };
+	return failed ? { stdout, stderr, error } : { stdout, stderr, result };
 }
 
 /** Minimal structural surface of `execute()` invoked by {@link captureExecute}. */

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -4,8 +4,10 @@ import type {
 	AnyCrust,
 	CommandPath,
 	CommandShapeAt,
+	ExtensionId,
 	InvocationIO,
 	RunInputArguments,
+	RunOutcome,
 } from "@crustjs/core";
 import { type ProgressSink, withProgressSink } from "@crustjs/progress";
 import { withPromptIO } from "@crustjs/prompts";
@@ -24,15 +26,18 @@ type ShapeAtPath<App extends AnyCrust, Path extends CommandPath<AppTree<App>>> =
 >;
 
 /**
- * Result of {@link captureRun}: the success branch carries the action's typed
- * result (present even when its value is `undefined`, e.g. after a `preRun`
- * finish); the failure branch carries the thrown value instead. Narrow with
- * `"error" in captured` — thrown values can be falsy, so property presence is
- * the reliable discriminant.
+ * Result of {@link captureRun}. Completed runs carry the selected action's
+ * typed result, finished runs name the finishing Extension, and failed runs
+ * carry the thrown value. Narrow with the `status` discriminant.
  */
-export type CapturedRun<Result = unknown> =
-	| { readonly stdout: string; readonly stderr: string; readonly result: Result }
-	| { readonly stdout: string; readonly stderr: string; readonly error: unknown };
+export type CapturedRun<Result = unknown> = {
+	readonly stdout: string;
+	readonly stderr: string;
+} & (
+	| { readonly status: "completed"; readonly result: Result }
+	| { readonly status: "finished"; readonly by: ExtensionId }
+	| { readonly status: "failed"; readonly error: unknown }
+);
 
 /** Run an application and capture its text output without throwing invocation errors. */
 export async function captureRun<
@@ -52,18 +57,23 @@ export async function captureRun<
 		const [input] = args;
 		// The `as never` path/input erasure in this call loses the typed link to
 		// the selected shape, so restore it once here.
-		const result = (await app.run(path as never, input as never, {
+		const outcome = (await app.run(path as never, input as never, {
 			stdout: (text) => {
 				stdoutLines.push(text);
 			},
 			stderr: (text) => {
 				stderrLines.push(text);
 			},
-		})) as ShapeAtPath<App, Path>["result"];
-		return { stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n"), result };
+		})) as RunOutcome<ShapeAtPath<App, Path>["result"]>;
+		return { stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n"), ...outcome };
 	} catch (error) {
 		// Output written before the failure is retained.
-		return { stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n"), error };
+		return {
+			stdout: stdoutLines.join("\n"),
+			stderr: stderrLines.join("\n"),
+			status: "failed",
+			error,
+		};
 	}
 }
 
@@ -161,13 +171,15 @@ export function runInteractive<App extends AnyCrust, const Path extends CommandP
 	const [input] = args;
 	const done = withProgressSink(sink, () =>
 		withPromptIO(harness.io, () =>
-			app.run(path as never, input as never, {
-				stdout: () => {},
-				stderr: (text) => {
-					// Line-oriented like core's console.error default.
-					output.write(`${text}\n`);
-				},
-			}),
+			app
+				.run(path as never, input as never, {
+					stdout: () => {},
+					stderr: (text) => {
+						// Line-oriented like core's console.error default.
+						output.write(`${text}\n`);
+					},
+				})
+				.then(() => {}),
 		),
 	);
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -3,9 +3,7 @@ import { setTimeout } from "node:timers/promises";
 import type {
 	AnyCrust,
 	CommandPath,
-	CommandShape,
 	CommandShapeAt,
-	Crust,
 	InvocationIO,
 	RunInputArguments,
 } from "@crustjs/core";
@@ -16,13 +14,12 @@ import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 /** Structural io shape shared by `run()` and `execute()` captures. */
 export type CaptureIO = Partial<InvocationIO>;
 
-type AppTypes<App extends AnyCrust> =
-	App extends Crust<infer Flags, infer Args, any, any, any, infer Tree, any, any, infer Result>
-		? { shape: CommandShape<Args, Flags, Tree, Result>; tree: Tree }
-		: never;
-type AppTree<App extends AnyCrust> = AppTypes<App>["tree"];
+// Indexed access into the `_types` phantom instead of conditionally inferring
+// all nine `Crust` generics — the conditional forced a full structural match
+// (and union distribution) per helper call.
+type AppTree<App extends AnyCrust> = App["_types"]["tree"];
 type ShapeAtPath<App extends AnyCrust, Path extends CommandPath<AppTree<App>>> = CommandShapeAt<
-	AppTypes<App>["shape"],
+	App["_types"]["shape"],
 	Path
 >;
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -23,12 +23,16 @@ type ShapeAtPath<App extends AnyCrust, Path extends CommandPath<AppTree<App>>> =
 	Path
 >;
 
-export interface CapturedRun<Result = unknown> {
-	readonly stdout: string;
-	readonly stderr: string;
-	readonly result?: Result;
-	readonly error?: unknown;
-}
+/**
+ * Result of {@link captureRun}: the success branch carries the action's typed
+ * result (present even when its value is `undefined`, e.g. after a `preRun`
+ * finish); the failure branch carries the thrown value instead. Narrow with
+ * `"error" in captured` — thrown values can be falsy, so property presence is
+ * the reliable discriminant.
+ */
+export type CapturedRun<Result = unknown> =
+	| { readonly stdout: string; readonly stderr: string; readonly result: Result }
+	| { readonly stdout: string; readonly stderr: string; readonly error: unknown };
 
 /** Run an application and capture its text output without throwing invocation errors. */
 export async function captureRun<
@@ -43,28 +47,24 @@ export async function captureRun<
 	// defaults are console.log/console.error), so join captured calls with "\n".
 	const stdoutLines: string[] = [];
 	const stderrLines: string[] = [];
-	let failed = false;
-	let result: unknown;
-	let error: unknown;
 
 	try {
 		const [input] = args;
-		result = await app.run(path as never, input as never, {
+		// The `as never` path/input erasure in this call loses the typed link to
+		// the selected shape, so restore it once here.
+		const result = (await app.run(path as never, input as never, {
 			stdout: (text) => {
 				stdoutLines.push(text);
 			},
 			stderr: (text) => {
 				stderrLines.push(text);
 			},
-		});
-	} catch (caught) {
-		failed = true;
-		error = caught;
+		})) as ShapeAtPath<App, Path>["result"];
+		return { stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n"), result };
+	} catch (error) {
+		// Output written before the failure is retained.
+		return { stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n"), error };
 	}
-
-	const stdout = stdoutLines.join("\n");
-	const stderr = stderrLines.join("\n");
-	return failed ? { stdout, stderr, error } : { stdout, stderr, result };
 }
 
 /** Minimal structural surface of `execute()` invoked by {@link captureExecute}. */


### PR DESCRIPTION
## Summary

Implements #239: `.action()` return values now flow through typed `run()` — CLI-as-embedded-library with full types in *and* out.

```ts
const app = new Crust("cli").args({ name: "file", type: "string", required: true })
  .action(({ args }) => ({ bytes: statSync(args.file).size }));

const result = await app.run([], { args: { file: "a.txt" } }); // { bytes: number } | undefined
```

**Contract:**
- `.action()` (both `Crust` and `CommandDefinitionBuilder`) infers `Awaited<R>`; `CommandShape` carries an optional `result` phantom slot resolved per path by `CommandShapeAt`.
- `run(path, input?, io?)` returns `Promise<R | undefined>` — **`undefined` when an Extension `preRun` hook finishes the invocation before the action runs** (normal control flow, no throw, no outcome wrapper).
- The result resolves only after existing cleanup (postRun hooks, context settlement, disposal); error propagation, hook ordering, IO, and process-status semantics unchanged.
- `execute()` stays `Promise<void>` (terminal boundary); `runInteractive`/`captureExecute` unchanged.
- `@crustjs/testing`: `CapturedRun` gains a typed optional `result`, present on success (including present-`undefined` after a preRun finish), absent alongside `error`.

## Type performance

| Metric | Delta vs parent branch |
|---|---|
| Consumer 10 / 50 / 100 | +3.4% / +2.7% / +2.5% (repo warn threshold: 10%; #238 precedent: +76.7%) |
| Core (`tsc -p packages/core`) | +21.8% — **conflates test-suite fixture cost**: `.action()` is now generic, so every `.action()` call in the core test suite mints a distinct builder instantiation instead of a cache hit. The consumer fixtures above are the library-facing gating number. |

A dedicated type-perf review judged this acceptable as-is; deferring `Awaited` and a void fast-path overload were examined and rejected (the latter would silently swallow result types via TS's void-return assignability rule).

## Tests
Root+child path result inference (type + runtime), async `Awaited`, preRun-finish → `undefined` (type + runtime), `captureRun` success/error/short-circuit including the result-key-present contract.

## Validation
- `bun test` core typed-run/crust + testing suites — 149 pass, 0 fail
- `check:types` (core, testing, docs), declaration-emission, lint, format — pass
- Three independent review passes (correctness, tests/standards, type-perf): no blockers; nits addressed in follow-up commit

## Stack
PR 4/6 of the v0.2 stack, based on #284. Retarget to `main` after #284 merges.

Fixes #239
