### PR TITLE
refactor(style,man): remove dead flexibility, document chain capture

### DIFF
--- a/.changeset/style-chain-capture.md
+++ b/.changeset/style-chain-capture.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/style": patch
+---
+
+Document that stored sub-chains freeze terminal capabilities at access time and that table rows drop cells beyond the declared headers.

--- a/apps/docs/content/docs/modules/style.mdx
+++ b/apps/docs/content/docs/modules/style.mdx
@@ -153,7 +153,7 @@ table(
 );
 ```
 
-`padStart` / `padEnd` / `center` measure visible width — unlike `String.prototype.padStart`, which counts code units and ANSI escapes. `table` supports per-column alignment, padding, separators, and styled cells.
+`padStart` / `padEnd` / `center` measure visible width — unlike `String.prototype.padStart`, which counts code units and ANSI escapes. `table` supports per-column alignment, padding, separators, and styled cells. Headers define its column count, so extra row cells beyond the last header are dropped.
 
 Use the exported `stringWidth(text)` helper for ANSI-, CJK-, combining-mark-, and emoji-aware terminal width measurement.
 

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -63,9 +63,17 @@ function resolveDdLine(explicit?: string): string {
 }
 
 export interface RenderManPageMdocOptions {
+	/** Prepared, validated Command Snapshot for the CLI. */
 	root: CommandSnapshot;
+	/** Name for `.Nm` / `man <name>` (usually the installed binary name). */
 	name: string;
+	/**
+	 * Manual section.
+	 *
+	 * @default 1
+	 */
 	section?: number;
+	/** Override `.Dd` in the mdoc output (see `renderManPageMdoc` `date`). */
 	date?: string;
 }
 

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -1,6 +1,7 @@
-import { type CommandSnapshot, type ExtensionId, defineExtensionId } from "@crustjs/core";
+import { type ExtensionId, defineExtensionId } from "@crustjs/core";
 import {
 	buildCommandDocumentation,
+	type CommandSnapshot,
 	formatDescription,
 	sectionsFor,
 	visibleSectionsFor,

--- a/packages/man/src/write-man-page.ts
+++ b/packages/man/src/write-man-page.ts
@@ -1,25 +1,11 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import type { CommandSnapshot } from "@crustjs/core/tooling";
+import { renderManPageMdoc, type RenderManPageMdocOptions } from "./mdoc.ts";
 
-import { renderManPageMdoc } from "./mdoc.ts";
-
-export interface WriteManPageOptions {
-	/** Prepared, validated Command Snapshot for the CLI. */
-	root: CommandSnapshot;
-	/** Name for `.Nm` / `man <name>` (usually the installed binary name). */
-	name: string;
+export interface WriteManPageOptions extends RenderManPageMdocOptions {
 	/** Output path (e.g. `man/mycli.1`). Parent directories are created. */
 	outfile: string;
-	/**
-	 * Manual section.
-	 *
-	 * @default 1
-	 */
-	section?: number;
-	/** Override `.Dd` in the mdoc output (see `renderManPageMdoc` `date`). */
-	date?: string;
 }
 
 /** Render an mdoc(7) manual page from a Command Snapshot and write it to `outfile`. */

--- a/packages/style/src/blocks/tables.ts
+++ b/packages/style/src/blocks/tables.ts
@@ -145,6 +145,7 @@ function formatSeparator(
  * Format tabular data as an aligned, bordered table string.
  *
  * The table includes a header row, a separator row, and data rows.
+ * Headers define the column count; row cells beyond the last header are dropped.
  * Column widths are computed from the visible width of all cell content
  * (ANSI escape sequences are excluded from width calculations), so styled
  * cell values align correctly.

--- a/packages/style/src/createStyle.ts
+++ b/packages/style/src/createStyle.ts
@@ -21,18 +21,13 @@ import type {
 
 // A single step in a chainable style. Either a registered method (looked
 // up by name in the style registry) or an ad-hoc `AnsiPair` produced by a
-// dynamic-color call like `style.bold.fg("#f00")`. The `isModifier` flag on
-// pair-steps is `false` for dynamic colors (currently the only producers).
+// dynamic-color call like `style.bold.fg("#f00")`.
 type ChainStep =
 	| { readonly kind: "named"; readonly name: StyleMethodName }
-	| {
-			readonly kind: "pair";
-			readonly pair: AnsiPair;
-			readonly isModifier: boolean;
-	  };
+	| { readonly kind: "pair"; readonly pair: AnsiPair };
 
 function stepIsModifier(step: ChainStep): boolean {
-	return step.kind === "named" ? isModifierName(step.name) : step.isModifier;
+	return step.kind === "named" && isModifierName(step.name);
 }
 
 function stepPair(step: ChainStep): AnsiPair {
@@ -44,7 +39,6 @@ interface ResolvedStyleCapabilities {
 	readonly colorDepth: ColorDepth;
 	readonly colorsEnabled: boolean;
 	readonly trueColorEnabled: boolean;
-	readonly hyperlinksEnabled: boolean;
 }
 
 function applyChain(
@@ -88,6 +82,8 @@ function buildChainableStyleFactory(
 	resolveCapabilities: () => ResolvedStyleCapabilities,
 	runtime: boolean,
 ) {
+	// ponytail: unbounded for CLI lifetimes; add eviction if long-running processes build
+	// chains from unbounded user-provided colors.
 	const cache = new Map<string, ChainableStyleFn>();
 
 	function makeKey(
@@ -162,7 +158,6 @@ function buildChainableStyleFactory(
 						{
 							kind: "pair",
 							pair: fgPairAtDepth(input, resolved.colorDepth),
-							isModifier: false,
 						},
 					],
 					false,
@@ -182,7 +177,6 @@ function buildChainableStyleFactory(
 						{
 							kind: "pair",
 							pair: bgPairAtDepth(input, resolved.colorDepth),
-							isModifier: false,
 						},
 					],
 					false,
@@ -279,7 +273,6 @@ function resolveStyleCapabilities(options?: StyleOptions): ResolvedStyleCapabili
 		colorDepth,
 		colorsEnabled: colorDepth !== "none",
 		trueColorEnabled: colorDepth === "truecolor",
-		hyperlinksEnabled: resolveModifierCapability(mode, options?.overrides),
 	};
 }
 
@@ -305,7 +298,6 @@ function createStyleInstance(options: StyleOptions | undefined, runtime: boolean
 					{
 						kind: "pair",
 						pair: fgPairAtDepth(args[0], resolved.colorDepth),
-						isModifier: false,
 					},
 				],
 				false,
@@ -327,7 +319,6 @@ function createStyleInstance(options: StyleOptions | undefined, runtime: boolean
 					{
 						kind: "pair",
 						pair: bgPairAtDepth(args[0], resolved.colorDepth),
-						isModifier: false,
 					},
 				],
 				false,
@@ -353,7 +344,7 @@ function createStyleInstance(options: StyleOptions | undefined, runtime: boolean
 		},
 
 		link(text, url, hyperlinkOptions) {
-			if (resolveCapabilities().hyperlinksEnabled) {
+			if (resolveCapabilities().modifiersEnabled) {
 				return linkDirect(text, url, hyperlinkOptions);
 			}
 			// Validate even when emission is disabled so malformed URLs and IDs

--- a/packages/style/src/runtimeExports.test.ts
+++ b/packages/style/src/runtimeExports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "bun:test";
+
+import * as runtimeExports from "./runtimeExports.ts";
+import { styleMethodNames } from "./styleMethodRegistry.ts";
+
+describe("runtime exports", () => {
+	it("exports every registered style method", () => {
+		expect(styleMethodNames.filter((name) => !(name in runtimeExports))).toEqual([]);
+	});
+});

--- a/packages/style/src/types.ts
+++ b/packages/style/src/types.ts
@@ -43,8 +43,9 @@ export type ColorInput = ColorString | readonly [r: number, g: number, b: number
  *
  * The default `style` facade and top-level helpers always run in
  * `"auto"` mode — to influence them globally, set the standard
- * environment variables (`NO_COLOR`, `FORCE_COLOR`); they re-resolve on
- * every call.
+ * environment variables (`NO_COLOR`, `FORCE_COLOR`). The facade and helpers
+ * re-resolve capabilities on every direct call; stored sub-chains capture them
+ * when accessed (see {@link ChainableStyleFn}).
  *
  * @example
  * ```ts

--- a/packages/style/src/types.ts
+++ b/packages/style/src/types.ts
@@ -140,6 +140,11 @@ export type StyleMethodMap = {
  * Every chainable is simultaneously a function, a chain root, and an
  * ANSI pair. Chains compose `open` left-to-right and `close` right-to-left.
  *
+ * On the default runtime facade, a first-level chainable such as `style.bold`
+ * re-resolves terminal capabilities when called. Extending it freezes the
+ * current capabilities, so a stored sub-chain such as `style.bold.red` keeps
+ * the environment state from when the property was accessed.
+ *
  * To pass a style around as a value, pass the chainable itself — it is
  * already a `(text: string) => string` function (see {@link StyleFn}).
  *


### PR DESCRIPTION
Part 6/8 of the architecture cleanup stack.

- Deleted dead flexibility in the chain engine: `ChainStep.isModifier` (always false) and `hyperlinksEnabled` (definitionally = `modifiersEnabled`)
- Parity test pins `styleMethodNames` ↔ top-level `runtimeExports` (closes a hand-maintained 43-alias drift channel)
- Documented stored sub-chain capability capture (`const c = style.bold.red` snapshots at access time) + `table` extra-cell behavior
- man: single `CommandSnapshot` import path; `WriteManPageOptions extends RenderManPageMdocOptions` with field docs hoisted to the parent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

