### PR TITLE
refactor(prompts,progress): fix multifilter/spinner bugs, trim public kit

### DIFF
--- a/.changeset/final-spinner-line.md
+++ b/.changeset/final-spinner-line.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/progress": patch
+---
+
+Render the final spinner line when an imperative handle is stopped before it is started.

--- a/.changeset/trim-prompt-kit.md
+++ b/.changeset/trim-prompt-kit.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/prompts": minor
+---
+
+Trim the custom-prompt utility surface to the prompt engine, text editing, and fuzzy matching APIs. The formatting and list-normalization helpers, `NormalizedChoice`, and `CURSOR_CHAR` are no longer exported.
+
+Fix multifilter selection when duplicate choices share a label and value.

--- a/.changeset/trim-prompt-kit.md
+++ b/.changeset/trim-prompt-kit.md
@@ -4,4 +4,4 @@
 
 Trim the custom-prompt utility surface to the prompt engine, text editing, and fuzzy matching APIs. The formatting and list-normalization helpers, `NormalizedChoice`, and `CURSOR_CHAR` are no longer exported.
 
-Fix multifilter selection when duplicate choices share a label and value.
+Fix multifilter selection when duplicate choices share a label and value, and preserve the initial cursor when the first default value is `undefined`.

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -67,7 +67,7 @@ if (failed) {
 }
 ```
 
-`stop()` is idempotent; the default outcome is `"success"`. `SpinnerOutcome` is the union `"success" | "error"`.
+`stop()` is idempotent; the default outcome is `"success"`. Calling it before `start()` still renders the final line. `SpinnerOutcome` is the union `"success" | "error"`.
 
 <auto-type-table
   path="../../../../../packages/progress/src/spinner.ts"
@@ -95,7 +95,7 @@ bar.stop("success", "All files translated");
   name="ProgressOptions"
 />
 
-`progress()` returns a `ProgressHandle`:
+`progress()` returns a `ProgressHandle`. Calling `advance()` before `start()` mutates the current count but does not repaint; the updated count appears after starting or on the final line.
 
 <auto-type-table
   path="../../../../../packages/progress/src/progress.ts"

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -92,7 +92,7 @@ test("accepts a name", async () => {
 });
 ```
 
-Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey` and the types `Key`, `NamedKey`, `PromptTestIO`, and `RenderedPrompt`; `keys()` autocompletes named key names while still accepting `ctrl+<letter>` and single characters.
+Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey`, `pressKey`, and the types `Key`, `NamedKey`, `PromptTestIO`, and `RenderedPrompt`; `keys()` autocompletes named key names while still accepting `ctrl+<letter>` and single characters.
 
 ## Prompts
 
@@ -200,6 +200,8 @@ const port = await select({
 
 When the choices list is written inline (or declared `as const`), the result narrows to the union of the choice values — `80 | 443` above, or `"react" | "vue" | "svelte"` for string choices. A widened `string[]` keeps `string`. The same applies to `multiselect`, `filter`, and `multifilter` (element type of the returned array).
 
+For object-valued choices, `default` matches by reference equality. Pass the same object instance used in `choices`.
+
 <auto-type-table
   path="../../../../../packages/prompts/src/prompts/select.ts"
   name="SelectOptions"
@@ -209,7 +211,7 @@ When the choices list is written inline (or declared `as const`), the result nar
 
 Checkbox-style multi-selection. Use Space to toggle, `a` to toggle all, `i` to invert, and Enter to confirm.
 
-When `max` is set, toggle-all and invert respect the constraint.
+When `max` is set, toggle-all and invert respect the constraint. Object values in `default` match choices by reference equality.
 
 ```ts
 const features = await multiselect({
@@ -234,7 +236,7 @@ const features = await multiselect({
 
 Fuzzy-search selection. Type to filter, navigate with Up/Down, and confirm with Enter. Matched characters are highlighted in results.
 
-Use `filter` when users should choose a single item from a long list and need search to narrow it quickly. For fuzzy multi-selection, use `multifilter`.
+Use `filter` when users should choose a single item from a long list and need search to narrow it quickly. For fuzzy multi-selection, use `multifilter`. Object values in `default` match choices by reference equality.
 
 ```ts
 const lang = await filter({
@@ -379,7 +381,7 @@ const result = await runPrompt<CounterState, number>({
 For custom prompts that need text input, use the shared `handleTextEdit` helper instead of reimplementing cursor editing logic.
 
 ```ts
-import { handleTextEdit, CURSOR_CHAR } from "@crustjs/prompts";
+import { handleTextEdit } from "@crustjs/prompts";
 
 const edit = handleTextEdit(key, currentText, cursorPos);
 if (edit) {
@@ -428,16 +430,11 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 
 ### Utilities
 
-| Export                  | Description                                     |
-| ----------------------- | ----------------------------------------------- |
-| `handleTextEdit`        | Shared text-editing keypress handler            |
-| `CURSOR_CHAR`           | Cursor indicator character (`│`)                |
-| `fuzzyMatch`            | Score a query against a single candidate string |
-| `fuzzyFilter`           | Filter and rank choices by fuzzy query          |
-| `normalizeChoices`      | Normalize choices to `{ label, value }`         |
-| `formatPromptLine`      | Format prompt header with inline content        |
-| `formatSubmitted`       | Format submitted line for a prompt              |
-| `calculateScrollOffset` | Calculate viewport scroll offset for lists      |
+| Export           | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `handleTextEdit` | Shared text-editing keypress handler            |
+| `fuzzyMatch`     | Score a query against a single candidate string |
+| `fuzzyFilter`    | Filter and rank choices by fuzzy query          |
 
 ### Types
 
@@ -463,7 +460,6 @@ Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` 
 | `PromptConfig<S,T>`       | Configuration for `runPrompt()`                                                     |
 | `SubmitResult<T>`         | Submit action type                                                                  |
 | `HandleKeyResult<S,T>`    | Return type of keypress handlers                                                    |
-| `NormalizedChoice<T>`     | Normalized choice with explicit label and value                                     |
 | `FuzzyMatchResult`        | Single fuzzy match result with score and indices                                    |
 | `FuzzyFilterResult<T>`    | Fuzzy filter result with item and match data                                        |
 | `TextEditState`           | Text plus cursor position for `handleTextEdit`                                      |

--- a/packages/progress/src/progress.ts
+++ b/packages/progress/src/progress.ts
@@ -17,7 +17,7 @@ export interface ProgressOptions extends SpinnerHandleOptions {
 export interface ProgressHandle {
 	/** Begin rendering at `(0/total)`. */
 	start: () => void;
-	/** Advance by `amount` units and repaint, optionally with a new message. */
+	/** Advance by `amount` units and repaint, optionally with a new message. Before `start()`, this mutates the count without repainting. */
 	advance: (amount?: number, message?: string) => void;
 	/**
 	 * Finish: render the final `✓`/`✗` line with the last `(current/total)`.

--- a/packages/progress/src/spinner.test.ts
+++ b/packages/progress/src/spinner.test.ts
@@ -144,6 +144,15 @@ describe("spinner — terminal sink", () => {
 		expect(writes).toEqual(finalOutput);
 	});
 
+	it("renders the final line when stopped before starting", () => {
+		const { sink, writes } = createFakeSink(false);
+		const handle = spinner({ message: "Working", sink });
+
+		handle.stop("error", "Failed");
+
+		expect(writes).toEqual(["✗ Failed\n"]);
+	});
+
 	it("leaves SIGINT to the application when disabled", () => {
 		const { sink } = createFakeSink(true);
 		const previousHandlers = process.listeners("SIGINT");

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -257,12 +257,12 @@ export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandl
 		},
 
 		stop(outcome: SpinnerOutcome = "success", message?: string) {
-			if (!started || finished) return;
+			if (finished) return;
 			finished = true;
 			if (message !== undefined) currentMessage = message;
 			cleanup();
-			sink.write(renderFinal(currentMessage, theme, outcome, isInteractive));
-			if (isInteractive) {
+			sink.write(renderFinal(currentMessage, theme, outcome, started && isInteractive));
+			if (started && isInteractive) {
 				sink.write(SHOW_CURSOR);
 			}
 		},

--- a/packages/prompts/src/core/fuzzy.ts
+++ b/packages/prompts/src/core/fuzzy.ts
@@ -3,7 +3,6 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { PromptTheme } from "./types.ts";
-import { calculateScrollOffset } from "./utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -178,28 +177,6 @@ export function fuzzyFilter<T>(
 	results.sort((a, b) => b.score - a.score);
 
 	return results;
-}
-
-/** @internal Re-filter a list prompt after its query changes. */
-export function refilter<
-	T,
-	S extends {
-		readonly query: string;
-		readonly choices: readonly { readonly label: string; readonly value: T }[];
-	},
->(
-	state: S,
-	maxVisible: number,
-): S & {
-	readonly results: FuzzyFilterResult<T>[];
-	readonly listCursor: number;
-	readonly scrollOffset: number;
-	readonly error: null;
-} {
-	const results = fuzzyFilter(state.query, state.choices);
-	const listCursor = 0;
-	const scrollOffset = calculateScrollOffset(listCursor, 0, results.length, maxVisible);
-	return { ...state, results, listCursor, scrollOffset, error: null };
 }
 
 /** @internal Apply the filter-match style to matched runs in a label. */

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -1,0 +1,77 @@
+import type { FuzzyFilterResult } from "./fuzzy.ts";
+import { fuzzyFilter } from "./fuzzy.ts";
+import type { PromptIO } from "./renderer.ts";
+import { isTTY, resolvePromptIO } from "./renderer.ts";
+import type { Choice } from "./types.ts";
+import type { NormalizedChoice } from "./utils.ts";
+import { calculateScrollOffset, DEFAULT_MAX_VISIBLE, normalizeChoices } from "./utils.ts";
+
+interface ListPromptOptions<T, Answer> {
+	readonly choices: readonly Choice<T>[];
+	readonly initial?: Answer;
+	readonly default?: Answer;
+	readonly maxVisible?: number;
+}
+
+type ListPromptSetup<T, Answer> =
+	| { readonly shortCircuited: true; readonly value: Answer }
+	| {
+			readonly shortCircuited: false;
+			readonly choices: readonly NormalizedChoice<T>[];
+			readonly maxVisible: number;
+			readonly cursor: number;
+			readonly scrollOffset: number;
+			readonly promptIO: Required<PromptIO>;
+	  };
+
+/** @internal Resolve the shared lifecycle and initial viewport for list prompts. */
+export function setupListPrompt<T, Answer>(
+	options: ListPromptOptions<T, Answer>,
+	io?: PromptIO,
+	defaultCursorValue?: T,
+): ListPromptSetup<T, Answer> {
+	if (options.initial !== undefined) return { shortCircuited: true, value: options.initial };
+
+	const promptIO = resolvePromptIO(io);
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
+		return { shortCircuited: true, value: options.default };
+	}
+
+	const choices = normalizeChoices(options.choices);
+	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
+	const defaultCursor =
+		defaultCursorValue === undefined
+			? -1
+			: choices.findIndex((choice) => choice.value === defaultCursorValue);
+	const cursor = defaultCursor === -1 ? 0 : defaultCursor;
+
+	return {
+		shortCircuited: false,
+		choices,
+		maxVisible,
+		cursor,
+		scrollOffset: calculateScrollOffset(cursor, 0, choices.length, maxVisible),
+		promptIO,
+	};
+}
+
+/** @internal Re-filter a list prompt after its query changes. */
+export function refilter<
+	T,
+	S extends {
+		readonly query: string;
+		readonly choices: readonly { readonly label: string; readonly value: T }[];
+	},
+>(
+	state: S,
+	maxVisible: number,
+): S & {
+	readonly results: FuzzyFilterResult<T>[];
+	readonly listCursor: number;
+	readonly scrollOffset: number;
+} {
+	const results = fuzzyFilter(state.query, state.choices);
+	const listCursor = 0;
+	const scrollOffset = calculateScrollOffset(listCursor, 0, results.length, maxVisible);
+	return { ...state, results, listCursor, scrollOffset };
+}

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -29,6 +29,7 @@ export function setupListPrompt<T, Answer>(
 	options: ListPromptOptions<T, Answer>,
 	io?: PromptIO,
 	defaultCursorValue?: T,
+	hasDefaultCursor = defaultCursorValue !== undefined,
 ): ListPromptSetup<T, Answer> {
 	if (options.initial !== undefined) return { shortCircuited: true, value: options.initial };
 
@@ -39,10 +40,9 @@ export function setupListPrompt<T, Answer>(
 
 	const choices = normalizeChoices(options.choices);
 	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const defaultCursor =
-		defaultCursorValue === undefined
-			? -1
-			: choices.findIndex((choice) => choice.value === defaultCursorValue);
+	const defaultCursor = hasDefaultCursor
+		? choices.findIndex((choice) => choice.value === defaultCursorValue)
+		: -1;
 	const cursor = defaultCursor === -1 ? 0 : defaultCursor;
 
 	return {

--- a/packages/prompts/src/core/textEdit.ts
+++ b/packages/prompts/src/core/textEdit.ts
@@ -7,7 +7,7 @@ import type { StandardSchema } from "@crustjs/utils/schema";
 import type { KeypressEvent, SubmitResult } from "./renderer.ts";
 import { submit } from "./renderer.ts";
 import type { PromptTheme, ValidateFn } from "./types.ts";
-import { validateSubmitValue } from "./types.ts";
+import { validateSubmitValue } from "./validate.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Constants

--- a/packages/prompts/src/core/types.ts
+++ b/packages/prompts/src/core/types.ts
@@ -136,39 +136,3 @@ export type SchemaOrValidate<Output> =
 			readonly validate: ValidateFn<string>;
 	  }
 	| { readonly schema?: never; readonly validate?: never };
-
-export async function validateSubmitValue<Output>(
-	value: string,
-	schema: StandardSchema<unknown, Output> | undefined,
-	validate: ValidateFn<string> | undefined,
-): Promise<{ ok: true; value: Output | string } | { ok: false; error: string }> {
-	if (schema) {
-		const result = await schema["~standard"].validate(value);
-		const issue = result.issues?.[0];
-		if (issue) return { ok: false, error: issue.message || "Validation failed" };
-		if ("value" in result) return { ok: true, value: result.value };
-		return { ok: false, error: "Validation failed" };
-	}
-	if (validate) {
-		try {
-			await validate(value);
-		} catch (err) {
-			return { ok: false, error: err instanceof Error ? err.message : "Validation failed" };
-		}
-	}
-	return { ok: true, value };
-}
-
-/** @internal Parse an initial/default value through a Standard Schema. */
-export async function parseShortCircuit<Output>(
-	schema: StandardSchema<unknown, Output>,
-	value: string,
-	source: "initial" | "default",
-): Promise<Output> {
-	const result = await schema["~standard"].validate(value);
-	const issue = result.issues?.[0];
-	if (issue)
-		throw new Error(`${source} value rejected by schema: ${issue.message || "Validation failed"}`);
-	if ("value" in result) return result.value;
-	throw new Error(`${source} value rejected by schema: Validation failed`);
-}

--- a/packages/prompts/src/core/validate.ts
+++ b/packages/prompts/src/core/validate.ts
@@ -1,0 +1,39 @@
+import type { StandardSchema } from "@crustjs/utils/schema";
+
+import type { ValidateFn } from "./types.ts";
+
+export async function validateSubmitValue<Output>(
+	value: string,
+	schema: StandardSchema<unknown, Output> | undefined,
+	validate: ValidateFn<string> | undefined,
+): Promise<{ ok: true; value: Output | string } | { ok: false; error: string }> {
+	if (schema) {
+		const result = await schema["~standard"].validate(value);
+		const issue = result.issues?.[0];
+		if (issue) return { ok: false, error: issue.message || "Validation failed" };
+		if ("value" in result) return { ok: true, value: result.value };
+		return { ok: false, error: "Validation failed" };
+	}
+	if (validate) {
+		try {
+			await validate(value);
+		} catch (err) {
+			return { ok: false, error: err instanceof Error ? err.message : "Validation failed" };
+		}
+	}
+	return { ok: true, value };
+}
+
+/** @internal Parse an initial/default value through a Standard Schema. */
+export async function parseShortCircuit<Output>(
+	schema: StandardSchema<unknown, Output>,
+	value: string,
+	source: "initial" | "default",
+): Promise<Output> {
+	const result = await schema["~standard"].validate(value);
+	const issue = result.issues?.[0];
+	if (issue)
+		throw new Error(`${source} value rejected by schema: ${issue.message || "Validation failed"}`);
+	if ("value" in result) return result.value;
+	throw new Error(`${source} value rejected by schema: Validation failed`);
+}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -14,7 +14,6 @@ export type {
 	PromptTheme,
 	ValidateFn,
 } from "./core/types.ts";
-export type { NormalizedChoice } from "./core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Theme
@@ -71,10 +70,4 @@ export { select } from "./prompts/select.ts";
 
 export { fuzzyFilter, fuzzyMatch } from "./core/fuzzy.ts";
 export type { TextEditResult, TextEditState } from "./core/textEdit.ts";
-export { CURSOR_CHAR, handleTextEdit } from "./core/textEdit.ts";
-export {
-	calculateScrollOffset,
-	formatPromptLine,
-	formatSubmitted,
-	normalizeChoices,
-} from "./core/utils.ts";
+export { handleTextEdit } from "./core/textEdit.ts";

--- a/packages/prompts/src/prompts/confirm.test.ts
+++ b/packages/prompts/src/prompts/confirm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { confirm, type ConfirmOptions } from "./confirm.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -13,19 +13,6 @@ function start(options: ConfirmOptions): Promise<boolean> {
 	const prompt = renderPrompt<ConfirmOptions, boolean>(confirm, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -48,7 +35,7 @@ describe("confirm — default value", () => {
 		const promise = start({ message: "Continue?" });
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(true);
@@ -61,7 +48,7 @@ describe("confirm — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -78,9 +65,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, left should toggle to false
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -91,9 +78,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, right should toggle to false
-		pressKey("", { name: "right" });
+		pressKey(activePrompt, "", { name: "right" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -104,9 +91,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, tab should toggle to false
-		pressKey("", { name: "tab" });
+		pressKey(activePrompt, "", { name: "tab" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -117,11 +104,11 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Toggle twice — should be back to true
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("", { name: "right" });
+		pressKey(activePrompt, "", { name: "right" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(true);
@@ -140,9 +127,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey("y");
+		pressKey(activePrompt, "y");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(true);
@@ -155,9 +142,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey("Y", { name: "y", shift: true });
+		pressKey(activePrompt, "Y", { name: "y", shift: true });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(true);
@@ -167,9 +154,9 @@ describe("confirm — shortcuts", () => {
 		const promise = start({ message: "Continue?" });
 
 		await tick();
-		pressKey("n");
+		pressKey(activePrompt, "n");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -179,9 +166,9 @@ describe("confirm — shortcuts", () => {
 		const promise = start({ message: "Continue?" });
 
 		await tick();
-		pressKey("N", { name: "n", shift: true });
+		pressKey(activePrompt, "N", { name: "n", shift: true });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -194,9 +181,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey("h", { name: "h" });
+		pressKey(activePrompt, "h", { name: "h" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(true);
@@ -206,9 +193,9 @@ describe("confirm — shortcuts", () => {
 		const promise = start({ message: "Continue?" });
 
 		await tick();
-		pressKey("l", { name: "l" });
+		pressKey(activePrompt, "l", { name: "l" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(false);
@@ -231,7 +218,7 @@ describe("confirm — custom labels", () => {
 		expect(screen()).toContain("Agree");
 		expect(screen()).toContain("Decline");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -245,9 +232,9 @@ describe("confirm — custom labels", () => {
 
 		await tick();
 		// Toggle to true (Accept)
-		pressKey("y");
+		pressKey(activePrompt, "y");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Accept");
@@ -265,7 +252,7 @@ describe("confirm — rendering", () => {
 		await tick();
 		expect(screen()).toContain("Deploy to production?");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -273,9 +260,9 @@ describe("confirm — rendering", () => {
 		const promise = start({ message: "Continue?" });
 
 		await tick();
-		pressKey("n");
+		pressKey(activePrompt, "n");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		// After submission, the selected answer should appear
@@ -297,7 +284,7 @@ describe("confirm — no message", () => {
 		expect(screen()).toContain("Yes");
 		expect(screen()).toContain("No");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe(true);
 	});
@@ -306,7 +293,7 @@ describe("confirm — no message", () => {
 		const promise = start({});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Are you sure?");

--- a/packages/prompts/src/prompts/confirm.ts
+++ b/packages/prompts/src/prompts/confirm.ts
@@ -5,7 +5,6 @@
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
 import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
-import { resolveTheme } from "../core/theme.ts";
 import type { PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
 
@@ -196,7 +195,6 @@ export async function confirm(options: ConfirmOptions, io?: PromptIO): Promise<b
 		return options.default;
 	}
 
-	const theme = resolveTheme(options.theme);
 	const activeLabel = options.active ?? "Yes";
 	const inactiveLabel = options.inactive ?? "No";
 	const defaultValue = options.default ?? true;
@@ -208,7 +206,7 @@ export async function confirm(options: ConfirmOptions, io?: PromptIO): Promise<b
 	return runPrompt<ConfirmState, boolean>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, t) => renderConfirm(state, t, options.message, activeLabel, inactiveLabel),
 			handleKey,
 			renderSubmitted: (state, value, t) =>

--- a/packages/prompts/src/prompts/filter.test.ts
+++ b/packages/prompts/src/prompts/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { filter, type FilterOptions } from "./filter.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -13,19 +13,6 @@ function start<T>(options: FilterOptions<T>): Promise<T> {
 	const prompt = renderPrompt<FilterOptions<T>, T>(filter, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -74,7 +61,7 @@ describe("filter — default value", () => {
 
 		await tick();
 		// Submit immediately — should select "Rust" (cursor at matching index)
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("Rust");
@@ -87,7 +74,7 @@ describe("filter — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("TypeScript");
@@ -101,7 +88,7 @@ describe("filter — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("TypeScript");
@@ -124,7 +111,7 @@ describe("filter — typing filters the list", () => {
 		expect(screen()).toContain("JavaScript");
 		expect(screen()).toContain("Rust");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -136,15 +123,15 @@ describe("filter — typing filters the list", () => {
 
 		await tick();
 		// Type "py" to filter
-		pressKey("p", { name: "p" });
+		pressKey(activePrompt, "p", { name: "p" });
 		await tick();
-		pressKey("y", { name: "y" });
+		pressKey(activePrompt, "y", { name: "y" });
 		await tick();
 
 		// "Python" should be visible, "Go" should not
 		expect(screen()).toContain("Python");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("Python");
 	});
@@ -157,23 +144,23 @@ describe("filter — typing filters the list", () => {
 
 		await tick();
 		// Type something that won't match anything
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
 
 		expect(screen()).toContain("No matches");
 
 		// Backspace to clear and get matches again, then submit
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -190,9 +177,9 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("beta");
@@ -205,13 +192,13 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("beta");
@@ -224,9 +211,9 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("gamma");
@@ -240,27 +227,27 @@ describe("filter — navigation", () => {
 
 		await tick();
 		// Type something that won't match
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
-		pressKey("z", { name: "z" });
+		pressKey(activePrompt, "z", { name: "z" });
 		await tick();
 
 		// Navigation should be ignored (no crash)
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
 
 		// Clear query and submit
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -278,19 +265,19 @@ describe("filter — query editing", () => {
 
 		await tick();
 		// Type "ac"
-		pressKey("a", { name: "a" });
+		pressKey(activePrompt, "a", { name: "a" });
 		await tick();
-		pressKey("c", { name: "c" });
+		pressKey(activePrompt, "c", { name: "c" });
 		await tick();
 
 		// Move cursor left and insert "b" to make "abc"
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("b", { name: "b" });
+		pressKey(activePrompt, "b", { name: "b" });
 		await tick();
 
 		// "abc" should now match
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("abc");
 	});
@@ -310,7 +297,7 @@ describe("filter — rendering", () => {
 		await tick();
 		expect(screen()).toContain("Find a language");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -324,7 +311,7 @@ describe("filter — rendering", () => {
 		await tick();
 		expect(screen()).toContain("Type to filter...");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -335,9 +322,9 @@ describe("filter — rendering", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("banana");
@@ -356,7 +343,7 @@ describe("filter — rendering", () => {
 		expect(screen()).toContain("Option A");
 		expect(screen()).toContain("Option B");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -380,7 +367,7 @@ describe("filter — viewport scrolling", () => {
 		expect(screen()).toContain("item-4");
 		expect(screen()).not.toContain("item-5");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -394,17 +381,17 @@ describe("filter — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
 
 		// item-3 should now be visible
 		expect(screen()).toContain("item-3");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("item-3");
 	});
@@ -425,7 +412,7 @@ describe("filter — no message", () => {
 		expect(screen()).not.toContain("undefined");
 		expect(screen()).toContain("apple");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("apple");
 	});
@@ -436,7 +423,7 @@ describe("filter — no message", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Search and select");

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -3,23 +3,15 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { FuzzyFilterResult } from "../core/fuzzy.ts";
-import { fuzzyFilter, highlightMatches, refilter } from "../core/fuzzy.ts";
+import { fuzzyFilter, highlightMatches } from "../core/fuzzy.ts";
+import { refilter, setupListPrompt } from "../core/list.ts";
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
+import { runPrompt, submit } from "../core/renderer.ts";
 import { CURSOR_INDICATOR, PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { handleTextEdit, renderTextWithCursor } from "../core/textEdit.ts";
-import { resolveTheme } from "../core/theme.ts";
 import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
-import {
-	calculateScrollOffset,
-	DEFAULT_MAX_VISIBLE,
-	formatPromptLine,
-	formatSubmitted,
-	moveCursor,
-	normalizeChoices,
-	renderChoiceList,
-} from "../core/utils.ts";
+import { formatPromptLine, formatSubmitted, moveCursor, renderChoiceList } from "../core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -33,7 +25,7 @@ export interface FilterOptions<T> {
 	readonly choices: readonly Choice<T>[];
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: T;
-	/** Default value — sets the initial cursor position to the matching choice. In non-interactive environments, this value is returned automatically */
+	/** Default value — matches a choice using reference equality for object values. Returned automatically in non-interactive environments. */
 	readonly default?: T;
 	/** Placeholder text shown when the query input is empty */
 	readonly placeholder?: string;
@@ -235,55 +227,23 @@ export function filter(
 ): Promise<string>;
 export function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T>;
 export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
-	// Short-circuit: return initial value immediately without rendering
-	if (options.initial !== undefined) {
-		return options.initial;
-	}
+	const setup = setupListPrompt<T, T>(options, io, options.default);
+	if (setup.shortCircuited) return setup.value;
 
-	const promptIO = resolvePromptIO(io);
-
-	// Non-interactive fallback: return default value when stdin is not a TTY
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return options.default;
-	}
-
-	const theme = resolveTheme(options.theme);
-	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const choices = normalizeChoices(options.choices);
-
-	// Initial results: all items (empty query matches everything)
-	const initialResults = fuzzyFilter("", choices);
-
-	// Find initial cursor position from default value
-	let initialListCursor = 0;
-	if (options.default !== undefined) {
-		const idx = initialResults.findIndex((result) => result.item.value === options.default);
-		if (idx !== -1) {
-			initialListCursor = idx;
-		}
-	}
-
-	// Calculate initial scroll offset to keep cursor visible
-	const initialScrollOffset = calculateScrollOffset(
-		initialListCursor,
-		0,
-		initialResults.length,
-		maxVisible,
-	);
-
+	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
 	const initialState: FilterState<T> = {
 		query: "",
 		cursorPos: 0,
 		choices,
-		results: initialResults,
-		listCursor: initialListCursor,
-		scrollOffset: initialScrollOffset,
+		results: fuzzyFilter("", choices),
+		listCursor: cursor,
+		scrollOffset,
 	};
 
 	return runPrompt<FilterState<T>, T>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, resolvedTheme) =>
 				renderFilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
 			handleKey: createHandleKey<T>(maxVisible),

--- a/packages/prompts/src/prompts/input.test.ts
+++ b/packages/prompts/src/prompts/input.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 
 import type { PromptIO } from "../core/renderer.ts";
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { input, type InputOptions } from "./input.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -21,19 +21,6 @@ function start<Output>(options: InputOptions<Output>): Promise<Output | string> 
 	const prompt = renderPrompt<InputOptions<Output>, Output | string>(runInput, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -91,7 +78,7 @@ describe("input — interactive", () => {
 		expect(screen()).toContain("Your name?");
 
 		// Submit empty to resolve
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -104,7 +91,7 @@ describe("input — interactive", () => {
 		await tick();
 		expect(screen()).toContain("Enter your name");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -119,7 +106,7 @@ describe("input — interactive", () => {
 		expect(screen()).toContain("World");
 		expect(screen()).not.toContain("(World)");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -134,7 +121,7 @@ describe("input — interactive", () => {
 		expect(screen()).toContain("Enter your name");
 		expect(screen()).toContain("(World)");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -142,13 +129,13 @@ describe("input — interactive", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A", { name: "a" });
+		pressKey(activePrompt, "A", { name: "a" });
 		await tick();
-		pressKey("B", { name: "b" });
+		pressKey(activePrompt, "B", { name: "b" });
 		await tick();
-		pressKey("C", { name: "c" });
+		pressKey(activePrompt, "C", { name: "c" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ABC");
@@ -161,7 +148,7 @@ describe("input — interactive", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("DefaultName");
@@ -174,9 +161,9 @@ describe("input — interactive", () => {
 		});
 
 		await tick();
-		pressKey("X", { name: "x" });
+		pressKey(activePrompt, "X", { name: "x" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("X");
@@ -186,11 +173,11 @@ describe("input — interactive", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("O", { name: "o" });
+		pressKey(activePrompt, "O", { name: "o" });
 		await tick();
-		pressKey("K", { name: "k" });
+		pressKey(activePrompt, "K", { name: "k" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		// After submission, the confirmed value should appear in output
@@ -207,13 +194,13 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("A");
@@ -223,11 +210,11 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("A");
@@ -237,21 +224,21 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
-		pressKey("C");
+		pressKey(activePrompt, "C");
 		await tick();
 		// Move cursor left to position before C
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
 		// Delete the character at cursor (B)
-		pressKey("", { name: "delete" });
+		pressKey(activePrompt, "", { name: "delete" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("AC");
@@ -261,16 +248,16 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
 		// Move left, then type C — inserts before B
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("C");
+		pressKey(activePrompt, "C");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ACB");
@@ -280,20 +267,20 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
 		// Move left twice, then right once — cursor is between A and B
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("", { name: "left" });
+		pressKey(activePrompt, "", { name: "left" });
 		await tick();
-		pressKey("", { name: "right" });
+		pressKey(activePrompt, "", { name: "right" });
 		await tick();
-		pressKey("C");
+		pressKey(activePrompt, "C");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ACB");
@@ -303,15 +290,15 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
-		pressKey("", { name: "home" });
+		pressKey(activePrompt, "", { name: "home" });
 		await tick();
-		pressKey("C");
+		pressKey(activePrompt, "C");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("CAB");
@@ -321,17 +308,17 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
-		pressKey("", { name: "home" });
+		pressKey(activePrompt, "", { name: "home" });
 		await tick();
-		pressKey("", { name: "end" });
+		pressKey(activePrompt, "", { name: "end" });
 		await tick();
-		pressKey("C");
+		pressKey(activePrompt, "C");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ABC");
@@ -341,12 +328,12 @@ describe("input — keypress editing", () => {
 		const promise = start({ message: "Name?" });
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
 		// Ctrl+A should be ignored (not inserted)
-		pressKey("a", { name: "a", ctrl: true });
+		pressKey(activePrompt, "a", { name: "a", ctrl: true });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("A");
@@ -367,21 +354,21 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey("a");
+		pressKey(activePrompt, "a");
 		await tick();
-		pressKey("b");
+		pressKey(activePrompt, "b");
 		await tick();
 		// Try to submit invalid value
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		// Error should be displayed
 		expect(screen()).toContain("Must contain @");
 
 		// Now type valid input and resubmit
-		pressKey("@");
+		pressKey(activePrompt, "@");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ab@");
@@ -399,18 +386,18 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
 		// Submit too-short value
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("Too short");
 
 		// Add more text and resubmit
-		pressKey("B");
+		pressKey(activePrompt, "B");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("AB");
@@ -427,15 +414,15 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey("1");
+		pressKey(activePrompt, "1");
 		await tick();
-		pressKey("2");
+		pressKey(activePrompt, "2");
 		await tick();
-		pressKey("3");
+		pressKey(activePrompt, "3");
 		await tick();
-		pressKey("4");
+		pressKey(activePrompt, "4");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("1234");
@@ -452,15 +439,15 @@ describe("input — validation", () => {
 
 		await tick();
 		// Submit empty — default is "" which should fail validation
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("Required");
 
 		// Type something and submit
-		pressKey("X");
+		pressKey(activePrompt, "X");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("X");
@@ -479,9 +466,9 @@ describe("input — no message", () => {
 		expect(screen()).toContain("Enter a value");
 		expect(screen()).not.toContain("undefined");
 
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("A");
@@ -491,9 +478,9 @@ describe("input — no message", () => {
 		const promise = start({});
 
 		await tick();
-		pressKey("X");
+		pressKey(activePrompt, "X");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Enter a value");
@@ -551,13 +538,13 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
-		pressKey("l");
+		pressKey(activePrompt, "l");
 		await tick();
-		pressKey("i");
+		pressKey(activePrompt, "i");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("Ali");
@@ -570,11 +557,11 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey("4");
+		pressKey(activePrompt, "4");
 		await tick();
-		pressKey("2");
+		pressKey(activePrompt, "2");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(42);
@@ -587,20 +574,20 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey("A");
+		pressKey(activePrompt, "A");
 		await tick();
 		// Submit too-short value
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("Too short");
 
 		// Add more characters and retry
-		pressKey("l");
+		pressKey(activePrompt, "l");
 		await tick();
-		pressKey("i");
+		pressKey(activePrompt, "i");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("Ali");
@@ -625,21 +612,21 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey("x");
+		pressKey(activePrompt, "x");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("Validation failed");
 
 		// Clear field, type valid value, submit
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("o");
+		pressKey(activePrompt, "o");
 		await tick();
-		pressKey("k");
+		pressKey(activePrompt, "k");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ok");
@@ -663,11 +650,11 @@ describe("input — schema validation", () => {
 		const promise = start({ message: "Word?", schema: emptyIssuesSchema });
 
 		await tick();
-		pressKey("o");
+		pressKey(activePrompt, "o");
 		await tick();
-		pressKey("k");
+		pressKey(activePrompt, "k");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("ok");
@@ -686,27 +673,27 @@ describe("input — schema validation", () => {
 		const promise = start({ message: "Confirm?", schema: asyncSchema });
 
 		await tick();
-		pressKey("n");
+		pressKey(activePrompt, "n");
 		await tick();
-		pressKey("o");
+		pressKey(activePrompt, "o");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await waitForScreen("must be yes");
 
 		expect(screen()).toContain("must be yes");
 
 		// Clear and type valid value
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("", { name: "backspace" });
+		pressKey(activePrompt, "", { name: "backspace" });
 		await tick();
-		pressKey("y");
+		pressKey(activePrompt, "y");
 		await tick();
-		pressKey("e");
+		pressKey(activePrompt, "e");
 		await tick();
-		pressKey("s");
+		pressKey(activePrompt, "s");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("yes");
@@ -778,7 +765,7 @@ describe("input — schema + interactive default", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(4000);
@@ -816,13 +803,13 @@ describe("input — callable Standard Schema", () => {
 		const promise = start({ message: "Word?", schema: callable });
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 		expect(screen()).toContain("empty");
 
-		pressKey("a");
+		pressKey(activePrompt, "a");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("[a]");

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -8,15 +8,14 @@ import type { PromptIO } from "../core/renderer.ts";
 import { isTTY, resolvePromptIO, runPrompt } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { createTextSubmitHandler, renderTextWithCursor } from "../core/textEdit.ts";
-import { resolveTheme } from "../core/theme.ts";
-import {
-	parseShortCircuit,
-	type PartialPromptTheme,
-	type PromptTheme,
-	type SchemaOrValidate,
-	type ValidateFn,
+import type {
+	PartialPromptTheme,
+	PromptTheme,
+	SchemaOrValidate,
+	ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
+import { parseShortCircuit } from "../core/validate.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -204,8 +203,6 @@ export async function input<Output>(
 		return options.default;
 	}
 
-	const theme = resolveTheme(options.theme);
-
 	const initialState: InputState = {
 		value: "",
 		cursorPos: 0,
@@ -215,7 +212,7 @@ export async function input<Output>(
 	return runPrompt<InputState, Output | string>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, t) =>
 				renderInput(state, t, options.message, options.placeholder, options.default),
 			handleKey: createTextSubmitHandler<Output>(options.schema, options.validate, options.default),

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -148,6 +148,24 @@ describe("multifilter — interactive", () => {
 		expect(result).toEqual(["c"]);
 	});
 
+	it("positions the cursor on an undefined default value", async () => {
+		const promise = start<string | undefined>({
+			message: "Search",
+			choices: [
+				{ label: "first", value: "first" },
+				{ label: "unset", value: undefined },
+			],
+			default: [undefined],
+		});
+
+		await tick();
+		pressKey(activePrompt, "", { name: "space" });
+		await tick();
+		pressKey(activePrompt, "", { name: "return" });
+
+		expect(await promise).toEqual([]);
+	});
+
 	it("Enter with required and no selection shows error", async () => {
 		const promise = start({
 			message: "Search",

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { multifilter, type MultifilterOptions } from "./multifilter.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -13,19 +13,6 @@ function start<T>(options: MultifilterOptions<T>): Promise<T[]> {
 	const prompt = renderPrompt<MultifilterOptions<T>, T[]>(multifilter, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -109,16 +96,41 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["alpha", "beta"]);
+	});
+
+	it("toggles the highlighted choice when duplicate choices share a label and value", async () => {
+		const value = { id: 1 };
+		const promise = start({
+			message: "Search",
+			choices: [
+				{ label: "duplicate", value },
+				{ label: "duplicate", value },
+			],
+		});
+
+		await tick();
+		pressKey(activePrompt, "", { name: "down" });
+		await tick();
+		pressKey(activePrompt, "", { name: "space" });
+		await tick();
+
+		const duplicateLines = screen()
+			.split("\n")
+			.filter((line) => line.includes("duplicate"));
+		expect(duplicateLines.map((line) => line.includes("●"))).toEqual([false, true]);
+
+		pressKey(activePrompt, "", { name: "return" });
+		expect(await promise).toEqual([value]);
 	});
 
 	it("pre-selects from default", async () => {
@@ -130,7 +142,7 @@ describe("multifilter — interactive", () => {
 
 		await tick();
 		expect(screen()).toContain("●");
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["c"]);
@@ -144,14 +156,14 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("At least one");
 
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["x"]);
@@ -164,21 +176,21 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("g", { name: "g" });
+		pressKey(activePrompt, "g", { name: "g" });
 		await tick();
-		pressKey("a", { name: "a" });
+		pressKey(activePrompt, "a", { name: "a" });
 		await tick();
-		pressKey("m", { name: "m" });
+		pressKey(activePrompt, "m", { name: "m" });
 		await tick();
 
 		expect(screen()).toContain("gamma");
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["gamma"]);

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -260,7 +260,12 @@ export function multifilter(
 ): Promise<string[]>;
 export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
-	const setup = setupListPrompt<T, readonly T[]>(options, io, options.default?.[0]);
+	const setup = setupListPrompt<T, readonly T[]>(
+		options,
+		io,
+		options.default?.[0],
+		(options.default?.length ?? 0) > 0,
+	);
 	if (setup.shortCircuited) return [...setup.value];
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -3,9 +3,10 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { FuzzyFilterResult } from "../core/fuzzy.ts";
-import { fuzzyFilter, highlightMatches, refilter } from "../core/fuzzy.ts";
+import { fuzzyFilter, highlightMatches } from "../core/fuzzy.ts";
+import { refilter, setupListPrompt } from "../core/list.ts";
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
+import { runPrompt, submit } from "../core/renderer.ts";
 import {
 	CHECKBOX_CHECKED,
 	CHECKBOX_UNCHECKED,
@@ -14,16 +15,12 @@ import {
 	PREFIX_SYMBOL,
 } from "../core/symbols.ts";
 import { handleTextEdit, renderTextWithCursor } from "../core/textEdit.ts";
-import { resolveTheme } from "../core/theme.ts";
 import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
 import {
-	calculateScrollOffset,
-	DEFAULT_MAX_VISIBLE,
 	formatPromptLine,
 	formatSubmitted,
 	moveCursor,
-	normalizeChoices,
 	renderChoiceList,
 	validateSelection,
 } from "../core/utils.ts";
@@ -96,17 +93,6 @@ interface MultifilterState<T> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Helpers
-// ────────────────────────────────────────────────────────────────────────────
-
-function choiceIndex<T>(
-	choices: readonly NormalizedChoice<T>[],
-	item: { readonly label: string; readonly value: T },
-): number {
-	return choices.findIndex((choice) => choice.label === item.label && choice.value === item.value);
-}
-
-// ────────────────────────────────────────────────────────────────────────────
 // Keypress handler
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -133,7 +119,7 @@ function createHandleKey<T>(
 			const result = state.results[state.listCursor];
 			if (!result) return state;
 
-			const selectedIndex = choiceIndex(state.choices, result.item);
+			const selectedIndex = state.choices.indexOf(result.item);
 			if (selectedIndex === -1) return state;
 
 			const selected = new Set(state.selected);
@@ -167,7 +153,7 @@ function createHandleKey<T>(
 				query: edit.text,
 				cursorPos: edit.cursorPos,
 			};
-			return queryChanged ? refilter(nextState, maxVisible) : nextState;
+			return queryChanged ? { ...refilter(nextState, maxVisible), error: null } : nextState;
 		}
 
 		return state;
@@ -207,7 +193,7 @@ function renderMultifilter<T>(
 			state.scrollOffset,
 			maxVisible,
 			(result, resultIndex) => {
-				const choiceIdx = choiceIndex(state.choices, result.item);
+				const choiceIdx = state.choices.indexOf(result.item);
 				const choice = choiceIdx === -1 ? undefined : state.choices[choiceIdx];
 				const checkbox =
 					choiceIdx !== -1 && state.selected.has(choiceIdx)
@@ -274,19 +260,10 @@ export function multifilter(
 ): Promise<string[]>;
 export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
-	if (options.initial !== undefined) {
-		return [...options.initial];
-	}
+	const setup = setupListPrompt<T, readonly T[]>(options, io, options.default?.[0]);
+	if (setup.shortCircuited) return [...setup.value];
 
-	const promptIO = resolvePromptIO(io);
-
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return [...options.default];
-	}
-
-	const theme = resolveTheme(options.theme);
-	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const choices = normalizeChoices(options.choices);
+	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
 	const results = fuzzyFilter("", choices);
 
 	const selected = new Set<number>();
@@ -299,22 +276,12 @@ export async function multifilter<T>(options: MultifilterOptions<T>, io?: Prompt
 		}
 	}
 
-	let listCursor = 0;
-	if (options.default && options.default.length > 0) {
-		const idx = results.findIndex((result) => result.item.value === options.default?.[0]);
-		if (idx !== -1) {
-			listCursor = idx;
-		}
-	}
-
-	const scrollOffset = calculateScrollOffset(listCursor, 0, results.length, maxVisible);
-
 	const initialState: MultifilterState<T> = {
 		query: "",
 		cursorPos: 0,
 		choices,
 		results,
-		listCursor,
+		listCursor: cursor,
 		scrollOffset,
 		selected,
 		error: null,
@@ -323,7 +290,7 @@ export async function multifilter<T>(options: MultifilterOptions<T>, io?: Prompt
 	return runPrompt<MultifilterState<T>, T[]>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, resolvedTheme) =>
 				renderMultifilter(state, resolvedTheme, options.message, options.placeholder, maxVisible),
 			handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { multiselect, type MultiselectOptions } from "./multiselect.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -13,19 +13,6 @@ function start<T>(options: MultiselectOptions<T>): Promise<T[]> {
 	const prompt = renderPrompt<MultiselectOptions<T>, T[]>(multiselect, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -74,7 +61,7 @@ describe("multiselect — default value", () => {
 
 		await tick();
 		// Submit immediately — should return pre-selected items
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["cheese", "mushrooms"]);
@@ -87,7 +74,7 @@ describe("multiselect — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual([]);
@@ -101,7 +88,7 @@ describe("multiselect — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["cheese"]);
@@ -121,9 +108,9 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Toggle first item on
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a"]);
@@ -138,9 +125,9 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Toggle first item off (it was pre-selected)
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual([]);
@@ -154,14 +141,14 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Select first item
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
 		// Move down and select second
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a", "b"]);
@@ -180,11 +167,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["b"]);
@@ -198,13 +185,13 @@ describe("multiselect — navigation", () => {
 
 		await tick();
 		// Move down to b, then up back to a
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a"]);
@@ -217,11 +204,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey("j", { name: "j" });
+		pressKey(activePrompt, "j", { name: "j" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["b"]);
@@ -234,13 +221,13 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("k", { name: "k" });
+		pressKey(activePrompt, "k", { name: "k" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a"]);
@@ -253,11 +240,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["c"]);
@@ -276,9 +263,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey("a", { name: "a" });
+		pressKey(activePrompt, "a", { name: "a" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a", "b", "c"]);
@@ -292,9 +279,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey("a", { name: "a" });
+		pressKey(activePrompt, "a", { name: "a" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual([]);
@@ -308,9 +295,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey("a", { name: "a" });
+		pressKey(activePrompt, "a", { name: "a" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a", "b", "c"]);
@@ -324,9 +311,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey("i", { name: "i" });
+		pressKey(activePrompt, "i", { name: "i" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["b", "c"]);
@@ -347,16 +334,16 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Try to submit with nothing selected
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		// Error should be shown
 		expect(screen()).toContain("At least one item must be selected");
 
 		// Select something and submit
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a"]);
@@ -371,20 +358,20 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Select only 1 item
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		// Error should be shown
 		expect(screen()).toContain("Select at least 2 items");
 
 		// Select another item and submit
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a", "b"]);
@@ -399,16 +386,16 @@ describe("multiselect — validation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		// Error should be shown
 		expect(screen()).toContain("Select at most 1 item");
 
 		// Deselect one and submit
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["b"]);
@@ -423,22 +410,22 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Submit with nothing — triggers error
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 		expect(screen()).toContain("At least one item must be selected");
 
 		// Navigate — error should clear
 
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
 
 		// The error should no longer appear in new output
 		expect(screen()).not.toContain("At least one item must be selected");
 
 		// Select and submit
-		pressKey(" ", { name: "space" });
+		pressKey(activePrompt, " ", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["b"]);
@@ -459,7 +446,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(screen()).toContain("Select toppings");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -475,7 +462,7 @@ describe("multiselect — rendering", () => {
 		expect(screen()).toContain("gamma");
 		expect(screen()).toContain("○");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -489,7 +476,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(screen()).toContain("●");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -501,7 +488,7 @@ describe("multiselect — rendering", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		// After submit, should show comma-separated labels
@@ -520,7 +507,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(screen()).toContain("recommended");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -543,7 +530,7 @@ describe("multiselect — viewport scrolling", () => {
 		expect(screen()).toContain("item-4");
 		expect(screen()).not.toContain("item-5");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -557,17 +544,17 @@ describe("multiselect — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
 
 		// item-3 should now be visible
 		expect(screen()).toContain("item-3");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -588,9 +575,9 @@ describe("multiselect — no message", () => {
 		expect(screen()).toContain("a");
 
 		// Select first item and submit
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toEqual(["a"]);
@@ -602,9 +589,9 @@ describe("multiselect — no message", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "space" });
+		pressKey(activePrompt, "", { name: "space" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Pick one or more");

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -2,8 +2,9 @@
 // Multiselect — Checkbox-style multi selection from a list for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
+import { setupListPrompt } from "../core/list.ts";
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
+import { runPrompt, submit } from "../core/renderer.ts";
 import {
 	CHECKBOX_CHECKED,
 	CHECKBOX_UNCHECKED,
@@ -11,17 +12,9 @@ import {
 	PREFIX_SUBMITTED,
 	PREFIX_SYMBOL,
 } from "../core/symbols.ts";
-import { resolveTheme } from "../core/theme.ts";
 import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
-import {
-	DEFAULT_MAX_VISIBLE,
-	formatSubmitted,
-	moveCursor,
-	normalizeChoices,
-	renderChoiceList,
-	validateSelection,
-} from "../core/utils.ts";
+import { formatSubmitted, moveCursor, renderChoiceList, validateSelection } from "../core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -57,7 +50,7 @@ export interface MultiselectOptions<T> {
 	readonly message?: string;
 	/** List of choices — strings or `{ label, value, hint? }` objects */
 	readonly choices: readonly Choice<T>[];
-	/** Default selected values — pre-selects matching choices */
+	/** Default selected values — matches choices using reference equality for object values. */
 	readonly default?: readonly T[];
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: readonly T[];
@@ -299,21 +292,10 @@ export function multiselect(
 ): Promise<string[]>;
 export function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
-	// Short-circuit: return initial value immediately without rendering
-	if (options.initial !== undefined) {
-		return [...options.initial];
-	}
+	const setup = setupListPrompt<T, readonly T[]>(options, io);
+	if (setup.shortCircuited) return [...setup.value];
 
-	const promptIO = resolvePromptIO(io);
-
-	// Non-interactive fallback: return default values when stdin is not a TTY
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return [...options.default];
-	}
-
-	const theme = resolveTheme(options.theme);
-	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const choices = normalizeChoices(options.choices);
+	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
 
 	// Pre-select items matching default values
 	const initialSelected = new Set<number>();
@@ -327,17 +309,17 @@ export async function multiselect<T>(options: MultiselectOptions<T>, io?: Prompt
 	}
 
 	const initialState: MultiselectState<T> = {
-		cursor: 0,
+		cursor,
 		choices,
 		selected: initialSelected,
-		scrollOffset: 0,
+		scrollOffset,
 		error: null,
 	};
 
 	return runPrompt<MultiselectState<T>, T[]>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, t) => renderMultiselect(state, t, options.message, maxVisible),
 			handleKey: createHandleKey<T>(maxVisible, options.required, options.min, options.max),
 			renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message),

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 
 import type { PromptIO } from "../core/renderer.ts";
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { password, type PasswordOptions } from "./password.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -24,19 +24,6 @@ function start<Output>(options: PasswordOptions<Output>): Promise<Output | strin
 	const prompt = renderPrompt<PasswordOptions<Output>, Output | string>(runPassword, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -93,7 +80,7 @@ describe("password — masked rendering", () => {
 		await tick();
 		expect(screen()).toContain("Enter password:");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -101,11 +88,11 @@ describe("password — masked rendering", () => {
 		const promise = start({ message: "Password?" });
 
 		await tick();
-		pressKey("a");
+		pressKey(activePrompt, "a");
 		await tick();
-		pressKey("b");
+		pressKey(activePrompt, "b");
 		await tick();
-		pressKey("c");
+		pressKey(activePrompt, "c");
 		await tick();
 
 		// Should see mask characters (***) but NOT the actual value "abc"
@@ -113,7 +100,7 @@ describe("password — masked rendering", () => {
 		// The actual characters should not appear in output
 		// (except potentially in keypress event data, not in rendered output)
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		// The actual value is returned, even though it was masked in display
 		expect(result).toBe("abc");
@@ -123,15 +110,15 @@ describe("password — masked rendering", () => {
 		const promise = start({ message: "Password?", mask: "●" });
 
 		await tick();
-		pressKey("x");
+		pressKey(activePrompt, "x");
 		await tick();
-		pressKey("y");
+		pressKey(activePrompt, "y");
 		await tick();
 
 		// Custom mask character should appear in output
 		expect(screen()).toContain("●");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("xy");
 	});
@@ -142,11 +129,11 @@ describe("password — masked rendering", () => {
 		await tick();
 		// Type a 10-character password
 		for (const ch of "abcdefghij") {
-			pressKey(ch);
+			pressKey(activePrompt, ch);
 			await tick();
 		}
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 
 		// After submission, should show exactly 4 mask characters (SUBMITTED_MASK_LENGTH)
@@ -161,7 +148,7 @@ describe("password — masked rendering", () => {
 		// U+2502 (│) is the cursor character
 		expect(screen()).toContain("\u2502");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -180,22 +167,22 @@ describe("password — validation", () => {
 		});
 
 		await tick();
-		pressKey("a");
+		pressKey(activePrompt, "a");
 		await tick();
-		pressKey("b");
+		pressKey(activePrompt, "b");
 		await tick();
 		// Try to submit invalid value (too short)
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await tick();
 
 		expect(screen()).toContain("Password must be at least 4 characters");
 
 		// Type more and resubmit
-		pressKey("c");
+		pressKey(activePrompt, "c");
 		await tick();
-		pressKey("d");
+		pressKey(activePrompt, "d");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("abcd");
@@ -214,13 +201,13 @@ describe("password — no message", () => {
 		expect(screen()).toContain("Enter a password");
 		expect(screen()).not.toContain("undefined");
 
-		pressKey("s");
+		pressKey(activePrompt, "s");
 		await tick();
-		pressKey("e");
+		pressKey(activePrompt, "e");
 		await tick();
-		pressKey("c");
+		pressKey(activePrompt, "c");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("sec");
@@ -230,9 +217,9 @@ describe("password — no message", () => {
 		const promise = start({});
 
 		await tick();
-		pressKey("x");
+		pressKey(activePrompt, "x");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Enter a password");
@@ -281,15 +268,15 @@ describe("password — schema validation", () => {
 		});
 
 		await tick();
-		pressKey("4");
+		pressKey(activePrompt, "4");
 		await tick();
-		pressKey("2");
+		pressKey(activePrompt, "2");
 		await tick();
-		pressKey("4");
+		pressKey(activePrompt, "4");
 		await tick();
-		pressKey("2");
+		pressKey(activePrompt, "2");
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(4242);
@@ -358,10 +345,10 @@ describe("password — secrecy", () => {
 
 		await tick();
 		for (const ch of SECRET) {
-			pressKey(ch);
+			pressKey(activePrompt, ch);
 			await tick();
 		}
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 
 		expect(screen()).not.toContain(SECRET);
@@ -375,10 +362,10 @@ describe("password — secrecy", () => {
 
 		await tick();
 		for (const ch of SECRET) {
-			pressKey(ch);
+			pressKey(activePrompt, ch);
 			await tick();
 		}
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		// Schema validation is async; a fixed tick races the error render on slow runners.
 		await waitForScreen("too short");
 
@@ -387,14 +374,14 @@ describe("password — secrecy", () => {
 
 		// Resolve the prompt cleanly with a long-enough valid value.
 		for (let i = 0; i < SECRET.length; i++) {
-			pressKey("", { name: "backspace" });
+			pressKey(activePrompt, "", { name: "backspace" });
 			await tick();
 		}
 		for (const ch of "x".repeat(64)) {
-			pressKey(ch);
+			pressKey(activePrompt, ch);
 			await tick();
 		}
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -8,15 +8,14 @@ import type { PromptIO } from "../core/renderer.ts";
 import { resolvePromptIO, runPrompt } from "../core/renderer.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { createTextSubmitHandler, CURSOR_CHAR } from "../core/textEdit.ts";
-import { resolveTheme } from "../core/theme.ts";
-import {
-	parseShortCircuit,
-	type PartialPromptTheme,
-	type PromptTheme,
-	type SchemaOrValidate,
-	type ValidateFn,
+import type {
+	PartialPromptTheme,
+	PromptTheme,
+	SchemaOrValidate,
+	ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
+import { parseShortCircuit } from "../core/validate.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -189,7 +188,6 @@ export async function password<Output>(
 
 	const promptIO = resolvePromptIO(io);
 
-	const theme = resolveTheme(options.theme);
 	const mask = options.mask ?? "*";
 
 	const initialState: PasswordState = {
@@ -201,7 +199,7 @@ export async function password<Output>(
 	return runPrompt<PasswordState, Output | string>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, t) => renderPassword(state, t, options.message, mask),
 			handleKey: createTextSubmitHandler<Output>(options.schema, options.validate),
 			renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message, mask),

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { createPrompts } from "../create-prompts.ts";
-import { createPromptIO, renderPrompt, type RenderedPrompt } from "../testing.ts";
+import { createPromptIO, pressKey, renderPrompt, type RenderedPrompt } from "../testing.ts";
 import { select, type SelectOptions } from "./select.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -14,19 +14,6 @@ function start<T>(options: SelectOptions<T>): Promise<T> {
 	const prompt = renderPrompt<SelectOptions<T>, T>(select, options);
 	activePrompt = prompt;
 	return prompt.answer;
-}
-
-function pressKey(
-	char: string,
-	key?: Partial<{ name: string; ctrl: boolean; meta: boolean; shift: boolean }>,
-): void {
-	if (key?.ctrl) {
-		activePrompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		activePrompt.keys(key?.name ?? "");
-	} else {
-		activePrompt.type(char);
-	}
 }
 
 function screen(): string {
@@ -75,7 +62,7 @@ describe("select — default value", () => {
 
 		await tick();
 		// Submit immediately — should select "green" (cursor at index 1)
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("green");
@@ -88,7 +75,7 @@ describe("select — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("red");
@@ -102,7 +89,7 @@ describe("select — default value", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("red");
@@ -121,9 +108,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("b");
@@ -137,9 +124,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("a");
@@ -152,9 +139,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey("j", { name: "j" });
+		pressKey(activePrompt, "j", { name: "j" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("b");
@@ -168,9 +155,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey("k", { name: "k" });
+		pressKey(activePrompt, "k", { name: "k" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("b");
@@ -184,9 +171,9 @@ describe("select — navigation", () => {
 
 		await tick();
 		// Cursor at 0, up should wrap to index 2
-		pressKey("", { name: "up" });
+		pressKey(activePrompt, "", { name: "up" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe("c");
@@ -208,9 +195,9 @@ describe("select — choice types", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		const result = await promise;
 		expect(result).toBe(443);
@@ -229,7 +216,7 @@ describe("select — choice types", () => {
 		// Verify hint text is rendered
 		expect(screen()).toContain("recommended");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -248,7 +235,7 @@ describe("select — rendering", () => {
 		await tick();
 		expect(screen()).toContain("Choose your favorite");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -263,7 +250,7 @@ describe("select — rendering", () => {
 		expect(screen()).toContain("beta");
 		expect(screen()).toContain("gamma");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -274,9 +261,9 @@ describe("select — rendering", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		// After submit, the selected label should appear in the output
@@ -296,7 +283,7 @@ describe("select — rendering", () => {
 		expect(screen()).toContain("Option A");
 		expect(screen()).toContain("Option B");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -320,7 +307,7 @@ describe("select — viewport scrolling", () => {
 		expect(screen()).toContain("item-4");
 		expect(screen()).not.toContain("item-5");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -335,7 +322,7 @@ describe("select — viewport scrolling", () => {
 		await tick();
 		expect(screen()).toContain("...");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 
@@ -349,17 +336,17 @@ describe("select — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
-		pressKey("", { name: "down" });
+		pressKey(activePrompt, "", { name: "down" });
 		await tick();
 
 		// item-3 should now be visible
 		expect(screen()).toContain("item-3");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("item-3");
 	});
@@ -378,7 +365,7 @@ describe("select — viewport scrolling", () => {
 		const scrollLines = lines.filter((l) => l.trim() === "...");
 		expect(scrollLines.length).toBe(0);
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		await promise;
 	});
 });
@@ -398,7 +385,7 @@ describe("select — no message", () => {
 		expect(screen()).not.toContain("undefined");
 		expect(screen()).toContain("a");
 
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 		const result = await promise;
 		expect(result).toBe("a");
 	});
@@ -409,7 +396,7 @@ describe("select — no message", () => {
 		});
 
 		await tick();
-		pressKey("", { name: "return" });
+		pressKey(activePrompt, "", { name: "return" });
 
 		await promise;
 		expect(screen()).toContain("Pick an option");

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -2,20 +2,13 @@
 // Select — Single selection from a list of choices for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
+import { setupListPrompt } from "../core/list.ts";
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
+import { runPrompt, submit } from "../core/renderer.ts";
 import { CURSOR_INDICATOR, PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
-import { resolveTheme } from "../core/theme.ts";
 import type { Choice, ChoiceValue, PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import type { NormalizedChoice } from "../core/utils.ts";
-import {
-	calculateScrollOffset,
-	DEFAULT_MAX_VISIBLE,
-	formatSubmitted,
-	moveCursor,
-	normalizeChoices,
-	renderChoiceList,
-} from "../core/utils.ts";
+import { formatSubmitted, moveCursor, renderChoiceList } from "../core/utils.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -49,7 +42,7 @@ export interface SelectOptions<T> {
 	readonly message?: string;
 	/** List of choices — strings or `{ label, value, hint? }` objects */
 	readonly choices: readonly Choice<T>[];
-	/** Default value — sets the initial cursor position to the matching choice */
+	/** Default value — sets the initial cursor position using reference equality for object values. */
 	readonly default?: T;
 	/** Initial value — if provided, the prompt is skipped and this value is returned immediately */
 	readonly initial?: T;
@@ -215,44 +208,16 @@ export function select(
 ): Promise<string>;
 export function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T>;
 export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
-	// Short-circuit: return initial value immediately without rendering
-	if (options.initial !== undefined) {
-		return options.initial;
-	}
+	const setup = setupListPrompt<T, T>(options, io, options.default);
+	if (setup.shortCircuited) return setup.value;
 
-	const promptIO = resolvePromptIO(io);
-
-	// Non-interactive fallback: return default value when stdin is not a TTY
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return options.default;
-	}
-
-	const theme = resolveTheme(options.theme);
-	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const choices = normalizeChoices(options.choices);
-
-	// Find initial cursor position from default value
-	let initialCursor = 0;
-	if (options.default !== undefined) {
-		const idx = choices.findIndex((c) => c.value === options.default);
-		if (idx !== -1) {
-			initialCursor = idx;
-		}
-	}
-
-	// Calculate initial scroll offset to keep cursor visible
-	const initialScrollOffset = calculateScrollOffset(initialCursor, 0, choices.length, maxVisible);
-
-	const initialState: SelectState<T> = {
-		cursor: initialCursor,
-		choices,
-		scrollOffset: initialScrollOffset,
-	};
+	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
+	const initialState: SelectState<T> = { cursor, choices, scrollOffset };
 
 	return runPrompt<SelectState<T>, T>(
 		{
 			initialState,
-			theme,
+			theme: options.theme,
 			render: (state, t) => renderSelect(state, t, options.message, maxVisible),
 			handleKey: createHandleKey<T>(maxVisible),
 			renderSubmitted: (state, value, t) => renderSubmitted(state, value, t, options.message),

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Writable } from "node:stream";
 import { stripVTControlCharacters } from "node:util";
 
-import type { PromptIO } from "./core/renderer.ts";
+import type { KeypressEvent, PromptIO } from "./core/renderer.ts";
 
 const namedKeys = {
 	return: "\r",
@@ -175,6 +175,21 @@ export interface RenderedPrompt<Answer> {
 	keys(...namedKeys: Key[]): void;
 	screen(): string;
 	readonly answer: Promise<Answer>;
+}
+
+/** Drive one keypress through a rendered prompt test harness. */
+export function pressKey(
+	prompt: Pick<RenderedPrompt<unknown>, "type" | "keys">,
+	char: string,
+	key?: Partial<Pick<KeypressEvent, "name" | "ctrl" | "meta" | "shift">>,
+): void {
+	if (key?.ctrl) {
+		prompt.keys(`ctrl+${key.name ?? char}`);
+	} else if (char === "") {
+		prompt.keys(key?.name ?? "");
+	} else {
+		prompt.type(char);
+	}
 }
 
 /** Run a prompt function against fake TTY streams and expose terminal-style controls. */

--- a/packages/prompts/tests/integration.test.ts
+++ b/packages/prompts/tests/integration.test.ts
@@ -44,7 +44,6 @@ import type {
 	KeypressEvent,
 	MultifilterOptions,
 	MultiselectOptions,
-	NormalizedChoice,
 	PartialPromptTheme,
 	PasswordOptions,
 	PromptConfig,
@@ -103,10 +102,6 @@ describe("type exports", () => {
 		// ValidateFn<T> is throw-on-fail / void-on-success.
 		const _validateFn: ValidateFn<string> = () => {};
 		const _partialTheme: PartialPromptTheme = {};
-		const _normalized: NormalizedChoice<string> = {
-			label: "a",
-			value: "a",
-		};
 		const _fuzzyMatch: FuzzyMatchResult = {
 			match: true,
 			score: 1,


### PR DESCRIPTION
Part 2/8 of the architecture cleanup stack.

- Fix: multifilter toggled the wrong item for duplicate label+value choices (now identity-based `indexOf`), O(n)-per-row lookup removed
- Fix: `spinner.stop()` before `start()` silently dropped the final status line
- Removed 7 redundant per-prompt `resolveTheme` calls (runPrompt is the single resolution point); shared `setupListPrompt()` prelude for the 4 list prompts
- Public kit trimmed to the engine (`runPrompt`, `submit`, `handleTextEdit`, `fuzzy*`); formatting/list helpers now private (breaking)
- `refilter` moved out of fuzzy.ts; runtime validators out of core/types.ts; shared `pressKey` test helper

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

