### PR TITLE
feat(skills): add Description column to the SKILL.md command reference table

### DIFF
--- a/.changeset/command-reference-descriptions.md
+++ b/.changeset/command-reference-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": minor
+---
+
+Add command descriptions to generated SKILL.md command reference tables.

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -171,14 +171,27 @@ describe("renderSkill", () => {
 	// ────────────────────────────────────────────────────────────────────────
 
 	describe("SKILL.md command reference content", () => {
-		it("includes a markdown table header", () => {
-			const manifest = buildSimpleManifest();
-			const files = renderSkill(manifest, baseMeta);
+		it("includes command descriptions in the markdown table", () => {
+			const child = makeCommand({
+				meta: { name: "child" },
+				run() {},
+			});
+			const root = makeCommand({
+				meta: { name: "app", description: "Build | deploy" },
+				subCommands: { child },
+			});
+			const files = renderSkill(buildManifest(snapshotCommand(root)), baseMeta);
 			const skill = findFile(files, "SKILL.md");
 
 			expect(skill).toBeDefined();
 			expect(skill?.content).toContain("## Command Reference");
-			expect(skill?.content).toContain("| Command | Type | Documentation |");
+			expect(skill?.content).toContain("| Command | Type | Description | Documentation |");
+			expect(skill?.content).toContain(
+				"| `app` | group | Build \\| deploy | [commands/app.md](commands/app.md) |",
+			);
+			expect(skill?.content).toContain(
+				"| `app child` | runnable | - | [commands/child.md](commands/child.md) |",
+			);
 		});
 
 		it("shows correct type labels for runnable vs group", () => {

--- a/packages/skills/src/render.ts
+++ b/packages/skills/src/render.ts
@@ -217,14 +217,15 @@ function renderSkillMd(manifest: ManifestNode, meta: SkillMeta, allNodes: Manife
 function renderCommandReferenceTable(allNodes: ManifestNode[]): string[] {
 	const lines: string[] = [];
 
-	lines.push("| Command | Type | Documentation |");
-	lines.push("| ------- | ---- | ------------- |");
+	lines.push("| Command | Type | Description | Documentation |");
+	lines.push("| ------- | ---- | ----------- | ------------- |");
 
 	for (const node of allNodes) {
 		const invocation = commandInvocation(node);
 		const filePath = commandFilePath(node);
 		const type = commandType(node);
-		lines.push(`| \`${invocation}\` | ${type} | [${filePath}](${filePath}) |`);
+		const description = escapeTableCell(node.description || "-");
+		lines.push(`| \`${invocation}\` | ${type} | ${description} | [${filePath}](${filePath}) |`);
 	}
 
 	return lines;


### PR DESCRIPTION
## Summary

The `## Command Reference` table in generated SKILL.md files now includes a `Description` column sourced from each command's description, so agents picking a command from the table get context without opening every documentation file.

- Missing/empty descriptions render as `-`, matching the arg/flag table convention.
- Pipes in descriptions go through the existing `escapeTableCell` path — no second escaping mechanism.

Before: `| Command | Type | Documentation |`
After: `| Command | Type | Description | Documentation |`

## Tests
TDD (red → green): new assertions for the four-column header, a populated description, pipe escaping, and the `-` fallback in `render.test.ts`. 34 skills tests pass.

## Changeset
`@crustjs/skills` minor — generated SKILL.md output shape changes.

## Stack
PR 7/7, based on #287. Retarget to `main` after #287 merges.
