### PR TITLE
feat(core): inline .command() and chainable .use(), remove uses config

### DIFF
--- a/.changeset/inline-command-chainable-use.md
+++ b/.changeset/inline-command-chainable-use.md
@@ -1,0 +1,16 @@
+---
+"@crustjs/core": minor
+---
+
+Add inline `Crust.command(name, recipe)` (root-only) for app-local leaf subcommands and a chainable `CommandDefinitionBuilder.use(factory)` for declaring Context demand.
+
+**Breaking (pre-1.0):** the `uses` config field on `defineCommand` is removed. Declare command dependencies with chained `.use(factory)` calls inside the recipe instead:
+
+```ts
+// before
+defineCommand("deploy", { uses: [logging, auth] }, (cmd) => cmd.action(...));
+// after
+defineCommand("deploy", (cmd) => cmd.use(logging).use(auth).action(...));
+```
+
+`.use(logger)` is demand (a factory); `.provide(logger())` is supply (an instance). Context and Extension `uses` config fields are unchanged. Inline `.command()` recipes are seeded with the call-site Contexts and Context-owned flags; unmet inline `.use()` demands fail typecheck with `FIX_MISSING_DEPENDENCY`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,6 @@ Doc surfaces:
 - `apps/docs/content/docs/guide/*.mdx` — conceptual guides
 - `apps/docs/content/docs/modules/*.mdx` — per-package reference
 - `apps/docs/content/docs/api/*.mdx` — public API reference
-- `packages/<pkg>/README.md` — npm landing page
 
 Before submitting:
 

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -23,7 +23,7 @@ import {
 
 ## Reusable command definitions
 
-Every sealed unit declares consumed Context factories in `uses`. Actions and setup receive a typed lazy bag and await values with `await ctx.<name>`; missing wiring is reported at `.provide()`, `.add()`, or `.extend()`.
+A sealed command declares consumed Context factories with chained `.use(factory)` calls — `.use(logger)` is demand (a factory), `.provide(logger())` is supply (an instance). Actions and setup receive a typed lazy bag and await values with `await ctx.<name>`; missing wiring is reported at `.provide()`, `.add()`, or `.extend()`.
 
 ### `CommandDefinitionBuilder`
 
@@ -37,6 +37,7 @@ interface CommandDefinitionBuilder<
 > {
   flags(...defs: readonly NamedFlagDef[]): CommandDefinitionBuilder;
   args(...defs: ArgsDef): CommandDefinitionBuilder;
+  use(factory: AnyContextFactory): CommandDefinitionBuilder;
   provide(...instances: readonly ContextInstance[]): CommandDefinitionBuilder;
   add(...definitions: readonly CommandDefinition[]): CommandDefinitionBuilder;
   action<R>(action: (ctx: CrustCommandContext<A, Flags, Ctx>) => R): CommandDefinitionBuilder;
@@ -49,7 +50,7 @@ interface CommandDefinitionBuilder<
   for the exact signatures.
 </Callout>
 
-This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and provided Context types. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. Both are defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
+This is the configure-only builder passed to a `defineCommand()` recipe. Its fluent methods preserve and refine argument, accumulated flag, and provided Context types. Each `.use(factory)` call accumulates the factory's value and transitive dependency closure into the action's typed `ctx` and into the sealed definition's declared dependencies. `Sibs` accumulates the sibling command names and aliases registered through `.add()`, and `Sp` caches the known flag spellings accumulated through `.flags()` and `.provide()`. Both are defaulted parameters. It intentionally has no `.extend()`, `.run()`, or `.execute()` methods.
 
 ### `CommandDefinition`
 
@@ -75,7 +76,6 @@ defineCommand<const Name extends string>(
 
 interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
   readonly sections?: readonly CommandSectionInput[];
-  readonly uses?: readonly AnyContextFactory[];
 }
 
 defineCommand<const Name extends string, const C extends CommandConfig>(
@@ -98,9 +98,11 @@ const auth = defineContext("auth", () => ({ user: "Ada" }));
 
 const deploy = defineCommand(
   "deploy",
-  { description: "Deploy an application", aliases: ["ship"], uses: [logging, auth] },
+  { description: "Deploy an application", aliases: ["ship"] },
   (command) =>
     command
+      .use(logging)
+      .use(auth)
       .args({ name: "target", type: "string", required: true })
       .action(async ({ args, ctx }) => {
         (await ctx.logging).debug(`${(await ctx.auth).user}:${args.target}`);
@@ -233,7 +235,7 @@ const app = new Crust("my-cli")
   });
 ```
 
-`uses` declarations are checked at composition time. Dependencies may appear in either order within one `.provide()` call; across calls, provide dependencies first. Core does not repeat these dependency checks at runtime; dynamically assembled inputs fail lazily with `missing-context` on first access.
+Declared dependencies (Context `uses`, command `.use()`, Extension `uses`) are checked at composition time. Dependencies may appear in either order within one `.provide()` call; across calls, provide dependencies first. Core does not repeat these dependency checks at runtime; dynamically assembled inputs fail lazily with `missing-context` on first access.
 
 A Context's top-level `flags` are installed as propagating flags on this builder and later-added descendants, without mutating the original definitions. Dependencies construct recursively on the first pull.
 
@@ -309,7 +311,7 @@ const app = new Crust("my-cli").add(
 
 Statically known sibling name and alias collisions fail at `.add()` with `FIX_COMMAND_COLLISION`; alias shape violations fail at `defineCommand()` with `FIX_ALIAS_SHAPE`. Dynamically assembled definitions fail loud instead: `.add()` rejects a duplicate sibling name with a `DEFINITION` error. Materialization also checks that each recipe returns its seeded builder, does not register nested Extensions, and does not provide a Context whose owned flags collide with an ancestor Context's.
 
-A definition can add other definitions. Context providers are inherited on the materialized command path; a nested definition accesses one by declaring its factory in `uses` and awaiting the corresponding `ctx` property.
+A definition can add other definitions. Context providers are inherited on the materialized command path; a nested definition accesses one by declaring its factory with `.use()` and awaiting the corresponding `ctx` property.
 
 The typed [`run()`](#runpath-input-io) shape of an added definition merges the Context-owned flags already provided on the parent path, matching the runtime parser: descendants accept inherited Context-owned flags, while parent-local flags stay excluded.
 
@@ -317,6 +319,30 @@ The typed [`run()`](#runpath-input-io) shape of an added definition merges the C
   Finalize Contexts on the builder used for `.add()`. Later fluent calls create a new builder and do
   not backfill a definition that was already added.
 </Callout>
+
+## `.command(name, recipe)`
+
+```ts
+command<const N extends string, B extends CommandDefinitionBuilder>(
+  name: N & EmptyNameBrand<N>,
+  recipe: (command: CommandDefinitionBuilder) => B,
+): Crust
+```
+
+Defines an app-local leaf subcommand inline — root-only sugar for `.add(defineCommand(name, recipe))`:
+
+```ts
+const app = new Crust("my-cli").provide(logging()).command("up", (command) =>
+  command.flags({ name: "detach", type: "boolean" }).action(async ({ flags, ctx, stdout }) => {
+    (await ctx.logging).debug(`detach: ${String(flags.detach)}`);
+    stdout("up");
+  }),
+);
+```
+
+The recipe builder is seeded with the Contexts and Context-owned flags accumulated on the builder so far — the call site — so the inline action's `ctx` is typed without `.use()` declarations. Contexts provided after the `.command()` call are not visible to it, matching the positional semantics of `.provide()`. Inline `.use()` demands that the call site does not satisfy fail typecheck with `FIX_MISSING_DEPENDENCY`.
+
+Use `.command()` for short, app-local leaf commands; extract to `defineCommand` when a command needs its own file, reuse, or a package. `.command()` exists on `Crust` roots and is intentionally absent from `CommandDefinitionBuilder`.
 
 ## `.snapshot()`
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -240,7 +240,7 @@ Extracts the awaited value type a Context factory produces: `FactoryValueOf<type
 type ContextMap = object;
 ```
 
-The upper bound for the name/value registry accumulated by `.provide()` and Extension `provides`. It is a phantom constraint: the builder infers the concrete property map, so consumer-defined context shapes do not need a string index signature. Command actions receive `ContextBag<Ctx>` for that inferred registry. Reusable command definitions and Extensions expose only Contexts declared in their `uses` contract.
+The upper bound for the name/value registry accumulated by `.provide()` and Extension `provides`. It is a phantom constraint: the builder infers the concrete property map, so consumer-defined context shapes do not need a string index signature. Command actions receive `ContextBag<Ctx>` for that inferred registry. Reusable command definitions and Extensions expose only Contexts declared through chained `.use()` calls (command definitions) or the `uses` config field (Extensions).
 
 ## Extension types
 

--- a/apps/docs/content/docs/guide/contexts.mdx
+++ b/apps/docs/content/docs/guide/contexts.mdx
@@ -34,8 +34,8 @@ const api = defineContext("api", { flags: [apiKey] }, ({ flags }) => ({
   get: (path: string) => `${flags["api-key"] ?? "anonymous"}:${path}`,
 }));
 
-const deploy = defineCommand("deploy", { uses: [api] }, (command) =>
-  command.action(async ({ ctx, stdout }) => {
+const deploy = defineCommand("deploy", (command) =>
+  command.use(api).action(async ({ ctx, stdout }) => {
     stdout((await ctx.api).get("/deploy"));
   }),
 );
@@ -61,7 +61,7 @@ new Crust("app").provide(database(), config());
 
 Dependencies remain lazy: `config` starts only if setup accesses `ctx.config`. A `.provide()` call verifies the transitive dependency closure at the type level and at definition time. Dependencies may appear in either order within one call; across calls, provide dependencies first so the next call can be checked.
 
-Reusable commands and Extensions declare their dependencies with the same `uses: [factory]` field. `.add()` and `.extend()` validate those declarations against Contexts already provided on the builder. Put `.provide()` or provider `.extend()` calls before `.add()`.
+Reusable commands declare demand with chained `.use(factory)` calls — `.use(logger)` demands (a factory), `.provide(logger())` supplies (an instance) — and Extensions declare theirs with the `uses` config field. `.add()` and `.extend()` validate those declarations against Contexts already provided on the builder. Put `.provide()` or provider `.extend()` calls before `.add()`.
 
 Contexts are inherited by descendants present when the builder is added. Immutable builder chains do not backfill already-added children.
 

--- a/apps/docs/content/docs/guide/flags.mdx
+++ b/apps/docs/content/docs/guide/flags.mdx
@@ -91,8 +91,8 @@ const logging = defineContext("logging", { flags: [verbose] }, ({ flags, stderr 
   },
 }));
 
-const deploy = defineCommand("deploy", { uses: [logging] }, (command) =>
-  command.action(async ({ ctx }) => (await ctx.logging).debug("deploying")),
+const deploy = defineCommand("deploy", (command) =>
+  command.use(logging).action(async ({ ctx }) => (await ctx.logging).debug("deploying")),
 );
 
 const app = new Crust("app").provide(logging()).add(deploy);

--- a/apps/docs/content/docs/guide/split-files.mdx
+++ b/apps/docs/content/docs/guide/split-files.mdx
@@ -41,8 +41,8 @@ The composition root imports both sides:
   ../../../examples/split-files/cli.ts
 </include>
 
-Because `.provide(logger())` precedes `.add()`, the logger and its owned `--verbose` flag are available on the command path. The `uses: [logger]` contract is checked when the definition is added. [How `.add()` and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-adding rule — is covered in Subcommands.
+Because `.provide(logger())` precedes `.add()`, the logger and its owned `--verbose` flag are available on the command path. The `.use(logger)` contract is checked when the definition is added. [How `.add()` and `.as()` renaming work](/docs/guide/subcommands) — including the finalize-before-adding rule — is covered in Subcommands.
 
 ## Inline or split?
 
-Add `defineCommand(name, recipe)` inline when the implementation is short and local. Move the definition to its own file when that improves readability or when the same command should be added more than once; the `uses` contract keeps its dependencies explicit and type-checkable.
+Use inline `.command(name, recipe)` on the root for app-local leaf commands that stay short. Extract to `defineCommand` when a command needs its own file, reuse, or a package; the `.use()` contract keeps its dependencies explicit and type-checkable either way.

--- a/apps/docs/content/docs/guide/subcommands.mdx
+++ b/apps/docs/content/docs/guide/subcommands.mdx
@@ -23,7 +23,7 @@ Routing consumes command names before parsing the resolved command's arguments a
 
 ## Requirements
 
-A definition declares Context capabilities in `uses` and awaits them from its typed `ctx` bag. The app decides where to provide them:
+A definition declares Context capabilities with chained `.use(factory)` calls and awaits them from its typed `ctx` bag. The app decides where to provide them:
 
 ```ts
 import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
@@ -38,8 +38,10 @@ const repository = defineContext("repository", () => ({
   defaultBranch: "main",
 }));
 
-const clone = defineCommand("clone", { uses: [logging, repository] }, (command) =>
+const clone = defineCommand("clone", (command) =>
   command
+    .use(logging)
+    .use(repository)
     .args({ name: "url", type: "url", required: true })
     .action(async ({ args, ctx, stdout }) => {
       (await ctx.logging).debug(`cloning ${args.url}`);
@@ -66,14 +68,17 @@ Definitions can add other definitions. Providers available on that command path 
 const environment = defineFlag("environment", { type: "string" });
 const deployment = defineContext("deployment", { flags: [environment] }, ({ flags }) => flags);
 
-const status = defineCommand("status", { uses: [logging, deployment] }, (command) =>
-  command.action(async ({ ctx }) => {
-    (await ctx.logging).debug(`environment: ${(await ctx.deployment).environment}`);
-  }),
+const status = defineCommand("status", (command) =>
+  command
+    .use(logging)
+    .use(deployment)
+    .action(async ({ ctx }) => {
+      (await ctx.logging).debug(`environment: ${(await ctx.deployment).environment}`);
+    }),
 );
 
-const deploy = defineCommand("deploy", { uses: [logging] }, (command) =>
-  command.provide(deployment()).add(status),
+const deploy = defineCommand("deploy", (command) =>
+  command.use(logging).provide(deployment()).add(status),
 );
 
 const app = new Crust("app").provide(logging()).add(deploy);
@@ -81,7 +86,7 @@ const app = new Crust("app").provide(logging()).add(deploy);
 
 ## Context inheritance
 
-Adding materializes a fresh command scope seeded with the parent's current Context path. Nested definitions declare inherited providers in `uses`; the corresponding lazy bag property carries the factory's value type.
+Adding materializes a fresh command scope seeded with the parent's current Context path. Nested definitions declare inherited providers with `.use()`; the corresponding lazy bag property carries the factory's value type.
 
 Finalize `.provide()` calls on the parent builder before `.add()`. [Flags owned by a provided Context](/docs/guide/contexts#owned-flags) propagate only into descendants added later. Later fluent calls return a new builder and do not backfill a definition that was already added.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -32,7 +32,7 @@ $ greet --help
 
 ## Philosophy
 
-- **One way to do it.** One starter pattern. `defineCommand()` for every command; `new Crust()` appears exactly once, at the root.
+- **One way to do it.** One starter pattern. Inline `.command()` for app-local commands, `defineCommand()` when a command needs its own file, reuse, or a package; `new Crust()` appears exactly once, at the root.
 - **Inference over annotation.** Types flow from definitions to actions. No decorators, no codegen, no manual generics.
 - **Plain values, immutable builders.** Definitions and Extensions are frozen data; every fluent call returns a new builder.
 - **TypeScript-first definitions.** Statically known collisions and malformed definitions fail at their authoring call sites during type checking; argv is still validated at runtime.

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -18,10 +18,13 @@ import { Crust } from "@crustjs/core";
 
 const app = new Crust("hello")
   .flags({ name: "verbose", type: "boolean", short: "v" })
-  .action(({ flags, stdout }) => stdout(flags.verbose ? "hello!" : "hello"));
+  .action(({ flags, stdout }) => stdout(flags.verbose ? "hello!" : "hello"))
+  .command("wave", (command) => command.action(({ stdout }) => stdout("o/")));
 
 await app.execute();
 ```
+
+Inline `.command()` defines app-local leaf subcommands; extract to [`defineCommand`](/docs/api/crust) when a command needs its own file, reuse, or a package. Commands declare Context demand with `.use(factory)` and applications supply values with `.provide(instance)`.
 
 ## Context-owned flags
 
@@ -42,16 +45,16 @@ Downstream commands and other Context setups call `await ctx.api`. See [Contexts
 
 ## Runtime exports
 
-| Export                                | Description                                                                                                                                         |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, `.add()`, `.action()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
-| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition                                                                                                   |
-| `defineContext(name, config?, setup)` | Define a named Context factory with optional owned flags; setup receives its declared lazy Context bag and invocation I/O                           |
-| `defineExtension(id, config)`         | Define a frozen, application-wide Extension value                                                                                                   |
-| `defineExtensionId(id)`               | Mint a branded Extension identity from any non-blank string                                                                                         |
-| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                            |
-| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                             |
-| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                           |
+| Export                                | Description                                                                                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`Crust`](/docs/api/crust)            | Immutable command builder with Context `.provide()`, inline `.command()`, `.add()`, `.action()`, tooling `.snapshot()`, programmatic `.run()`, and terminal `.execute()` |
+| [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition; its builder declares Context demand with chained `.use()`                                                             |
+| `defineContext(name, config?, setup)` | Define a named Context factory with optional owned flags; setup receives its declared lazy Context bag and invocation I/O                                                |
+| `defineExtension(id, config)`         | Define a frozen, application-wide Extension value                                                                                                                        |
+| `defineExtensionId(id)`               | Mint a branded Extension identity from any non-blank string                                                                                                              |
+| `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                                                 |
+| `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                                                  |
+| [`CrustError`](/docs/api/errors)      | Framework error for definition, routing, parsing, and validation failures                                                                                                |
 
 ## Definition types
 

--- a/apps/docs/content/docs/quick-start.mdx
+++ b/apps/docs/content/docs/quick-start.mdx
@@ -28,7 +28,7 @@ bun run src/cli.ts Ada --greet Welcome
 
 <include lang="ts">../../examples/quick-start/subcommand.ts</include>
 
-Use [the split-file pattern](/docs/guide/split-files) when the command tree grows.
+Inline `.command()` suits app-local leaf commands. Extract to `defineCommand` and [the split-file pattern](/docs/guide/split-files) when a command needs its own file, reuse, or a package.
 
 ## Invoke from code
 

--- a/apps/docs/examples/quick-start/subcommand.ts
+++ b/apps/docs/examples/quick-start/subcommand.ts
@@ -1,12 +1,10 @@
-import { Crust, defineCommand } from "@crustjs/core";
+import { Crust } from "@crustjs/core";
 import { help } from "@crustjs/extensions";
 
 export const app = new Crust("my-cli")
   .extend(help())
-  .add(
-    defineCommand("build", (command) =>
-      command
-        .flags({ name: "minify", type: "boolean" })
-        .action(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
-    ),
+  .command("build", (command) =>
+    command
+      .flags({ name: "minify", type: "boolean" })
+      .action(({ flags, stdout }) => stdout(`minify: ${flags.minify ?? false}`)),
   );

--- a/apps/docs/examples/split-files/commands/greet.ts
+++ b/apps/docs/examples/split-files/commands/greet.ts
@@ -2,8 +2,9 @@ import { defineCommand } from "@crustjs/core";
 
 import { logger } from "../shared.ts";
 
-export const greetCommand = defineCommand("greet", { uses: [logger] }, (command) =>
+export const greetCommand = defineCommand("greet", (command) =>
   command
+    .use(logger)
     .args({ name: "name", type: "string", default: "world" })
     .flags({ name: "greeting", type: "string", default: "Hello", short: "g" })
     .action(async ({ args, flags, ctx, stdout }) => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,9 +15,27 @@ import { Crust } from "@crustjs/core";
 
 const app = new Crust("hello")
 	.flags({ name: "verbose", type: "boolean", short: "v" })
-	.action(({ flags, stdout }) => stdout(flags.verbose ? "hello!" : "hello"));
+	.action(({ flags, stdout }) => stdout(flags.verbose ? "hello!" : "hello"))
+	.command("wave", (command) => command.action(({ stdout }) => stdout("o/")));
 
 await app.execute();
+```
+
+Inline `.command()` defines app-local leaf subcommands; extract to `defineCommand` when a command needs its own file, reuse, or a package. Commands declare Context demand with `.use(factory)` and applications supply values with `.provide(instance)`.
+
+```ts
+import { Crust, defineCommand, defineContext } from "@crustjs/core";
+
+const logger = defineContext("logger", () => ({ write: console.error }));
+
+const greet = defineCommand("greet", (command) =>
+	command.use(logger).action(async ({ ctx, stdout }) => {
+		(await ctx.logger).write("greeting");
+		stdout("hello");
+	}),
+);
+
+await new Crust("my-cli").provide(logger()).add(greet).execute();
 ```
 
 The package root contains invocation-time authoring and execution APIs. Import build- and render-time helpers such as `buildCommandDocumentation`, `isListed`, `sectionsFor`, and `visibleSectionsFor` from `@crustjs/core/tooling`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,38 +8,6 @@ Core library for the Crust CLI framework.
 bun add @crustjs/core
 ```
 
-## Quick example
-
-```ts
-import { Crust } from "@crustjs/core";
-
-const app = new Crust("hello")
-	.flags({ name: "verbose", type: "boolean", short: "v" })
-	.action(({ flags, stdout }) => stdout(flags.verbose ? "hello!" : "hello"))
-	.command("wave", (command) => command.action(({ stdout }) => stdout("o/")));
-
-await app.execute();
-```
-
-Inline `.command()` defines app-local leaf subcommands; extract to `defineCommand` when a command needs its own file, reuse, or a package. Commands declare Context demand with `.use(factory)` and applications supply values with `.provide(instance)`.
-
-```ts
-import { Crust, defineCommand, defineContext } from "@crustjs/core";
-
-const logger = defineContext("logger", () => ({ write: console.error }));
-
-const greet = defineCommand("greet", (command) =>
-	command.use(logger).action(async ({ ctx, stdout }) => {
-		(await ctx.logger).write("greeting");
-		stdout("hello");
-	}),
-);
-
-await new Crust("my-cli").provide(logger()).add(greet).execute();
-```
-
-The package root contains invocation-time authoring and execution APIs. Import build- and render-time helpers such as `buildCommandDocumentation`, `isListed`, `sectionsFor`, and `visibleSectionsFor` from `@crustjs/core/tooling`.
-
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/core](https://crustjs.com/docs/modules/core)

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -28,8 +28,10 @@ describe("public beta API", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose === true,
 		}));
-		const deploy = defineCommand("deploy", { uses: [logging, db] }, (cmd) =>
+		const deploy = defineCommand("deploy", (cmd) =>
 			cmd
+				.use(logging)
+				.use(db)
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "env", type: "string", default: "prod" })
 				.action(async ({ args, flags, ctx }) => {
@@ -57,8 +59,9 @@ describe("public beta API", () => {
 	it("adds one definition twice via .as()", async () => {
 		const seen: string[] = [];
 		const auth = defineContext("auth", () => ({ user: "chenxin" }));
-		const deploy = defineCommand("deploy", { uses: [auth] }, (command) =>
+		const deploy = defineCommand("deploy", (command) =>
 			command
+				.use(auth)
 				.args({ name: "target", type: "string", required: true })
 				.action(async ({ args, ctx }) => {
 					const identity = await ctx.auth;

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -1451,6 +1451,44 @@ describe("inline .command()", () => {
 		void invalidCompositions;
 	});
 
+	it("demands the union of branch deps from a conditionally-returned recipe", async () => {
+		const a = defineContext("a", () => "a-value");
+		const b = defineContext("b", () => "b-value");
+		const choose: boolean = false;
+		const either = defineCommand("either", (cmd) =>
+			choose
+				? cmd.use(a).action(async ({ ctx }) => await ctx.a)
+				: cmd.use(b).action(async ({ ctx }) => await ctx.b),
+		);
+
+		// Supplying both branches' demands composes cleanly.
+		new Crust("cli").provide(a(), b()).add(either);
+
+		const invalidCompositions = () => {
+			// @ts-expect-error -- neither branch's demand is provided
+			new Crust("cli").add(either);
+			// @ts-expect-error -- inline recipe: union of branch demands is unmet
+			new Crust("cli").command("either", (cmd) =>
+				choose
+					? cmd.use(a).action(async ({ ctx }) => void (await ctx.a))
+					: cmd.use(b).action(async ({ ctx }) => void (await ctx.b)),
+			);
+		};
+		void invalidCompositions;
+
+		// Why the union is demanded: `.use()` records nothing at runtime, so a
+		// branch whose Context was never provided silently reads `undefined` off
+		// the bag instead of failing loud.
+		const app = new Crust("cli")
+			.provide(a())
+			// @ts-expect-error -- deliberately supply only the unchosen branch's demand
+			.add(either);
+		const outcome = await app.run(["either"]);
+		expect(outcome.status).toBe("completed");
+		// The action's `string`-typed result is actually `undefined` — the hole made real.
+		expect(outcome.status === "completed" && outcome.result).toBeUndefined();
+	});
+
 	it("brands inline flags that collide with registered Extension flags, matching .add()", () => {
 		const tracer = defineExtension(defineExtensionId("tracer"), {
 			flags: [{ name: "trace", type: "boolean" }],

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -117,10 +117,10 @@ describe("Crust .provide()", () => {
 	it("seeds added descendants with the parent Context path", async () => {
 		const seen: string[] = [];
 		const db = defineContext("db", () => "root-db");
-		const sub = defineCommand("sub", { uses: [db] }, (command) =>
-			command.add(
-				defineCommand("g", { uses: [db] }, (child) =>
-					child.action(async ({ ctx }) => {
+		const sub = defineCommand("sub", (command) =>
+			command.use(db).add(
+				defineCommand("g", (child) =>
+					child.use(db).action(async ({ ctx }) => {
 						seen.push(await ctx.db);
 					}),
 				),
@@ -177,8 +177,8 @@ describe("Crust .provide()", () => {
 
 		const seen: string[] = [];
 		const app = new Crust("cli").provide(base(), mid(), db(), unrelated()).add(
-			defineCommand("query", { uses: [db] }, (cmd) =>
-				cmd.action(async ({ ctx }) => {
+			defineCommand("query", (cmd) =>
+				cmd.use(db).action(async ({ ctx }) => {
 					seen.push(await ctx.db);
 				}),
 			),
@@ -215,11 +215,7 @@ describe("Crust .provide()", () => {
 
 		const app = new Crust("cli")
 			.provide(a(), b(), c(), d())
-			.add(
-				defineCommand("go", { uses: [d] }, (cmd) =>
-					cmd.action(async ({ ctx }) => void (await ctx.d)),
-				),
-			);
+			.add(defineCommand("go", (cmd) => cmd.use(d).action(async ({ ctx }) => void (await ctx.d))));
 
 		await app.run(["go"]);
 
@@ -246,10 +242,13 @@ describe("Crust .provide()", () => {
 
 		const seen: string[] = [];
 		const app = new Crust("cli").provide(session(), unrelated()).add(
-			defineCommand("account", { uses: [session] }, (cmd) =>
-				cmd.provide(user()).action(async ({ ctx }) => {
-					seen.push(await ctx.user);
-				}),
+			defineCommand("account", (cmd) =>
+				cmd
+					.use(session)
+					.provide(user())
+					.action(async ({ ctx }) => {
+						seen.push(await ctx.user);
+					}),
 			),
 		);
 
@@ -379,8 +378,8 @@ describe("Context-owned flags", () => {
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			apiKey: flags["api-key"],
 		}));
-		const deploy = defineCommand("deploy", { uses: [auth] }, (command) =>
-			command.action(async ({ ctx }) => {
+		const deploy = defineCommand("deploy", (command) =>
+			command.use(auth).action(async ({ ctx }) => {
 				seen.push(String((await ctx.auth).apiKey));
 			}),
 		);
@@ -462,8 +461,8 @@ describe("Context setup dependencies", () => {
 		new Crust("cli").provide(fake);
 		new Crust("cli").provide(db(), config());
 
-		const command = defineCommand("run", { uses: [db] }, (builder) =>
-			builder.action(async ({ ctx }) => {
+		const command = defineCommand("run", (builder) =>
+			builder.use(db).action(async ({ ctx }) => {
 				void (await ctx.db);
 				// @ts-expect-error -- action bags expose only declared Contexts
 				void ctx.logger;
@@ -900,8 +899,8 @@ describe("lazy Context bags", () => {
 			uses: [logger],
 			hooks: { preRun: async (ctx) => void events.push((await ctx.ctx.logger).label) },
 		});
-		const command = defineCommand("run", { uses: [logger] }, (builder) =>
-			builder.action(async ({ ctx }) => void events.push((await ctx.logger).label)),
+		const command = defineCommand("run", (builder) =>
+			builder.use(logger).action(async ({ ctx }) => void events.push((await ctx.logger).label)),
 		);
 		const app = new Crust("cli").extend(provider, consumer).add(command);
 
@@ -1367,5 +1366,106 @@ describe("FallbackAsyncDisposableStack", () => {
 		};
 		await expect(run()).rejects.toThrow("boom");
 		expect(order).toEqual(["last", "first"]);
+	});
+});
+
+describe("inline .command()", () => {
+	it("seeds the recipe with call-site Contexts and types the inline action", async () => {
+		const auth = defineContext("auth", () => ({ user: "chenxin" }));
+		const app = new Crust("cli").provide(auth()).command("whoami", (cmd) =>
+			cmd
+				.flags({ name: "loud", type: "boolean" })
+				.args({ name: "suffix", type: "string" })
+				.action(async ({ args, flags, ctx }) => {
+					type _Suffix = Assert<IsEqual<typeof args.suffix, string | undefined>>;
+					type _Loud = Assert<IsEqual<typeof flags.loud, boolean | undefined>>;
+					const identity = await ctx.auth;
+					type _Auth = Assert<IsEqual<typeof identity, { user: string }>>;
+					// @ts-expect-error -- undeclared Contexts are absent from the inline bag
+					void ctx.missing;
+					return `${identity.user}${args.suffix ?? ""}`;
+				}),
+		);
+
+		const outcome = await app.run(["whoami"], { args: { suffix: "!" } });
+		expect(outcome).toEqual({ status: "completed", result: "chenxin!" });
+	});
+
+	it("does not see Contexts provided after the .command() call site", async () => {
+		const logger = defineContext("logger", () => "logger");
+		const app = new Crust("cli")
+			.command("early", (cmd) =>
+				cmd.action(({ ctx }) => {
+					// @ts-expect-error -- .provide() is positional; a later Context never reaches an earlier .command()
+					void ctx.logger;
+					// Runtime matches the types: the earlier child path never inherits
+					// the later Context, so its bag has no such member.
+					return "logger" in ctx;
+				}),
+			)
+			.provide(logger())
+			.action(async ({ ctx }) => "logger" in ctx && (await ctx.logger));
+
+		expect(await app.run(["early"])).toEqual({ status: "completed", result: false });
+		// The root path itself sees the Context it provided.
+		expect(await app.run([])).toEqual({ status: "completed", result: "logger" });
+	});
+
+	it("brands inline .use() demands that the call site does not provide", () => {
+		const config = defineContext("config", () => ({ url: "memory://" }));
+		const db = defineContext("db", { uses: [config] }, async ({ ctx }) => await ctx.config);
+
+		// Satisfied demand (including db's transitive closure) composes cleanly.
+		new Crust("cli")
+			.provide(config(), db())
+			.command("query", (cmd) => cmd.use(db).action(async ({ ctx }) => void (await ctx.db)));
+
+		const invalidCompositions = () => {
+			// @ts-expect-error -- inline .use(db) demand is unmet at the call site
+			new Crust("cli").command("query", (cmd) => cmd.use(db).action(() => {}));
+			new Crust("cli")
+				.provide(db.of({ url: "fake" }))
+				// @ts-expect-error -- db's transitive config dependency is still unmet
+				.command("query", (cmd) => cmd.use(db).action(() => {}));
+		};
+		void invalidCompositions;
+	});
+
+	it("keeps .use() brand parity for defineCommand at .add() and .extend()", () => {
+		const config = defineContext("config", () => ({ url: "memory://" }));
+		const db = defineContext("db", { uses: [config] }, async ({ ctx }) => await ctx.config);
+		const query = defineCommand("query", (cmd) =>
+			cmd.use(db).action(async ({ ctx }) => void (await ctx.db)),
+		);
+		const carrier = defineExtension(defineExtensionId("carrier"), { commands: [query] });
+
+		new Crust("cli").provide(config(), db()).add(query);
+		new Crust("cli").provide(config(), db()).extend(carrier);
+
+		const invalidCompositions = () => {
+			// @ts-expect-error -- db's transitive config dependency is unmet at .add()
+			new Crust("cli").provide(db.of({ url: "fake" })).add(query);
+			// @ts-expect-error -- db's transitive config dependency is unmet at .extend()
+			new Crust("cli").provide(db.of({ url: "fake" })).extend(carrier);
+		};
+		void invalidCompositions;
+	});
+
+	it("rejects a Context instance passed to .use() at runtime", () => {
+		const logger = defineContext("logger", () => "logger");
+		expect(() =>
+			new Crust("cli").command("sub", (cmd) =>
+				// SAFETY: deliberately bypass the factory-only signature to verify the runtime guard.
+				(cmd.use as (instance: ContextInstance) => never)(logger()),
+			),
+		).toThrow(/expects a Context factory/);
+	});
+
+	it("rejects an inline command name that is already registered", () => {
+		expect(() =>
+			new Crust("cli")
+				.command("dup", (cmd) => cmd.action(() => {}))
+				.command("dup", (cmd) => cmd.action(() => {})),
+		).toThrow(/already registered/);
 	});
 });

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -1451,6 +1451,33 @@ describe("inline .command()", () => {
 		void invalidCompositions;
 	});
 
+	it("brands inline flags that collide with registered Extension flags, matching .add()", () => {
+		const tracer = defineExtension(defineExtensionId("tracer"), {
+			flags: [{ name: "trace", type: "boolean" }],
+		});
+		const rootOnly = defineExtension(defineExtensionId("root-only"), {
+			flags: [{ name: "depth", type: "string", recursive: false }],
+		});
+		const nestedColliding = defineCommand("child", (cmd) =>
+			cmd.flags({ name: "trace", type: "boolean" }).action(() => {}),
+		);
+
+		// Collision-free recipes compose cleanly after .extend().
+		new Crust("cli").extend(tracer).command("ok", (cmd) => cmd.action(() => {}));
+
+		const invalidCompositions = () => {
+			new Crust("cli")
+				.extend(tracer)
+				// @ts-expect-error -- nested child's "trace" collides with tracer's recursive flag (parity with .add())
+				.command("query", (cmd) => cmd.add(nestedColliding).action(() => {}));
+			new Crust("cli")
+				.extend(rootOnly)
+				// @ts-expect-error -- inline "depth" collides with a registered Extension flag (parity with .add())
+				.command("query", (cmd) => cmd.flags({ name: "depth", type: "string" }).action(() => {}));
+		};
+		void invalidCompositions;
+	});
+
 	it("rejects a Context instance passed to .use() at runtime", () => {
 		const logger = defineContext("logger", () => "logger");
 		expect(() =>

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -469,10 +469,11 @@ describe("Crust .add() type-level tests", () => {
 			.flags({ name: "rootOnly", type: "string" })
 			.provide(logging())
 			.add(
-				defineCommand("level1", { uses: [logging] }, (command) =>
-					command.add(
-						defineCommand("level2", { uses: [logging] }, (child) =>
+				defineCommand("level1", (command) =>
+					command.use(logging).add(
+						defineCommand("level2", (child) =>
 							child
+								.use(logging)
 								.args({ name: "target", type: "string", required: true })
 								.action(async ({ args, flags, ctx }) => {
 									const log = await ctx.logging;
@@ -2095,8 +2096,8 @@ describe("Crust .execute()", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => ({
 			verbose: flags.verbose === true,
 		}));
-		const sub = defineCommand("sub", { uses: [logging] }, (command) =>
-			command.action(async ({ ctx }) => {
+		const sub = defineCommand("sub", (command) =>
+			command.use(logging).action(async ({ ctx }) => {
 				receivedVerbose = (await ctx.logging).verbose;
 			}),
 		);
@@ -2115,8 +2116,8 @@ describe("Crust .execute()", () => {
 			port: flags.port,
 		}));
 		const app = new Crust("cli").provide(ports()).add(
-			defineCommand("sub", { uses: [ports] }, (cmd) =>
-				cmd.action(async ({ ctx }) => {
+			defineCommand("sub", (cmd) =>
+				cmd.use(ports).action(async ({ ctx }) => {
 					receivedPort = (await ctx.ports).port;
 				}),
 			),
@@ -2135,8 +2136,8 @@ describe("Crust .execute()", () => {
 			verbose: flags.verbose,
 		}));
 		const app = new Crust("cli").provide(logging()).add(
-			defineCommand("sub", { uses: [logging] }, (cmd) =>
-				cmd.action(async ({ ctx }) => {
+			defineCommand("sub", (cmd) =>
+				cmd.use(logging).action(async ({ ctx }) => {
 					receivedVerbose = (await ctx.logging).verbose;
 				}),
 			),

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -59,7 +59,7 @@ import type {
 	SpellingsOf,
 	ValidateNamedFlagDefs,
 } from "../validation/flags.brands.ts";
-import type { IsStaticTuple, IsUnion } from "../validation/shared.ts";
+import type { IsStaticTuple, IsUnion, UnionToIntersection } from "../validation/shared.ts";
 import { cloneCommandNode, installExtensionContexts } from "./extensions-install.ts";
 import {
 	executeInvocation,
@@ -496,9 +496,19 @@ type ShapeOfBuilder<B> =
 
 // Deps accumulated by `.use()` calls inside the recipe; `defineCommand` and
 // `Crust.command()` extract them from the recipe's returned builder type.
+// A conditionally-returning recipe (`cond ? cmd.use(a)... : cmd.use(b)...`)
+// infers `B` as a union; the naked-`B` conditional distributes, so without
+// merging, `Deps` would be a union whose `keyof` is the branches'
+// INTERSECTION — disjoint demands would validate as demanding nothing. A
+// conditional recipe demands the UNION of its branches' keys, so merge before
+// any key extraction.
 type DepsOfBuilder<B> =
-	B extends CommandDefinitionBuilder<any, any, any, any, any, any, any, any, infer Deps>
-		? Deps
+	UnionToIntersection<
+		B extends CommandDefinitionBuilder<any, any, any, any, any, any, any, any, infer Deps>
+			? Deps
+			: {}
+	> extends infer Merged extends ContextMap
+		? Merged
 		: {};
 
 // Matching against CommandDefinitionSpellings (never for widened names) keeps a

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -43,7 +43,7 @@ import type {
 	ValidateExtensionCommands,
 } from "../validation/commands.brands.ts";
 import type {
-	DeclaredDepsOf,
+	MissingDeclaredDependencyBrand,
 	ValidateContextDeps,
 	ValidateContextNames,
 	ValidateDeclaredDeps,
@@ -961,15 +961,10 @@ type AfterAdd<
 // Missing-dependency brand for inline `.command()`: parity with
 // `ValidateDeclaredDeps` at `.add()`, attached to the name parameter because
 // the builder type `B` is inferred from the recipe argument itself.
-type ValidateInlineCommandDeps<Ctx extends ContextMap, B> =
-	Exclude<
-		keyof DeclaredDepsOf<{ readonly _deps?: DepsOfBuilder<B> }> & string,
-		string extends keyof Ctx ? never : keyof Ctx & string
-	> extends infer Missing extends string
-		? [Missing] extends [never]
-			? unknown
-			: { readonly FIX_MISSING_DEPENDENCY: `Uses Context "${Missing}" which is not provided` }
-		: never;
+type ValidateInlineCommandDeps<Ctx extends ContextMap, B> = MissingDeclaredDependencyBrand<
+	{ readonly _deps?: DepsOfBuilder<B> },
+	string extends keyof Ctx ? never : keyof Ctx & string
+>;
 
 /** Broad application type for APIs that accept any fully-built Crust application. */
 export type AnyCrust = Crust<any, any, any, any, any, any, any, any, any>;

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -53,6 +53,7 @@ import type {
 	ExtensionsSpellings,
 	ProvideChecks,
 	DefinitionTreeSpellings,
+	ShapeFlagCollisionBrand,
 	ValidateDefinitionFlags,
 	ValidateExtensionFlags,
 	SpellingsOf,
@@ -1286,7 +1287,13 @@ export class Crust<
 	 * expose this method.
 	 */
 	command<const N extends string, B extends AnyCommandDefinitionBuilder>(
-		name: N & EmptyNameBrand<N> & ValidateInlineCommandDeps<Ctx, B>,
+		// ShapeFlagCollisionBrand keeps parity with `.add()`'s ValidateDefinitionFlags:
+		// the recipe's whole tree (including nested `.add()` children, which the seeded
+		// `Sp` cannot see) is checked against registered Extension flag spellings.
+		name: N &
+			EmptyNameBrand<N> &
+			ValidateInlineCommandDeps<Ctx, B> &
+			ShapeFlagCollisionBrand<ShapeOfBuilder<B>, CollisionSp["extension"]>,
 		recipe: (
 			command: CommandDefinitionBuilder<{}, [], Ctx, never, SpellingsOf<CtxFlags>, {}, CtxFlags>,
 		) => B,

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -9,7 +9,6 @@ import type {
 	ContextsOutput,
 	ContextsOwnedFlags,
 	MergeContext,
-	UsesOf,
 } from "../api/context.ts";
 import type { Extension, ExtensionsProvidesOutput } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
@@ -44,6 +43,7 @@ import type {
 	ValidateExtensionCommands,
 } from "../validation/commands.brands.ts";
 import type {
+	DeclaredDepsOf,
 	ValidateContextDeps,
 	ValidateContextNames,
 	ValidateDeclaredDeps,
@@ -224,8 +224,6 @@ export type RunArguments<Shape extends CommandShape> = readonly [
 export interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
 	/** Plain-text sections rendered after built-in command documentation. */
 	readonly sections?: readonly CommandSectionInput[];
-	/** Contexts this command consumes. */
-	readonly uses?: readonly AnyContextFactory[];
 }
 
 /** Static metadata accepted by the root command constructor. */
@@ -239,26 +237,32 @@ function copyUnvalidatedSections(sections: readonly CommandSectionInput[]): Comm
 	return sections.map((section) => ({ ...section })) as CommandSection[];
 }
 
-type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<any, any, any, any, any, any, any, any>;
+type AnyCommandDefinitionBuilder = CommandDefinitionBuilder<
+	any,
+	any,
+	any,
+	any,
+	any,
+	any,
+	any,
+	any,
+	any
+>;
 
 // Child builders start without inherited flags, so brands cannot see ancestor
 // spellings from inside a sealed recipe. Materialization seeds the child with
 // the parent's owned flags and catches collisions at runtime: `.flags()` hits
 // the seeded spelling table, and recipe-provided Contexts are checked against
 // ancestor owners in `materializeCommandDefinition`.
-type CommandRecipe<
-	Deps extends ContextMap = {},
-	Builder extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder,
-> = (command: CommandDefinitionBuilder<{}, [], Deps, never, never>) => Builder;
-
-type CommandDeps<C extends CommandConfig> = ContextDependencies<UsesOf<C>>;
+type CommandRecipe<Builder extends AnyCommandDefinitionBuilder = AnyCommandDefinitionBuilder> = (
+	command: CommandDefinitionBuilder<{}, [], {}, never, never>,
+) => Builder;
 
 const commandDefinitionInternal: unique symbol = Symbol.for("crust.commandDefinition");
 
 interface CommandDefinitionInternal {
 	readonly recipe: (command: AnyCommandDefinitionBuilder) => AnyCommandDefinitionBuilder;
 	readonly meta: Omit<CommandMeta, "name">;
-	readonly uses: readonly AnyContextFactory[];
 }
 
 export interface CommandDefinition<
@@ -311,7 +315,9 @@ function materializeCommandDefinition(
 	// A compile-time check is structurally impossible: branded generic method parameters compare
 	// recursively, while Crust transitions return Crust and recipe-builder transitions return the
 	// restricted builder type. Runtime validation below still requires Crust return identity.
-	const configured = internal.recipe(child as AnyCommandDefinitionBuilder);
+	/* oxlint-disable anti-slop/no-chained-type-assertions -- Crust's declared type omits the builder-only `.use()` (implemented on its prototype), so the cast must pass through unknown. */
+	const configured = internal.recipe(child as unknown as AnyCommandDefinitionBuilder);
+	/* oxlint-enable anti-slop/no-chained-type-assertions */
 	if (!(configured instanceof Crust) || configured._ancestorOwnedFlags !== parent.ownedFlags) {
 		throw new CrustError(
 			"DEFINITION",
@@ -384,6 +390,7 @@ export interface CommandDefinitionBuilder<
 	Tree extends object = {},
 	out CtxFlags extends FlagsDef = {},
 	Result = void,
+	out Deps extends ContextMap = {},
 > {
 	flags<const Defs extends readonly NamedFlagDef[]>(
 		...defs: ValidateNamedFlagDefs<Defs, Sp>
@@ -395,12 +402,46 @@ export interface CommandDefinitionBuilder<
 		Sp | SpellingsOf<NamedFlagsRecord<Defs>>,
 		Tree,
 		CtxFlags,
-		Result
+		Result,
+		Deps
 	>;
 
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
-	): CommandDefinitionBuilder<Flags, AppendedArgs<A, NewA>, Ctx, Sibs, Sp, Tree, CtxFlags, Result>;
+	): CommandDefinitionBuilder<
+		Flags,
+		AppendedArgs<A, NewA>,
+		Ctx,
+		Sibs,
+		Sp,
+		Tree,
+		CtxFlags,
+		Result,
+		Deps
+	>;
+
+	/**
+	 * Declare a Context this command consumes without supplying its value.
+	 *
+	 * `.use(logger)` is demand (a factory); `.provide(logger())` is supply (an
+	 * instance). Each call accumulates the factory's value and transitive
+	 * dependency closure into the action's typed `ctx`, and into the sealed
+	 * definition's declared dependencies checked at `.provide()`/`.add()`/`.extend()`
+	 * composition sites.
+	 */
+	use<const F extends AnyContextFactory>(
+		factory: F,
+	): CommandDefinitionBuilder<
+		Flags,
+		A,
+		MergeContext<Ctx, ContextDependencies<readonly [F]>>,
+		Sibs,
+		Sp,
+		Tree,
+		CtxFlags,
+		Result,
+		MergeContext<Deps, ContextDependencies<readonly [F]>>
+	>;
 
 	provide<const Cs extends readonly ContextInstance[]>(
 		...instances: ProvideChecks<Sp, Cs> &
@@ -414,7 +455,8 @@ export interface CommandDefinitionBuilder<
 		Sp | SpellingsOf<ContextsOwnedFlags<Cs>>,
 		Tree,
 		MergeFlags<CtxFlags, ContextsOwnedFlags<Cs>>,
-		Result
+		Result,
+		Deps
 	>;
 
 	add<const Ds extends readonly CommandDefinition<any, any, any, any>[]>(
@@ -427,12 +469,13 @@ export interface CommandDefinitionBuilder<
 		Sp,
 		Tree & DefinitionsTree<Ds, CtxFlags>,
 		CtxFlags,
-		Result
+		Result,
+		Deps
 	>;
 
 	action<R>(
 		action: (ctx: NoInfer<CrustCommandContext<A, Flags, Ctx>>) => R,
-	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, Awaited<R>>;
+	): CommandDefinitionBuilder<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, Awaited<R>, Deps>;
 }
 
 type ShapeOfBuilder<B> =
@@ -444,10 +487,18 @@ type ShapeOfBuilder<B> =
 		any,
 		infer Tree,
 		any,
-		infer Result
+		infer Result,
+		any
 	>
 		? CommandShape<A, Flags, Tree, Result>
 		: never;
+
+// Deps accumulated by `.use()` calls inside the recipe; `defineCommand` and
+// `Crust.command()` extract them from the recipe's returned builder type.
+type DepsOfBuilder<B> =
+	B extends CommandDefinitionBuilder<any, any, any, any, any, any, any, any, infer Deps>
+		? Deps
+		: {};
 
 // Matching against CommandDefinitionSpellings (never for widened names) keeps a
 // widened definition in the same tuple or union from degrading a literal
@@ -557,8 +608,8 @@ export function defineCommand<
 	Builder extends AnyCommandDefinitionBuilder,
 >(
 	name: Name & EmptyNameBrand<Name>,
-	recipe: CommandRecipe<{}, Builder>,
-): CommandDefinition<Name, readonly [], ShapeOfBuilder<Builder>>;
+	recipe: CommandRecipe<Builder>,
+): CommandDefinition<Name, readonly [], ShapeOfBuilder<Builder>, DepsOfBuilder<Builder>>;
 export function defineCommand<
 	const Name extends string,
 	const C extends CommandConfig,
@@ -566,8 +617,8 @@ export function defineCommand<
 >(
 	name: Name & EmptyNameBrand<Name>,
 	config: C & ValidateCommandConfig<Name, C>,
-	recipe: CommandRecipe<CommandDeps<C>, Builder>,
-): CommandDefinition<Name, AliasesOf<C>, ShapeOfBuilder<Builder>, CommandDeps<C>>;
+	recipe: CommandRecipe<Builder>,
+): CommandDefinition<Name, AliasesOf<C>, ShapeOfBuilder<Builder>, DepsOfBuilder<Builder>>;
 export function defineCommand(
 	name: string,
 	configOrRecipe: CommandConfig | CommandRecipe,
@@ -577,7 +628,7 @@ export function defineCommand(
 	const config: CommandConfig = hasConfig ? configOrRecipe : {};
 	const recipe = hasConfig ? maybeRecipe : configOrRecipe;
 	if (!recipe) throw new CrustError("DEFINITION", `Command "${name}" requires a recipe`);
-	const { uses = [], sections, ...metaRest } = config;
+	const { sections, ...metaRest } = config;
 	const meta: Omit<CommandMeta, "name"> = {
 		...metaRest,
 		...(config.aliases ? { aliases: [...config.aliases] } : {}),
@@ -586,7 +637,6 @@ export function defineCommand(
 	const internal: CommandDefinitionInternal = {
 		// SAFETY: overloads pair each recipe with its declared dependency context; storage erases it.
 		recipe: recipe as CommandDefinitionInternal["recipe"],
-		uses: Object.freeze([...uses]),
 		meta,
 	};
 	const named = <const DefName extends string>(defName: DefName): CommandDefinition<DefName> => {
@@ -896,6 +946,19 @@ type AfterAdd<
 	CollisionSpellings<CollisionSp["extension"], CollisionSp["tree"] | DefinitionTreeSpellings<Ds>>,
 	Result
 >;
+
+// Missing-dependency brand for inline `.command()`: parity with
+// `ValidateDeclaredDeps` at `.add()`, attached to the name parameter because
+// the builder type `B` is inferred from the recipe argument itself.
+type ValidateInlineCommandDeps<Ctx extends ContextMap, B> =
+	Exclude<
+		keyof DeclaredDepsOf<{ readonly _deps?: DepsOfBuilder<B> }> & string,
+		string extends keyof Ctx ? never : keyof Ctx & string
+	> extends infer Missing extends string
+		? [Missing] extends [never]
+			? unknown
+			: { readonly FIX_MISSING_DEPENDENCY: `Uses Context "${Missing}" which is not provided` }
+		: never;
 
 /** Broad application type for APIs that accept any fully-built Crust application. */
 export type AnyCrust = Crust<any, any, any, any, any, any, any, any, any>;
@@ -1211,6 +1274,60 @@ export class Crust<
 		>({});
 	}
 
+	/**
+	 * Define an app-local leaf subcommand inline (root-only sugar for
+	 * `.add(defineCommand(name, recipe))`).
+	 *
+	 * The recipe builder is seeded with the Contexts and Context-owned flags
+	 * accumulated on this builder so far — the call site. Contexts provided
+	 * after `.command()` are not visible to it, matching the positional runtime
+	 * semantics of `.provide()`. Extract to `defineCommand` when a command needs
+	 * its own file, reuse, or a package. Command definition builders do not
+	 * expose this method.
+	 */
+	command<const N extends string, B extends AnyCommandDefinitionBuilder>(
+		name: N & EmptyNameBrand<N> & ValidateInlineCommandDeps<Ctx, B>,
+		recipe: (
+			command: CommandDefinitionBuilder<{}, [], Ctx, never, SpellingsOf<CtxFlags>, {}, CtxFlags>,
+		) => B,
+	): AfterAdd<
+		Flags,
+		A,
+		Ctx,
+		Sibs,
+		Sp,
+		Tree,
+		CtxFlags,
+		CollisionSp,
+		Result,
+		readonly [CommandDefinition<N, readonly [], ShapeOfBuilder<B>, DepsOfBuilder<B>>]
+	> {
+		/* oxlint-disable anti-slop/no-chained-type-assertions -- inline sugar erases the call-site-seeded recipe generics before delegating to the defineCommand + add runtime. */
+		// SAFETY: the seeded recipe generics restate runtime facts — materialization
+		// seeds the child node from this node's contexts and owned flags.
+		const define = defineCommand as unknown as (
+			name: string,
+			recipe: CommandRecipe,
+		) => CommandDefinition;
+		// SAFETY: the erased recipe still returns the builder it receives; materialization re-validates that at runtime.
+		const definition = define(name, recipe as unknown as CommandRecipe);
+		/* oxlint-enable anti-slop/no-chained-type-assertions */
+		return this._addDefinition(definition)._clone<
+			AfterAdd<
+				Flags,
+				A,
+				Ctx,
+				Sibs,
+				Sp,
+				Tree,
+				CtxFlags,
+				CollisionSp,
+				Result,
+				readonly [CommandDefinition<N, readonly [], ShapeOfBuilder<B>, DepsOfBuilder<B>>]
+			>
+		>({});
+	}
+
 	private _addDefinition(
 		definition: CommandDefinition,
 	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result> {
@@ -1303,3 +1420,26 @@ export class Crust<
 		await executeInvocation(this._node, options, materializeCommandDefinition);
 	}
 }
+
+// `.use()` is a compile-time demand: it feeds the recipe builder's `Deps`
+// generic and the sealed definition's `_deps` phantom, while invocation
+// resolves values from the provided path contexts, so nothing is recorded at
+// runtime. The implementation lives on the prototype because recipes execute
+// against Crust instances, while Crust's declared type omits it — root
+// applications supply Contexts with `.provide()`.
+function useContextDemand(this: AnyCrust, factory: AnyContextFactory): AnyCrust {
+	// oxlint-disable-next-line anti-slop/no-runtime-typeof -- recipes are an authoring boundary: the demand/supply mixup (`.use(logger())`) must fail loud here, not lazily at invocation.
+	if (typeof factory !== "function" || typeof factory.contextName !== "string") {
+		throw new CrustError(
+			"DEFINITION",
+			`.use() expects a Context factory (e.g. \`.use(logger)\`); call \`.provide(logger())\` to supply a Context value`,
+			{ subject: "context", name: String(factory), reason: "use-expects-factory" },
+		);
+	}
+	return this;
+}
+Object.defineProperty(Crust.prototype, "use", {
+	value: useContextDemand,
+	writable: true,
+	configurable: true,
+});

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -37,7 +37,10 @@ describe("command definitions", () => {
 	it("rejects Extensions registered inside command definitions", () => {
 		const nestedExtension = defineCommand("bad", (command) => {
 			// SAFETY: deliberately escape the sealed recipe surface to verify its runtime guard.
-			return (command as Crust).extend(defineExtension(defineExtensionId("nested"))) as never;
+			// oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Crust's declared type omits the builder-only `.use()`, so the escape must pass through unknown.
+			return (command as unknown as Crust).extend(
+				defineExtension(defineExtensionId("nested")),
+			) as never;
 		});
 
 		expect(() => new Crust("cli").add(nestedExtension)).toThrow(
@@ -94,8 +97,8 @@ describe("command definitions", () => {
 			apiKey: flags["api-key"],
 		}));
 		const before = defineCommand("before", (command) => command.action(() => {}));
-		const after = defineCommand("after", { uses: [auth] }, (command) =>
-			command.action(async ({ ctx }) => {
+		const after = defineCommand("after", (command) =>
+			command.use(auth).action(async ({ ctx }) => {
 				calls.push(String((await ctx.auth).apiKey));
 			}),
 		);
@@ -118,14 +121,15 @@ describe("command definitions", () => {
 			verbose: flags.verbose === true,
 		}));
 		const db = defineContext("db", () => "database");
-		const status = defineCommand("status", { uses: [db, logging] }, (command) =>
-			command.action(async ({ ctx }) => {
-				calls.push(`${await ctx.db}:${String((await ctx.logging).verbose)}`);
-			}),
+		const status = defineCommand("status", (command) =>
+			command
+				.use(db)
+				.use(logging)
+				.action(async ({ ctx }) => {
+					calls.push(`${await ctx.db}:${String((await ctx.logging).verbose)}`);
+				}),
 		);
-		const deploy = defineCommand("deploy", { uses: [db, logging] }, (command) =>
-			command.add(status),
-		);
+		const deploy = defineCommand("deploy", (command) => command.use(db).use(logging).add(status));
 		const app = new Crust("cli").provide(logging(), db()).add(deploy);
 
 		await app.run(["deploy", "status"], { flags: { verbose: true } });
@@ -137,7 +141,8 @@ describe("command definitions", () => {
 		const annotation = Symbol("annotation");
 		const definition = defineCommand("one", { description: "Reusable" }, (command) => {
 			// SAFETY: this fixture attaches an ecosystem annotation to the runtime node.
-			Object.defineProperty((command as Crust)._node, annotation, {
+			// oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Crust's declared type omits the builder-only `.use()`, so the escape must pass through unknown.
+			Object.defineProperty((command as unknown as Crust)._node, annotation, {
 				value: "preserved",
 				enumerable: true,
 			});
@@ -210,8 +215,9 @@ describe("command definitions", () => {
 	it("infers pulled Context values while preserving fluent action types", () => {
 		const auth = defineContext("auth", () => ({ user: "yan" }));
 		const region = defineContext("region", () => "us-east-1");
-		const definition = defineCommand("deploy", { uses: [auth] }, (command) =>
+		const definition = defineCommand("deploy", (command) =>
 			command
+				.use(auth)
 				.args({ name: "target", type: "string", required: true })
 				.flags({ name: "force", type: "boolean", required: true })
 				.provide(region())
@@ -238,6 +244,13 @@ describe("command definitions", () => {
 		type _NoDerive = Assert<
 			IsEqual<"derive" extends keyof CommandDefinitionBuilder ? true : false, false>
 		>;
+		// `.use()` is a recipe-builder surface; Crust's declared type omits it.
+		type _HasUse = Assert<
+			IsEqual<"use" extends keyof CommandDefinitionBuilder ? true : false, true>
+		>;
+		type _NoCrustUse = Assert<IsEqual<"use" extends keyof Crust ? true : false, false>>;
+		// `.command()` is root-only: on Crust, not on the definition builder.
+		type _CrustCommand = Assert<IsEqual<"command" extends keyof Crust ? true : false, true>>;
 
 		defineCommand("configured", (command) => {
 			// @ts-expect-error -- Extensions are root-only

--- a/packages/core/src/validation/contexts.brands.ts
+++ b/packages/core/src/validation/contexts.brands.ts
@@ -152,7 +152,8 @@ export type DeclaredDepsOf<T> =
 					: Deps
 			: {};
 
-type MissingDeclaredDependencyBrand<T, Known extends string> =
+/** Missing-dependency brand shared by `ValidateDeclaredDeps` and inline `.command()`. */
+export type MissingDeclaredDependencyBrand<T, Known extends string> =
 	Exclude<keyof DeclaredDepsOf<T> & string, Known> extends infer Missing extends string
 		? [Missing] extends [never]
 			? {}

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -322,14 +322,25 @@ export type DefinitionTreeSpellings<Ds extends readonly unknown[]> = DefinitionS
 	Ds[number]
 >;
 
-type DefinitionFlagCollisionBrand<D, Ext extends string> =
-	Overlap<DefinitionSpellings<D>, Ext> extends infer Collision extends string
+/**
+ * Extension-collision brand over a built command shape. Shared by `.add()`
+ * (via {@link ValidateDefinitionFlags}) and inline `.command()`, whose recipe
+ * builder exposes a shape instead of a definition tuple.
+ */
+export type ShapeFlagCollisionBrand<S, Ext extends string> =
+	Overlap<ShapeSpellings<S>, Ext> extends infer Collision extends string
 		? [Collision] extends [never]
 			? {}
 			: {
 					readonly FIX_ALIAS_COLLISION: `Flag spelling "${Collision}" collides with a registered Extension flag`;
 				}
 		: never;
+
+type DefinitionFlagCollisionBrand<D, Ext extends string> = D extends {
+	readonly _shape?: infer S;
+}
+	? ShapeFlagCollisionBrand<S, Ext>
+	: {};
 
 /**
  * Validate an added definition tree's flag spellings against already-registered

--- a/packages/core/src/validation/shared.ts
+++ b/packages/core/src/validation/shared.ts
@@ -13,7 +13,7 @@ export type DefName<T> = T extends { name: infer N extends string }
 		: N
 	: never;
 
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
+export type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
 	x: infer I,
 ) => void
 	? I

--- a/packages/core/tests/declaration-emission.test.ts
+++ b/packages/core/tests/declaration-emission.test.ts
@@ -40,11 +40,16 @@ export const authenticatedApi = defineContext("authenticated-api", { uses: [auth
 	apiKey: (await ctx.auth).apiKey,
 }));
 
-// A declared Context bag preserves the factory's value type
-export const deploy = defineCommand("deploy", { uses: [auth] }, (cmd) =>
-	cmd.action(async ({ ctx }) => {
-		void (await ctx.auth).apiKey;
-	}),
+// A declared Context bag preserves the factory's value type; .use() chains
+// accumulate demand and the transitive dependency closure
+export const deploy = defineCommand("deploy", (cmd) =>
+	cmd
+		.use(auth)
+		.use(authenticatedApi)
+		.action(async ({ ctx }) => {
+			void (await ctx.auth).apiKey;
+			void (await ctx["authenticated-api"]).apiKey;
+		}),
 );
 
 // An exported Extension carries evaluated dependency intersections,
@@ -63,6 +68,29 @@ export const app = new Crust("consumer-cli")
 	.provide(auth(), authenticatedApi())
 	.add(defineCommand("build", (cmd) => cmd.action(() => {})))
 	.add(deploy);
+
+// ~30 chained inline commands with chained .use() demands: generic depth
+// must stay bounded (no TS2589) and every intermediate builder type must
+// remain nameable in the emitted declarations.
+export const inlineApp = new Crust("inline-cli")
+	.provide(auth(), authenticatedApi())
+${Array.from(
+	{ length: 30 },
+	(_, index) => `	.command("inline-${index}", (cmd) =>
+		cmd
+			.use(auth)
+			.use(authenticatedApi)
+			.flags({ name: "inline-${index}-verbose", type: "boolean" })
+			.args({ name: "inline-${index}-target", type: "string" })
+			.action(async ({ args, flags, ctx }) => {
+				void args["inline-${index}-target"];
+				void flags["inline-${index}-verbose"];
+				void (await ctx.auth).apiKey;
+				return ${index};
+			}),
+	)`,
+).join("\n")}
+;
 `;
 
 let fixtureDir: string;

--- a/packages/core/tests/integration.test.ts
+++ b/packages/core/tests/integration.test.ts
@@ -77,8 +77,9 @@ describe("integration: .execute() full pipeline with argv override", () => {
 		const dryRun = defineFlag("dryRun", { type: "boolean" });
 		const deployment = defineContext("deployment", { flags: [env, dryRun] }, ({ flags }) => flags);
 		const app = new Crust("deploy").provide(deployment()).add(
-			defineCommand("service", { uses: [deployment] }, (cmd) =>
+			defineCommand("service", (cmd) =>
 				cmd
+					.use(deployment)
 					.args(defineArg("name", { type: "string", required: true }))
 					.action(async ({ args, ctx }) => {
 						const config = await ctx.deployment;
@@ -115,8 +116,8 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const auth = defineContext("auth", { flags: [apiKey] }, ({ flags }) => ({
 			credential: flags["api-key"],
 		}));
-		const deploy = defineCommand("deploy", { uses: [auth] }, (command) =>
-			command.action(async ({ ctx }) => {
+		const deploy = defineCommand("deploy", (command) =>
+			command.use(auth).action(async ({ ctx }) => {
 				const identity = await ctx.auth;
 				console.log(`${identity.credential.constructor.name.toLowerCase()}:${identity.credential}`);
 			}),
@@ -137,14 +138,16 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 			.flags({ name: "root-only", type: "boolean" })
 			.provide(logging())
 			.add(
-				defineCommand("group", { uses: [logging] }, (group) =>
-					group.add(
-						defineCommand("deploy", { uses: [logging] }, (deploy) =>
-							deploy.action(async ({ ctx }) =>
-								console.log(`verbose=${(await ctx.logging).verbose}`),
+				defineCommand("group", (group) =>
+					group
+						.use(logging)
+						.add(
+							defineCommand("deploy", (deploy) =>
+								deploy
+									.use(logging)
+									.action(async ({ ctx }) => console.log(`verbose=${(await ctx.logging).verbose}`)),
 							),
 						),
-					),
 				),
 			);
 
@@ -174,10 +177,12 @@ describe("integration: Context-owned flag → derived Context and descendant", (
 		const app = new Crust("cli")
 			.provide(outputConfig())
 			.add(
-				defineCommand("render", { uses: [outputConfig] }, (command) =>
-					command.action(async ({ ctx }) =>
-						console.log(`output=${(await ctx["output-config"]).output}`),
-					),
+				defineCommand("render", (command) =>
+					command
+						.use(outputConfig)
+						.action(async ({ ctx }) =>
+							console.log(`output=${(await ctx["output-config"]).output}`),
+						),
 				),
 			);
 
@@ -267,18 +272,23 @@ describe("integration: nested added definitions end-to-end", () => {
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const remoteConfig = defineContext("remote-config", { flags: [timeout] }, ({ flags }) => flags);
 		const app = new Crust("git").provide(logging()).add(
-			defineCommand("remote", { uses: [logging] }, (cmd) =>
-				cmd.provide(remoteConfig()).add(
-					defineCommand("add", { uses: [logging, remoteConfig] }, (cmd2) =>
-						cmd2
-							.args({ name: "name", type: "string", required: true })
-							.action(async ({ args, ctx }) => {
-								console.log(
-									`add remote=${args.name} verbose=${(await ctx.logging).verbose} timeout=${(await ctx["remote-config"]).timeout}`,
-								);
-							}),
+			defineCommand("remote", (cmd) =>
+				cmd
+					.use(logging)
+					.provide(remoteConfig())
+					.add(
+						defineCommand("add", (cmd2) =>
+							cmd2
+								.use(logging)
+								.use(remoteConfig)
+								.args({ name: "name", type: "string", required: true })
+								.action(async ({ args, ctx }) => {
+									console.log(
+										`add remote=${args.name} verbose=${(await ctx.logging).verbose} timeout=${(await ctx["remote-config"]).timeout}`,
+									);
+								}),
+						),
 					),
-				),
 			),
 		);
 
@@ -322,8 +332,9 @@ describe("integration: split-file definitions end-to-end", () => {
 
 	const verbose = defineFlag("verbose", { type: "boolean" });
 	const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
-	const listCommand = defineCommand("list", { uses: [logging] }, (command) =>
+	const listCommand = defineCommand("list", (command) =>
 		command
+			.use(logging)
 			.flags({ name: "format", type: "string", default: "table" })
 			.args({ name: "resource", type: "string", required: true })
 			.action(async ({ args, flags, ctx }) => {
@@ -332,8 +343,9 @@ describe("integration: split-file definitions end-to-end", () => {
 				);
 			}),
 	);
-	const getCommand = defineCommand("get", { uses: [logging] }, (command) =>
+	const getCommand = defineCommand("get", (command) =>
 		command
+			.use(logging)
 			.args(
 				{ name: "resource", type: "string", required: true },
 				{ name: "id", type: "string", required: true },
@@ -380,13 +392,16 @@ describe("integration: added definitions", () => {
 		const env = defineFlag("env", { type: "string" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const deployment = defineContext("deployment", { flags: [env] }, ({ flags }) => flags);
-		const status = defineCommand("status", { uses: [logging, deployment] }, (command) =>
-			command.action(async ({ ctx }) => {
-				console.log(`verbose=${(await ctx.logging).verbose} env=${(await ctx.deployment).env}`);
-			}),
+		const status = defineCommand("status", (command) =>
+			command
+				.use(logging)
+				.use(deployment)
+				.action(async ({ ctx }) => {
+					console.log(`verbose=${(await ctx.logging).verbose} env=${(await ctx.deployment).env}`);
+				}),
 		);
-		const deploy = defineCommand("deploy", { uses: [logging] }, (command) =>
-			command.provide(deployment()).add(status),
+		const deploy = defineCommand("deploy", (command) =>
+			command.use(logging).provide(deployment()).add(status),
 		);
 		const app = new Crust("cli").provide(logging()).add(deploy);
 
@@ -405,8 +420,8 @@ describe("integration: Context-owned boolean flag negation", () => {
 		const verbose = defineFlag("verbose", { type: "boolean", default: true });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(logging()).add(
-			defineCommand("sub", { uses: [logging] }, (cmd) =>
-				cmd.action(async ({ ctx }) => {
+			defineCommand("sub", (cmd) =>
+				cmd.use(logging).action(async ({ ctx }) => {
 					console.log(`verbose=${(await ctx.logging).verbose}`);
 				}),
 			),
@@ -431,8 +446,8 @@ describe("integration: Context-owned multiple-value flag", () => {
 		const tag = defineFlag("tag", { type: "string", multiple: true });
 		const tags = defineContext("tags", { flags: [tag] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(tags()).add(
-			defineCommand("sub", { uses: [tags] }, (cmd) =>
-				cmd.action(async ({ ctx }) => {
+			defineCommand("sub", (cmd) =>
+				cmd.use(tags).action(async ({ ctx }) => {
 					console.log(`tags=${JSON.stringify((await ctx.tags).tag)}`);
 				}),
 			),
@@ -457,8 +472,8 @@ describe("integration: separator (--) with subcommand and Context-owned flags", 
 		const verbose = defineFlag("verbose", { type: "boolean" });
 		const logging = defineContext("logging", { flags: [verbose] }, ({ flags }) => flags);
 		const app = new Crust("cli").provide(logging()).add(
-			defineCommand("sub", { uses: [logging] }, (cmd) =>
-				cmd.action(async ({ ctx, rawArgs }) => {
+			defineCommand("sub", (cmd) =>
+				cmd.use(logging).action(async ({ ctx, rawArgs }) => {
 					console.log(`verbose=${(await ctx.logging).verbose}`);
 					console.log(`rawArgs=${JSON.stringify(rawArgs)}`);
 				}),
@@ -500,8 +515,9 @@ describe("integration: complex real-world CLI scenario", () => {
 			.provide(settings())
 			.extend(auditExtension)
 			.add(
-				defineCommand("deploy", { uses: [settings] }, (cmd) =>
+				defineCommand("deploy", (cmd) =>
 					cmd
+						.use(settings)
 						.flags({ name: "env", type: "string", required: true })
 						.action(async ({ flags, ctx }) => {
 							const config = await ctx.settings;
@@ -511,8 +527,8 @@ describe("integration: complex real-world CLI scenario", () => {
 							);
 						}),
 				),
-				defineCommand("status", { uses: [settings] }, (cmd) =>
-					cmd.action(async ({ ctx }) => {
+				defineCommand("status", (cmd) =>
+					cmd.use(settings).action(async ({ ctx }) => {
 						const config = await ctx.settings;
 						order.push("status:run");
 						console.log(`status verbose=${config.verbose} config=${config.config}`);

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -8,10 +8,6 @@ DX-first, typed persistence for CLI apps with config/data/state/cache separation
 bun add @crustjs/store
 ```
 
-## Behavior
-
-`write()`, `update()`, and `patch()` return the state persisted after validation and schema transformations. Values that JSON serialization would alter (`NaN`, `Infinity`, `-0`, sparse arrays, `undefined` object properties) are rejected with `VALIDATION`. File replacement is atomic, but `update()` does not lock its read-modify-write sequence across processes.
-
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/store](https://crustjs.com/docs/modules/store)

--- a/scripts/type-perf-report.test.ts
+++ b/scripts/type-perf-report.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import {
+	distSupportsBuilderUse,
 	formatComparison,
 	generateConsumerFixture,
 	generateConsumerSource,
@@ -63,6 +64,12 @@ describe("type performance report", () => {
 		expect(generateConsumerSource(10).match(/const command\d+ = defineCommand/g)).toHaveLength(10);
 	});
 
+	it("emits the pre-.use() config API for base trees that predate builder .use()", () => {
+		const source = generateConsumerSource(10, false);
+		expect(source).toContain("uses: [context");
+		expect(source).not.toContain(".use(");
+	});
+
 	it("compiles the size-10 consumer fixture against built dist declarations", () => {
 		const build = Bun.spawnSync(["bun", "run", "build"], {
 			cwd: corePackage,
@@ -74,6 +81,8 @@ describe("type performance report", () => {
 		}
 		const fixtureDir = mkdtempSync(join(tmpdir(), "crust-type-perf-test-"));
 		try {
+			// This repo's dist is a head tree: the probe must pick the .use() fixture.
+			expect(distSupportsBuilderUse(corePackage)).toBe(true);
 			const consumerDir = join(fixtureDir, "consumer-10");
 			generateConsumerFixture(consumerDir, corePackage, 10);
 			const result = Bun.spawnSync([tsc, "--noEmit", "--incremental", "false", "-p", consumerDir], {

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -156,8 +156,9 @@ export function generateConsumerSource(size: number): string {
 	for (let index = 0; index < size; index++) {
 		const contextIndex = index % contextCount;
 		lines.push(
-			`const command${index} = defineCommand("command-${index}", { aliases: ["cmd-${index}", "c-${index}"], uses: [context${contextIndex}] }, (command) =>`,
-			"\tcommand",
+			`const command${index} = defineCommand("command-${index}", { aliases: ["cmd-${index}", "c-${index}"] }, (command) =>`,
+			`\tcommand`,
+			`\t\t.use(context${contextIndex})`,
 			`\t\t.flags({ name: "command-${index}-verbose", type: "boolean", short: "v", aliases: ["verbose-${index}"] })`,
 			`\t\t.flags({ name: "command-${index}-output", type: "string", short: "o", aliases: ["output-${index}"] })`,
 			`\t\t.flags({ name: "command-${index}-force", type: "boolean", short: "f", aliases: ["force-${index}"] })`,
@@ -166,8 +167,8 @@ export function generateConsumerSource(size: number): string {
 		);
 		if (index % 10 === 0) {
 			lines.push(
-				`\t\t.add(defineCommand("nested-${index}", { aliases: ["n-${index}"], uses: [context${contextIndex}] }, (nested) =>`,
-				`\t\t\tnested.flags({ name: "nested-${index}-mode", type: "string", short: "m", aliases: ["mode-${index}"] }).action(async ({ flags, ctx }) => { void flags["nested-${index}-mode"]; void await ctx["context-${contextIndex}"]; }),`,
+				`\t\t.add(defineCommand("nested-${index}", { aliases: ["n-${index}"] }, (nested) =>`,
+				`\t\t\tnested.use(context${contextIndex}).flags({ name: "nested-${index}-mode", type: "string", short: "m", aliases: ["mode-${index}"] }).action(async ({ flags, ctx }) => { void flags["nested-${index}-mode"]; void await ctx["context-${contextIndex}"]; }),`,
 				"\t\t))",
 			);
 		}

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -1,4 +1,12 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -129,7 +137,25 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
  * Each command has three chained flags and two chained args. Context count is
  * max(3, ceil(size / 10)); every tenth command also owns one nested subcommand.
  */
-export function generateConsumerSource(size: number): string {
+/**
+ * Whether a core package's built declarations expose the chainable builder
+ * `.use()`. The head copy of this script measures both trees (type-perf.yml:
+ * "Head's script measures both trees"), so the fixture must speak the API of
+ * the dist it compiles against: `.use()` chains on trees that ship it, the
+ * removed `uses:` config on older base revisions.
+ */
+export function distSupportsBuilderUse(corePackageDir: string): boolean {
+	const distDir = join(corePackageDir, "dist");
+	return readdirSync(distDir).some(
+		(file) =>
+			file.endsWith(".d.ts") &&
+			/\buse<[\s\S]{0,200}?\)\s*:\s*CommandDefinitionBuilder</.test(
+				readFileSync(join(distDir, file), "utf8"),
+			),
+	);
+}
+
+export function generateConsumerSource(size: number, builderUse = true): string {
 	if (!Number.isInteger(size) || size < 1) throw new Error("size must be a positive integer");
 	const contextCount = Math.max(3, Math.ceil(size / 10));
 	const lines = [
@@ -155,10 +181,13 @@ export function generateConsumerSource(size: number): string {
 
 	for (let index = 0; index < size; index++) {
 		const contextIndex = index % contextCount;
+		const commandConfig = builderUse
+			? `{ aliases: ["cmd-${index}", "c-${index}"] }`
+			: `{ aliases: ["cmd-${index}", "c-${index}"], uses: [context${contextIndex}] }`;
 		lines.push(
-			`const command${index} = defineCommand("command-${index}", { aliases: ["cmd-${index}", "c-${index}"] }, (command) =>`,
+			`const command${index} = defineCommand("command-${index}", ${commandConfig}, (command) =>`,
 			`\tcommand`,
-			`\t\t.use(context${contextIndex})`,
+			...(builderUse ? [`\t\t.use(context${contextIndex})`] : []),
 			`\t\t.flags({ name: "command-${index}-verbose", type: "boolean", short: "v", aliases: ["verbose-${index}"] })`,
 			`\t\t.flags({ name: "command-${index}-output", type: "string", short: "o", aliases: ["output-${index}"] })`,
 			`\t\t.flags({ name: "command-${index}-force", type: "boolean", short: "f", aliases: ["force-${index}"] })`,
@@ -166,9 +195,13 @@ export function generateConsumerSource(size: number): string {
 			`\t\t.args({ name: "destination-${index}", type: "string" })`,
 		);
 		if (index % 10 === 0) {
+			const nestedConfig = builderUse
+				? `{ aliases: ["n-${index}"] }`
+				: `{ aliases: ["n-${index}"], uses: [context${contextIndex}] }`;
+			const nestedUse = builderUse ? `.use(context${contextIndex})` : "";
 			lines.push(
-				`\t\t.add(defineCommand("nested-${index}", { aliases: ["n-${index}"] }, (nested) =>`,
-				`\t\t\tnested.use(context${contextIndex}).flags({ name: "nested-${index}-mode", type: "string", short: "m", aliases: ["mode-${index}"] }).action(async ({ flags, ctx }) => { void flags["nested-${index}-mode"]; void await ctx["context-${contextIndex}"]; }),`,
+				`\t\t.add(defineCommand("nested-${index}", ${nestedConfig}, (nested) =>`,
+				`\t\t\tnested${nestedUse}.flags({ name: "nested-${index}-mode", type: "string", short: "m", aliases: ["mode-${index}"] }).action(async ({ flags, ctx }) => { void flags["nested-${index}-mode"]; void await ctx["context-${contextIndex}"]; }),`,
 				"\t\t))",
 			);
 		}
@@ -205,7 +238,10 @@ export function generateConsumerFixture(
 	const packageDir = resolve(corePackageDir);
 	mkdirSync(join(fixtureDir, "node_modules/@crustjs"), { recursive: true });
 	symlinkSync(packageDir, join(fixtureDir, "node_modules/@crustjs/core"), "dir");
-	writeFileSync(join(fixtureDir, "consumer.ts"), generateConsumerSource(size));
+	writeFileSync(
+		join(fixtureDir, "consumer.ts"),
+		generateConsumerSource(size, distSupportsBuilderUse(packageDir)),
+	);
 	writeFileSync(
 		join(fixtureDir, "tsconfig.json"),
 		`${JSON.stringify(

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -133,11 +133,6 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
 }
 
 /**
- * Generate a deterministic downstream app with `size` top-level sibling commands.
- * Each command has three chained flags and two chained args. Context count is
- * max(3, ceil(size / 10)); every tenth command also owns one nested subcommand.
- */
-/**
  * Whether a core package's built declarations expose the chainable builder
  * `.use()`. The head copy of this script measures both trees (type-perf.yml:
  * "Head's script measures both trees"), so the fixture must speak the API of
@@ -155,6 +150,11 @@ export function distSupportsBuilderUse(corePackageDir: string): boolean {
 	);
 }
 
+/**
+ * Generate a deterministic downstream app with `size` top-level sibling commands.
+ * Each command has three chained flags and two chained args. Context count is
+ * max(3, ceil(size / 10)); every tenth command also owns one nested subcommand.
+ */
 export function generateConsumerSource(size: number, builderUse = true): string {
 	if (!Number.isInteger(size) || size < 1) throw new Error("size must be a positive integer");
 	const contextCount = Math.max(3, Math.ceil(size / 10));
@@ -343,8 +343,10 @@ async function measure(outputPath: string, rootDir = "."): Promise<void> {
 	try {
 		for (const size of scalingSizes) {
 			const fixtureDir = join(fixtureRoot, String(size));
-			generateConsumerFixture(fixtureDir, join(root, "packages/core"), size);
 			try {
+				// Inside the catch so fixture *generation* failures (e.g. missing dist
+				// during the .use() probe) follow the same n/a policy as compile failures.
+				generateConsumerFixture(fixtureDir, join(root, "packages/core"), size);
 				const fixtureDiagnostics = run(
 					[tsc, "--noEmit", "--incremental", "false", "--extendedDiagnostics", "-p", fixtureDir],
 					root,

--- a/scripts/type-perf-report.ts
+++ b/scripts/type-perf-report.ts
@@ -139,6 +139,7 @@ export function formatComparison(base: TypePerfReport, head: TypePerfReport): st
  * the dist it compiles against: `.use()` chains on trees that ship it, the
  * removed `uses:` config on older base revisions.
  */
+// ponytail: one-release compat shim — delete this probe and every builderUse=false branch once released base trees ship builder `.use()`.
 export function distSupportsBuilderUse(corePackageDir: string): boolean {
 	const distDir = join(corePackageDir, "dist");
 	return readdirSync(distDir).some(
@@ -186,7 +187,7 @@ export function generateConsumerSource(size: number, builderUse = true): string 
 			: `{ aliases: ["cmd-${index}", "c-${index}"], uses: [context${contextIndex}] }`;
 		lines.push(
 			`const command${index} = defineCommand("command-${index}", ${commandConfig}, (command) =>`,
-			`\tcommand`,
+			"\tcommand",
 			...(builderUse ? [`\t\t.use(context${contextIndex})`] : []),
 			`\t\t.flags({ name: "command-${index}-verbose", type: "boolean", short: "v", aliases: ["verbose-${index}"] })`,
 			`\t\t.flags({ name: "command-${index}-output", type: "string", short: "o", aliases: ["output-${index}"] })`,


### PR DESCRIPTION
## Summary

Approved DI API redesign (see maintainer-approved handoff decision):

- **Inline `.command(name, recipe)` on `Crust`** (root-only v1). Recipe builder is seeded with the call-site `Ctx`/`CtxFlags` — never the final root `Ctx`, so an earlier `.command()` cannot see later `.provide()` contexts. Runtime delegates to `defineCommand` + existing materialization.
- **Chainable `.use(factory)` on `CommandDefinitionBuilder`** replaces the `uses:` config field (removed outright, pre-1.0). Each `.use()` accumulates the factory's name→value and transitive `_deps` closure into the builder's `Deps` generic; `defineCommand` infers `Deps` from the recipe's return type. `_deps` phantom, brands, and owned-flag accumulation unchanged. Extensions' `uses`/`provides` config stays as-is.
- Duality: `.use(logger)` = demand (factory), `.provide(logger())` = supply (instance). `defineCommand` remains for file-split / shared / published / Extension-contributed commands.

## Tests

- Type tests: inline ctx access typed; undeclared names `@ts-expect-error`
- Stale-order: `.command()` before `.provide()` does NOT see the later context (type + runtime)
- Brand parity: missing transitive dep errors at `.command()`/`.add()`/`.extend()`
- Declaration emission: 30 chained inline commands with chained `.use()` — no TS2589, clean `.d.ts`

## Docs

quick-start, contexts, subcommands, split-files, flags, api/crust, api/types, modules/core, core README synced. Changeset included (breaking: `uses` field removed).

## Known deferral

Inline `.command()` has no compile-time sibling-collision brand (runtime error covers it, tested). Follow-up: intersect name param with a `Sibs`-overlap brand.

## Gates

`check:types` 26/26 · `lint` · `format` · `test` 545/545 — all green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

