### PR TITLE
refactor(crust,create-crust): pure build planning, declared sibling deps

### DIFF
--- a/.changeset/clean-cli-build-planning.md
+++ b/.changeset/clean-cli-build-planning.md
@@ -1,0 +1,8 @@
+---
+"@crustjs/crust": minor
+"create-crust": minor
+---
+
+Make build option validation deterministic through a reusable build plan, and consistently reject malformed project package manifests.
+
+Fix create-crust's workspace version inputs, declaratively validate distribution choices, and avoid announcing overwrites before confirmation.

--- a/apps/docs/content/docs/guide/build.mdx
+++ b/apps/docs/content/docs/guide/build.mdx
@@ -6,7 +6,7 @@ description: Build your CLI for Bun, Deno, or Node with crust build.
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
-The `crust build` command builds CLIs for Bun, Deno, or Node. Bun (the default) and Deno produce standalone executables; Node produces one bundled, executable JavaScript file. Select the runtime with `--runtime` or persist it in `package.json`:
+The `crust build` command builds CLIs for Bun, Deno, or Node. Bun (the default) and Deno produce standalone executables; Node produces one bundled, executable JavaScript file. Select the runtime with `--runtime` or persist it in `package.json`. A malformed project `package.json` fails the build before output planning begins.
 
 ```json title="package.json"
 {

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,8 @@
       },
       "devDependencies": {
         "@crustjs/config": "workspace:*",
+        "@crustjs/crust": "workspace:*",
+        "@crustjs/extensions": "workspace:*",
         "tsdown": "catalog:",
       },
     },

--- a/packages/create-crust/package.json
+++ b/packages/create-crust/package.json
@@ -52,6 +52,8 @@
 	},
 	"devDependencies": {
 		"@crustjs/config": "workspace:*",
+		"@crustjs/crust": "workspace:*",
+		"@crustjs/extensions": "workspace:*",
 		"tsdown": "catalog:"
 	},
 	"engines": {

--- a/packages/create-crust/src/index.ts
+++ b/packages/create-crust/src/index.ts
@@ -8,16 +8,16 @@ import { isInGitRepo, runSteps, scaffold } from "@crustjs/create";
 import { spinner } from "@crustjs/progress";
 import { confirm, input, select } from "@crustjs/prompts";
 
-import corePackage from "../../core/package.json";
-import crustPackage from "../../crust/package.json";
-import extensionsPackage from "../../extensions/package.json";
+declare const CRUST_CORE_VERSION: string;
+declare const CRUST_CLI_VERSION: string;
+declare const CRUST_EXTENSIONS_VERSION: string;
 
 type DistributionMode = "binary" | "runtime";
 
 const CRUST_TEMPLATE_VERSION_CONTEXT = {
-	crustCoreVersion: corePackage.version,
-	crustExtensionsVersion: extensionsPackage.version,
-	crustCliVersion: crustPackage.version,
+	crustCoreVersion: CRUST_CORE_VERSION,
+	crustExtensionsVersion: CRUST_EXTENSIONS_VERSION,
+	crustCliVersion: CRUST_CLI_VERSION,
 } satisfies Record<string, string>;
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -34,16 +34,6 @@ function validateProjectName(name: string): void {
 	}
 }
 
-function parseDistributionMode(value: string | undefined): DistributionMode | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-	if (value === "binary" || value === "runtime") {
-		return value;
-	}
-	throw new Error(`Invalid distribution "${value}". Expected "binary" or "runtime".`);
-}
-
 // ────────────────────────────────────────────────────────────────────────────
 // Command definition
 // ────────────────────────────────────────────────────────────────────────────
@@ -53,6 +43,7 @@ const app = new Crust("create-crust", { description: "Scaffold a new Crust CLI p
 		{
 			name: "distribution",
 			type: "string",
+			choices: ["binary", "runtime"],
 			description: 'Distribution mode ("binary" or "runtime")',
 		},
 		{
@@ -91,7 +82,7 @@ const app = new Crust("create-crust", { description: "Scaffold a new Crust CLI p
 
 		const resolvedDir = resolve(process.cwd(), targetDir);
 		const dirName = basename(resolvedDir);
-		const distributionInitial = parseDistributionMode(flags.distribution);
+		const distributionInitial = flags.distribution;
 
 		// Ask before writing into an existing destination. The cwd (".") always
 		// exists, so it only needs confirmation when non-empty; a named directory
@@ -100,9 +91,6 @@ const app = new Crust("create-crust", { description: "Scaffold a new Crust CLI p
 			targetDir === "." ? readdirSync(resolvedDir).length > 0 : existsSync(resolvedDir);
 		let overwrite = false;
 		if (needsOverwriteConfirm) {
-			if (flags.overwrite === true) {
-				console.log(`Directory "${dirName}" already exists; overwriting (--overwrite).`);
-			}
 			overwrite = await confirm({
 				message:
 					targetDir === "."

--- a/packages/create-crust/tests/cli.test.ts
+++ b/packages/create-crust/tests/cli.test.ts
@@ -92,7 +92,7 @@ describe("create-crust CLI", () => {
 
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain(
-			'Error: Invalid distribution "invalid". Expected "binary" or "runtime".',
+			'Error: Invalid value "invalid" for --distribution. Expected one of: binary, runtime',
 		);
 		expect(existsSync(projectDir)).toBe(false);
 	}, 30_000);
@@ -144,6 +144,7 @@ describe("create-crust CLI", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stderr).not.toContain("Error:");
+		expect(result.stdout).not.toContain("overwriting (--overwrite)");
 		expect(existsSync(join(tempRoot, "src", "cli.ts"))).toBe(true);
 		const pkg = JSON.parse(readFileSync(join(tempRoot, "package.json"), "utf-8"));
 		expect(pkg.name).not.toBe("old");

--- a/packages/create-crust/tsdown.config.ts
+++ b/packages/create-crust/tsdown.config.ts
@@ -1,6 +1,24 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "tsdown";
 
 import base from "../../tsdown.config.ts";
+
+function packageVersion(specifier: string): string {
+	let directory = dirname(fileURLToPath(import.meta.resolve(specifier)));
+	while (true) {
+		const packagePath = join(directory, "package.json");
+		if (existsSync(packagePath)) {
+			// SAFETY: workspace package manifests own the build-time version source.
+			return (JSON.parse(readFileSync(packagePath, "utf8")) as { version: string }).version;
+		}
+		const parent = dirname(directory);
+		if (parent === directory) throw new Error(`Could not find package.json for ${specifier}`);
+		directory = parent;
+	}
+}
 
 export default defineConfig({
 	...base,
@@ -9,4 +27,9 @@ export default defineConfig({
 	// bin-only package, no types published; auto-detect wrongly enables dts here
 	dts: false,
 	minify: true,
+	define: {
+		CRUST_CORE_VERSION: JSON.stringify(packageVersion("@crustjs/core")),
+		CRUST_CLI_VERSION: JSON.stringify(packageVersion("@crustjs/crust/package.json")),
+		CRUST_EXTENSIONS_VERSION: JSON.stringify(packageVersion("@crustjs/extensions")),
+	},
 });

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -3,35 +3,31 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { Crust } from "@crustjs/core";
-import { which } from "@crustjs/utils/process";
 
+import type { BunTarget } from "../utils/build-helpers.ts";
 import {
-	buildCommand,
-	generateCmdResolver,
-	generateDenoCmdResolver,
-	generateDenoResolver,
-	generateResolver,
-	resolveBuildRuntime,
-	resolveEnvFilePaths,
-	resolveOutfile,
-} from "../../src/commands/build.ts";
-import type { BunTarget } from "../../src/utils/build-helpers.ts";
-import {
-	createBunCompileArgs,
-	createDenoCompileArgs,
-	createNodeBuildArgs,
 	DENO_TARGET_INFO,
 	getBinaryFilename,
 	getDenoBinaryFilename,
 	resolveBaseName,
-	resolveBunBuildRunner,
 	resolveDenoTarget,
 	resolveDenoTargets,
 	resolveTarget,
 	SUPPORTED_DENO_TARGETS,
 	SUPPORTED_TARGETS,
 	TARGET_INFO,
-} from "../../src/utils/build-helpers.ts";
+} from "../utils/build-helpers.ts";
+import {
+	buildCommand,
+	generateCmdResolver,
+	generateDenoCmdResolver,
+	generateDenoResolver,
+	generateResolver,
+	planBuild,
+	resolveBuildRuntime,
+	resolveEnvFilePaths,
+	type BuildFlags,
+} from "./build.ts";
 
 describe("env file helpers", () => {
 	const tmpDir = join(import.meta.dir, ".tmp-env-files");
@@ -83,78 +79,99 @@ describe("runtime build configuration", () => {
 		writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ crust: { runtime: "python" } }));
 		expect(() => resolveBuildRuntime(tmpDir)).toThrow(/Invalid package.json crust.runtime/);
 	});
-});
 
-describe("build argument construction", () => {
-	it("constructs a Node bundle with portable env embedding", () => {
-		expect(createNodeBuildArgs("/src/cli.ts", "/dist/cli.js", true, ["/src/.env"])).toEqual([
-			"build",
-			"--env-file",
-			"/src/.env",
-			"--env=PUBLIC_*",
-			"--target",
-			"node",
-			"--format",
-			"esm",
-			"--outfile",
-			"/dist/cli.js",
-			"--minify",
-			"/src/cli.ts",
-		]);
-	});
-
-	it("constructs a Bun compile with the legacy argument sequence", () => {
-		expect(
-			createBunCompileArgs("/src/cli.ts", "/dist/cli", true, "bun-linux-x64-baseline", [
-				"/src/.env",
-			]),
-		).toEqual([
-			"build",
-			"--compile",
-			"--env-file",
-			"/src/.env",
-			"--env=PUBLIC_*",
-			"--outfile",
-			"/dist/cli",
-			"--minify",
-			"--target",
-			"bun-linux-x64-baseline",
-			"/src/cli.ts",
-		]);
-	});
-
-	it("constructs a Deno compile with its canonical target", () => {
-		expect(createDenoCompileArgs("/src/cli.ts", "/dist/cli", "x86_64-unknown-linux-gnu")).toEqual([
-			"compile",
-			"-A",
-			"--output",
-			"/dist/cli",
-			"--target",
-			"x86_64-unknown-linux-gnu",
-			"/src/cli.ts",
-		]);
+	it("uses one parse-error policy for runtime and output-name resolution", () => {
+		writeFileSync(join(tmpDir, "package.json"), "not json");
+		expect(() => resolveBuildRuntime(tmpDir)).toThrow(`Failed to parse package.json in ${tmpDir}`);
+		expect(() => resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir)).toThrow(
+			`Failed to parse package.json in ${tmpDir}`,
+		);
 	});
 });
 
-describe("resolveBunBuildRunner", () => {
-	it("prefers the real bun binary when available", () => {
-		const bunPath = which("bun");
-		expect(bunPath).not.toBeNull();
-		const runner = resolveBunBuildRunner();
-		expect(runner.command).toBe(bunPath!);
-		expect(runner.env.BUN_BE_BUN).toBe(process.env.BUN_BE_BUN);
+describe("planBuild", () => {
+	const tmpDir = join(import.meta.dir, ".tmp-build-plan");
+	const baseFlags: BuildFlags = {
+		entry: "src/cli.ts",
+		outdir: "dist",
+		resolver: "cli",
+		validate: true,
+		package: false,
+		"stage-dir": "dist/npm",
+	};
+
+	beforeAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+		mkdirSync(join(tmpDir, "src"), { recursive: true });
+		writeFileSync(join(tmpDir, "src", "cli.ts"), "export {};\n");
+		writeFileSync(join(tmpDir, ".env"), "PUBLIC_TEST=1\n");
 	});
 
-	it("falls back to the current executable when bun is unavailable", () => {
-		const originalPath = process.env.PATH;
-		process.env.PATH = "";
-		try {
-			const runner = resolveBunBuildRunner();
-			expect(runner.command).toBe(process.execPath);
-			expect(runner.env.BUN_BE_BUN).toBe("1");
-		} finally {
-			process.env.PATH = originalPath;
-		}
+	afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+	for (const testCase of [
+		{
+			name: "Deno package builds",
+			flags: { runtime: "deno", package: true },
+			error: "--package does not yet support Deno builds",
+		},
+		{
+			name: "Node package builds",
+			flags: { runtime: "node", package: true },
+			error: "--package does not apply to Node builds",
+		},
+		{
+			name: "package builds with outfile",
+			flags: { package: true, outfile: "dist/cli" },
+			error: "--outfile cannot be used with --package",
+		},
+		{
+			name: "Node builds with targets",
+			flags: { runtime: "node", target: ["bun-linux-x64-baseline"] },
+			error: "--target cannot be used with --runtime node",
+		},
+		{
+			name: "minified Deno builds",
+			flags: { runtime: "deno", minify: true },
+			error: "--minify is not supported with --runtime deno",
+		},
+		{
+			name: "Deno builds with env files",
+			flags: { runtime: "deno", "env-file": [".env"] },
+			error: "--env-file is not supported with --runtime deno",
+		},
+		{
+			name: "multi-target builds with outfile",
+			flags: { outfile: "dist/cli" },
+			error: "--outfile cannot be used when building for multiple targets",
+		},
+	] as const) {
+		it(`rejects ${testCase.name}`, () => {
+			expect(() => planBuild({ ...baseFlags, ...testCase.flags } as BuildFlags, tmpDir)).toThrow(
+				testCase.error,
+			);
+		});
+	}
+
+	it("plans runtime-specific outputs without executing a build", () => {
+		const plan = planBuild(
+			{
+				...baseFlags,
+				runtime: "node",
+				name: "my-tool",
+				outdir: "out",
+				resolver: "ignored",
+			},
+			tmpDir,
+		);
+
+		expect(plan).toMatchObject({
+			runtime: "node",
+			mode: "node",
+			minify: true,
+			outfilePath: resolve(tmpDir, "out", "my-tool.js"),
+		});
+		expect(plan.warnings).toHaveLength(1);
 	});
 });
 
@@ -246,44 +263,6 @@ describe("resolveBaseName", () => {
 	it("strips file extension from entry filename", () => {
 		expect(resolveBaseName(undefined, "/nonexistent/src/app.cli.ts", "/nonexistent")).toBe(
 			"app.cli",
-		);
-	});
-});
-
-// ────────────────────────────────────────────────────────────────────────────
-// Unit tests for resolveOutfile
-// ────────────────────────────────────────────────────────────────────────────
-
-describe("resolveOutfile", () => {
-	const cwd = "/test/project";
-	const entry = "/test/project/src/cli.ts";
-
-	it("uses --outfile when provided", () => {
-		const result = resolveOutfile("./my-cli", undefined, entry, cwd, "dist");
-		expect(result).toBe(resolve(cwd, "./my-cli"));
-	});
-
-	it("uses --name as dist/<name> when --outfile not provided", () => {
-		const result = resolveOutfile(undefined, "my-tool", entry, cwd, "dist");
-		expect(result).toBe(resolve(cwd, "dist", "my-tool"));
-	});
-
-	it("prefers --outfile over --name", () => {
-		const result = resolveOutfile("./custom", "my-tool", entry, cwd, "dist");
-		expect(result).toBe(resolve(cwd, "./custom"));
-	});
-
-	it("uses custom outdir when provided", () => {
-		const result = resolveOutfile(undefined, "my-tool", entry, cwd, "out");
-		expect(result).toBe(resolve(cwd, "out", "my-tool"));
-	});
-
-	it("adds .js to implicit Node outputs but respects explicit outfile", () => {
-		expect(resolveOutfile(undefined, "my-tool", entry, cwd, "dist", ".js")).toBe(
-			resolve(cwd, "dist", "my-tool.js"),
-		);
-		expect(resolveOutfile("bin/custom.mjs", undefined, entry, cwd, "dist", ".js")).toBe(
-			resolve(cwd, "bin/custom.mjs"),
 		);
 	});
 });

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import { defineCommand } from "@crustjs/core";
@@ -18,6 +18,7 @@ import {
 	getDenoBinaryFilename,
 	resolveBaseName,
 	resolveDenoTargets,
+	readUserPackageJson,
 	resolveTargets,
 	TARGET_INFO,
 	buildEntrypoint,
@@ -37,20 +38,21 @@ import {
  * @param ext - Extension appended to a derived base name (e.g. ".js" for Node)
  * @returns The resolved output file path
  */
-export function resolveOutfile(
+function resolveOutfile(
 	outfile: string | undefined,
 	name: string | undefined,
 	entry: string,
 	cwd: string,
 	outdir: string,
-	ext = "",
+	ext: string,
+	packageJson: JsonValue | undefined,
 ): string {
 	// Explicit --outfile takes highest priority
 	if (outfile) {
 		return resolve(cwd, outfile);
 	}
 
-	const baseName = resolveBaseName(name, entry, cwd);
+	const baseName = resolveBaseName(name, entry, cwd, packageJson);
 	return resolve(cwd, outdir, baseName.endsWith(ext) ? baseName : baseName + ext);
 }
 
@@ -64,28 +66,23 @@ function isBuildRuntime(value: JsonValue): value is BuildRuntime {
 	return typeof value === "string" && BUILD_RUNTIMES.some((runtime) => runtime === value);
 }
 
-export function resolveBuildRuntime(cwd: string, override?: BuildRuntime): BuildRuntime {
+function resolveBuildRuntimeFromPackageJson(
+	pkg: JsonValue | undefined,
+	override?: BuildRuntime,
+): BuildRuntime {
 	// --runtime is validated by the flag's `choices`; no re-check needed here.
 	if (override !== undefined) return override;
-
-	const packagePath = resolve(cwd, "package.json");
-	if (!existsSync(packagePath)) return "bun";
-	let pkg: JsonValue;
-	try {
-		pkg = JSON.parse(readFileSync(packagePath, "utf8"));
-	} catch {
-		// Malformed package.json: legacy builds tolerated this (resolveBaseName falls
-		// through), so keep default-bun builds working — but say so, since a
-		// configured crust.runtime in that file would be silently ignored.
-		console.warn(`Warning: could not parse ${packagePath}; defaulting to the bun runtime.`);
-		return "bun";
-	}
+	if (pkg === undefined) return "bun";
 	const configured = getConfiguredRuntime(pkg);
 	if (configured === undefined) return "bun";
 	if (isBuildRuntime(configured)) return configured;
 	throw new Error(
 		`Invalid package.json crust.runtime ${JSON.stringify(configured)}. Valid runtimes: ${BUILD_RUNTIMES.join(", ")}`,
 	);
+}
+
+export function resolveBuildRuntime(cwd: string, override?: BuildRuntime): BuildRuntime {
+	return resolveBuildRuntimeFromPackageJson(readUserPackageJson(cwd), override);
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -279,16 +276,14 @@ function writeDenoResolver(
 	writeFileSync(`${resolverPath}.cmd`, generateDenoCmdResolver(baseName, targets));
 }
 
-type BinaryBuildOptions<T extends string> = {
-	entryPath: string;
-	outfile?: string;
-	name?: string;
-	cwd: string;
-	outdir: string;
-	resolver: string;
-	targets: readonly T[];
-	envFiles: readonly string[];
-	getFilename: (baseName: string, target: T) => string;
+type BinaryOutput<T extends string> = { target: T; outfilePath: string };
+type ResolverPlan = { path: string; baseName: string };
+type PlannedBinaryOutputs<T extends string> = {
+	outputs: Array<BinaryOutput<T>>;
+	resolver: ResolverPlan;
+};
+
+type BinaryExecutor<T extends string> = {
 	execute: (
 		entry: string,
 		outfile: string,
@@ -298,47 +293,35 @@ type BinaryBuildOptions<T extends string> = {
 	writeResolver: (path: string, baseName: string, targets: readonly T[]) => void;
 };
 
-async function buildBinaryOutputs<T extends string>(options: BinaryBuildOptions<T>): Promise<void> {
-	if (options.targets.length === 1) {
-		const target = options.targets[0]!;
-		// Windows targets produce `.exe` files; suffix the outfile so the path we
-		// print (and pass to the compiler) matches the artifact on disk.
-		const ext = options.getFilename("x", target).endsWith(".exe") ? ".exe" : "";
-		const resolved = resolveOutfile(
-			options.outfile,
-			options.name,
-			options.entryPath,
-			options.cwd,
-			options.outdir,
-		);
-		const outfilePath = ext && !resolved.endsWith(ext) ? resolved + ext : resolved;
-		console.log(`Building ${dim(options.entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
-		await options.execute(options.entryPath, outfilePath, target, options.envFiles);
-		console.log(`${green("✓")} Built successfully: ${outfilePath}`);
+async function buildBinaryOutputs<T extends string>(
+	plan: {
+		entryPath: string;
+		envFiles: readonly string[];
+		outputs: readonly BinaryOutput<T>[];
+		resolver: ResolverPlan;
+	},
+	executor: BinaryExecutor<T>,
+): Promise<void> {
+	if (plan.outputs.length === 1) {
+		const output = plan.outputs[0]!;
+		console.log(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(output.outfilePath)}...`);
+		await executor.execute(plan.entryPath, output.outfilePath, output.target, plan.envFiles);
+		console.log(`${green("✓")} Built successfully: ${output.outfilePath}`);
 		return;
 	}
 
-	const baseName = resolveBaseName(options.name, options.entryPath, options.cwd);
-	console.log(
-		`Building ${dim(options.entryPath)} for ${bold(`${options.targets.length}`)} target(s)...`,
-	);
-	const results: string[] = [];
-	for (const target of options.targets) {
-		const targetOutfile = resolve(
-			options.cwd,
-			options.outdir,
-			options.getFilename(baseName, target),
-		);
-		console.log(`  ${cyan("→")} ${bold(target)}: ${dim(targetOutfile)}`);
-		await options.execute(options.entryPath, targetOutfile, target, options.envFiles);
-		results.push(targetOutfile);
+	console.log(`Building ${dim(plan.entryPath)} for ${bold(`${plan.outputs.length}`)} target(s)...`);
+	for (const output of plan.outputs) {
+		console.log(`  ${cyan("→")} ${bold(output.target)}: ${dim(output.outfilePath)}`);
+		await executor.execute(plan.entryPath, output.outfilePath, output.target, plan.envFiles);
 	}
 
-	const resolverPath = resolve(options.cwd, options.outdir, options.resolver);
-	options.writeResolver(resolverPath, baseName, options.targets);
-	console.log(`\n${green("✓")} Built ${bold(`${results.length}`)} target(s) successfully:`);
-	for (const result of results) console.log(`  ${result}`);
-	console.log(`\n${dim("Resolver:")} ${resolverPath} ${dim(`(+ ${resolverPath}.cmd)`)}`);
+	const resolver = plan.resolver;
+	const targets = plan.outputs.map((output) => output.target);
+	executor.writeResolver(resolver.path, resolver.baseName, targets);
+	console.log(`\n${green("✓")} Built ${bold(`${plan.outputs.length}`)} target(s) successfully:`);
+	for (const output of plan.outputs) console.log(`  ${output.outfilePath}`);
+	console.log(`\n${dim("Resolver:")} ${resolver.path} ${dim(`(+ ${resolver.path}.cmd)`)}`);
 }
 
 export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined): string[] {
@@ -355,6 +338,254 @@ export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined)
 		}
 		return envPath;
 	});
+}
+
+export type BuildFlags = {
+	entry: string;
+	outfile?: string;
+	name?: string;
+	minify?: boolean;
+	runtime?: BuildRuntime;
+	target?: string[];
+	outdir: string;
+	resolver: string;
+	validate: boolean;
+	"env-file"?: string[];
+	package: boolean;
+	"stage-dir": string;
+};
+
+type CommonBuildPlan = {
+	cwd: string;
+	userPackageJson: JsonValue | undefined;
+	entryPath: string;
+	envFiles: string[];
+	outDir: string;
+	validate: boolean;
+	minify: boolean;
+	warnings: string[];
+};
+
+type BunBuildPlan = CommonBuildPlan &
+	(
+		| {
+				runtime: "bun";
+				mode: "package";
+				staging: {
+					entry: string;
+					name?: string;
+					targets: BunTarget[];
+					stageDir: string;
+				};
+		  }
+		| {
+				runtime: "bun";
+				mode: "binary";
+				outputs: Array<BinaryOutput<BunTarget>>;
+				resolver: ResolverPlan;
+		  }
+	);
+
+type DenoBuildPlan = CommonBuildPlan & {
+	runtime: "deno";
+	mode: "binary";
+	outputs: Array<BinaryOutput<DenoTarget>>;
+	resolver: ResolverPlan;
+};
+
+type NodeBuildPlan = CommonBuildPlan & {
+	runtime: "node";
+	mode: "node";
+	outfilePath: string;
+};
+
+export type BuildPlan = BunBuildPlan | DenoBuildPlan | NodeBuildPlan;
+
+function planBinaryOutputs<T extends string>(options: {
+	targets: T[];
+	getFilename: (baseName: string, target: T) => string;
+	flags: BuildFlags;
+	cwd: string;
+	entryPath: string;
+	packageJson: JsonValue | undefined;
+}): PlannedBinaryOutputs<T> {
+	const baseName = resolveBaseName(
+		options.flags.name,
+		options.entryPath,
+		options.cwd,
+		options.packageJson,
+	);
+	if (options.targets.length === 1) {
+		const target = options.targets[0]!;
+		const ext = options.getFilename("x", target).endsWith(".exe") ? ".exe" : "";
+		const resolved = resolveOutfile(
+			options.flags.outfile,
+			options.flags.name,
+			options.entryPath,
+			options.cwd,
+			options.flags.outdir,
+			"",
+			options.packageJson,
+		);
+		return {
+			outputs: [
+				{ target, outfilePath: ext && !resolved.endsWith(ext) ? resolved + ext : resolved },
+			],
+			resolver: {
+				path: resolve(options.cwd, options.flags.outdir, options.flags.resolver),
+				baseName,
+			},
+		};
+	}
+
+	return {
+		outputs: options.targets.map((target) => ({
+			target,
+			outfilePath: resolve(
+				options.cwd,
+				options.flags.outdir,
+				options.getFilename(baseName, target),
+			),
+		})),
+		resolver: {
+			path: resolve(options.cwd, options.flags.outdir, options.flags.resolver),
+			baseName,
+		},
+	};
+}
+
+export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
+	const userPackageJson = readUserPackageJson(cwd);
+	const runtime = resolveBuildRuntimeFromPackageJson(userPackageJson, flags.runtime);
+	const entryPath = resolve(cwd, flags.entry);
+	const envFiles = resolveEnvFilePaths(cwd, flags["env-file"]);
+
+	if (!existsSync(entryPath)) {
+		throw new Error(
+			`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
+		);
+	}
+	if (flags.package && runtime === "deno") {
+		throw new Error(
+			"--package does not yet support Deno builds.\n  Deno per-platform npm staging is reserved for a follow-up; build a specific target without --package for now.",
+		);
+	}
+	if (flags.package && runtime === "node") {
+		throw new Error(
+			"--package does not apply to Node builds.\n  Publish the generated JavaScript artifact as a normal npm package.",
+		);
+	}
+	if (flags.package && flags.outfile) {
+		throw new Error(
+			"--outfile cannot be used with --package.\n  Use --stage-dir to control the staged npm output directory.",
+		);
+	}
+	if (runtime === "node" && flags.target?.length) {
+		throw new Error(
+			"--target cannot be used with --runtime node.\n  Node builds produce one portable JavaScript artifact.",
+		);
+	}
+	if (runtime === "deno" && flags.minify) {
+		throw new Error(
+			"--minify is not supported with --runtime deno.\n  deno compile has no minification step; drop the flag.",
+		);
+	}
+	if (runtime === "deno" && envFiles.length > 0) {
+		throw new Error(
+			"--env-file is not supported with --runtime deno.\n" +
+				"  deno compile embeds every variable from the file into the binary — secrets included —\n" +
+				"  with no PUBLIC_* filter. Load configuration at runtime instead (e.g. deno run --env-file).",
+		);
+	}
+
+	const minify = runtime === "deno" ? false : (flags.minify ?? true);
+	const outDir = flags.outfile ? dirname(resolve(cwd, flags.outfile)) : resolve(cwd, flags.outdir);
+	const common = {
+		cwd,
+		userPackageJson,
+		entryPath,
+		envFiles,
+		outDir,
+		validate: flags.validate,
+		minify,
+		warnings:
+			runtime === "node" && flags.resolver !== "cli"
+				? [
+						"Warning: --resolver is ignored with --runtime node; Node builds produce a single JavaScript artifact.",
+					]
+				: [],
+	};
+
+	if (runtime === "node") {
+		return {
+			...common,
+			runtime,
+			mode: "node",
+			outfilePath: resolveOutfile(
+				flags.outfile,
+				flags.name,
+				entryPath,
+				cwd,
+				flags.outdir,
+				".js",
+				userPackageJson,
+			),
+		};
+	}
+	if (runtime === "bun") {
+		const targets = resolveTargets(flags.target);
+		if (!flags.package && flags.outfile && targets.length > 1) {
+			throw new Error(
+				"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
+			);
+		}
+		if (flags.package) {
+			return {
+				...common,
+				runtime,
+				mode: "package",
+				staging: {
+					entry: flags.entry,
+					...(flags.name === undefined ? {} : { name: flags.name }),
+					targets,
+					stageDir: resolve(cwd, flags["stage-dir"]),
+				},
+			};
+		}
+		return {
+			...common,
+			runtime,
+			mode: "binary",
+			...planBinaryOutputs({
+				targets,
+				getFilename: getBinaryFilename,
+				flags,
+				cwd,
+				entryPath,
+				packageJson: userPackageJson,
+			}),
+		};
+	}
+
+	const targets = resolveDenoTargets(flags.target);
+	if (flags.outfile && targets.length > 1) {
+		throw new Error(
+			"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
+		);
+	}
+	return {
+		...common,
+		runtime,
+		mode: "binary",
+		...planBinaryOutputs({
+			targets,
+			getFilename: getDenoBinaryFilename,
+			flags,
+			cwd,
+			entryPath,
+			packageJson: userPackageJson,
+		}),
+	};
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -467,129 +698,44 @@ export const buildCommand = defineCommand(
 				},
 			)
 			.action(async ({ flags }) => {
-				const cwd = process.cwd();
-				const runtime = resolveBuildRuntime(cwd, flags.runtime);
-				const entryPath = resolve(cwd, flags.entry);
-				const envFiles = resolveEnvFilePaths(cwd, flags["env-file"]);
-
-				if (!existsSync(entryPath)) {
-					throw new Error(
-						`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
-					);
-				}
-
-				if (flags.package && runtime === "deno") {
-					throw new Error(
-						"--package does not yet support Deno builds.\n  Deno per-platform npm staging is reserved for a follow-up; build a specific target without --package for now.",
-					);
-				}
-				if (flags.package && runtime === "node") {
-					throw new Error(
-						"--package does not apply to Node builds.\n  Publish the generated JavaScript artifact as a normal npm package.",
-					);
-				}
-				if (flags.package && flags.outfile) {
-					throw new Error(
-						"--outfile cannot be used with --package.\n  Use --stage-dir to control the staged npm output directory.",
-					);
-				}
-				if (runtime === "node" && flags.target?.length) {
-					throw new Error(
-						"--target cannot be used with --runtime node.\n  Node builds produce one portable JavaScript artifact.",
-					);
-				}
-				// Warn (not error): "cli" is the flag default, so only a non-default
-				// value signals explicit — and ignored — user intent.
-				if (runtime === "node" && flags.resolver !== "cli") {
-					console.warn(
-						"Warning: --resolver is ignored with --runtime node; Node builds produce a single JavaScript artifact.",
-					);
-				}
-				if (runtime === "deno" && flags.minify) {
-					throw new Error(
-						"--minify is not supported with --runtime deno.\n  deno compile has no minification step; drop the flag.",
-					);
-				}
-				if (runtime === "deno" && envFiles.length > 0) {
-					throw new Error(
-						"--env-file is not supported with --runtime deno.\n" +
-							"  deno compile embeds every variable from the file into the binary — secrets included —\n" +
-							"  with no PUBLIC_* filter. Load configuration at runtime instead (e.g. deno run --env-file).",
-					);
-				}
-				// deno compile has no minifier; bun/node bundling minifies unless --no-minify.
-				const minify = runtime === "deno" ? false : (flags.minify ?? true);
-
-				const bunTargets = runtime === "bun" ? resolveTargets(flags.target) : undefined;
-				const denoTargets = runtime === "deno" ? resolveDenoTargets(flags.target) : undefined;
-				const targetCount = bunTargets?.length ?? denoTargets?.length ?? 0;
-				if (!flags.package && flags.outfile && targetCount > 1) {
-					throw new Error(
-						"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
-					);
-				}
-
-				const outDir = flags.outfile
-					? dirname(resolve(cwd, flags.outfile))
-					: resolve(cwd, flags.outdir);
-				const prepared = flags.validate
-					? await buildEntrypoint(entryPath, outDir, envFiles)
+				const plan = planBuild(flags, process.cwd());
+				for (const warning of plan.warnings) console.warn(warning);
+				const prepared = plan.validate
+					? await buildEntrypoint(plan.entryPath, plan.outDir, plan.envFiles)
 					: undefined;
 
-				if (flags.package) {
+				if (plan.runtime === "bun" && plan.mode === "package") {
 					const { runDistributeBuild } = await import("../utils/distribute.ts");
 					await runDistributeBuild({
-						cwd,
-						entry: flags.entry,
-						name: flags.name,
-						minify,
-						target: flags.target,
-						stageDir: flags["stage-dir"],
-						envFiles,
-						artifactOutDir: prepared ? outDir : undefined,
+						cwd: plan.cwd,
+						entry: plan.staging.entry,
+						name: plan.staging.name,
+						stageDir: plan.staging.stageDir,
+						minify: plan.minify,
+						target: plan.staging.targets,
+						envFiles: plan.envFiles,
+						artifactOutDir: prepared ? plan.outDir : undefined,
+						userPackageJson: plan.userPackageJson,
 					});
 					return;
 				}
 
-				if (runtime === "node") {
-					const outfilePath = resolveOutfile(
-						flags.outfile,
-						flags.name,
-						entryPath,
-						cwd,
-						flags.outdir,
-						".js",
-					);
-					console.log(`Building ${dim(entryPath)} ${cyan("→")} ${dim(outfilePath)}...`);
-					await execNodeBuild(entryPath, outfilePath, minify, envFiles);
-					console.log(`${green("✓")} Built successfully: ${outfilePath}`);
+				if (plan.runtime === "node") {
+					console.log(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(plan.outfilePath)}...`);
+					await execNodeBuild(plan.entryPath, plan.outfilePath, plan.minify, plan.envFiles);
+					console.log(`${green("✓")} Built successfully: ${plan.outfilePath}`);
 					return;
 				}
 
-				const common = {
-					entryPath,
-					outfile: flags.outfile,
-					name: flags.name,
-					cwd,
-					outdir: flags.outdir,
-					resolver: flags.resolver,
-					envFiles,
-				};
-				if (bunTargets) {
-					await buildBinaryOutputs({
-						...common,
-						targets: bunTargets,
-						getFilename: getBinaryFilename,
-						execute: (entry, outfile, target, files) =>
-							execBuild(entry, outfile, minify, target, files),
+				if (plan.runtime === "bun") {
+					await buildBinaryOutputs(plan, {
+						execute: (entry, outfile, target, envFiles) =>
+							execBuild(entry, outfile, plan.minify, target, envFiles),
 						writeResolver,
 					});
 					return;
 				}
-				await buildBinaryOutputs({
-					...common,
-					targets: denoTargets!,
-					getFilename: getDenoBinaryFilename,
+				await buildBinaryOutputs(plan, {
 					execute: (entry, outfile, target) => execDenoBuild(entry, outfile, target),
 					writeResolver: writeDenoResolver,
 				});

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -232,23 +232,38 @@ export function getDenoBinaryFilename(baseName: string, target: DenoTarget): str
 	return `${baseName}-${target}${ext}`;
 }
 
-function hasStringName(value: JsonValue): value is { name: string } {
-	return isJsonObject(value) && typeof value.name === "string";
+export function readUserPackageJson(cwd: string): JsonValue | undefined {
+	const packageJsonPath = join(cwd, "package.json");
+	if (!existsSync(packageJsonPath)) return undefined;
+
+	try {
+		// SAFETY: JSON.parse returns only JSON-compatible values for a valid JSON document.
+		return JSON.parse(readFileSync(packageJsonPath, "utf8")) as JsonValue;
+	} catch (error) {
+		throw new Error(
+			`Failed to parse package.json in ${cwd}: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error },
+		);
+	}
 }
 
+function hasStringName(value: JsonValue | undefined): value is { name: string } {
+	return value !== undefined && isJsonObject(value) && typeof value.name === "string";
+}
+
+const READ_USER_PACKAGE_JSON = Symbol("read-user-package-json");
+
 /** Resolve the base binary name from an explicit name, package name, or entry filename. */
-export function resolveBaseName(name: string | undefined, entry: string, cwd: string): string {
+export function resolveBaseName(
+	name: string | undefined,
+	entry: string,
+	cwd: string,
+	packageJson: JsonValue | undefined | typeof READ_USER_PACKAGE_JSON = READ_USER_PACKAGE_JSON,
+): string {
 	if (name) return name;
 
-	const pkgPath = join(cwd, "package.json");
-	if (existsSync(pkgPath)) {
-		try {
-			const pkgJson: JsonValue = JSON.parse(readFileSync(pkgPath, "utf-8"));
-			if (hasStringName(pkgJson)) return pkgJson.name.replace(/^@[^/]+\//, "");
-		} catch {
-			// Ignore parse errors, fall through to entry filename
-		}
-	}
+	const pkgJson = packageJson === READ_USER_PACKAGE_JSON ? readUserPackageJson(cwd) : packageJson;
+	if (hasStringName(pkgJson)) return pkgJson.name.replace(/^@[^/]+\//, "");
 
 	return basename(entry).replace(/\.[^.]+$/, "");
 }
@@ -272,7 +287,7 @@ export type BuildRunner = {
  * Fall back to the current executable with `BUN_BE_BUN=1` so packaged Crust
  * binaries still work in environments without a separate Bun install.
  */
-export function resolveBunBuildRunner(): BuildRunner {
+function resolveBunBuildRunner(): BuildRunner {
 	const bunPath = which("bun");
 	if (bunPath) {
 		return {
@@ -317,7 +332,7 @@ export async function execBuild(
 	await runBuildProcess(runner, args, outfilePath);
 }
 
-export function createBunCompileArgs(
+function createBunCompileArgs(
 	entryPath: string,
 	outfilePath: string,
 	minify: boolean,
@@ -337,7 +352,7 @@ export function createBunCompileArgs(
 	];
 }
 
-export function createNodeBuildArgs(
+function createNodeBuildArgs(
 	entryPath: string,
 	outfilePath: string,
 	minify: boolean,
@@ -358,7 +373,7 @@ export function createNodeBuildArgs(
 	];
 }
 
-export function createDenoCompileArgs(
+function createDenoCompileArgs(
 	entryPath: string,
 	outfilePath: string,
 	target: DenoTarget,

--- a/packages/crust/src/utils/distribute.ts
+++ b/packages/crust/src/utils/distribute.ts
@@ -4,14 +4,13 @@ import {
 	existsSync,
 	mkdirSync,
 	readdirSync,
-	readFileSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { bold, cyan, dim, green } from "@crustjs/style";
-import type { JsonValue } from "@crustjs/utils/json";
+import { isJsonObject, type JsonValue } from "@crustjs/utils/json";
 
 import {
 	type BunTarget,
@@ -19,6 +18,7 @@ import {
 	getBinaryFilename,
 	resolveBaseName,
 	resolveTargets,
+	readUserPackageJson,
 	TARGET_INFO,
 	type TargetInfo,
 } from "./build-helpers.ts";
@@ -124,23 +124,18 @@ export type DistributionManifest = {
 	publishOrder: string[];
 };
 
-function readPackageJson(cwd: string): UserPackageJson {
-	const packageJsonPath = join(cwd, "package.json");
-	if (!existsSync(packageJsonPath)) {
+function readPackageJson(cwd: string, packageJson: JsonValue | undefined): UserPackageJson {
+	if (packageJson === undefined) {
 		throw new Error(
 			`package.json not found in ${cwd}\n  crust build --package requires a package.json with name and version fields.`,
 		);
 	}
-
-	try {
-		// SAFETY: required identity fields are validated before use; optional npm metadata is copied without interpretation.
-		return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as UserPackageJson;
-	} catch (error) {
-		throw new Error(
-			`Failed to parse package.json in ${cwd}: ${error instanceof Error ? error.message : String(error)}`,
-			{ cause: error },
-		);
+	if (!isJsonObject(packageJson)) {
+		throw new Error(`package.json in ${cwd} must contain a JSON object.`);
 	}
+
+	// SAFETY: required identity fields are validated before use; optional npm metadata is copied without interpretation.
+	return packageJson as UserPackageJson;
 }
 
 export function derivePlatformPackageName(rootPackageName: string, targetAlias: string): string {
@@ -255,8 +250,9 @@ function resolveDistributionMetadata(
 	cwd: string,
 	entryPath: string,
 	name: string | undefined,
+	userPackageJson: JsonValue | undefined,
 ): DistributionMetadata {
-	const pkgJson = readPackageJson(cwd);
+	const pkgJson = readPackageJson(cwd, userPackageJson);
 	if (!pkgJson.name) {
 		throw new Error("package.json is missing a name field.");
 	}
@@ -266,7 +262,7 @@ function resolveDistributionMetadata(
 
 	validatePackageNameLength(pkgJson.name);
 
-	const baseName = resolveBaseName(name, entryPath, cwd);
+	const baseName = resolveBaseName(name, entryPath, cwd, userPackageJson);
 	const commandName = inferCommandName(pkgJson.name, pkgJson.bin, baseName);
 	const rootPackageJson = pickRootMetadata(pkgJson);
 
@@ -506,6 +502,8 @@ export async function runDistributeBuild(options: {
 	envFiles?: readonly string[];
 	/** Directory whose Extension-emitted artifact subdirectories are staged in the root package. */
 	artifactOutDir?: string;
+	/** Pre-read by build planning so package metadata is parsed once per build. */
+	userPackageJson?: JsonValue;
 }): Promise<void> {
 	const cwd = options.cwd ?? process.cwd();
 	const entryPath = resolve(cwd, options.entry);
@@ -518,7 +516,10 @@ export async function runDistributeBuild(options: {
 
 	const stageDir = resolve(cwd, options.stageDir);
 	const targets = resolveTargets(options.target);
-	const metadata = resolveDistributionMetadata(cwd, entryPath, options.name);
+	const userPackageJson = Object.hasOwn(options, "userPackageJson")
+		? options.userPackageJson
+		: readUserPackageJson(cwd);
+	const metadata = resolveDistributionMetadata(cwd, entryPath, options.name, userPackageJson);
 
 	const distributionTargets = targets.map((target) =>
 		resolveDistributionTarget(stageDir, metadata.baseName, metadata.rootPackageName, target),


### PR DESCRIPTION
Part 4/8 of the architecture cleanup stack.

- Fix: create-crust imported sibling `package.json`s via undeclared relative paths (silent stale-version baking); now declared devDeps with build-time version constants
- Fix: `--overwrite` logged "overwriting" before the confirm prompt that can still decline
- Pure `planBuild(flags, cwd)` extracted from the build action: the 13-flag interaction matrix is now table-testable
- One `readUserPackageJson` (one parse, one error policy — was 3 readers with 3 policies); build-helpers test-only exports narrowed
- `--distribution` uses declarative `choices`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

