### PR TITLE
refactor(store): honest typed reads, mutators return persisted config

### DIFF
--- a/.changeset/honest-store-results.md
+++ b/.changeset/honest-store-results.md
@@ -2,4 +2,4 @@
 "@crustjs/store": minor
 ---
 
-Reject persisted core field values that still mismatch their declared type after coercion. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.
+Reject persisted core field values that still mismatch their declared type after coercion. Core field definitions now require a declared primitive `type`. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.

--- a/.changeset/honest-store-results.md
+++ b/.changeset/honest-store-results.md
@@ -2,4 +2,4 @@
 "@crustjs/store": minor
 ---
 
-Reject persisted core field values that still mismatch their declared type after coercion, and reject non-finite built-in numbers before persistence. Core field definitions now require a declared primitive `type`. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.
+Reject persisted core field values that still mismatch their declared type after coercion, and reject non-finite built-in numbers before persistence. Core field definitions now require a declared primitive `type`. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations, and reject values that JSON serialization would alter (`NaN`, `Infinity`, `-0`, sparse arrays, `undefined` object properties). Hand-written `validate` transforms are now typed to return the field's declared type and are re-checked at runtime. The internal `PlatformEnv` type is no longer exported.

--- a/.changeset/honest-store-results.md
+++ b/.changeset/honest-store-results.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/store": minor
+---
+
+Reject persisted core field values that still mismatch their declared type after coercion. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.

--- a/.changeset/honest-store-results.md
+++ b/.changeset/honest-store-results.md
@@ -2,4 +2,4 @@
 "@crustjs/store": minor
 ---
 
-Reject persisted core field values that still mismatch their declared type after coercion. Core field definitions now require a declared primitive `type`. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.
+Reject persisted core field values that still mismatch their declared type after coercion, and reject non-finite built-in numbers before persistence. Core field definitions now require a declared primitive `type`. `write()`, `update()`, and `patch()` now return the config they persisted, including schema transformations. The internal `PlatformEnv` type is no longer exported.

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -315,8 +315,8 @@ const state = await store.read();
 - Persisted values override defaults.
 - Missing keys fall back to defaults.
 - Unknown persisted keys are dropped by default (`pruneUnknown: true`). Set `pruneUnknown: false` to preserve them.
-- Array defaults are shallow-copied to prevent shared mutation from defaults.
-- Falsy values (`null`, `0`, `""`, `false`) in the persisted file are preserved — only truly missing keys trigger defaults.
+- Array defaults are deep-copied to prevent shared mutation from defaults.
+- Falsy values (`0`, `""`, `false`) in the persisted file are preserved — only truly missing keys trigger defaults. Typed fields reject `null` with `VALIDATION`.
 
 <Callout>
   Merged defaults exist only in memory. The persisted file remains unchanged until you explicitly
@@ -496,7 +496,7 @@ if (err instanceof CrustStoreError) {
 
 ### Types
 
-`FieldDef` accepts core value definitions and schema-backed `{ schema }` definitions. The schema-backed branch carries the Standard Schema output type directly; `createStore` requires the output to be recursively JSON-compatible, including named interfaces whose properties are JSON data.
+`FieldDef` accepts typed primitive scalar/array definitions and schema-backed `{ schema }` definitions. The schema-backed branch carries the Standard Schema output type directly; `createStore` requires the output to be recursively JSON-compatible, including named interfaces whose properties are JSON data.
 
 #### `FieldDef`
 

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -32,14 +32,14 @@ const store = createStore({
 const state = await store.read();
 // → { theme: "light", fontSize: 14, verbose: false }
 
-// Write a full state object
-await store.write({ theme: "dark", fontSize: 16, verbose: true });
+// Mutations return the state that was persisted
+const written = await store.write({ theme: "dark", fontSize: 16, verbose: true });
 
 // Update with a function
-await store.update((current) => ({ ...current, verbose: false }));
+const updated = await store.update((current) => ({ ...current, verbose: false }));
 
 // Patch only specific keys
-await store.patch({ theme: "solarized" });
+const patched = await store.patch({ theme: "solarized" });
 
 // Reset to defaults (removes persisted file)
 await store.reset();
@@ -52,9 +52,9 @@ No explicit generics needed — types are inferred from your `fields` definition
 1. Pick a path helper (`configDir`, `dataDir`, `stateDir`, `cacheDir`) to resolve a platform-standard directory.
 2. `createStore()` resolves the file path once (`<dirPath>/<name>.json`) and returns a typed store instance.
 3. `read()` loads persisted JSON, applies field defaults for missing keys, and returns the complete state.
-4. `write()` atomically persists the full state (temp file + rename — no partial writes on crash).
-5. `update()` reads the current state, applies an updater function, and persists the result.
-6. `patch()` shallow-merges a partial update into the current state and persists.
+4. `write()` atomically persists the full state (temp file + rename — no partial writes on crash) and returns it.
+5. `update()` reads the current state, applies an updater function, persists the result, and returns it.
+6. `patch()` shallow-merges a partial update into the current state, persists it, and returns it.
 7. `reset()` deletes the persisted file, reverting to defaults-on-read behavior.
 
 ## Storage Intent
@@ -127,7 +127,7 @@ All four helpers follow XDG conventions on Linux and macOS, and Windows-native c
   `~/Library/...` paths.
 </Callout>
 
-The optional `env` parameter on each helper accepts a `PlatformEnv` object for deterministic testing without mutating `process.env`.
+The optional `env` parameter on each helper accepts a structural test environment (`platform`, `env`, and `homedir`) for deterministic testing without mutating `process.env`.
 
 ### Multiple Stores
 
@@ -233,7 +233,7 @@ const state = await store.read();
 
 Always returns the inferred store shape. Fields with defaults are guaranteed present; fields without defaults may be `undefined`. Does not write merged defaults back to disk.
 
-When per-field `validate` functions are configured, each field is validated after defaults are applied. Invalid persisted config fails loudly.
+After coercion, every core field is checked against its declared primitive and array type. Per-field `validate` functions then run after defaults are applied. Invalid persisted config fails loudly with `VALIDATION`.
 
 **Throws:** `CrustStoreError` with `PARSE` code on malformed JSON, `VALIDATION` if the config fails validation, `IO` code on filesystem failure.
 
@@ -242,8 +242,10 @@ When per-field `validate` functions are configured, each field is validated afte
 Atomically persists a full state object. The entire previous state is replaced. Parent directories are created if missing.
 
 ```ts
-await store.write({ theme: "dark", fontSize: 14, verbose: true });
+const persisted = await store.write({ theme: "dark", fontSize: 14, verbose: true });
 ```
+
+Returns the persisted state, including schema transformations.
 
 **Throws:** `CrustStoreError` with `VALIDATION` if field validators reject, `IO` on filesystem failure.
 
@@ -252,13 +254,15 @@ await store.write({ theme: "dark", fontSize: 14, verbose: true });
 Reads the current effective state, applies the updater function, and atomically persists the result.
 
 ```ts
-await store.update((current) => ({
+const persisted = await store.update((current) => ({
   ...current,
   theme: "dark",
 }));
 ```
 
-When no persisted file exists, the updater receives field `defaults` as the current value.
+When no persisted file exists, the updater receives field `defaults` as the current value. The method returns the persisted state, including schema transformations.
+
+The final file replacement is atomic, but the read-modify-write sequence is not locked across processes. Concurrent updates can overwrite each other.
 
 **Throws:** `CrustStoreError` with `VALIDATION` if field validators reject, `PARSE` on malformed JSON, `IO` on filesystem failure.
 
@@ -267,8 +271,10 @@ When no persisted file exists, the updater receives field `defaults` as the curr
 Applies a shallow partial update to the current state and persists. Only the provided keys are updated; everything else is preserved.
 
 ```ts
-await store.patch({ theme: "solarized" });
+const persisted = await store.patch({ theme: "solarized" });
 ```
+
+Returns the persisted state, including schema transformations.
 
 **Throws:** `CrustStoreError` with `VALIDATION` if field validators reject, `PARSE` on malformed JSON, `IO` on filesystem failure.
 
@@ -509,10 +515,6 @@ if (err instanceof CrustStoreError) {
 #### Validation issues
 
 <auto-type-table path="../../../../../packages/store/src/types.ts" name="StoreValidatorIssue" />
-
-#### Platform environment
-
-<auto-type-table path="../../../../../packages/store/src/path.ts" name="PlatformEnv" />
 
 The package also exports `CreateStoreOptions`, `StoreUpdater`, `FieldsDef`, `InferStoreConfig`, `ValidationErrorDetails`, `StoreErrorCode`, `ValueType`, and the `CrustStoreError` class.
 

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -400,11 +400,13 @@ The inferred store type follows the schema's exact output type (`InferOutput`), 
 
 Optional `type` and `array` fields remain available as tooling metadata on schema definitions. They do not replace the schema as the source of value semantics.
 
-Hand-written `validate` callbacks on non-schema definitions remain validation-only: throw to reject and return `void` to accept.
+Hand-written `validate` callbacks on non-schema definitions throw to reject and return `void` to accept. They may also return `{ value }` to transform the input, as long as the output stays within the field's declared type — a wrong-typed output is rejected with `VALIDATION`.
+
+Mutations return exactly what the next `read()` sees, so `write`, `update`, and `patch` reject values that JSON serialization would alter: `NaN`, `Infinity`, `-0`, sparse arrays, and objects with `undefined` properties all fail with `VALIDATION` instead of silently persisting something different.
 
 ### Operation behavior
 
-- **Write:** validates each field before persisting. Schema transforms replace the input value; hand-written validators cannot transform it.
+- **Write:** validates each field before persisting. Schema and validator transforms replace the input value.
 - **Read:** applies defaults, then validates. Schema transform output is discarded so the returned value matches the persisted value.
 - **Update:** reads the current config, applies the updater, validates, then persists any schema-transformed output.
 - **Patch:** shallow-merges the partial input, validates, then persists any schema-transformed output.

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -452,13 +452,14 @@ function updateNotifierFactory(options: UpdateNotifierOptions): Extension {
 									return state.registryUrl === registryUrl ? state : null;
 								},
 								// Explicit keys: the store's write type requires every field present
-								write: (state) =>
-									store.write({
+								write: async (state) => {
+									await store.write({
 										lastCheckedAt: state.lastCheckedAt,
 										latestVersion: state.latestVersion,
 										lastNotifiedVersion: state.lastNotifiedVersion,
 										registryUrl,
-									}),
+									});
+								},
 							};
 						}
 					}

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -29,7 +29,7 @@ export function setupListPrompt<T, Answer>(
 	options: ListPromptOptions<T, Answer>,
 	io?: PromptIO,
 	defaultCursorValue?: T,
-	hasDefaultCursor = defaultCursorValue !== undefined,
+	hasDefaultCursor: boolean = defaultCursorValue !== undefined,
 ): ListPromptSetup<T, Answer> {
 	if (options.initial !== undefined) return { shortCircuited: true, value: options.initial };
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -10,7 +10,7 @@ bun add @crustjs/store
 
 ## Behavior
 
-`write()`, `update()`, and `patch()` return the state persisted after validation and schema transformations. File replacement is atomic, but `update()` does not lock its read-modify-write sequence across processes.
+`write()`, `update()`, and `patch()` return the state persisted after validation and schema transformations. Values that JSON serialization would alter (`NaN`, `Infinity`, `-0`, sparse arrays, `undefined` object properties) are rejected with `VALIDATION`. File replacement is atomic, but `update()` does not lock its read-modify-write sequence across processes.
 
 ## Documentation
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -8,6 +8,10 @@ DX-first, typed persistence for CLI apps with config/data/state/cache separation
 bun add @crustjs/store
 ```
 
+## Behavior
+
+`write()`, `update()`, and `patch()` return the state persisted after validation and schema transformations. File replacement is atomic, but `update()` does not lock its read-modify-write sequence across processes.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/store](https://crustjs.com/docs/modules/store)

--- a/packages/store/src/errors.ts
+++ b/packages/store/src/errors.ts
@@ -125,10 +125,6 @@ export type StoreErrorDetails<C extends StoreErrorCode> = StoreErrorDetailsMap[C
  * }
  * ```
  */
-function sameStoreErrorCode(left: StoreErrorCode, right: StoreErrorCode): boolean {
-	return left === right;
-}
-
 export class CrustStoreError<C extends StoreErrorCode = StoreErrorCode> extends Error {
 	/** Machine-readable error code for programmatic handling. */
 	readonly code: C;
@@ -165,6 +161,6 @@ export class CrustStoreError<C extends StoreErrorCode = StoreErrorCode> extends 
 	 * ```
 	 */
 	is<T extends StoreErrorCode>(code: T): this is CrustStoreError<T> {
-		return sameStoreErrorCode(this.code, code);
+		return Object.is(this.code, code);
 	}
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -5,7 +5,6 @@
 // Errors
 export type { StoreErrorCode, ValidationErrorDetails } from "./errors.ts";
 export { CrustStoreError } from "./errors.ts";
-export type { PlatformEnv } from "./path.ts";
 // Path
 export { cacheDir, configDir, dataDir, stateDir } from "./path.ts";
 // Store

--- a/packages/store/src/merge.test.ts
+++ b/packages/store/src/merge.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "bun:test";
 
-import { isJsonObject } from "@crustjs/utils/json";
-
 import { applyFieldDefaults } from "./merge.ts";
 import type { FieldsDef } from "./types.ts";
 
@@ -173,34 +171,18 @@ describe("applyFieldDefaults", () => {
 	// Immutability — cloned defaults
 	// ──────────────────────────────────────────────────────────────────────
 
-	it("should deep-copy JSON defaults to prevent shared nested mutation", () => {
+	it("should copy array defaults to prevent shared mutation", () => {
 		const fields = {
-			settings: { default: { nested: { enabled: true } } },
-			groups: { array: true, default: [{ names: ["default"] }] },
+			tags: { type: "string", array: true, default: ["default"] },
 		} as const satisfies FieldsDef;
 
 		const result1 = applyFieldDefaults(undefined, fields);
 		const result2 = applyFieldDefaults(undefined, fields);
 
-		if (result1.settings === undefined || !isJsonObject(result1.settings)) {
-			expect.unreachable("expected the object default");
-		}
-		const nested = result1.settings.nested;
-		if (nested === undefined || !isJsonObject(nested)) {
-			expect.unreachable("expected a nested object");
-		}
-		nested.enabled = false;
+		if (!Array.isArray(result1.tags)) expect.unreachable("expected the array default");
+		result1.tags.push("mutated");
 
-		if (!Array.isArray(result1.groups)) expect.unreachable("expected the array default");
-		const group = result1.groups[0];
-		if (!isJsonObject(group)) expect.unreachable("expected a nested group");
-		if (!Array.isArray(group.names)) expect.unreachable("expected nested names");
-		group.names.push("mutated");
-
-		expect(result2).toEqual({
-			settings: { nested: { enabled: true } },
-			groups: [{ names: ["default"] }],
-		});
+		expect(result2).toEqual({ tags: ["default"] });
 	});
 
 	it("should handle pruneUnknown=false with no persisted data", () => {

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -816,6 +816,29 @@ describe("field validation", () => {
 		}
 	});
 
+	it("should reject non-finite mutation values before persistence", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { amount: { type: "number", default: 0 } },
+		});
+
+		await expect(store.write({ amount: Number.NaN })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "write" },
+		});
+		await expect(store.update(() => ({ amount: Number.POSITIVE_INFINITY }))).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "update" },
+		});
+		const malformedPatch: { amount?: number } = JSON.parse('{"amount":"Infinity"}');
+		await expect(store.patch(malformedPatch)).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "patch" },
+		});
+		expect(existsSync(join(tempDir, "config.json"))).toBe(false);
+	});
+
 	it("should support async field validators", async () => {
 		const fields = {
 			token: {

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -1099,3 +1099,115 @@ describe("schema transform persistence", () => {
 		expect(JSON.parse(raw)).toEqual({ tags: ["a", "b"] });
 	});
 });
+
+describe("JSON serialization stability", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = createTempDir();
+		await mkdir(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("rejects schema values that JSON serialization would corrupt", async () => {
+		// z.custom accepts NaN, which the built-in number check never sees.
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { amount: { schema: z.custom<number>(() => true) } },
+		});
+
+		await expect(store.write({ amount: Number.NaN })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "write", issues: [{ path: "amount" }] },
+		});
+		expect(existsSync(join(tempDir, "config.json"))).toBe(false);
+	});
+
+	it("rejects sparse arrays whose holes would persist as null", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { nums: { type: "number", array: true } },
+		});
+
+		await expect(store.write({ nums: new Array<number>(1) })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "write", issues: [{ path: "nums" }] },
+		});
+	});
+
+	it("rejects negative zero, which JSON persists as 0", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { amount: { type: "number", default: 0 } },
+		});
+
+		await expect(store.patch({ amount: -0 })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "patch", issues: [{ path: "amount" }] },
+		});
+	});
+
+	it("rejects undefined object properties that JSON serialization drops", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { payload: { schema: z.custom<{ note: string }>(() => true) } },
+		});
+
+		// Object.assign sneaks the undefined property past the schema's declared
+		// output type — locks the runtime guard against schema outputs whose own
+		// keys would change across persistence.
+		const withUndefined = Object.assign({ note: "x" }, { note: undefined });
+		await expect(store.write({ payload: withUndefined })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: { operation: "write", issues: [{ path: "payload" }] },
+		});
+	});
+});
+
+describe("core validator transform type enforcement", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = createTempDir();
+		await mkdir(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("rejects core transforms that leave the declared type", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			// JSON.parse hides the wrong-typed output — a JS caller can return any JSON value.
+			fields: { name: { type: "string", validate: () => ({ value: JSON.parse("1") }) } },
+		});
+
+		await expect(store.write({ name: "hi" })).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: {
+				operation: "write",
+				issues: [{ message: "Expected string", path: "name" }],
+			},
+		});
+		expect(existsSync(join(tempDir, "config.json"))).toBe(false);
+	});
+
+	it("still accepts core transforms within the declared type", async () => {
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { name: { type: "string", validate: (value) => ({ value: value.trim() }) } },
+		});
+
+		await expect(store.write({ name: "  hi  " })).resolves.toEqual({ name: "hi" });
+	});
+});

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -316,6 +316,28 @@ describe("store.read", () => {
 			},
 		});
 	});
+
+	it.each([
+		["a non-array value", "not-an-array"],
+		["an element with the wrong type", ["valid", 1]],
+	])("should reject %s for an array field", async (_case, tags) => {
+		const filePath = join(tempDir, "config.json");
+		await writeFile(filePath, JSON.stringify({ tags }));
+
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { tags: { type: "string", array: true } },
+		});
+
+		await expect(store.read()).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: {
+				operation: "read",
+				issues: [{ message: "Expected string[]", path: "tags" }],
+			},
+		});
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -297,6 +297,25 @@ describe("store.read", () => {
 		const result = await store.read();
 		expect(result.ports).toEqual([3000, 8080]);
 	});
+
+	it("should reject persisted values that do not match their declared type", async () => {
+		const filePath = join(tempDir, "config.json");
+		await writeFile(filePath, JSON.stringify({ port: "abc" }));
+
+		const store = createStore({
+			dirPath: tempDir,
+			name: "config",
+			fields: { port: { type: "number" } },
+		});
+
+		await expect(store.read()).rejects.toMatchObject({
+			code: "VALIDATION",
+			details: {
+				operation: "read",
+				issues: [{ path: "port" }],
+			},
+		});
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -906,11 +925,12 @@ describe("schema transform persistence", () => {
 
 		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
-		await store.write({ name: "  hi  " });
+		const persisted = await store.write({ name: "  hi  " });
 
+		expect(persisted).toEqual({ name: "hi" });
 		const filePath = join(tempDir, "config.json");
 		const raw = await readFile(filePath, "utf-8");
-		expect(JSON.parse(raw)).toEqual({ name: "hi" });
+		expect(JSON.parse(raw)).toEqual(persisted);
 	});
 
 	it("persists Zod transform output on update", async () => {
@@ -920,11 +940,12 @@ describe("schema transform persistence", () => {
 
 		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
-		await store.update(() => ({ name: "  spaced  " }));
+		const persisted = await store.update(() => ({ name: "  spaced  " }));
 
+		expect(persisted).toEqual({ name: "spaced" });
 		const filePath = join(tempDir, "config.json");
 		const raw = await readFile(filePath, "utf-8");
-		expect(JSON.parse(raw)).toEqual({ name: "spaced" });
+		expect(JSON.parse(raw)).toEqual(persisted);
 	});
 
 	it("persists Zod transform output on patch", async () => {
@@ -934,11 +955,12 @@ describe("schema transform persistence", () => {
 
 		const store = createStore({ dirPath: tempDir, name: "config", fields });
 
-		await store.patch({ name: "  patched  " });
+		const persisted = await store.patch({ name: "  patched  " });
 
+		expect(persisted).toEqual({ name: "patched" });
 		const filePath = join(tempDir, "config.json");
 		const raw = await readFile(filePath, "utf-8");
-		expect(JSON.parse(raw)).toEqual({ name: "patched" });
+		expect(JSON.parse(raw)).toEqual(persisted);
 	});
 
 	// Pin: reads MUST NOT mutate on-disk state, even when the schema would

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -13,13 +13,13 @@ import { resolveStorePath } from "./path.ts";
 import { deleteJson, readJson, type WriteJsonOptions, writeJson } from "./persistence.ts";
 import type {
 	CreateStoreOptions,
-	FieldDef,
 	FieldsDef,
 	InferStoreConfig,
 	Store,
 	StoreDocument,
 	StoreUpdater,
 	StoreValidatorIssue,
+	ValueType,
 } from "./types.ts";
 
 type FieldValidationResult = void | { value: JsonValue | undefined };
@@ -66,11 +66,10 @@ function isBoolean(value: JsonValue | undefined): value is boolean {
 	return typeof value === "boolean";
 }
 
-function matchesValueType(value: JsonValue, type: FieldDef["type"]): boolean {
+function matchesValueType(value: JsonValue, type: ValueType): boolean {
 	if (type === "string") return isString(value);
 	if (type === "number") return isNumber(value);
-	if (type === "boolean") return isBoolean(value);
-	return true;
+	return isBoolean(value);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -164,8 +163,7 @@ export function createStore<const F extends FieldsDef>(
 	// normalizeStateTypes — Coerce values by field `type`
 	// ──────────────────────────────────────────────────────────────────────
 
-	function coerceByType(value: JsonValue, type: FieldDef["type"]): JsonValue {
-		if (type === undefined) return value;
+	function coerceByType(value: JsonValue, type: ValueType): JsonValue {
 		if (type === "number" && isString(value)) {
 			return tryCoerceNumber(value) ?? value;
 		}
@@ -212,7 +210,7 @@ export function createStore<const F extends FieldsDef>(
 
 			if (value === undefined && def.schema === undefined) continue;
 
-			if (value !== undefined && def.schema === undefined && def.type !== undefined) {
+			if (value !== undefined && def.schema === undefined) {
 				const matches =
 					def.array === true
 						? Array.isArray(value) && value.every((item) => matchesValueType(item, def.type))

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -59,7 +59,7 @@ function isString(value: JsonValue | undefined): value is string {
 }
 
 function isNumber(value: JsonValue | undefined): value is number {
-	return typeof value === "number";
+	return typeof value === "number" && Number.isFinite(value);
 }
 
 function isBoolean(value: JsonValue | undefined): value is boolean {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -58,6 +58,21 @@ function isString(value: JsonValue | undefined): value is string {
 	return typeof value === "string";
 }
 
+function isNumber(value: JsonValue | undefined): value is number {
+	return typeof value === "number";
+}
+
+function isBoolean(value: JsonValue | undefined): value is boolean {
+	return typeof value === "boolean";
+}
+
+function matchesValueType(value: JsonValue, type: FieldDef["type"]): boolean {
+	if (type === "string") return isString(value);
+	if (type === "number") return isNumber(value);
+	if (type === "boolean") return isBoolean(value);
+	return true;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // createStore — Public factory
 // ────────────────────────────────────────────────────────────────────────────
@@ -126,9 +141,7 @@ export function createStore<const F extends FieldsDef>(
 			}
 			validators.set(key, makeSchemaValidator(def.schema));
 		} else if (def.validate !== undefined) {
-			// SAFETY: each validator is only called for its own field. Coercion does not guarantee the
-			// persisted value matches the validator's declared parameter type: corrupt files can hand a
-			// wrong-typed value to it, which surfaces as a validator throw → VALIDATION issue.
+			// SAFETY: each validator is only called for its own field after coercion and type checking.
 			validators.set(key, def.validate as FieldValidator);
 		}
 	}
@@ -195,12 +208,26 @@ export function createStore<const F extends FieldsDef>(
 		const issues: StoreValidatorIssue[] = [];
 
 		for (const [key, def] of Object.entries(fields)) {
-			const validator = validators.get(key);
-			if (!validator) continue;
-
 			const value = mutableState[key];
 
 			if (value === undefined && def.schema === undefined) continue;
+
+			if (value !== undefined && def.schema === undefined && def.type !== undefined) {
+				const matches =
+					def.array === true
+						? Array.isArray(value) && value.every((item) => matchesValueType(item, def.type))
+						: matchesValueType(value, def.type);
+				if (!matches) {
+					issues.push({
+						message: `Expected ${def.type}${def.array === true ? "[]" : ""}`,
+						path: key,
+					});
+					continue;
+				}
+			}
+
+			const validator = validators.get(key);
+			if (!validator) continue;
 
 			let result: Awaited<ReturnType<FieldValidator>>;
 			try {
@@ -308,33 +335,36 @@ export function createStore<const F extends FieldsDef>(
 	// write — Validate then atomically persist full config
 	// ──────────────────────────────────────────────────────────────────────
 
-	async function write(config: Config): Promise<void> {
+	async function write(config: Config): Promise<Config> {
 		const normalized = normalizeStateTypes(documentFromConfig(config));
 		await runFieldValidators(normalized, "write");
 		await writeJson(filePath, normalized, writeOptions);
+		return configFromDocument(normalized);
 	}
 
 	// ──────────────────────────────────────────────────────────────────────
 	// update — Read current (raw), apply updater, validate, persist
 	// ──────────────────────────────────────────────────────────────────────
 
-	async function update(updater: StoreUpdater<Config>): Promise<void> {
+	async function update(updater: StoreUpdater<Config>): Promise<Config> {
 		const current = await readRaw();
 		const updated = updater(configFromDocument(current));
 		const normalized = normalizeStateTypes(documentFromConfig(updated));
 		await runFieldValidators(normalized, "update");
 		await writeJson(filePath, normalized, writeOptions);
+		return configFromDocument(normalized);
 	}
 
 	// ──────────────────────────────────────────────────────────────────────
 	// patch — Shallow merge into current config, validate, persist
 	// ──────────────────────────────────────────────────────────────────────
 
-	async function patch(partial: Partial<Config>): Promise<void> {
+	async function patch(partial: Partial<Config>): Promise<Config> {
 		const current = await readRaw();
 		const normalized = normalizeStateTypes({ ...current, ...partial });
 		await runFieldValidators(normalized, "patch");
 		await writeJson(filePath, normalized, writeOptions);
+		return configFromDocument(normalized);
 	}
 
 	// ──────────────────────────────────────────────────────────────────────

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -66,10 +66,23 @@ function isBoolean(value: JsonValue | undefined): value is boolean {
 	return typeof value === "boolean";
 }
 
-function matchesValueType(value: JsonValue, type: ValueType): boolean {
+function matchesValueType(value: JsonValue | undefined, type: ValueType): boolean {
 	if (type === "string") return isString(value);
 	if (type === "number") return isNumber(value);
 	return isBoolean(value);
+}
+
+function matchesDeclaredType(
+	def: { type: ValueType; array?: true },
+	value: JsonValue | undefined,
+): boolean {
+	return def.array === true
+		? Array.isArray(value) && value.every((item) => matchesValueType(item, def.type))
+		: matchesValueType(value, def.type);
+}
+
+function expectedTypeMessage(def: { type: ValueType; array?: true }): string {
+	return `Expected ${def.type}${def.array === true ? "[]" : ""}`;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -210,18 +223,9 @@ export function createStore<const F extends FieldsDef>(
 
 			if (value === undefined && def.schema === undefined) continue;
 
-			if (value !== undefined && def.schema === undefined) {
-				const matches =
-					def.array === true
-						? Array.isArray(value) && value.every((item) => matchesValueType(item, def.type))
-						: matchesValueType(value, def.type);
-				if (!matches) {
-					issues.push({
-						message: `Expected ${def.type}${def.array === true ? "[]" : ""}`,
-						path: key,
-					});
-					continue;
-				}
+			if (value !== undefined && def.schema === undefined && !matchesDeclaredType(def, value)) {
+				issues.push({ message: expectedTypeMessage(def), path: key });
+				continue;
 			}
 
 			const validator = validators.get(key);
@@ -247,6 +251,13 @@ export function createStore<const F extends FieldsDef>(
 				// materialize missing values by validating `undefined` (e.g. defaults).
 				if (operation === "read") {
 					if (value === undefined) mutableState[key] = transformed;
+					continue;
+				}
+
+				// Core transforms must stay within the declared type; a wrong-typed
+				// output would persist a value the next read() rejects.
+				if (def.schema === undefined && !matchesDeclaredType(def, transformed)) {
+					issues.push({ message: expectedTypeMessage(def), path: key });
 					continue;
 				}
 
@@ -286,6 +297,23 @@ export function createStore<const F extends FieldsDef>(
 					}
 
 					mutableState[key] = transformed;
+				}
+			}
+		}
+
+		// Mutations promise to return exactly what the next read() sees, so any
+		// value JSON serialization would alter (NaN/Infinity → null, -0 → 0,
+		// array holes → null, dropped undefined object properties) is rejected.
+		if (operation !== "read") {
+			for (const [key, value] of Object.entries(mutableState)) {
+				// A dropped undefined key is harmless: the next read reapplies defaults identically.
+				if (value === undefined) continue;
+				if (!isDeepStrictEqual(JSON.parse(JSON.stringify(value)), value)) {
+					issues.push({
+						message:
+							"value does not survive JSON serialization (NaN, Infinity, -0, sparse arrays, or undefined properties)",
+						path: key,
+					});
 				}
 			}
 		}

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -32,23 +32,20 @@ interface FieldDefBase<V> {
 	 *
 	 * Return shapes:
 	 * - `void` (or `Promise<void>`) — validation-only; the input value is
-	 *   persisted as-is. This is the contract for hand-rolled validators.
-	 * - `{ value }` (or `Promise<{ value }>`) — the schema (or transform)
-	 *   produced a JSON-compatible output value. On `write` / `update` /
-	 *   `patch`, the transformed
-	 *   value replaces the input before persistence and is re-validated
-	 *   once to catch read-unstable transforms (cross-type transforms
-	 *   whose output would fail the schema on the next read). On `read`,
-	 *   the transformed value is discarded — reads always return the
-	 *   on-disk value verbatim.
+	 *   persisted as-is.
+	 * - `{ value }` (or `Promise<{ value }>`) — a transform produced an
+	 *   output within the field's declared type. On `write` / `update` /
+	 *   `patch`, the transformed value replaces the input before
+	 *   persistence and is re-validated once to catch read-unstable
+	 *   transforms. Outputs outside the declared type are rejected with
+	 *   `VALIDATION`. On `read`, the transformed value is discarded —
+	 *   reads always return the on-disk value verbatim.
 	 * - Throwing an error — the value is rejected; the error message is
 	 *   captured as a validation issue with the field name as `path`.
 	 *
 	 * @param value - The field value to validate.
 	 */
-	validate?: (
-		value: V,
-	) => void | Promise<void> | { value: JsonValue } | Promise<{ value: JsonValue }>;
+	validate?: (value: V) => void | Promise<void> | { value: V } | Promise<{ value: V }>;
 }
 
 // ── Scalar fields ─────────────────────────────────────────────────────────

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -138,16 +138,6 @@ interface SchemaFieldDef {
  * } satisfies FieldsDef;
  * ```
  */
-interface RawScalarFieldDef extends ScalarFieldBase<JsonValue> {
-	type?: never;
-	default?: JsonValue;
-}
-
-interface RawArrayFieldDef extends ArrayFieldBase<JsonValue[]> {
-	type?: never;
-	default?: readonly JsonValue[];
-}
-
 export type FieldDef =
 	| StringFieldDef
 	| NumberFieldDef
@@ -155,8 +145,6 @@ export type FieldDef =
 	| StringArrayFieldDef
 	| NumberArrayFieldDef
 	| BooleanArrayFieldDef
-	| RawScalarFieldDef
-	| RawArrayFieldDef
 	| SchemaFieldDef;
 
 /** Record mapping field names to their definitions. */
@@ -197,9 +185,7 @@ type InferFieldValue<F extends FieldDef> = F extends {
 			: F extends { default: ResolvePrimitive<F["type"]> }
 				? ResolvePrimitive<F["type"]>
 				: ResolvePrimitive<F["type"]> | undefined
-		: F extends { default: infer D }
-			? D
-			: unknown;
+		: never;
 
 /**
  * Maps a full {@link FieldsDef} record to the inferred config object type.

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -338,7 +338,7 @@ export interface CreateStoreOptions<F extends FieldsDef> {
 /**
  * Receives the current effective config and returns an updated config.
  *
- * Used by {@link Store.update} to apply mutations atomically.
+ * Used by {@link Store.update} to calculate the next config in process.
  *
  * @example
  * ```ts
@@ -404,20 +404,25 @@ export interface Store<TConfig> {
 	 * persistence.
 	 *
 	 * @param config - The complete config to persist.
+	 * @returns The persisted config, including schema transformations.
 	 * @throws {CrustStoreError} `VALIDATION` if field validation fails.
 	 * @throws {CrustStoreError} `IO` on filesystem write failures.
 	 */
-	write(config: NoInfer<TConfig>): Promise<void>;
+	write(config: NoInfer<TConfig>): Promise<TConfig>;
 
 	/**
 	 * Reads current effective config, applies the updater, and persists.
 	 *
+	 * The final file replacement is atomic, but the read-modify-write sequence
+	 * is not locked across processes; concurrent updates can overwrite each other.
+	 *
 	 * @param updater - Function receiving current config and returning updated config.
+	 * @returns The persisted config, including schema transformations.
 	 * @throws {CrustStoreError} `PARSE` if persisted JSON is malformed.
 	 * @throws {CrustStoreError} `VALIDATION` if field validation fails.
 	 * @throws {CrustStoreError} `IO` on filesystem failures.
 	 */
-	update(updater: StoreUpdater<TConfig>): Promise<void>;
+	update(updater: StoreUpdater<TConfig>): Promise<TConfig>;
 
 	/**
 	 * Applies a partial update to the current config and persists.
@@ -425,11 +430,12 @@ export interface Store<TConfig> {
 	 * Only the provided keys are updated; everything else is preserved.
 	 *
 	 * @param partial - A partial subset of the config to merge in.
+	 * @returns The persisted config, including schema transformations.
 	 * @throws {CrustStoreError} `VALIDATION` if field validation fails.
 	 * @throws {CrustStoreError} `PARSE` if persisted JSON is malformed.
 	 * @throws {CrustStoreError} `IO` on filesystem failures.
 	 */
-	patch(partial: Partial<NoInfer<TConfig>>): Promise<void>;
+	patch(partial: Partial<NoInfer<TConfig>>): Promise<TConfig>;
 
 	/**
 	 * Removes the persisted config file, returning the store to


### PR DESCRIPTION
Part 3/8 of the architecture cleanup stack.

- Fix: corrupt on-disk values for typed fields without validators were returned with wrong types; declared type is now enforced post-coercion (`VALIDATION`)
- `write`/`update`/`patch` return the persisted `TConfig` (breaking; schema transforms made `void` returns lossy)
- Deleted `RawScalarFieldDef`/`RawArrayFieldDef` (test-only usage) and their workaround branches; deleted `sameStoreErrorCode`; un-exported `PlatformEnv`
- `update()` docs no longer imply cross-process read-modify-write protection

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

