### PR TITLE
refactor(skills): pure reconcile planning, registry-derived agent targets

### DIFF
--- a/.changeset/tidy-skill-policies.md
+++ b/.changeset/tidy-skill-policies.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Reject missing, empty, or whitespace-only `name` and `description` fields consistently across generated, authored, and packaged skills.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -74,7 +74,7 @@ my-cli skill --all --scope project
 my-cli skill update
 ```
 
-If `distDir` cannot be found relative to the package, Crust also checks next to `process.execPath` — for the directory's basename when it is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the directory resolves but a packaged skill is invalid (for example a `SKILL.md` without a description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the packaged directory as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
+If `distDir` cannot be found relative to the package, Crust also checks next to `process.execPath` — for the directory's basename when it is an absolute path or `file:` URL, or the same relative path otherwise — supporting compiled distributions staged with their skills. When neither path resolves, the Agent skills section shows a fallback message pointing to the `skill` command instead. When the directory resolves but a packaged skill is invalid (for example a `SKILL.md` with a missing or empty description), the section reports that packaged skills could not be read. Directories without a `SKILL.md`, such as archive cruft, are skipped rather than failing valid skills. In every case the explicit `skill` command fails with a descriptive error, but unrelated CLI commands and help remain available. Skills are read when a snapshot is prepared, so help and generated man pages reflect the packaged directory as it exists at render time. Artifacts generated at build time — man pages from `crust build` and the skill written by `writeSkills` — therefore capture the paths (or fallback text) resolved on the build machine, not on the end user's machine.
 
 <auto-type-table path="../../../../../packages/skills/src/types.ts" name="SkillOptions" />
 
@@ -151,7 +151,7 @@ Skill names follow the [Agent Skills specification](https://agentskills.io/speci
 
 ## Source helpers and errors
 
-`resolveSkillSource()` resolves a packaged source root without canonicalizing its logical path and includes the executable-relative fallback. `loadPackagedSkills()` reads each `SKILL.md` frontmatter and validates that its declared name matches its directory.
+`resolveSkillSource()` resolves a packaged source root without canonicalizing its logical path and includes the executable-relative fallback. `loadPackagedSkills()` requires non-empty `name` and `description` fields in each `SKILL.md` frontmatter and validates that the declared name matches its directory.
 
 Agent helpers back the install prompts: `detectInstalledAgents()` performs the non-executing `PATH` lookup, `getUniversalAgents()` / `getAdditionalAgents()` split the registry by class, and `isUniversalAgent()` classifies a single target.
 

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 import { which } from "@crustjs/utils/process";
 
-import type { AgentClass, AgentTarget, Scope } from "./types.ts";
+import type { AgentClass, Scope } from "./types.ts";
 
 interface AgentConfig {
 	readonly label: string;
@@ -37,34 +37,35 @@ export function resolveEffectiveScope(scope: Scope): Scope {
 	return scope === "project" && process.cwd() === homedir() ? "global" : scope;
 }
 
+// SAFETY: Entry assertions provide declaration-safe value types after each literal is checked against AgentConfig.
 const AGENTS = {
 	amp: {
 		label: "Amp",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	adal: {
 		label: "AdaL",
 		class: "additional",
 		projectSkillsDir: join(".adal", "skills"),
 		globalSkillsDir: (home) => join(home, ".adal", "skills"),
 		detectCommands: ["adal"],
-	},
+	} as AgentConfig,
 	antigravity: {
 		label: "Antigravity",
 		class: "additional",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: (home) => join(home, ".gemini", "config", "skills"),
 		detectCommands: ["antigravity"],
-	},
+	} as AgentConfig,
 	augment: {
 		label: "Augment",
 		class: "additional",
 		projectSkillsDir: join(".augment", "skills"),
 		globalSkillsDir: (home) => join(home, ".augment", "skills"),
 		detectCommands: ["augment"],
-	},
+	} as AgentConfig,
 	"claude-code": {
 		label: "Claude Code",
 		class: "additional",
@@ -72,256 +73,259 @@ const AGENTS = {
 		globalSkillsDir: (home) =>
 			join(process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, ".claude"), "skills"),
 		detectCommands: ["claude", "claude-code"],
-	},
+	} as AgentConfig,
 	cline: {
 		label: "Cline",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	codebuddy: {
 		label: "CodeBuddy",
 		class: "additional",
 		projectSkillsDir: join(".codebuddy", "skills"),
 		globalSkillsDir: (home) => join(home, ".codebuddy", "skills"),
 		detectCommands: ["codebuddy"],
-	},
+	} as AgentConfig,
 	codex: {
 		label: "Codex",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	"command-code": {
 		label: "Command Code",
 		class: "additional",
 		projectSkillsDir: join(".commandcode", "skills"),
 		globalSkillsDir: (home) => join(home, ".commandcode", "skills"),
 		detectCommands: ["command-code", "commandcode"],
-	},
+	} as AgentConfig,
 	continue: {
 		label: "Continue",
 		class: "additional",
 		projectSkillsDir: join(".continue", "skills"),
 		globalSkillsDir: (home) => join(home, ".continue", "skills"),
 		detectCommands: ["continue"],
-	},
+	} as AgentConfig,
 	cortex: {
 		label: "Cortex Code",
 		class: "additional",
 		projectSkillsDir: join(".cortex", "skills"),
 		globalSkillsDir: (home) => join(home, ".snowflake", "cortex", "skills"),
 		detectCommands: ["cortex"],
-	},
+	} as AgentConfig,
 	crush: {
 		label: "Crush",
 		class: "additional",
 		projectSkillsDir: join(".crush", "skills"),
 		globalSkillsDir: (home) => join(configHome(home), "crush", "skills"),
 		detectCommands: ["crush"],
-	},
+	} as AgentConfig,
 	cursor: {
 		label: "Cursor",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	droid: {
 		label: "Droid",
 		class: "additional",
 		projectSkillsDir: join(".factory", "skills"),
 		globalSkillsDir: (home) => join(home, ".factory", "skills"),
 		detectCommands: ["droid"],
-	},
+	} as AgentConfig,
 	"gemini-cli": {
 		label: "Gemini CLI",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	"github-copilot": {
 		label: "GitHub Copilot",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	goose: {
 		label: "Goose",
 		class: "additional",
 		projectSkillsDir: join(".goose", "skills"),
 		globalSkillsDir: (home) => join(configHome(home), "goose", "skills"),
 		detectCommands: ["goose"],
-	},
+	} as AgentConfig,
 	"iflow-cli": {
 		label: "iFlow CLI",
 		class: "additional",
 		projectSkillsDir: join(".iflow", "skills"),
 		globalSkillsDir: (home) => join(home, ".iflow", "skills"),
 		detectCommands: ["iflow", "iflow-cli"],
-	},
+	} as AgentConfig,
 	junie: {
 		label: "Junie",
 		class: "additional",
 		projectSkillsDir: join(".junie", "skills"),
 		globalSkillsDir: (home) => join(home, ".junie", "skills"),
 		detectCommands: ["junie"],
-	},
+	} as AgentConfig,
 	kilo: {
 		label: "Kilo Code",
 		class: "additional",
 		projectSkillsDir: join(".kilocode", "skills"),
 		globalSkillsDir: (home) => join(home, ".kilocode", "skills"),
 		detectCommands: ["kilo", "kilocode"],
-	},
+	} as AgentConfig,
 	"kimi-cli": {
 		label: "Kimi Code CLI",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	"kiro-cli": {
 		label: "Kiro CLI",
 		class: "additional",
 		projectSkillsDir: join(".kiro", "skills"),
 		globalSkillsDir: (home) => join(home, ".kiro", "skills"),
 		detectCommands: ["kiro", "kiro-cli"],
-	},
+	} as AgentConfig,
 	kode: {
 		label: "Kode",
 		class: "additional",
 		projectSkillsDir: join(".kode", "skills"),
 		globalSkillsDir: (home) => join(home, ".kode", "skills"),
 		detectCommands: ["kode"],
-	},
+	} as AgentConfig,
 	mcpjam: {
 		label: "MCPJam",
 		class: "additional",
 		projectSkillsDir: join(".mcpjam", "skills"),
 		globalSkillsDir: (home) => join(home, ".mcpjam", "skills"),
 		detectCommands: ["mcpjam"],
-	},
+	} as AgentConfig,
 	"mistral-vibe": {
 		label: "Mistral Vibe",
 		class: "additional",
 		projectSkillsDir: join(".vibe", "skills"),
 		globalSkillsDir: (home) => join(process.env.VIBE_HOME || join(home, ".vibe"), "skills"),
 		detectCommands: ["mistral-vibe", "vibe"],
-	},
+	} as AgentConfig,
 	mux: {
 		label: "Mux",
 		class: "additional",
 		projectSkillsDir: join(".mux", "skills"),
 		globalSkillsDir: (home) => join(home, ".mux", "skills"),
 		detectCommands: ["mux"],
-	},
+	} as AgentConfig,
 	neovate: {
 		label: "Neovate",
 		class: "additional",
 		projectSkillsDir: join(".neovate", "skills"),
 		globalSkillsDir: (home) => join(home, ".neovate", "skills"),
 		detectCommands: ["neovate"],
-	},
+	} as AgentConfig,
 	opencode: {
 		label: "OpenCode",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	openclaw: {
 		label: "OpenClaw",
 		class: "additional",
 		projectSkillsDir: "skills",
 		globalSkillsDir: (home) => join(home, ".openclaw", "skills"),
 		detectCommands: ["openclaw"],
-	},
+	} as AgentConfig,
 	openhands: {
 		label: "OpenHands",
 		class: "additional",
 		projectSkillsDir: join(".openhands", "skills"),
 		globalSkillsDir: (home) => join(home, ".openhands", "skills"),
 		detectCommands: ["openhands"],
-	},
+	} as AgentConfig,
 	pi: {
 		label: "Pi",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	pochi: {
 		label: "Pochi",
 		class: "additional",
 		projectSkillsDir: join(".pochi", "skills"),
 		globalSkillsDir: (home) => join(home, ".pochi", "skills"),
 		detectCommands: ["pochi"],
-	},
+	} as AgentConfig,
 	qoder: {
 		label: "Qoder",
 		class: "additional",
 		projectSkillsDir: join(".qoder", "skills"),
 		globalSkillsDir: (home) => join(home, ".qoder", "skills"),
 		detectCommands: ["qoder"],
-	},
+	} as AgentConfig,
 	"qwen-code": {
 		label: "Qwen Code",
 		class: "additional",
 		projectSkillsDir: join(".qwen", "skills"),
 		globalSkillsDir: (home) => join(home, ".qwen", "skills"),
 		detectCommands: ["qwen", "qwen-code"],
-	},
+	} as AgentConfig,
 	replit: {
 		label: "Replit",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	roo: {
 		label: "Roo Code",
 		class: "additional",
 		projectSkillsDir: join(".roo", "skills"),
 		globalSkillsDir: (home) => join(home, ".roo", "skills"),
 		detectCommands: ["roo", "roo-code"],
-	},
+	} as AgentConfig,
 	trae: {
 		label: "Trae",
 		class: "additional",
 		projectSkillsDir: join(".trae", "skills"),
 		globalSkillsDir: (home) => join(home, ".trae", "skills"),
 		detectCommands: ["trae"],
-	},
+	} as AgentConfig,
 	"trae-cn": {
 		label: "Trae CN",
 		class: "additional",
 		projectSkillsDir: join(".trae", "skills"),
 		globalSkillsDir: (home) => join(home, ".trae-cn", "skills"),
 		detectCommands: ["trae-cn", "trae"],
-	},
+	} as AgentConfig,
 	warp: {
 		label: "Warp",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	windsurf: {
 		label: "Windsurf",
 		class: "additional",
 		projectSkillsDir: join(".windsurf", "skills"),
 		globalSkillsDir: (home) => join(home, ".codeium", "windsurf", "skills"),
 		detectCommands: ["windsurf"],
-	},
+	} as AgentConfig,
 	zed: {
 		label: "Zed",
 		class: "universal",
 		projectSkillsDir: PROJECT_UNIVERSAL_SKILLS_DIR,
 		globalSkillsDir: universalGlobalSkillsDir,
-	},
+	} as AgentConfig,
 	zencoder: {
 		label: "Zencoder",
 		class: "additional",
 		projectSkillsDir: join(".zencoder", "skills"),
 		globalSkillsDir: (home) => join(home, ".zencoder", "skills"),
 		detectCommands: ["zencoder"],
-	},
-} satisfies Record<AgentTarget, AgentConfig>;
+	} as AgentConfig,
+};
+
+/** Supported agent targets for skill installation. */
+export type AgentTarget = keyof typeof AGENTS;
 
 const agentKeys = Object.keys(AGENTS);
 
@@ -331,12 +335,8 @@ const agentKeys = Object.keys(AGENTS);
  * @internal
  */
 export const ALL_AGENTS =
-	// SAFETY: AGENTS is checked above to contain exactly every AgentTarget key.
+	// SAFETY: Object.keys returns exactly the enumerable string keys of AGENTS.
 	agentKeys as AgentTarget[];
-
-const agentLabelEntries = Object.fromEntries(
-	ALL_AGENTS.map((agent) => [agent, AGENTS[agent].label]),
-);
 
 /**
  * Human-readable labels for each agent target.
@@ -344,8 +344,11 @@ const agentLabelEntries = Object.fromEntries(
  * @internal
  */
 export const AGENT_LABELS =
-	// SAFETY: ALL_AGENTS contains every AgentTarget, so the mapped entries are exhaustive.
-	agentLabelEntries as Record<AgentTarget, string>;
+	// SAFETY: ALL_AGENTS supplies every AgentTarget key to the mapped entries.
+	Object.fromEntries(ALL_AGENTS.map((agent) => [agent, AGENTS[agent].label])) as Record<
+		AgentTarget,
+		string
+	>;
 
 /** Returns agents that use the canonical `.agents/skills` layout. */
 export function getUniversalAgents(): AgentTarget[] {

--- a/packages/skills/src/build.ts
+++ b/packages/skills/src/build.ts
@@ -1,12 +1,13 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import type { CommandSnapshot } from "@crustjs/core";
 import { resolveSourceDir } from "@crustjs/utils/source";
 
-import { loadBundleFiles } from "./bundle.ts";
+import { loadBundleFiles, requireSkillFrontmatter } from "./bundle.ts";
 import { SkillSourceConflictError } from "./errors.ts";
 import { buildManifest } from "./manifest.ts";
+import { isWithin } from "./path.ts";
 import { renderSkill } from "./render.ts";
 import { isValidSkillName } from "./skill-name.ts";
 import type { RenderedFile, SkillMeta } from "./types.ts";
@@ -46,11 +47,7 @@ export async function writeSkillsFromSnapshot(
 		version: options.version,
 	};
 	validateSkillName(generatedMeta.name);
-	if (generatedMeta.description.trim() === "") {
-		throw new Error(
-			`Skill "${generatedMeta.name}" requires a description for SKILL.md frontmatter.`,
-		);
-	}
+	requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
 
 	const outDir = resolve(options.outDir);
 	if (basename(outDir) !== "skills") {
@@ -64,7 +61,7 @@ export async function writeSkillsFromSnapshot(
 	for (const sourceDir of options.extras ?? []) {
 		const resolved = resolveSourceDir(sourceDir);
 		// outDir is replaced wholesale below; an extra nested inside it would be destroyed.
-		if (resolved === outDir || resolved.startsWith(outDir + sep)) {
+		if (isWithin(outDir, resolved)) {
 			throw new Error(
 				`Extra skill directory "${resolved}" is inside outDir "${outDir}", which is replaced on every build. Move authored skills outside the build output.`,
 			);
@@ -79,7 +76,7 @@ export async function writeSkillsFromSnapshot(
 
 	const cwd = resolve(".");
 	// outDir is replaced wholesale below; refuse targets that would delete the caller's project.
-	if (outDir === dirname(outDir) || outDir === cwd || cwd.startsWith(outDir + sep)) {
+	if (outDir === dirname(outDir) || isWithin(outDir, cwd)) {
 		throw new Error(
 			`Refusing to replace "${outDir}": outDir must be a dedicated directory, not the filesystem root, the working directory, or an ancestor of it.`,
 		);

--- a/packages/skills/src/bundle.test.ts
+++ b/packages/skills/src/bundle.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,18 +21,11 @@ const FIXTURE_DIR = join(
 let tmpDir: string;
 
 beforeEach(async () => {
-	const base = join(import.meta.dirname ?? ".", ".tmp-test");
-	const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	tmpDir = join(base, id);
-	await mkdir(tmpDir, { recursive: true });
+	tmpDir = await mkdtemp(join(tmpdir(), "crust-skill-bundle-"));
 });
 
 afterEach(async () => {
-	try {
-		await rm(tmpDir, { recursive: true });
-	} catch {
-		// Ignore cleanup errors
-	}
+	await rm(tmpDir, { recursive: true, force: true });
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -132,6 +126,13 @@ describe("loadBundleFiles", () => {
 		await mkdir(dir, { recursive: true });
 		await writeFile(join(dir, "SKILL.md"), '---\nname: ""\ndescription: ""\n---\n');
 		await expect(loadBundleFiles(dir)).rejects.toThrow(/`name:`/);
+	});
+
+	it("rejects whitespace-only frontmatter values", async () => {
+		const dir = join(tmpDir, "whitespace-values");
+		await mkdir(dir, { recursive: true });
+		await writeFile(join(dir, "SKILL.md"), '---\nname: skill\ndescription: "   "\n---\n');
+		await expect(loadBundleFiles(dir)).rejects.toThrow(/`description:`/);
 	});
 
 	it("strips a leading UTF-8 BOM before locating the opening fence", async () => {

--- a/packages/skills/src/bundle.ts
+++ b/packages/skills/src/bundle.ts
@@ -26,6 +26,11 @@ interface BundleFrontmatter {
 	description: string | null;
 }
 
+interface RequiredSkillFrontmatter {
+	readonly name: string;
+	readonly description: string;
+}
+
 /**
  * Parses one single-line YAML scalar: double-quoted, single-quoted, or plain
  * (trailing ` # comment` stripped per YAML's whitespace-then-hash rule).
@@ -66,6 +71,22 @@ export function probeFrontmatter(content: string): BundleFrontmatter {
 		}
 	}
 	return result;
+}
+
+/** Requires non-empty Agent Skills frontmatter fields. */
+export function requireSkillFrontmatter(
+	frontmatter: BundleFrontmatter,
+	subject: string,
+): RequiredSkillFrontmatter {
+	if (frontmatter.name === null || frontmatter.name.trim() === "") {
+		throw new Error(`${subject} requires a name (\`name:\`) field in SKILL.md frontmatter.`);
+	}
+	if (frontmatter.description === null || frontmatter.description.trim() === "") {
+		throw new Error(
+			`${subject} requires a description (\`description:\`) field in SKILL.md frontmatter.`,
+		);
+	}
+	return { name: frontmatter.name, description: frontmatter.description };
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -212,25 +233,10 @@ export async function loadBundleFiles(sourceDir: string | URL): Promise<LoadedBu
 	);
 
 	const skillContent = await readFile(skillMd.absPath, "utf-8");
-	const probed = probeFrontmatter(skillContent);
+	const frontmatter = requireSkillFrontmatter(
+		probeFrontmatter(skillContent),
+		`Extra skill SKILL.md at "${join(canonicalRoot, SKILL_MD)}"`,
+	);
 
-	if (probed.name === null || probed.name === "") {
-		throw new Error(
-			`Extra skill SKILL.md is missing a top-level \`name:\` field in its YAML frontmatter ` +
-				`(at "${join(canonicalRoot, SKILL_MD)}"). ` +
-				`Add \`name: <skill-name>\` to the frontmatter block.`,
-		);
-	}
-	if (probed.description === null || probed.description === "") {
-		throw new Error(
-			`Extra skill SKILL.md is missing a top-level \`description:\` field in its YAML frontmatter ` +
-				`(at "${join(canonicalRoot, SKILL_MD)}"). ` +
-				`Add \`description: <one-line summary>\` to the frontmatter block.`,
-		);
-	}
-
-	return {
-		files,
-		frontmatter: { name: probed.name, description: probed.description },
-	};
+	return { files, frontmatter };
 }

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, readFile, rm } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 
 import {
 	type Extension,
@@ -29,6 +29,8 @@ import {
 	uninstallSkill,
 } from "./generate.ts";
 import { SKILLS } from "./manifest.ts";
+import { isWithin } from "./path.ts";
+import { planReconcile, UNIVERSAL_GROUP, type ReconcileChoice } from "./reconcile.ts";
 import {
 	SkillSourceUnavailableError,
 	loadPackagedSkills,
@@ -40,7 +42,6 @@ import type { AgentTarget, InstallSkillResult, Scope, SkillOptions } from "./typ
 const DEFAULT_SKILL_COMMAND_NAME = "skill";
 const SKILLS_SECTION_TITLE = "Agent skills";
 const DEFAULT_SKILL_SCOPE = "global";
-const UNIVERSAL_GROUP = "__universal__";
 
 function parseScopeFlag(value: string | undefined): Scope | undefined {
 	if (value === undefined) return undefined;
@@ -187,11 +188,6 @@ function formatSkillDocumentation(
 	}
 }
 
-function isWithin(parent: string, child: string): boolean {
-	const path = relative(parent, child);
-	return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith(`..${sep}`));
-}
-
 function hasPackageVersion<Value>(value: Value): value is Value & { version: string } {
 	return (
 		typeof value === "object" &&
@@ -295,11 +291,7 @@ async function reconcileSkill(opts: {
 	const additional = getAdditionalAgents().filter(
 		(agent) => detected.has(agent) || installed.has(agent),
 	);
-	const choices: Array<{
-		label: string;
-		value: AgentTarget | typeof UNIVERSAL_GROUP;
-		hint: string;
-	}> = [];
+	const choices: Array<ReconcileChoice & { hint: string }> = [];
 	if (universal.length > 0) {
 		choices.push({
 			label: "Universal",
@@ -334,27 +326,18 @@ async function reconcileSkill(opts: {
 		if (values.includes(UNIVERSAL_GROUP)) selected.push(...universal);
 	}
 
-	const toInstall = selected.filter((agent) => statusMap.get(agent)?.status !== "linked");
-	// Agents can share one resolved output directory (e.g. Antigravity and the
-	// universal group at project scope); removing a deselected agent's link there
-	// would also uninstall the retained agents.
-	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
-	const toUninstall = [...installed].filter(
-		(agent) => !selected.includes(agent) && !keptDirs.has(statusMap.get(agent)?.outputDir),
-	);
-	// Warn per offered choice (not per installed agent) so a fresh shared install
-	// also explains why a deselected agent still discovers the skill.
-	for (const choice of choices) {
-		const agent = choice.value === UNIVERSAL_GROUP ? universal[0]! : choice.value;
-		if (selected.includes(agent)) continue;
-		const entry = statusMap.get(agent);
-		if (entry && keptDirs.has(entry.outputDir)) {
-			console.warn(
-				yellow(
-					`${choice.label} [${packagedSkill.name}]: "${entry.outputDir}" is shared with a selected agent, so the skill stays available to it.`,
-				),
-			);
-		}
+	const { toInstall, toUninstall, sharedDirWarnings } = planReconcile({
+		statusMap,
+		choices,
+		selected,
+		universal,
+	});
+	for (const warning of sharedDirWarnings) {
+		console.warn(
+			yellow(
+				`${warning.label} [${packagedSkill.name}]: "${warning.outputDir}" is shared with a selected agent, so the skill stays available to it.`,
+			),
+		);
 	}
 
 	if (toInstall.length > 0) {

--- a/packages/skills/src/path.test.ts
+++ b/packages/skills/src/path.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import { isWithin } from "./path.ts";
+
+describe("isWithin", () => {
+	it("distinguishes descendants from sibling paths with the same prefix", () => {
+		const parent = join("tmp", "skills");
+		expect(isWithin(parent, join(parent, "authored"))).toBe(true);
+		expect(isWithin(parent, join("tmp", "skills-backup"))).toBe(false);
+	});
+});

--- a/packages/skills/src/path.ts
+++ b/packages/skills/src/path.ts
@@ -1,0 +1,7 @@
+import { isAbsolute, relative, sep } from "node:path";
+
+/** Returns whether child is parent itself or lies below it. */
+export function isWithin(parent: string, child: string): boolean {
+	const path = relative(parent, child);
+	return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith(`..${sep}`));
+}

--- a/packages/skills/src/reconcile.test.ts
+++ b/packages/skills/src/reconcile.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { planReconcile, UNIVERSAL_GROUP, type ReconcileChoice } from "./reconcile.ts";
+import type { AgentTarget, SkillStatusResult } from "./types.ts";
+
+function statusMap(
+	entries: SkillStatusResult["agents"],
+): Map<AgentTarget, SkillStatusResult["agents"][number]> {
+	return new Map(entries.map((entry) => [entry.agent, entry]));
+}
+
+const choices: ReconcileChoice[] = [
+	{ label: "Universal", value: UNIVERSAL_GROUP },
+	{ label: "Antigravity", value: "antigravity" },
+];
+
+const universal = ["amp"] as const;
+
+const sharedStatuses: SkillStatusResult["agents"] = [
+	{ agent: "amp", outputDir: "/project/.agents/skills/demo", status: "linked" },
+	{
+		agent: "antigravity",
+		outputDir: "/project/.agents/skills/demo",
+		status: "linked",
+	},
+];
+
+describe("planReconcile", () => {
+	it("retains a shared output directory and warns the deselected choice", () => {
+		expect(
+			planReconcile({
+				statusMap: statusMap(sharedStatuses),
+				choices,
+				selected: ["amp"],
+				universal,
+			}),
+		).toEqual({
+			toInstall: [],
+			toUninstall: [],
+			sharedDirWarnings: [{ label: "Antigravity", outputDir: "/project/.agents/skills/demo" }],
+		});
+	});
+
+	it("uses selected output directories even when the selected link needs installation", () => {
+		const statuses: SkillStatusResult["agents"] = [
+			{ ...sharedStatuses[0]!, status: "absent" },
+			sharedStatuses[1]!,
+		];
+
+		expect(
+			planReconcile({
+				statusMap: statusMap(statuses),
+				choices,
+				selected: ["amp"],
+				universal,
+			}),
+		).toEqual({
+			toInstall: ["amp"],
+			toUninstall: [],
+			sharedDirWarnings: [{ label: "Antigravity", outputDir: "/project/.agents/skills/demo" }],
+		});
+	});
+});

--- a/packages/skills/src/reconcile.ts
+++ b/packages/skills/src/reconcile.ts
@@ -1,0 +1,48 @@
+import type { AgentTarget, SkillStatusResult } from "./types.ts";
+
+export const UNIVERSAL_GROUP = "__universal__";
+
+type SkillStatusEntry = SkillStatusResult["agents"][number];
+
+export interface ReconcileChoice {
+	readonly label: string;
+	readonly value: AgentTarget | typeof UNIVERSAL_GROUP;
+}
+
+export interface SharedDirWarning {
+	readonly label: string;
+	readonly outputDir: string;
+}
+
+export interface ReconcilePlan {
+	readonly toInstall: AgentTarget[];
+	readonly toUninstall: AgentTarget[];
+	readonly sharedDirWarnings: SharedDirWarning[];
+}
+
+/** @internal Plans link changes without performing prompt or filesystem I/O. */
+export function planReconcile(options: {
+	readonly statusMap: ReadonlyMap<AgentTarget, SkillStatusEntry>;
+	readonly choices: readonly ReconcileChoice[];
+	readonly selected: readonly AgentTarget[];
+	readonly universal: readonly AgentTarget[];
+}): ReconcilePlan {
+	const { statusMap, choices, selected, universal } = options;
+	const installed = [...statusMap.values()]
+		.filter((entry) => entry.status === "linked" || entry.status === "dangling")
+		.map((entry) => entry.agent);
+	const toInstall = selected.filter((agent) => statusMap.get(agent)?.status !== "linked");
+	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
+	const toUninstall = installed.filter(
+		(agent) => !selected.includes(agent) && !keptDirs.has(statusMap.get(agent)?.outputDir),
+	);
+	const sharedDirWarnings = choices.flatMap((choice) => {
+		const agent = choice.value === UNIVERSAL_GROUP ? universal[0]! : choice.value;
+		const entry = statusMap.get(agent);
+		return !selected.includes(agent) && entry && keptDirs.has(entry.outputDir)
+			? [{ label: choice.label, outputDir: entry.outputDir }]
+			: [];
+	});
+
+	return { toInstall, toUninstall, sharedDirWarnings };
+}

--- a/packages/skills/src/source.test.ts
+++ b/packages/skills/src/source.test.ts
@@ -83,9 +83,7 @@ describe("packaged skill sources", () => {
 		const dir = join(root, "demo");
 		await mkdir(dir, { recursive: true });
 		await writeFile(join(dir, "SKILL.md"), "---\nname: demo\n---\n");
-		expect(() => loadPackagedSkills(root)).toThrow(
-			"requires name and description in SKILL.md frontmatter",
-		);
+		expect(() => loadPackagedSkills(root)).toThrow("requires a description");
 	});
 
 	it("skips directories without SKILL.md instead of failing valid skills", async () => {

--- a/packages/skills/src/source.ts
+++ b/packages/skills/src/source.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { isErrnoException } from "@crustjs/utils/error";
 import { resolveSourceDir } from "@crustjs/utils/source";
 
-import { probeFrontmatter } from "./bundle.ts";
+import { probeFrontmatter, requireSkillFrontmatter } from "./bundle.ts";
 
 export class SkillSourceUnavailableError extends Error {
 	override readonly name = "SkillSourceUnavailableError";
@@ -75,13 +75,10 @@ export function readSkillFrontmatter(
 		if (!isErrnoException(error) || error.code !== "ENOENT") throw error;
 		throw new Error(`Skill source directory "${sourceDir}" is missing SKILL.md.`, { cause: error });
 	}
-	const frontmatter = probeFrontmatter(content);
-	if (!frontmatter.name || !frontmatter.description) {
-		throw new Error(
-			`Skill source directory "${sourceDir}" requires name and description in SKILL.md frontmatter.`,
-		);
-	}
-	return { name: frontmatter.name, description: frontmatter.description };
+	return requireSkillFrontmatter(
+		probeFrontmatter(content),
+		`Skill source directory "${sourceDir}"`,
+	);
 }
 
 /** Reads every self-describing skill directory in a packaged skill source. */

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -1,57 +1,16 @@
 import type { CommandSection } from "@crustjs/core";
 import type { BaseValueType } from "@crustjs/utils/primitive";
 
+import type { AgentTarget } from "./agents.ts";
+
+export type { AgentTarget };
+
 /** Metadata used to render a generated skill. */
 export interface SkillMeta {
 	name: string;
 	description: string;
 	version?: string;
 }
-
-/** Supported agent targets for skill installation. */
-export type AgentTarget =
-	| "amp"
-	| "adal"
-	| "antigravity"
-	| "augment"
-	| "claude-code"
-	| "cline"
-	| "codebuddy"
-	| "codex"
-	| "command-code"
-	| "continue"
-	| "cortex"
-	| "crush"
-	| "cursor"
-	| "droid"
-	| "gemini-cli"
-	| "github-copilot"
-	| "goose"
-	| "iflow-cli"
-	| "junie"
-	| "kilo"
-	| "kimi-cli"
-	| "kiro-cli"
-	| "kode"
-	| "mcpjam"
-	| "mistral-vibe"
-	| "mux"
-	| "neovate"
-	| "opencode"
-	| "openclaw"
-	| "openhands"
-	| "pi"
-	| "pochi"
-	| "qoder"
-	| "qwen-code"
-	| "replit"
-	| "roo"
-	| "trae"
-	| "trae-cn"
-	| "warp"
-	| "windsurf"
-	| "zed"
-	| "zencoder";
 
 export type AgentClass = "universal" | "additional";
 export type Scope = "global" | "project";


### PR DESCRIPTION
Part 5/8 of the architecture cleanup stack.

- Pure `planReconcile()` extracted from the interactive extension: shared-output-dir retention/warning policy is now unit-tested instead of e2e-through-prompts
- Frontmatter validation consolidated (3 near-identical sites → 1 helper)
- `AgentTarget` derived from the `AGENTS` registry (`keyof typeof`): adding an agent is a one-file edit; deleted redundant SAFETY casts
- Registry filter exports trimmed; path-containment checks unified; test tmp-dir leftover cleaned

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

