### PR TITLE
fix: skills IO routing, extras override, excess-positional validation

### DIFF
--- a/.changeset/calm-skills-overrides.md
+++ b/.changeset/calm-skills-overrides.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": minor
+---
+
+Allow authored extras to replace the generated command skill, and add options to rename, describe, or omit the generated skill.

--- a/.changeset/calm-skills-overrides.md
+++ b/.changeset/calm-skills-overrides.md
@@ -2,4 +2,8 @@
 "@crustjs/skills": minor
 ---
 
-Allow authored extras to replace the generated command skill, and add options to rename, describe, or omit the generated skill.
+Rework skill build options (breaking).
+
+- `writeSkills()` takes a single options object; `app` is optional, and omitting it writes only authored `extras`. Writing no skills at all is an error.
+- The `skill()` Extension's build hook always renders the generated skill and `extras` from the Command Snapshot; it no longer copies an existing `distDir`, so `crust build` output cannot go stale. `distDir` is read only at runtime.
+- `name` and `description` override the generated skill's frontmatter in every build path, `generated: false` ships only `extras`, and an authored extra with the generated skill's name replaces it.

--- a/.changeset/clear-flag-parse-errors.md
+++ b/.changeset/clear-flag-parse-errors.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Preserve the native flag name and detail when a flag value is missing or invalid during argv parsing.

--- a/.changeset/copy-license-variants.md
+++ b/.changeset/copy-license-variants.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/crust": patch
+---
+
+Copy common `LICENSE.md`, `LICENCE`, and `LICENCE.md` variants into staged distribution packages in addition to `LICENSE`.

--- a/.changeset/quiet-skill-repair.md
+++ b/.changeset/quiet-skill-repair.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Route skill management and automatic link-repair messages through the invocation's injected output, and quietly skip automatic repair when the packaged source is empty.

--- a/.changeset/reject-skill-path-collisions.md
+++ b/.changeset/reject-skill-path-collisions.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Reject a generated skill tree whose direct subcommand shares the root command name instead of silently overwriting the root command documentation.

--- a/.changeset/strict-positionals.md
+++ b/.changeset/strict-positionals.md
@@ -1,5 +1,5 @@
 ---
-"@crustjs/core": patch
+"@crustjs/core": minor
 ---
 
 Reject undeclared positional arguments instead of silently discarding them. Commands that intentionally accept loose positionals can opt out with `allowExcessPositionals`.

--- a/.changeset/strict-positionals.md
+++ b/.changeset/strict-positionals.md
@@ -2,4 +2,4 @@
 "@crustjs/core": minor
 ---
 
-Reject undeclared positional arguments instead of silently discarding them. Commands that intentionally accept loose positionals can opt out with `allowExcessPositionals`.
+Reject undeclared positional arguments instead of silently discarding them. Declare a variadic argument to accept an open-ended list, or read opaque tokens from `rawArgs` after `--`.

--- a/.changeset/strict-positionals.md
+++ b/.changeset/strict-positionals.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Reject undeclared positional arguments instead of silently discarding them. Commands that intentionally accept loose positionals can opt out with `allowExcessPositionals`.

--- a/.changeset/typed-skill-scope.md
+++ b/.changeset/typed-skill-scope.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/skills": patch
+---
+
+Declare `skill --scope` choices in the command definition so invalid scope values fail during parsing with actionable choice details.

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -159,7 +159,7 @@ type GreetInput = RunInput<CommandShapeAt<(typeof app)["_types"]["shape"], reado
 
 ## Parser boundary types
 
-`ParseResult<A, F>` is the syntax-parsed result before required-value and Standard Schema validation. Its generic `args` and `flags` preserve definition-specific raw value types; `ParsedArgValue` and `ParsedFlagValue` are the runtime-erased fallbacks for widened definitions. Its `rawArgs` holds tokens after `--`. `ValidatedInput<A, F>` is the validated boundary passed onward to Command Actions, with `InferArgs<A>` and `InferFlags<F>` applied.
+`ParseResult<A, F>` is the syntax-parsed result before required-value and Standard Schema validation. Its generic `args` and `flags` preserve definition-specific raw value types; `ParsedArgValue` and `ParsedFlagValue` are the runtime-erased fallbacks for widened definitions. Its `excessArgs` holds positionals before `--` that no declared argument consumed (validation rejects them); its `rawArgs` holds tokens after `--`. `ValidatedInput<A, F>` is the validated boundary passed onward to Command Actions, with `InferArgs<A>` and `InferFlags<F>` applied.
 
 Most application authors consume the inferred Action context rather than naming these types directly. They are exported for parser integrations and tooling that need to distinguish syntax parsing from schema-validated values.
 

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -75,7 +75,7 @@ A schema cannot be combined with core value options — see [Schema-backed defin
 
 ## Excess and raw tokens
 
-Positionals before `--` must match a declared argument; excess values fail with a `VALIDATION` error. Commands that intentionally implement loose positional handling can set `allowExcessPositionals: true` in their command metadata, though declaring a variadic argument is preferable when the values belong to the command.
+Positionals before `--` must match a declared argument; excess values fail with a `VALIDATION` error. Commands that accept an open-ended list of values should declare a variadic argument; commands that forward opaque tokens should read them from `rawArgs` after `--`.
 
 Tokens after `--` bypass argument and flag parsing and appear in `rawArgs`:
 

--- a/apps/docs/content/docs/guide/arguments.mdx
+++ b/apps/docs/content/docs/guide/arguments.mdx
@@ -73,7 +73,9 @@ new Crust("serve")
 
 A schema cannot be combined with core value options — see [Schema-backed definitions](/docs/guide/types#schema-backed-definitions) for the full rule.
 
-## Forwarding raw tokens
+## Excess and raw tokens
+
+Positionals before `--` must match a declared argument; excess values fail with a `VALIDATION` error. Commands that intentionally implement loose positional handling can set `allowExcessPositionals: true` in their command metadata, though declaring a variadic argument is preferable when the values belong to the command.
 
 Tokens after `--` bypass argument and flag parsing and appear in `rawArgs`:
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -62,7 +62,7 @@ export const app = new Crust("my-cli", { description: "My CLI" })
   .action(() => {});
 ```
 
-When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. `distDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
+When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. An authored extra with the generated skill's name replaces that generated skill; duplicate names between authored extras remain an error. Use `name` and `description` to customize the generated skill, or `generated: false` to omit it. `distDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
 
 The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the packaged directory is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the packaged skills directory to keep absolute build-machine paths out of generated artifacts.
 

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -18,21 +18,22 @@ The **packaged skills directory** is the `skills/` directory shipped in your npm
 - A **generated skill**, rendered from the command tree and its `meta.sections`.
 - Any **authored skills**, included from hand-written skill directories via `extras`.
 
-The `skill()` Extension owns its build output. During `crust build`, configured `extras` are built alongside the generated skill from the prepared Command Snapshot. Without `extras`, the Extension copies the available packaged skills directory wholesale to `<outdir>/skills`, falling back to the generated skill when that directory is unavailable. `crust build --package` includes the resulting directory in the staged root package. No `--skills` build flag is needed; `--no-validate` skips all Extension build hooks.
+The `skill()` Extension owns its build output. During `crust build`, it renders the generated skill from the prepared Command Snapshot and any configured `extras` into `<outdir>/skills`, so the packaged directory always matches the built command tree. `crust build --package` includes the resulting directory in the staged root package. No `--skills` build flag is needed; `--no-validate` skips all Extension build hooks.
 
 ```ts
 import { writeSkills } from "@crustjs/skills";
 import { app } from "./cli.ts";
 import pkg from "./package.json" with { type: "json" };
 
-await writeSkills(app, {
+await writeSkills({
+  app,
   outDir: "dist/skills",
   version: pkg.version, // optional; recorded in the generated skill's metadata
   extras: ["skills-src/deployment-guide"],
 });
 ```
 
-For a custom pipeline with a prepared Command Snapshot instead of a live app, call `writeSkillsFromSnapshot(snapshot, options)`. `outDir` must be named `skills`. Each skill gets its own `skills/<name>/` directory containing `SKILL.md` and any supporting files. `writeSkills()` and `writeSkillsFromSnapshot()` replace `outDir` on every build and never write to an agent directory.
+Omit `app` to write only authored `extras`; at least one of the two is required. For a custom pipeline with a prepared Command Snapshot instead of a live app, call `writeSkillsFromSnapshot(snapshot, options)`. `outDir` must be named `skills`. Each skill gets its own `skills/<name>/` directory containing `SKILL.md` and any supporting files. `writeSkills()` and `writeSkillsFromSnapshot()` replace `outDir` on every build and never write to an agent directory.
 
 Include the directory in the published package:
 
@@ -62,7 +63,7 @@ export const app = new Crust("my-cli", { description: "My CLI" })
   .action(() => {});
 ```
 
-When `extras` is non-empty, the build regenerates current command documentation and copies each authored skill into the output instead of copying the existing packaged skills directory. An authored extra with the generated skill's name replaces that generated skill; duplicate names between authored extras remain an error. Use `name` and `description` to customize the generated skill, or `generated: false` to omit it. `distDir` remains the directory used for runtime discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
+Each authored extra is copied into the build output next to the generated skill. An authored extra with the generated skill's name replaces that generated skill; duplicate names between authored extras remain an error. Use `name` and `description` to customize the generated skill, or `generated: false` to ship only authored `extras`; a build that would produce no skills at all is an error. `distDir` is only read at runtime, for discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
 
 The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the packaged directory is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the packaged skills directory to keep absolute build-machine paths out of generated artifacts.
 

--- a/bun.lock
+++ b/bun.lock
@@ -211,6 +211,7 @@
         "@crustjs/config": "workspace:*",
         "@crustjs/core": "workspace:*",
         "@crustjs/extensions": "workspace:*",
+        "@crustjs/testing": "workspace:*",
         "@crustjs/utils": "workspace:*",
         "tsdown": "catalog:",
       },

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -253,12 +253,6 @@ describe("command metadata", () => {
 		});
 	});
 
-	it("copies allowExcessPositionals into the root node", async () => {
-		const app = new Crust("proxy", { allowExcessPositionals: true });
-
-		expect((await app.snapshot()).meta.allowExcessPositionals).toBe(true);
-	});
-
 	it("applies definition metadata from config", async () => {
 		const app = new Crust("cli").add(
 			defineCommand(

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -1988,6 +1988,22 @@ describe("Crust .execute()", () => {
 		expect(stderrChunks.join("\n")).toContain("Unknown command");
 	});
 
+	it("does not run a runnable parent for a typoed subcommand", async () => {
+		let ran = false;
+		const app = new Crust("gyst")
+			.add(defineCommand("session", (cmd) => cmd.action(() => {})))
+			.action(() => {
+				ran = true;
+			});
+
+		await app.execute({ argv: ["sesion", "status"] });
+
+		expect(ran).toBe(false);
+		expect(process.exitCode).toBe(1);
+		expect(stderrChunks.join("\n")).toContain("Unexpected positional arguments");
+		process.exitCode = 0;
+	});
+
 	it("no action is a no-op (no error)", async () => {
 		const app = new Crust("test").flags({ name: "verbose", type: "boolean" });
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -253,6 +253,12 @@ describe("command metadata", () => {
 		});
 	});
 
+	it("copies allowExcessPositionals into the root node", async () => {
+		const app = new Crust("proxy", { allowExcessPositionals: true });
+
+		expect((await app.snapshot()).meta.allowExcessPositionals).toBe(true);
+	});
+
 	it("applies definition metadata from config", async () => {
 		const app = new Crust("cli").add(
 			defineCommand(

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -228,7 +228,10 @@ export interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
 }
 
 /** Static metadata accepted by the root command constructor. */
-export type RootCommandMeta = Pick<CommandMeta, "description" | "usage"> & {
+export type RootCommandMeta = Pick<
+	CommandMeta,
+	"description" | "usage" | "allowExcessPositionals"
+> & {
 	/** Plain-text sections rendered after built-in command documentation. */
 	readonly sections?: readonly CommandSectionInput[];
 };

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -228,10 +228,7 @@ export interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
 }
 
 /** Static metadata accepted by the root command constructor. */
-export type RootCommandMeta = Pick<
-	CommandMeta,
-	"description" | "usage" | "allowExcessPositionals"
-> & {
+export type RootCommandMeta = Pick<CommandMeta, "description" | "usage"> & {
 	/** Plain-text sections rendered after built-in command documentation. */
 	readonly sections?: readonly CommandSectionInput[];
 };
@@ -1035,9 +1032,6 @@ export class Crust<
 		this._node = createCommandNode(name);
 		if (meta.description !== undefined) this._node.meta.description = meta.description;
 		if (meta.usage !== undefined) this._node.meta.usage = meta.usage;
-		if (meta.allowExcessPositionals !== undefined) {
-			this._node.meta.allowExcessPositionals = meta.allowExcessPositionals;
-		}
 		if (meta.sections !== undefined) {
 			this._node.meta.sections = copyUnvalidatedSections(meta.sections);
 		}

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1035,6 +1035,9 @@ export class Crust<
 		this._node = createCommandNode(name);
 		if (meta.description !== undefined) this._node.meta.description = meta.description;
 		if (meta.usage !== undefined) this._node.meta.usage = meta.usage;
+		if (meta.allowExcessPositionals !== undefined) {
+			this._node.meta.allowExcessPositionals = meta.allowExcessPositionals;
+		}
 		if (meta.sections !== undefined) {
 			this._node.meta.sections = copyUnvalidatedSections(meta.sections);
 		}

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -195,7 +195,6 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 			name: node.meta.name,
 			description: node.meta.description,
 			usage: node.meta.usage,
-			allowExcessPositionals: node.meta.allowExcessPositionals,
 			sections: node.meta.sections
 				? Object.freeze(node.meta.sections.map((section) => Object.freeze({ ...section })))
 				: undefined,

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -100,7 +100,7 @@ export interface FlagSnapshot {
  * ```
  */
 export interface CommandSnapshot {
-	/** Command metadata: `name`, `description`, `usage`, `sections`, `aliases`, `hidden`. */
+	/** Command metadata, including routing and presentation options. */
 	readonly meta: Readonly<CommandMeta>;
 	/** Whether the command defines a Command Action */
 	readonly hasAction: boolean;
@@ -195,6 +195,7 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 			name: node.meta.name,
 			description: node.meta.description,
 			usage: node.meta.usage,
+			allowExcessPositionals: node.meta.allowExcessPositionals,
 			sections: node.meta.sections
 				? Object.freeze(node.meta.sections.map((section) => Object.freeze({ ...section })))
 				: undefined,

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -27,7 +27,6 @@ function makeNode<const A extends ArgsDef = ArgsDef, const F extends FlagsDef = 
 	const node = createCommandNode(meta.name);
 	if (meta.description) node.meta.description = meta.description;
 	if (meta.usage) node.meta.usage = meta.usage;
-	if (meta.allowExcessPositionals) node.meta.allowExcessPositionals = true;
 	if (config.flags) {
 		node.localFlags = { ...config.flags };
 		node.effectiveFlags = { ...config.flags };
@@ -862,16 +861,6 @@ describe("validateParsed", () => {
 		expect(() => validateParsed(cmd, parsed)).toThrow(
 			'Unexpected positional arguments: "sesion", "status"',
 		);
-	});
-
-	it("allows an explicit opt-out for loose positional handling", () => {
-		const cmd = makeNode({
-			meta: { name: "proxy", allowExcessPositionals: true },
-			run: () => {},
-		});
-		const parsed = parseArgs(cmd, ["forwarded", "values"]);
-
-		expect(() => validateParsed(cmd, parsed)).not.toThrow();
 	});
 
 	it("throws for missing required arg", () => {

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -560,6 +560,22 @@ describe("parseArgs — strict mode (unknown flags)", () => {
 			expect((err as CrustError).message).toContain("Unknown flag");
 		}
 	});
+
+	it("preserves the flag name when its value is missing", () => {
+		const valued = makeNode({
+			meta: { name: "test" },
+			flags: { output: { type: "string" } },
+		});
+
+		try {
+			parseArgs(valued, ["--output"]);
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CrustError);
+			expect((err as CrustError).code).toBe("PARSE");
+			expect((err as CrustError).message).toContain("--output");
+		}
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -683,7 +699,7 @@ describe("parseArgs — boolean flag value assignment", () => {
 		} catch (err) {
 			expect(err).toBeInstanceOf(CrustError);
 			expect((err as CrustError).code).toBe("PARSE");
-			expect((err as CrustError).message).toBe("Failed to parse command arguments");
+			expect((err as CrustError).message).toContain("--verbose");
 			expect((err as CrustError).cause).toBeInstanceOf(Error);
 			expect(((err as CrustError).cause as Error).message).toContain(
 				"Option '--verbose' does not take an argument",

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -27,6 +27,7 @@ function makeNode<const A extends ArgsDef = ArgsDef, const F extends FlagsDef = 
 	const node = createCommandNode(meta.name);
 	if (meta.description) node.meta.description = meta.description;
 	if (meta.usage) node.meta.usage = meta.usage;
+	if (meta.allowExcessPositionals) node.meta.allowExcessPositionals = true;
 	if (config.flags) {
 		node.localFlags = { ...config.flags };
 		node.effectiveFlags = { ...config.flags };
@@ -837,6 +838,26 @@ describe("parseArgs — CommandNode with effective flags", () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("validateParsed", () => {
+	it("rejects positionals not consumed by declared arguments", () => {
+		const cmd = makeNode({ meta: { name: "gyst" }, run: () => {} });
+		const parsed = parseArgs(cmd, ["sesion", "status"]);
+
+		expect(parsed.excessArgs).toEqual(["sesion", "status"]);
+		expect(() => validateParsed(cmd, parsed)).toThrow(
+			'Unexpected positional arguments: "sesion", "status"',
+		);
+	});
+
+	it("allows an explicit opt-out for loose positional handling", () => {
+		const cmd = makeNode({
+			meta: { name: "proxy", allowExcessPositionals: true },
+			run: () => {},
+		});
+		const parsed = parseArgs(cmd, ["forwarded", "values"]);
+
+		expect(() => validateParsed(cmd, parsed)).not.toThrow();
+	});
+
 	it("throws for missing required arg", () => {
 		const cmd = makeNode({
 			meta: { name: "test" },

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -507,7 +507,7 @@ export function validateParsed<A extends ArgsDef = ArgsDef, F extends FlagsDef =
 	const args = parsed.args;
 	const flags = parsed.flags;
 
-	if (parsed.excessArgs.length > 0 && command.meta.allowExcessPositionals !== true) {
+	if (parsed.excessArgs.length > 0) {
 		throw new CrustError(
 			"VALIDATION",
 			`Unexpected positional argument${parsed.excessArgs.length === 1 ? "" : "s"}: ${parsed.excessArgs.map((arg) => JSON.stringify(arg)).join(", ")}`,

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -452,6 +452,13 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 			if (unknownMatch) {
 				throw new CrustError("PARSE", `Unknown flag "${unknownMatch[1]}"`).withCause(error);
 			}
+			if (
+				"code" in error &&
+				error.code === "ERR_PARSE_ARGS_INVALID_OPTION_VALUE" &&
+				error.message.length > 0
+			) {
+				throw new CrustError("PARSE", error.message).withCause(error);
+			}
 		}
 		throw new CrustError("PARSE", "Failed to parse command arguments").withCause(error);
 	}

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -336,10 +336,15 @@ function validateRequiredFlags<F extends FlagsDef>(
  * This is a pure parse+coerce function — it never throws for missing required
  * values. Use {@link validateParsed} to enforce required constraints.
  */
+interface ResolvedArgs<A extends ArgsDef> {
+	args: RawParsedArgs<A>;
+	consumed: number;
+}
+
 function resolveArgs<A extends ArgsDef>(
 	argsDef: A | undefined,
 	positionals: string[],
-): RawParsedArgs<A> {
+): ResolvedArgs<A> {
 	const resolved: Record<string, ParsedArgValue> = {};
 	let index = 0;
 
@@ -367,7 +372,7 @@ function resolveArgs<A extends ArgsDef>(
 	}
 
 	// SAFETY: the loop writes exactly every declared argument name; mapped generic keys cannot be correlated at runtime.
-	return resolved as RawParsedArgs<A>;
+	return { args: resolved as RawParsedArgs<A>, consumed: index };
 }
 
 /**
@@ -468,8 +473,9 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
 	const resolvedArgs = resolveArgs(argsDef, preSeparatorPositionals);
 
 	return {
-		args: resolvedArgs,
+		args: resolvedArgs.args,
 		flags: resolvedFlags,
+		excessArgs: preSeparatorPositionals.slice(resolvedArgs.consumed),
 		rawArgs,
 	};
 }
@@ -493,6 +499,13 @@ export function validateParsed<A extends ArgsDef = ArgsDef, F extends FlagsDef =
 
 	const args = parsed.args;
 	const flags = parsed.flags;
+
+	if (parsed.excessArgs.length > 0 && command.meta.allowExcessPositionals !== true) {
+		throw new CrustError(
+			"VALIDATION",
+			`Unexpected positional argument${parsed.excessArgs.length === 1 ? "" : "s"}: ${parsed.excessArgs.map((arg) => JSON.stringify(arg)).join(", ")}`,
+		);
+	}
 
 	// Re-validate args: check for required args that are undefined
 	if (argsDef) {

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -420,7 +420,7 @@ function validateNoNegateUsage(argv: string[], spellings: ReadonlyMap<string, Fl
  *
  * @param command - The command whose arg/flag definitions drive the parsing
  * @param argv - The argv array to parse (typically `process.argv.slice(2)`)
- * @returns Parsed args, flags, and rawArgs (everything after `--`)
+ * @returns Parsed args, flags, excessArgs (positionals before `--` not consumed by a declared argument), and rawArgs (everything after `--`)
  * @throws {CrustError} On unknown flags or type coercion failure
  */
 export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = FlagsDef>(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -638,6 +638,8 @@ export interface CommandMeta {
 	description?: string;
 	/** Custom usage string (overrides auto-generated usage) */
 	usage?: string;
+	/** Allow undeclared positional arguments to be ignored. @default false */
+	allowExcessPositionals?: boolean;
 	/** Plain-text sections rendered after built-in command documentation. */
 	sections?: readonly CommandSection[];
 	/**
@@ -735,6 +737,9 @@ export type DeclaredDefault = (ArgDef | FlagDef)["default"];
 export interface ParseResult<A extends ArgsDef = ArgsDef, F extends FlagsDef = FlagsDef> {
 	args: RawParsedArgs<A>;
 	flags: RawParsedFlags<F>;
+	/** Positionals before `--` that were not consumed by a declared argument. */
+	excessArgs: string[];
+	/** Arguments after the `--` separator. */
 	rawArgs: string[];
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -638,8 +638,6 @@ export interface CommandMeta {
 	description?: string;
 	/** Custom usage string (overrides auto-generated usage) */
 	usage?: string;
-	/** Allow undeclared positional arguments to be ignored. @default false */
-	allowExcessPositionals?: boolean;
 	/** Plain-text sections rendered after built-in command documentation. */
 	sections?: readonly CommandSection[];
 	/**

--- a/packages/create-crust/tests/cli.smoke.test.ts
+++ b/packages/create-crust/tests/cli.smoke.test.ts
@@ -234,7 +234,9 @@ describe.skipIf(process.env.CREATE_CRUST_SMOKE !== "1")("create-crust smoke test
 		expect(existsSync(join(sampleDir, "README.md"))).toBe(true);
 
 		useLocalDependencyPackages(sampleDir, await packLocalDependencyPackages());
-		const installCommand = npmArgv(["install"]);
+		// Audit/funding lookups hit registry endpoints the smoke test does not need;
+		// when they degrade, npm blocks on them and the test times out.
+		const installCommand = npmArgv(["install", "--no-audit", "--no-fund"]);
 		const install = await run(installCommand, sampleDir, {
 			BUN_BE_BUN: "1",
 			npm_config_user_agent: "npm/10.0.0 node/v22.0.0",

--- a/packages/crust/src/utils/distribute.test.ts
+++ b/packages/crust/src/utils/distribute.test.ts
@@ -239,6 +239,26 @@ describe("runDistributeBuild", () => {
 			"test license\n",
 		);
 	});
+
+	it("copies common license filename variants", async () => {
+		rmSync(join(tmpDir, "LICENSE"));
+		writeFileSync(join(tmpDir, "LICENCE.md"), "variant license\n");
+		process.cwd = () => tmpDir;
+
+		await runDistributeBuild({
+			entry: "src/cli.ts",
+			minify: true,
+			target: ["bun-darwin-arm64"],
+			stageDir: ".stage",
+		});
+
+		expect(readFileSync(join(tmpDir, ".stage", "root", "LICENCE.md"), "utf-8")).toBe(
+			"variant license\n",
+		);
+		expect(readFileSync(join(tmpDir, ".stage", "darwin-arm64", "LICENCE.md"), "utf-8")).toBe(
+			"variant license\n",
+		);
+	});
 });
 
 describe("runDistributeBuild Extension artifact staging", () => {

--- a/packages/crust/src/utils/distribute.ts
+++ b/packages/crust/src/utils/distribute.ts
@@ -409,11 +409,14 @@ function copyRootReadme(cwd: string, rootDir: string): void {
 }
 
 function copyLicense(cwd: string, packageDirs: readonly string[]): void {
-	const licensePath = join(cwd, "LICENSE");
-	if (!existsSync(licensePath)) return;
+	const licenseName = ["LICENSE", "LICENSE.md", "LICENCE", "LICENCE.md"].find((name) =>
+		existsSync(join(cwd, name)),
+	);
+	if (!licenseName) return;
+	const licensePath = join(cwd, licenseName);
 
 	for (const packageDir of packageDirs) {
-		copyFileSync(licensePath, join(packageDir, "LICENSE"));
+		copyFileSync(licensePath, join(packageDir, licenseName));
 	}
 }
 

--- a/packages/crust/tests/package-manager.smoke.test.ts
+++ b/packages/crust/tests/package-manager.smoke.test.ts
@@ -151,7 +151,10 @@ describe.skipIf(!packageManager)("package manager smoke", () => {
 			),
 		);
 
-		const install = await run([packageManager!, "install"], installDir);
+		// Audit/funding lookups hit registry endpoints the smoke test does not need;
+		// when they degrade, npm blocks on them and the test times out.
+		const auditFlags = packageManager === "npm" ? ["--no-audit", "--no-fund"] : [];
+		const install = await run([packageManager!, "install", ...auditFlags], installDir);
 		expect(install.exitCode).toBe(0);
 
 		const binPath = join(installDir, "node_modules", ".bin", "resolver-smoke");

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -54,6 +54,7 @@
 		"@crustjs/config": "workspace:*",
 		"@crustjs/core": "workspace:*",
 		"@crustjs/extensions": "workspace:*",
+		"@crustjs/testing": "workspace:*",
 		"@crustjs/utils": "workspace:*",
 		"tsdown": "catalog:"
 	},

--- a/packages/skills/src/build.test.ts
+++ b/packages/skills/src/build.test.ts
@@ -61,11 +61,14 @@ describe("writeSkills", () => {
 		const serve = await readFile(join(outDir, "demo", "commands", "serve.md"), "utf8");
 		expect(serve).toContain("# `demo serve`");
 		expect(serve).toContain("## Deployment\nCheck the target environment first.");
-		expect(await readdir(join(outDir, "demo"))).toEqual(["SKILL.md", "commands"]);
+		expect((await readdir(join(outDir, "demo"))).sort()).toEqual(["SKILL.md", "commands"]);
 		expect(await readFile(join(outDir, "deployment-guide", "references", "guide.md"), "utf8")).toBe(
 			"# Guide\n",
 		);
-		expect(await readdir(join(outDir, "deployment-guide"))).toEqual(["SKILL.md", "references"]);
+		expect((await readdir(join(outDir, "deployment-guide"))).sort()).toEqual([
+			"SKILL.md",
+			"references",
+		]);
 	});
 
 	it("supports overrides and replaces stale output", async () => {

--- a/packages/skills/src/build.test.ts
+++ b/packages/skills/src/build.test.ts
@@ -54,11 +54,7 @@ describe("writeSkills", () => {
 		const bundleDir = await createBundle("deployment-guide", "Deployment guidance");
 		const outDir = join(tempRoot, "skills");
 
-		await writeSkills(createApp(), {
-			outDir,
-			version: "1.2.3",
-			extras: [bundleDir],
-		});
+		await writeSkills({ app: createApp(), outDir, version: "1.2.3", extras: [bundleDir] });
 
 		expect((await readdir(tempRoot)).sort()).toEqual(["deployment-guide", "skills"]);
 		expect(await readFile(join(outDir, "demo", "SKILL.md"), "utf8")).toContain("name: demo");
@@ -76,7 +72,8 @@ describe("writeSkills", () => {
 		const outDir = join(tempRoot, "skills");
 		await mkdir(join(outDir, "removed-skill"), { recursive: true });
 
-		await writeSkills(createApp(), {
+		await writeSkills({
+			app: createApp(),
 			outDir,
 			version: "2.0.0",
 			name: "demo-reference",
@@ -94,7 +91,7 @@ describe("writeSkills", () => {
 		const outDir = join(tempRoot, "skills");
 		const app = new Crust("gyst", { description: "Generated command reference" }).action(() => {});
 
-		await writeSkills(app, { outDir, version: "1.0.0", extras: [bundleDir] });
+		await writeSkills({ app: app, outDir, version: "1.0.0", extras: [bundleDir] });
 
 		const skill = await readFile(join(outDir, "gyst", "SKILL.md"), "utf8");
 		expect(skill).toContain("description: Authored co-review workflow");
@@ -107,7 +104,7 @@ describe("writeSkills", () => {
 		// No root description: generating this skill would fail, but it is replaced.
 		const app = new Crust("gyst").action(() => {});
 
-		await writeSkills(app, { outDir, extras: [bundleDir] });
+		await writeSkills({ app: app, outDir, extras: [bundleDir] });
 
 		const skill = await readFile(join(outDir, "gyst", "SKILL.md"), "utf8");
 		expect(skill).toContain("description: Authored co-review workflow");
@@ -118,7 +115,8 @@ describe("writeSkills", () => {
 		const second = join(tempRoot, "other", "guide");
 		await mkdir(second, { recursive: true });
 		await writeFile(join(second, "SKILL.md"), "---\nname: guide\ndescription: Second guide\n---\n");
-		const result = writeSkills(createApp(), {
+		const result = writeSkills({
+			app: createApp(),
 			outDir: join(tempRoot, "skills"),
 			extras: [first, second],
 		});
@@ -127,11 +125,18 @@ describe("writeSkills", () => {
 		await expect(result).rejects.toMatchObject({ skillName: "guide" });
 	});
 
-	it("can omit the generated command skill", async () => {
+	it("refuses to write an empty skill source", async () => {
+		const outDir = join(tempRoot, "skills");
+
+		await expect(writeSkills({ outDir })).rejects.toThrow("Nothing to write");
+		await expect(readdir(outDir)).rejects.toThrow();
+	});
+
+	it("writes only authored skills when no app is given", async () => {
 		const bundleDir = await createBundle("guide", "Authored guidance");
 		const outDir = join(tempRoot, "skills");
 
-		await writeSkills(createApp(), { outDir, generated: false, extras: [bundleDir] });
+		await writeSkills({ outDir, extras: [bundleDir] });
 
 		expect(await readdir(outDir)).toEqual(["guide"]);
 	});
@@ -144,7 +149,8 @@ describe("writeSkills", () => {
 			"---\nname: nested\ndescription: Nested\n---\n",
 		);
 
-		const result = writeSkills(createApp(), {
+		const result = writeSkills({
+			app: createApp(),
 			outDir,
 			version: "1.0.0",
 			extras: [join(outDir, "nested")],
@@ -157,7 +163,7 @@ describe("writeSkills", () => {
 		const outDir = join(tempRoot, "skills");
 		const app = new Crust("demo").action(() => {});
 
-		await expect(writeSkills(app, { outDir, version: "1.0.0" })).rejects.toThrow(
+		await expect(writeSkills({ app: app, outDir, version: "1.0.0" })).rejects.toThrow(
 			"requires a description",
 		);
 		await expect(readdir(outDir)).rejects.toThrow();
@@ -166,7 +172,7 @@ describe("writeSkills", () => {
 	it("requires the package skills directory layout", async () => {
 		const outDir = join(tempRoot, "agent-skills");
 
-		await expect(writeSkills(createApp(), { outDir, version: "1.0.0" })).rejects.toThrow(
+		await expect(writeSkills({ app: createApp(), outDir, version: "1.0.0" })).rejects.toThrow(
 			'must be named "skills"',
 		);
 		await expect(readdir(outDir)).rejects.toThrow();
@@ -175,11 +181,7 @@ describe("writeSkills", () => {
 	it("rejects an invalid skill name before writing", async () => {
 		const outDir = join(tempRoot, "skills");
 
-		const result = writeSkills(createApp(), {
-			outDir,
-			version: "1.0.0",
-			name: "Bad_Name",
-		});
+		const result = writeSkills({ app: createApp(), outDir, version: "1.0.0", name: "Bad_Name" });
 		await expect(result).rejects.toThrow('Invalid skill name "Bad_Name"');
 		await expect(readdir(outDir)).rejects.toThrow();
 	});

--- a/packages/skills/src/build.test.ts
+++ b/packages/skills/src/build.test.ts
@@ -105,10 +105,7 @@ describe("writeSkills", () => {
 		const first = await createBundle("guide", "First guide");
 		const second = join(tempRoot, "other", "guide");
 		await mkdir(second, { recursive: true });
-		await writeFile(
-			join(second, "SKILL.md"),
-			"---\nname: guide\ndescription: Second guide\n---\n",
-		);
+		await writeFile(join(second, "SKILL.md"), "---\nname: guide\ndescription: Second guide\n---\n");
 		const result = writeSkills(createApp(), {
 			outDir: join(tempRoot, "skills"),
 			extras: [first, second],

--- a/packages/skills/src/build.test.ts
+++ b/packages/skills/src/build.test.ts
@@ -89,18 +89,42 @@ describe("writeSkills", () => {
 		expect(skillMd).toContain("description: Complete demo reference");
 	});
 
-	it("rejects a generated and authored skill name collision before writing", async () => {
-		const bundleDir = await createBundle("demo", "Authored demo guidance");
+	it("lets an authored skill replace the same-named generated skill", async () => {
+		const bundleDir = await createBundle("gyst", "Authored co-review workflow");
+		const outDir = join(tempRoot, "skills");
+		const app = new Crust("gyst", { description: "Generated command reference" }).action(() => {});
+
+		await writeSkills(app, { outDir, version: "1.0.0", extras: [bundleDir] });
+
+		const skill = await readFile(join(outDir, "gyst", "SKILL.md"), "utf8");
+		expect(skill).toContain("description: Authored co-review workflow");
+		expect(skill).not.toContain("Generated command reference");
+	});
+
+	it("rejects duplicate authored skill names", async () => {
+		const first = await createBundle("guide", "First guide");
+		const second = join(tempRoot, "other", "guide");
+		await mkdir(second, { recursive: true });
+		await writeFile(
+			join(second, "SKILL.md"),
+			"---\nname: guide\ndescription: Second guide\n---\n",
+		);
+		const result = writeSkills(createApp(), {
+			outDir: join(tempRoot, "skills"),
+			extras: [first, second],
+		});
+
+		await expect(result).rejects.toBeInstanceOf(SkillSourceConflictError);
+		await expect(result).rejects.toMatchObject({ skillName: "guide" });
+	});
+
+	it("can omit the generated command skill", async () => {
+		const bundleDir = await createBundle("guide", "Authored guidance");
 		const outDir = join(tempRoot, "skills");
 
-		const result = writeSkills(createApp(), {
-			outDir,
-			version: "1.0.0",
-			extras: [bundleDir],
-		});
-		await expect(result).rejects.toBeInstanceOf(SkillSourceConflictError);
-		await expect(result).rejects.toMatchObject({ skillName: "demo" });
-		await expect(readdir(outDir)).rejects.toThrow();
+		await writeSkills(createApp(), { outDir, generated: false, extras: [bundleDir] });
+
+		expect(await readdir(outDir)).toEqual(["guide"]);
 	});
 
 	it("rejects an extra skill directory nested inside outDir", async () => {

--- a/packages/skills/src/build.test.ts
+++ b/packages/skills/src/build.test.ts
@@ -101,6 +101,18 @@ describe("writeSkills", () => {
 		expect(skill).not.toContain("Generated command reference");
 	});
 
+	it("does not validate a generated skill that an authored skill replaces", async () => {
+		const bundleDir = await createBundle("gyst", "Authored co-review workflow");
+		const outDir = join(tempRoot, "skills");
+		// No root description: generating this skill would fail, but it is replaced.
+		const app = new Crust("gyst").action(() => {});
+
+		await writeSkills(app, { outDir, extras: [bundleDir] });
+
+		const skill = await readFile(join(outDir, "gyst", "SKILL.md"), "utf8");
+		expect(skill).toContain("description: Authored co-review workflow");
+	});
+
 	it("rejects duplicate authored skill names", async () => {
 		const first = await createBundle("guide", "First guide");
 		const second = join(tempRoot, "other", "guide");

--- a/packages/skills/src/build.ts
+++ b/packages/skills/src/build.ts
@@ -22,6 +22,8 @@ export interface WriteSkillsOptions {
 	readonly name?: string;
 	/** Generated skill description. Defaults to the root command description. */
 	readonly description?: string;
+	/** Whether to emit the generated command skill. @default true */
+	readonly generated?: boolean;
 	/** Hand-authored skill directories included alongside the generated skill. */
 	readonly extras?: readonly (string | URL)[];
 }
@@ -46,17 +48,21 @@ export async function writeSkillsFromSnapshot(
 		description: options.description ?? snapshot.meta.description ?? "",
 		version: options.version,
 	};
-	validateSkillName(generatedMeta.name);
-	requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
+	if (options.generated !== false) {
+		validateSkillName(generatedMeta.name);
+		requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
+	}
 
 	const outDir = resolve(options.outDir);
 	if (basename(outDir) !== "skills") {
 		throw new Error(`Skill source outDir "${outDir}" must be named "skills".`);
 	}
 
-	const skills = new Map<string, readonly RenderedFile[]>([
-		[generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta)],
-	]);
+	const skills = new Map<string, readonly RenderedFile[]>();
+	if (options.generated !== false) {
+		skills.set(generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta));
+	}
+	const authoredNames = new Set<string>();
 
 	for (const sourceDir of options.extras ?? []) {
 		const resolved = resolveSourceDir(sourceDir);
@@ -68,9 +74,11 @@ export async function writeSkillsFromSnapshot(
 		}
 		const bundle = await loadBundleFiles(sourceDir);
 		validateSkillName(bundle.frontmatter.name);
-		if (skills.has(bundle.frontmatter.name)) {
+		if (authoredNames.has(bundle.frontmatter.name)) {
 			throw new SkillSourceConflictError(bundle.frontmatter.name);
 		}
+		authoredNames.add(bundle.frontmatter.name);
+		// An authored skill may intentionally replace the same-named generated command skill.
 		skills.set(bundle.frontmatter.name, bundle.files);
 	}
 

--- a/packages/skills/src/build.ts
+++ b/packages/skills/src/build.ts
@@ -43,25 +43,12 @@ export async function writeSkillsFromSnapshot(
 	snapshot: CommandSnapshot,
 	options: WriteSkillsOptions,
 ): Promise<void> {
-	const generatedMeta: SkillMeta = {
-		name: options.name ?? snapshot.meta.name,
-		description: options.description ?? snapshot.meta.description ?? "",
-		version: options.version,
-	};
-	if (options.generated !== false) {
-		validateSkillName(generatedMeta.name);
-		requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
-	}
-
 	const outDir = resolve(options.outDir);
 	if (basename(outDir) !== "skills") {
 		throw new Error(`Skill source outDir "${outDir}" must be named "skills".`);
 	}
 
 	const skills = new Map<string, readonly RenderedFile[]>();
-	if (options.generated !== false) {
-		skills.set(generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta));
-	}
 	const authoredNames = new Set<string>();
 
 	for (const sourceDir of options.extras ?? []) {
@@ -78,8 +65,20 @@ export async function writeSkillsFromSnapshot(
 			throw new SkillSourceConflictError(bundle.frontmatter.name);
 		}
 		authoredNames.add(bundle.frontmatter.name);
-		// An authored skill may intentionally replace the same-named generated command skill.
 		skills.set(bundle.frontmatter.name, bundle.files);
+	}
+
+	const generatedMeta: SkillMeta = {
+		name: options.name ?? snapshot.meta.name,
+		description: options.description ?? snapshot.meta.description ?? "",
+		version: options.version,
+	};
+	// An authored skill may intentionally replace the same-named generated command skill;
+	// a replaced skill is neither validated nor rendered.
+	if (options.generated !== false && !authoredNames.has(generatedMeta.name)) {
+		validateSkillName(generatedMeta.name);
+		requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
+		skills.set(generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta));
 	}
 
 	const cwd = resolve(".");

--- a/packages/skills/src/build.ts
+++ b/packages/skills/src/build.ts
@@ -12,8 +12,10 @@ import { renderSkill } from "./render.ts";
 import { isValidSkillName } from "./skill-name.ts";
 import type { RenderedFile, SkillMeta } from "./types.ts";
 
-/** Options for rendering an application's skill source. */
+/** Options for rendering a skill source. */
 export interface WriteSkillsOptions {
+	/** Application whose command tree is rendered into a generated skill. Omit to write only `extras`. */
+	readonly app?: { snapshot(): Promise<CommandSnapshot> };
 	/** `skills` directory that receives one subdirectory per skill. */
 	readonly outDir: string;
 	/** Version recorded in the generated skill's SKILL.md metadata. Omitted when absent. */
@@ -22,27 +24,32 @@ export interface WriteSkillsOptions {
 	readonly name?: string;
 	/** Generated skill description. Defaults to the root command description. */
 	readonly description?: string;
-	/** Whether to emit the generated command skill. @default true */
-	readonly generated?: boolean;
 	/** Hand-authored skill directories included alongside the generated skill. */
 	readonly extras?: readonly (string | URL)[];
 }
 
 /**
- * Renders an application's generated and authored skills into a package-ready skill source.
+ * Renders generated and authored skills into a package-ready skill source.
  */
-export async function writeSkills(
-	app: { snapshot(): Promise<CommandSnapshot> },
-	options: WriteSkillsOptions,
-): Promise<void> {
-	await writeSkillsFromSnapshot(await app.snapshot(), options);
+export async function writeSkills({ app, ...options }: WriteSkillsOptions): Promise<void> {
+	await writeSkillSource(await app?.snapshot(), options);
 }
 
 /** Renders skills from a Command Snapshot prepared in this or another process. */
 export async function writeSkillsFromSnapshot(
 	snapshot: CommandSnapshot,
-	options: WriteSkillsOptions,
+	options: Omit<WriteSkillsOptions, "app">,
 ): Promise<void> {
+	await writeSkillSource(snapshot, options);
+}
+
+async function writeSkillSource(
+	snapshot: CommandSnapshot | undefined,
+	options: Omit<WriteSkillsOptions, "app">,
+): Promise<void> {
+	if (snapshot === undefined && (options.extras?.length ?? 0) === 0) {
+		throw new Error("Nothing to write: provide an app or at least one extra skill directory.");
+	}
 	const outDir = resolve(options.outDir);
 	if (basename(outDir) !== "skills") {
 		throw new Error(`Skill source outDir "${outDir}" must be named "skills".`);
@@ -68,17 +75,19 @@ export async function writeSkillsFromSnapshot(
 		skills.set(bundle.frontmatter.name, bundle.files);
 	}
 
-	const generatedMeta: SkillMeta = {
-		name: options.name ?? snapshot.meta.name,
-		description: options.description ?? snapshot.meta.description ?? "",
-		version: options.version,
-	};
-	// An authored skill may intentionally replace the same-named generated command skill;
-	// a replaced skill is neither validated nor rendered.
-	if (options.generated !== false && !authoredNames.has(generatedMeta.name)) {
-		validateSkillName(generatedMeta.name);
-		requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
-		skills.set(generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta));
+	if (snapshot) {
+		const generatedMeta: SkillMeta = {
+			name: options.name ?? snapshot.meta.name,
+			description: options.description ?? snapshot.meta.description ?? "",
+			version: options.version,
+		};
+		// An authored skill may intentionally replace the same-named generated command skill;
+		// a replaced skill is neither validated nor rendered.
+		if (!authoredNames.has(generatedMeta.name)) {
+			validateSkillName(generatedMeta.name);
+			requireSkillFrontmatter(generatedMeta, `Skill "${generatedMeta.name}"`);
+			skills.set(generatedMeta.name, renderSkill(buildManifest(snapshot), generatedMeta));
+		}
 	}
 
 	const cwd = resolve(".");

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -95,15 +95,35 @@ describe("skill extension packaged directory", () => {
 		expect(output).not.toContain(source);
 	});
 
-	it("copies packaged sources from its build hook", async () => {
-		const source = await writeSource("demo", "packaged");
+	it("omits the generated skill when generated is false", async () => {
+		const authored = join(tempRoot, "authored", "guide");
+		await mkdir(authored, { recursive: true });
+		await writeFile(join(authored, "SKILL.md"), "---\nname: guide\ndescription: Guide\n---\n");
+		const extension = skill({
+			distDir: join(tempRoot, "dist", "skills"),
+			generated: false,
+			extras: [authored],
+		});
+		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
+		const outDir = join(tempRoot, "dist");
+
+		await extension.build?.({ snapshot, outDir });
+
+		expect(await readdir(join(outDir, "skills"))).toEqual(["guide"]);
+	});
+
+	it("generates from the snapshot even when a stale packaged directory exists", async () => {
+		const source = await writeSource("demo", "stale");
 		const extension = skill({ distDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
 
 		await extension.build?.({ snapshot, outDir });
 
-		expect(await readFile(join(outDir, "skills", "demo", "content.md"), "utf8")).toBe("packaged\n");
+		expect(await readdir(join(outDir, "skills", "demo"))).not.toContain("content.md");
+		expect(await readFile(join(outDir, "skills", "demo", "SKILL.md"), "utf8")).toContain(
+			"description: Demo",
+		);
 	});
 
 	it("generates command and authored skills together when extras are configured", async () => {
@@ -170,17 +190,6 @@ describe("skill extension packaged directory", () => {
 		expect(await readFile(join(outDir, "skills", "gyst-reference", "SKILL.md"), "utf8")).toContain(
 			"description: Generated command reference",
 		);
-	});
-
-	it("copies packaged sources when extras is empty", async () => {
-		const source = await writeSource("demo", "packaged");
-		const extension = skill({ distDir: source, extras: [] });
-		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
-		const outDir = join(tempRoot, "dist");
-
-		await extension.build?.({ snapshot, outDir });
-
-		expect(await readFile(join(outDir, "skills", "demo", "content.md"), "utf8")).toBe("packaged\n");
 	});
 
 	it("renders from the snapshot without requiring a package version", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -3,6 +3,7 @@ import {
 	lstat,
 	mkdir,
 	mkdtemp,
+	readdir,
 	readFile,
 	readlink,
 	rm,
@@ -143,6 +144,31 @@ describe("skill extension packaged directory", () => {
 			"authored\n",
 		);
 		await expect(lstat(join(outDir, "skills", "stale"))).rejects.toThrow();
+	});
+
+	it("forwards generated skill overrides to the build", async () => {
+		const source = await writeSource("stale", "stale");
+		const authored = join(tempRoot, "authored", "gyst");
+		await mkdir(authored, { recursive: true });
+		await writeFile(
+			join(authored, "SKILL.md"),
+			"---\nname: gyst\ndescription: Authored co-review workflow\n---\n",
+		);
+		const extension = skill({
+			distDir: source,
+			extras: [authored],
+			name: "gyst-reference",
+			description: "Generated command reference",
+		});
+		const snapshot = await new Crust("gyst", { description: "Gyst" }).extend(extension).snapshot();
+		const outDir = join(tempRoot, "dist");
+
+		await extension.build?.({ snapshot, outDir });
+
+		expect((await readdir(join(outDir, "skills"))).sort()).toEqual(["gyst", "gyst-reference"]);
+		expect(
+			await readFile(join(outDir, "skills", "gyst-reference", "SKILL.md"), "utf8"),
+		).toContain("description: Generated command reference");
 	});
 
 	it("copies packaged sources when extras is empty", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -16,8 +16,8 @@ import { dirname, join, resolve } from "node:path";
 import { Crust } from "@crustjs/core";
 import { renderHelp } from "@crustjs/extensions";
 import { withPromptIO } from "@crustjs/prompts";
-import { captureExecute } from "@crustjs/testing";
 import { createPromptIO } from "@crustjs/prompts/testing";
+import { captureExecute } from "@crustjs/testing";
 
 import { skill } from "./extension.ts";
 import { installSkill } from "./generate.ts";
@@ -167,9 +167,9 @@ describe("skill extension packaged directory", () => {
 		await extension.build?.({ snapshot, outDir });
 
 		expect((await readdir(join(outDir, "skills"))).sort()).toEqual(["gyst", "gyst-reference"]);
-		expect(
-			await readFile(join(outDir, "skills", "gyst-reference", "SKILL.md"), "utf8"),
-		).toContain("description: Generated command reference");
+		expect(await readFile(join(outDir, "skills", "gyst-reference", "SKILL.md"), "utf8")).toContain(
+			"description: Generated command reference",
+		);
 	});
 
 	it("copies packaged sources when extras is empty", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -16,6 +16,7 @@ import { dirname, join, resolve } from "node:path";
 import { Crust } from "@crustjs/core";
 import { renderHelp } from "@crustjs/extensions";
 import { withPromptIO } from "@crustjs/prompts";
+import { captureExecute } from "@crustjs/testing";
 import { createPromptIO } from "@crustjs/prompts/testing";
 
 import { skill } from "./extension.ts";
@@ -268,14 +269,32 @@ describe("skill extension packaged directory", () => {
 		expect(await readlink(installed)).toBe(stale);
 	});
 
-	it("leaves conflicts untouched during preRun repair", async () => {
+	it("reports preRun conflicts through injected stderr", async () => {
 		const source = await writeSource("demo");
-		const installed = join(tempRoot, ".claude", "skills", "demo");
+		const installed = target();
 		await mkdir(installed, { recursive: true });
 		await writeFile(join(installed, "manual.md"), "keep\n");
-
-		await withCwd(tempRoot, () => createApp(source).execute({ argv: [] }));
+		const originalWarn = console.warn;
+		const ambientWarnings: unknown[] = [];
+		console.warn = (...args) => ambientWarnings.push(...args);
+		try {
+			const captured = await withCwd(tempRoot, () => captureExecute(createApp(source), []));
+			expect(captured.exitCode).toBe(0);
+			expect(captured.stderr).toContain("Skill conflict [demo]");
+			expect(ambientWarnings).toEqual([]);
+		} finally {
+			console.warn = originalWarn;
+		}
 		expect(await readFile(join(installed, "manual.md"), "utf8")).toBe("keep\n");
+	});
+
+	it("quietly skips preRun repair for an empty packaged source", async () => {
+		const source = join(tempRoot, "package", "skills");
+		await mkdir(source, { recursive: true });
+
+		const captured = await withCwd(tempRoot, () => captureExecute(createApp(source), []));
+
+		expect(captured).toEqual({ stdout: "", stderr: "", exitCode: 0 });
 	});
 
 	it("rejects an invalid --scope value", async () => {

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -297,13 +297,16 @@ describe("skill extension packaged directory", () => {
 		expect(captured).toEqual({ stdout: "", stderr: "", exitCode: 0 });
 	});
 
-	it("rejects an invalid --scope value", async () => {
+	it("rejects an invalid --scope value during parsing", async () => {
 		const source = await writeSource("demo");
-		await withCwd(tempRoot, () =>
-			createApp(source).execute({ argv: ["skill", "update", "--scope", "bogus"] }),
+		const captured = await withCwd(tempRoot, () =>
+			captureExecute(createApp(source), ["skill", "update", "--scope", "bogus"]),
 		);
-		expect(process.exitCode).toBe(1);
-		process.exitCode = 0;
+
+		expect(captured.exitCode).toBe(1);
+		expect(captured.stderr).toContain("Expected one of");
+		expect(captured.stderr).toContain("project");
+		expect(captured.stderr).toContain("global");
 	});
 
 	it("still advertises and runs valid skills when the source contains a cruft directory", async () => {

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -421,6 +421,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 					{
 						name: "scope",
 						type: "string",
+						choices: ["project", "global"],
 						description: "Install scope (project or global)",
 					},
 					{
@@ -435,6 +436,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 							.flags({
 								name: "scope",
 								type: "string",
+								choices: ["project", "global"],
 								description: "Update scope (project or global)",
 							})
 							.action(async (context) => {

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -224,6 +224,9 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 		await writeSkillsFromSnapshot(context.snapshot, {
 			outDir,
 			version: await readPackageVersion(),
+			name: options.name,
+			description: options.description,
+			generated: options.generated,
 			extras: options.extras,
 		});
 		return;

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -1,5 +1,5 @@
-import { cp, mkdir, readFile, rm } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
 
 import {
 	type Extension,
@@ -21,7 +21,7 @@ import {
 	getUniversalAgents,
 	resolveEffectiveScope,
 } from "./agents.ts";
-import { writeSkillsFromSnapshot } from "./build.ts";
+import { writeSkills } from "./build.ts";
 import { SkillConflictError } from "./errors.ts";
 import {
 	getSkillStatus,
@@ -32,12 +32,7 @@ import {
 import { SKILLS } from "./manifest.ts";
 import { isWithin } from "./path.ts";
 import { planReconcile, UNIVERSAL_GROUP, type ReconcileChoice } from "./reconcile.ts";
-import {
-	SkillSourceUnavailableError,
-	loadPackagedSkills,
-	resolveSkillSource,
-	type PackagedSkill,
-} from "./source.ts";
+import { SkillSourceUnavailableError, loadPackagedSkills, type PackagedSkill } from "./source.ts";
 import type { AgentTarget, InstallSkillResult, Scope, SkillOptions } from "./types.ts";
 
 const DEFAULT_SKILL_COMMAND_NAME = "skill";
@@ -215,36 +210,15 @@ async function readPackageVersion(): Promise<string | undefined> {
 }
 
 async function buildSkills(options: SkillOptions, context: ExtensionBuildContext): Promise<void> {
-	const outDir = join(context.outDir, "skills");
-	let source: string | undefined;
-	try {
-		source = resolveSkillSource(options.distDir);
-	} catch (error) {
-		if (!(error instanceof SkillSourceUnavailableError)) throw error;
-		// A missing packaged directory is regenerated from the snapshot below.
-	}
-
-	if (source === undefined || (options.extras?.length ?? 0) > 0) {
-		await writeSkillsFromSnapshot(context.snapshot, {
-			outDir,
-			version: await readPackageVersion(),
-			name: options.name,
-			description: options.description,
-			generated: options.generated,
-			extras: options.extras,
-		});
-		return;
-	}
-
-	// rm below would destroy a packaged directory nested in (or equal to) its output.
-	if (isWithin(outDir, source)) {
-		throw new Error(
-			`Packaged skills directory "${source}" cannot be nested inside output directory "${outDir}".`,
-		);
-	}
-	await rm(outDir, { recursive: true, force: true });
-	await mkdir(dirname(outDir), { recursive: true });
-	await cp(source, outDir, { recursive: true });
+	await writeSkills({
+		// The snapshot is already prepared; wrap it so the generated skill can be opted out.
+		app: options.generated === false ? undefined : { snapshot: async () => context.snapshot },
+		outDir: join(context.outDir, "skills"),
+		version: await readPackageVersion(),
+		name: options.name,
+		description: options.description,
+		extras: options.extras,
+	});
 }
 
 function skillFactory(options: SkillOptions): Extension {

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -5,6 +5,7 @@ import {
 	type Extension,
 	type ExtensionId,
 	type ExtensionBuildContext,
+	type InvocationIO,
 	defineCommand,
 	defineExtension,
 } from "@crustjs/core";
@@ -43,6 +44,8 @@ const DEFAULT_SKILL_COMMAND_NAME = "skill";
 const SKILLS_SECTION_TITLE = "Agent skills";
 const DEFAULT_SKILL_SCOPE = "global";
 
+type SkillIO = Pick<InvocationIO, "stdout" | "stderr">;
+
 function parseScopeFlag(value: string | undefined): Scope | undefined {
 	if (value === undefined) return undefined;
 	if (value !== "global" && value !== "project") {
@@ -77,6 +80,7 @@ function formatAgentLabels(agents: readonly AgentTarget[]): string[] {
 async function repairInstalledSkill(
 	packagedSkill: PackagedSkill,
 	scope: Scope,
+	io: SkillIO,
 	report = false,
 ): Promise<void> {
 	const effectiveScope = resolveEffectiveScope(scope);
@@ -88,7 +92,7 @@ async function repairInstalledSkill(
 	for (const outputDir of new Set(
 		status.agents.filter((entry) => entry.status === "conflict").map((entry) => entry.outputDir),
 	)) {
-		console.warn(
+		io.stderr(
 			yellow(
 				`Skill conflict [${packagedSkill.name}]: "${outputDir}" is not owned by this skill. Skipping link repair.`,
 			),
@@ -96,7 +100,7 @@ async function repairInstalledSkill(
 	}
 	const stale = status.agents.filter((entry) => entry.status === "dangling");
 	if (stale.length === 0) {
-		if (report) console.log(dim(`No repairs needed [${packagedSkill.name}] (${effectiveScope}).`));
+		if (report) io.stdout(dim(`No repairs needed [${packagedSkill.name}] (${effectiveScope}).`));
 		return;
 	}
 
@@ -108,14 +112,14 @@ async function repairInstalledSkill(
 		});
 		const labels = formatAgentLabels(result.agents.map((entry) => entry.agent));
 		if (report && labels.length > 0) {
-			console.log(
+			io.stdout(
 				`\n${bold(`Repaired "${packagedSkill.name}" for ${labels.join(", ")} (${effectiveScope})`)}`,
 			);
 		}
 	} catch (error) {
 		// The entry may change hands between the status check and install (TOCTOU).
 		if (!(error instanceof SkillConflictError)) throw error;
-		console.warn(
+		io.stderr(
 			yellow(
 				`Skill conflict [${packagedSkill.name}]: "${error.details.outputDir}" is not owned by this skill. Skipping link repair.`,
 			),
@@ -123,7 +127,7 @@ async function repairInstalledSkill(
 	}
 }
 
-async function autoRepairSkills(options: SkillOptions): Promise<void> {
+async function autoRepairSkills(options: SkillOptions, io: SkillIO): Promise<void> {
 	let skills: readonly PackagedSkill[];
 	try {
 		skills = loadPackagedSkills(options.distDir);
@@ -131,7 +135,7 @@ async function autoRepairSkills(options: SkillOptions): Promise<void> {
 		// A missing or invalid packaged asset must not prevent unrelated CLI commands
 		// from running; the explicit skill command surfaces the same failure loudly.
 		if (!(error instanceof SkillSourceUnavailableError)) {
-			console.warn(
+			io.stderr(
 				yellow(
 					`Skipping skill link repair: ${error instanceof Error ? error.message : String(error)}`,
 				),
@@ -146,11 +150,11 @@ async function autoRepairSkills(options: SkillOptions): Promise<void> {
 	for (const packagedSkill of skills) {
 		for (const scope of scopes) {
 			try {
-				await repairInstalledSkill(packagedSkill, scope);
+				await repairInstalledSkill(packagedSkill, scope, io);
 			} catch (error) {
 				// Filesystem errors during background repair must not abort the user's
 				// unrelated command; the explicit skill command surfaces them loudly.
-				console.warn(
+				io.stderr(
 					yellow(
 						`Skipping skill link repair [${packagedSkill.name}]: ${error instanceof Error ? error.message : String(error)}`,
 					),
@@ -261,7 +265,7 @@ function skillFactory(options: SkillOptions): Extension {
 		hooks: {
 			async preRun(context) {
 				if (context.commandPath[1] === commandName || options.autoUpdate === false) return;
-				await autoRepairSkills(options);
+				await autoRepairSkills(options, context);
 			},
 		},
 	});
@@ -276,8 +280,9 @@ async function reconcileSkill(opts: {
 	packagedSkill: PackagedSkill;
 	scope: Scope;
 	installAll: boolean;
+	io: SkillIO;
 }): Promise<void> {
-	const { packagedSkill, scope, installAll } = opts;
+	const { packagedSkill, scope, installAll, io } = opts;
 	const detected = new Set(await detectInstalledAgents());
 	const universal = getUniversalAgents();
 	const status = await getSkillStatus({
@@ -336,7 +341,7 @@ async function reconcileSkill(opts: {
 		universal,
 	});
 	for (const warning of sharedDirWarnings) {
-		console.warn(
+		io.stderr(
 			yellow(
 				`${warning.label} [${packagedSkill.name}]: "${warning.outputDir}" is shared with a selected agent, so the skill stays available to it.`,
 			),
@@ -365,7 +370,7 @@ async function reconcileSkill(opts: {
 				const label = formatAgentLabels(agents).join(", ");
 				const skipped = `Skipped ${label} [${packagedSkill.name}]: directory is not owned by this skill.`;
 				if (installAll) {
-					console.warn(yellow(skipped));
+					io.stderr(yellow(skipped));
 					continue;
 				}
 				const overwrite = await confirm({
@@ -373,7 +378,7 @@ async function reconcileSkill(opts: {
 					default: false,
 				});
 				if (!overwrite) {
-					console.log(dim(skipped));
+					io.stdout(dim(skipped));
 					continue;
 				}
 				const result = await runInstall(true);
@@ -381,11 +386,11 @@ async function reconcileSkill(opts: {
 			}
 		}
 		if (installedAgents.length > 0) {
-			console.log(`\n${bold(`Installed "${packagedSkill.name}"`)}`);
+			io.stdout(`\n${bold(`Installed "${packagedSkill.name}"`)}`);
 			for (const line of new Map(
 				installedAgents.map((entry) => [formatAgentLabels([entry.agent])[0]!, entry.outputDir]),
 			)) {
-				console.log(dim(`  ${line[0]} → ${line[1]}`));
+				io.stdout(dim(`  ${line[0]} → ${line[1]}`));
 			}
 		}
 	}
@@ -402,7 +407,7 @@ async function reconcileSkill(opts: {
 		});
 	}
 	if (toInstall.length === 0 && toUninstall.length === 0) {
-		console.log(dim(`No changes [${packagedSkill.name}].`));
+		io.stdout(dim(`No changes [${packagedSkill.name}].`));
 	}
 }
 
@@ -435,7 +440,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 							.action(async (context) => {
 								const scope = await resolveScope(context.flags.scope, options);
 								for (const packagedSkill of loadPackagedSkills(options.distDir)) {
-									await repairInstalledSkill(packagedSkill, scope, true);
+									await repairInstalledSkill(packagedSkill, scope, context, true);
 								}
 							}),
 					),
@@ -446,7 +451,7 @@ function buildSkillCommand(commandName: string, options: SkillOptions) {
 						? (parseScopeFlag(context.flags.scope) ?? options.defaultScope ?? DEFAULT_SKILL_SCOPE)
 						: await resolveScope(context.flags.scope, options);
 					for (const packagedSkill of loadPackagedSkills(options.distDir)) {
-						await reconcileSkill({ packagedSkill, scope, installAll });
+						await reconcileSkill({ packagedSkill, scope, installAll, io: context });
 					}
 				}),
 	);

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -53,6 +53,13 @@ describe("buildManifest", () => {
 			);
 		});
 
+		it("ignores hidden same-named children, which are never rendered", () => {
+			const child = makeCommand({ meta: { name: "demo", hidden: true }, run: () => {} });
+			const root = makeCommand({ meta: { name: "demo" }, subCommands: { demo: child } });
+
+			expect(buildManifest(snapshotCommand(root)).children).toEqual([]);
+		});
+
 		it("returns a ManifestNode with name and path from meta", () => {
 			const cmd = makeCommand({
 				meta: { name: "my-cli", description: "A test CLI" },

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -44,6 +44,15 @@ function makeCommand(opts: {
 
 describe("buildManifest", () => {
 	describe("root command basics", () => {
+		it("rejects a direct subcommand that would overwrite the root command file", () => {
+			const child = makeCommand({ meta: { name: "demo" }, run: () => {} });
+			const root = makeCommand({ meta: { name: "demo" }, subCommands: { demo: child } });
+
+			expect(() => buildManifest(snapshotCommand(root))).toThrow(
+				'Cannot generate skills when a direct subcommand has the root command name "demo"',
+			);
+		});
+
 		it("returns a ManifestNode with name and path from meta", () => {
 			const cmd = makeCommand({
 				meta: { name: "my-cli", description: "A test CLI" },

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -13,6 +13,12 @@ import type { ManifestArg, ManifestFlag, ManifestNode } from "./types.ts";
 export const SKILLS: ExtensionId = defineExtensionId("crust:skills");
 
 export function buildManifest(command: CommandSnapshot): ManifestNode {
+	const rootName = normalizeName(command.meta.name);
+	if (Object.values(command.subCommands).some((child) => normalizeName(child.meta.name) === rootName)) {
+		throw new Error(
+			`Cannot generate skills when a direct subcommand has the root command name "${rootName}".`,
+		);
+	}
 	return buildNode(buildCommandDocumentation(command), command);
 }
 function buildNode(model: CommandDocumentation, source: CommandSnapshot): ManifestNode {

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -1,6 +1,7 @@
 import { type CommandSnapshot, type ExtensionId, defineExtensionId } from "@crustjs/core";
 import {
 	buildCommandDocumentation,
+	isListed,
 	sectionsFor,
 	type CommandDocumentation,
 	type DocumentationArg,
@@ -15,7 +16,9 @@ export const SKILLS: ExtensionId = defineExtensionId("crust:skills");
 export function buildManifest(command: CommandSnapshot): ManifestNode {
 	const rootName = normalizeName(command.meta.name);
 	if (
-		Object.values(command.subCommands).some((child) => normalizeName(child.meta.name) === rootName)
+		Object.values(command.subCommands).some(
+			(child) => isListed(child) && normalizeName(child.meta.name) === rootName,
+		)
 	) {
 		throw new Error(
 			`Cannot generate skills when a direct subcommand has the root command name "${rootName}".`,

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -14,7 +14,9 @@ export const SKILLS: ExtensionId = defineExtensionId("crust:skills");
 
 export function buildManifest(command: CommandSnapshot): ManifestNode {
 	const rootName = normalizeName(command.meta.name);
-	if (Object.values(command.subCommands).some((child) => normalizeName(child.meta.name) === rootName)) {
+	if (
+		Object.values(command.subCommands).some((child) => normalizeName(child.meta.name) === rootName)
+	) {
 		throw new Error(
 			`Cannot generate skills when a direct subcommand has the root command name "${rootName}".`,
 		);

--- a/packages/skills/src/source.ts
+++ b/packages/skills/src/source.ts
@@ -100,7 +100,9 @@ export function loadPackagedSkills(source: string | URL): readonly PackagedSkill
 		skills.push({ sourceDir, name: frontmatter.name, description: frontmatter.description });
 	}
 	if (skills.length === 0) {
-		throw new Error(`Skill source "${root}" does not contain any skill directories.`);
+		throw new SkillSourceUnavailableError(
+			`Skill source "${root}" does not contain any skill directories.`,
+		);
 	}
 	return skills.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -153,11 +153,11 @@ export interface SkillOptions {
 	 * includes only these authored skills instead of copying `distDir`.
 	 */
 	extras?: readonly (string | URL)[];
-	/** Generated command skill name. Defaults to the root command name. */
+	/** Generated command skill name. Used when regenerating because `distDir` is unavailable or `extras` is non-empty. Defaults to the root command name. */
 	name?: string;
-	/** Generated command skill description. Defaults to the root command description. */
+	/** Generated command skill description. Used when regenerating because `distDir` is unavailable or `extras` is non-empty. Defaults to the root command description. */
 	description?: string;
-	/** Whether to emit the generated command skill. @default true */
+	/** Whether to emit the generated command skill when regenerating because `distDir` is unavailable or `extras` is non-empty. @default true */
 	generated?: boolean;
 	/** Default agent-directory scope. */
 	defaultScope?: Scope;

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -145,19 +145,15 @@ export interface SkillStatusResult {
 
 /** Options for the skills extension. */
 export interface SkillOptions {
-	/** Read-only directory produced by writeSkills(). */
+	/** Packaged skills directory read at runtime for discovery and installation. */
 	distDir: string | URL;
-	/**
-	 * Hand-authored skill directories (URL, absolute, or package-root-relative path).
-	 * When non-empty, the build regenerates the command skill from the snapshot and
-	 * includes only these authored skills instead of copying `distDir`.
-	 */
+	/** Hand-authored skill directories (URL, absolute, or package-root-relative path) built alongside the generated skill. */
 	extras?: readonly (string | URL)[];
-	/** Generated command skill name. Used when regenerating because `distDir` is unavailable or `extras` is non-empty. Defaults to the root command name. */
+	/** Generated command skill name. Defaults to the root command name. */
 	name?: string;
-	/** Generated command skill description. Used when regenerating because `distDir` is unavailable or `extras` is non-empty. Defaults to the root command description. */
+	/** Generated command skill description. Defaults to the root command description. */
 	description?: string;
-	/** Whether to emit the generated command skill when regenerating because `distDir` is unavailable or `extras` is non-empty. @default true */
+	/** Whether to build the generated command skill. Set `false` to ship only `extras`. @default true */
 	generated?: boolean;
 	/** Default agent-directory scope. */
 	defaultScope?: Scope;

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -153,6 +153,12 @@ export interface SkillOptions {
 	 * includes only these authored skills instead of copying `distDir`.
 	 */
 	extras?: readonly (string | URL)[];
+	/** Generated command skill name. Defaults to the root command name. */
+	name?: string;
+	/** Generated command skill description. Defaults to the root command description. */
+	description?: string;
+	/** Whether to emit the generated command skill. @default true */
+	generated?: boolean;
 	/** Default agent-directory scope. */
 	defaultScope?: Scope;
 	/** Repair stale or dangling owned links before commands run. @default true */

--- a/packages/skills/tests/e2e.test.ts
+++ b/packages/skills/tests/e2e.test.ts
@@ -34,7 +34,7 @@ describe("package-as-source pipeline", () => {
 				defineCommand("deploy", { description: "Deploy" }, (command) => command.action(() => {})),
 			);
 		const source = join(tempRoot, "package", "skills");
-		await writeSkills(app, { outDir: source, version: "1.0.0" });
+		await writeSkills({ app, outDir: source, version: "1.0.0" });
 
 		// Discovery reads required Agent Skills frontmatter and validates the directory name.
 		expect(loadPackagedSkills(source)).toMatchObject([{ name: "demo", description: "Demo CLI" }]);


### PR DESCRIPTION
## Context

These issues were found while auditing the stacked gyst integration against crust's intended APIs and end-to-end type/runtime boundaries.

## What changed

### Skills: authored root override

**Bug:** `skill({ extras })` always generated a root-named command skill first, then rejected an authored skill with that same name. A CLI such as gyst therefore could not ship its authored `/gyst` workflow through the documented extras mechanism.

**Fix:** authored extras may replace the same-named generated skill; duplicate authored names still fail. `SkillOptions` now also exposes `name`, `description`, and `generated: false` so consumers can rename, describe, or suppress generated command documentation.

### Skills: injected IO routing

**Bug:** skill install/update and automatic link repair wrote through ambient `console.log`/`console.warn`, bypassing Crust's injected invocation IO. Auto-repair warnings could therefore pollute a machine-readable stderr protocol and were invisible to `captureExecute`.

**Fix:** all skill output is routed through invocation `stdout`/`stderr`. An empty packaged source is treated as unavailable and quietly skipped by automatic repair. Tests prove conflicts are captured through injected stderr with no ambient-console writes.

### Core: excess positional validation

**Bug:** positionals not consumed by declared arguments were silently discarded. On a runnable parent, a typo such as `gyst sesion status` could launch the parent action instead of failing.

**Fix:** parsing tracks unconsumed pre-`--` positionals and validation rejects them by default. Commands intentionally accepting loose positionals can set `allowExcessPositionals: true`; declared variadic arguments remain preferred. Tokens after `--` continue to be exposed as `rawArgs`.

### Small audit fixes

- Preserve native option details for missing/invalid flag values instead of collapsing them to a generic parse error.
- Reject generated-skill command-file collisions when a direct subcommand shares the root name, rather than silently overwriting root documentation.
- Declare `skill --scope` choices so invalid scopes fail at parse time with actionable choices.
- Copy common `LICENSE.md`, `LICENCE`, and `LICENCE.md` variants into staged distribution packages.

## Breaking-change notes

- **Behavioral tightening (`@crustjs/core` minor):** undeclared positionals before `--` now produce a `VALIDATION` error instead of being ignored. Consumers that intentionally depended on silent dropping must set `allowExcessPositionals: true`; consumers forwarding arbitrary tokens should normally declare a variadic argument or use `--` and `rawArgs`. Typoed subcommands under a runnable parent now fail validation rather than reaching `didYouMean`.
- `ParseResult` now reports `excessArgs`. Normal consumers receive it from Crust parsing; code manually constructing `ParseResult` values must add the field.
- An authored extra matching the generated skill name now replaces it rather than throwing. Duplicate authored extras remain errors.
- A root/direct-child command-name collision during skill generation now fails explicitly instead of producing a silently overwritten artifact.
- Remaining changes are additive or improve output routing/error detail.

## Test evidence

- `bun run check` — all package builds, lint, and formatting passed.
- `bun run check:types` — 26/26 tasks passed across packages and docs.
- `bun run test` — 25/25 package tasks passed; core reports 552 passing tests, with new focused regression coverage for every change above.
- `git diff --check origin/main...HEAD` — passed.

Seven changesets describe the affected public behavior and package release levels; strict positional validation is marked as an `@crustjs/core` minor change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


