### PR TITLE
refactor(core): remove dead surface and single-use indirection

### DIFF
--- a/.changeset/remove-untyped-args.md
+++ b/.changeset/remove-untyped-args.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": minor
+---
+
+Remove untyped positional argument definitions. Declare a core `type` or provide a Standard Schema with `schema`.

--- a/.changeset/remove-untyped-args.md
+++ b/.changeset/remove-untyped-args.md
@@ -3,3 +3,5 @@
 ---
 
 Remove untyped positional argument definitions. Declare a core `type` or provide a Standard Schema with `schema`.
+
+Context instances no longer include `kind: "context"`. Stop reading or discriminating on `kind`; use the exported `ContextInstance` type for static typing.

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -49,8 +49,6 @@ const args = [{ name: "port", schema: z.coerce.number().int().min(1) }] as const
 
 The schema receives `string | undefined`, or `string[]` for a variadic argument. It exclusively owns coercion, defaults, requiredness, choices, and validation, so `type`, `required`, `default`, `choices`, and `parse` are not available in this variant. The schema's output type reaches the Command Action.
 
-An argument with neither `type` nor `schema` is a raw definition and returns the raw token value.
-
 ### `FlagDef`
 
 ```ts

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -60,7 +60,7 @@ Downstream commands and other Context setups call `await ctx.api`. See [Contexts
 
 | Type                                          | Description                                                               |
 | --------------------------------------------- | ------------------------------------------------------------------------- |
-| `ArgDef`                                      | Core-value, raw, or Standard Schema positional argument definition        |
+| `ArgDef`                                      | Core-value or Standard Schema positional argument definition              |
 | `ArgsDef`                                     | Readonly ordered argument definitions                                     |
 | [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                               |
 | [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                        |

--- a/packages/core/src/api/context.test.ts
+++ b/packages/core/src/api/context.test.ts
@@ -26,7 +26,6 @@ describe("defineContext()", () => {
 		expect(auth.contextName).toBe("auth");
 
 		const instance = auth();
-		expect(instance.kind).toBe("context");
 		expect(instance.name).toBe("auth");
 		await expect(
 			Promise.resolve(
@@ -740,7 +739,6 @@ describe("Context dependency runtime boundaries", () => {
 		const aFactory = defineContext("a", () => "a");
 		const bFactory = defineContext("b", () => "b");
 		const a: ContextInstance<"a"> = {
-			kind: "context",
 			name: "a",
 			ownedFlags: {},
 			uses: [bFactory],
@@ -750,7 +748,6 @@ describe("Context dependency runtime boundaries", () => {
 			},
 		};
 		const b: ContextInstance<"b"> = {
-			kind: "context",
 			name: "b",
 			ownedFlags: {},
 			uses: [aFactory],

--- a/packages/core/src/api/context.ts
+++ b/packages/core/src/api/context.ts
@@ -1,5 +1,5 @@
 import { CrustError, type CaughtError } from "../errors.ts";
-import { assertDefinableFlag } from "../parsing/spellings.ts";
+import { toFlagsRecord } from "../parsing/spellings.ts";
 import type {
 	FlagsDef,
 	InferFlags,
@@ -8,14 +8,11 @@ import type {
 	NamedFlagDef,
 	NamedFlagsRecord,
 } from "../types.ts";
-import type { ValidateNamedFlagDefs } from "../validation/flags.brands.ts";
+import type { ContextOwnedFlags, ValidateNamedFlagDefs } from "../validation/flags.brands.ts";
+import type { Awaitable } from "../validation/shared.ts";
 
 /** Upper bound for phantom name-to-value context maps. */
 export type ContextMap = object;
-export type Awaitable<T> = T | Promise<T>;
-export type Simplify<T> = { [K in keyof T]: T[K] };
-// Flat intersections keep chained composition at constant instantiation depth.
-export type MergeContext<A, B> = A & B;
 
 /** Lazy, invocation-scoped Context values. Reading a property starts construction. */
 export type ContextBag<Deps extends ContextMap = {}> = {
@@ -44,7 +41,6 @@ export interface ContextInstance<
 	OF extends FlagsDef = {},
 	Deps extends ContextMap = {},
 > {
-	readonly kind: "context";
 	readonly name: Name;
 	readonly ownedFlags: FlagsDef;
 	/** @internal — declared direct dependency factories */
@@ -103,8 +99,6 @@ export type ContextsOwnedFlags<Cs extends readonly ContextInstance[]> = Cs exten
 ]
 	? MergeFlags<ContextOwnedFlags<H>, ContextsOwnedFlags<T>>
 	: {};
-
-type ContextOwnedFlags<C> = C extends ContextInstance<any, any, infer OF, any> ? OF : {};
 
 export type FactoryOutput<F> =
 	F extends ContextFactory<infer Name, any, infer Value, any, any>
@@ -183,18 +177,9 @@ export function defineContext(
 	const config = hasConfig ? configOrSetup : {};
 	const setup = hasConfig ? maybeSetup : configOrSetup;
 	if (!setup) throw new CrustError("DEFINITION", `Context "${name}" requires a setup function`);
-	const ownedFlags: FlagsDef = {};
-	for (const def of config.flags ?? []) {
-		const { name: flagName, ...rest } = def;
-		// Validate before the record assignment: a `__proto__` key would be
-		// silently swallowed as the record's prototype.
-		const flag = rest;
-		assertDefinableFlag(flagName, flag);
-		ownedFlags[flagName] = flag;
-	}
+	const ownedFlags = toFlagsRecord(config.flags ?? []);
 	const uses = Object.freeze([...(config.uses ?? [])]);
 	const factory = (options: Parameters<AnyContextFactory>[0]): ContextInstance => ({
-		kind: "context",
 		name,
 		ownedFlags,
 		uses,
@@ -206,7 +191,6 @@ export function defineContext(
 	factory.contextName = name;
 	factory.uses = uses;
 	factory.of = (value: ContextValue): ContextInstance => ({
-		kind: "context",
 		name,
 		ownedFlags,
 		uses: [],

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -2,11 +2,10 @@ import type { CommandDefinition } from "../command/crust.ts";
 import type { CommandSnapshot } from "../command/snapshot.ts";
 import type { CaughtError } from "../errors.ts";
 import type { ExtensionId } from "../identity.ts";
-import { assertDefinableFlag } from "../parsing/spellings.ts";
+import { toFlagsRecord } from "../parsing/spellings.ts";
 import type {
 	CommandSectionInput,
 	FlagDef,
-	FlagsDef,
 	InferFlags,
 	InvocationIO,
 	NamedFlagDef,
@@ -21,9 +20,9 @@ import type {
 	ProvidedContextSpellings,
 	ValidateNamedFlagDefs,
 } from "../validation/flags.brands.ts";
+import type { Awaitable } from "../validation/shared.ts";
 import type {
 	AnyContextFactory,
-	Awaitable,
 	ContextBag,
 	ContextDependencies,
 	ContextInstance,
@@ -324,16 +323,7 @@ export function defineExtension<
 	Defs,
 	Commands
 > {
-	const ownedFlags: FlagsDef = {};
-	for (const def of config.flags ?? []) {
-		const { name: flagName, ...rest } = def;
-		// Validate before the record assignment: a `__proto__` key would be
-		// silently swallowed as the record's prototype.
-		// SAFETY: removing name from a NamedExtensionFlagDef leaves its runtime ExtensionFlagDef.
-		const flag = rest as ExtensionFlagDef;
-		assertDefinableFlag(flagName, flag);
-		ownedFlags[flagName] = flag;
-	}
+	const ownedFlags = toFlagsRecord(config.flags ?? []);
 
 	// SAFETY: the runtime registry erases Defs after this function contextually typed every hook.
 	return Object.freeze({

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -107,6 +107,14 @@ describe("Crust builder methods — immutability + non-mutation", () => {
 		apply(app);
 		expect(await app.snapshot()).toEqual(before);
 	});
+
+	it("shares immutable descendants across fluent clones", () => {
+		const app = new Crust("test").add(defineCommand("sub", (command) => command));
+		const derived = app.action(() => {});
+
+		expect(derived._node.subCommands).not.toBe(app._node.subCommands);
+		expect(derived._node.subCommands.sub).toBe(app._node.subCommands.sub);
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -1043,7 +1043,22 @@ export class Crust<
 	private _clone<Out = this>(nodeOverrides: Partial<CommandNode>): Out {
 		// SAFETY: the clone uses the same prototype and receives every instance field below.
 		const cloned = Object.create(Object.getPrototypeOf(this)) as this;
-		const newNode: CommandNode = { ...cloneCommandNode(this._node), ...nodeOverrides };
+		const effectiveFlags = { ...this._node.effectiveFlags };
+		const newNode: CommandNode = {
+			...this._node,
+			// Descendants are immutable builder values; sharing them keeps fluent updates O(1).
+			localFlags: { ...this._node.localFlags },
+			ownedFlags: { ...this._node.ownedFlags },
+			effectiveFlags,
+			flagSpellings: cloneFlagSpellings(this._node.flagSpellings, effectiveFlags),
+			args: [...this._node.args],
+			subCommands: { ...this._node.subCommands },
+			contexts: [...this._node.contexts],
+			contextExtensionIds: [...this._node.contextExtensionIds],
+			extensions: [...this._node.extensions],
+			meta: { ...this._node.meta },
+			...nodeOverrides,
+		};
 		cloned._node = newNode;
 		cloned._ancestorOwnedFlags = this._ancestorOwnedFlags;
 		/* oxlint-disable anti-slop/no-chained-type-assertions -- one runtime builder shape is re-parameterized after each matching mutation. */

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -8,7 +8,6 @@ import type {
 	ContextMap,
 	ContextsOutput,
 	ContextsOwnedFlags,
-	MergeContext,
 } from "../api/context.ts";
 import type { Extension, ExtensionsProvidesOutput } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
@@ -59,14 +58,14 @@ import type {
 	SpellingsOf,
 	ValidateNamedFlagDefs,
 } from "../validation/flags.brands.ts";
-import type { IsStaticTuple, IsUnion, UnionToIntersection } from "../validation/shared.ts";
+import type {
+	IsStaticTuple,
+	IsUnion,
+	MergeContext,
+	UnionToIntersection,
+} from "../validation/shared.ts";
 import { cloneCommandNode, installExtensionContexts } from "./extensions-install.ts";
-import {
-	executeInvocation,
-	prepareInvocationRoot,
-	prepareInvocationSnapshot,
-	runInvocation,
-} from "./invocation.ts";
+import { executeInvocation, prepareInvocation, runInvocation } from "./invocation.ts";
 import { type CommandAction, type CommandNode, createCommandNode } from "./node.ts";
 import { resolveCommand } from "./router.ts";
 import { snapshotCommand } from "./snapshot.ts";
@@ -723,7 +722,7 @@ function serializeRunArgv(
 	const args = input.args;
 	let omittedArgument: string | undefined;
 	let firstPositional: string | undefined;
-	for (const definition of command.args ?? []) {
+	for (const definition of command.args) {
 		const value = args?.[definition.name];
 		if (value === undefined) {
 			omittedArgument = definition.name;
@@ -754,7 +753,7 @@ function serializeRunArgv(
 	}
 	for (const name of Object.keys(args ?? {})) {
 		if (args?.[name] === undefined) continue;
-		if (!(command.args ?? []).some((definition) => definition.name === name)) {
+		if (!command.args.some((definition) => definition.name === name)) {
 			throw new CrustError("PARSE", `Unknown argument "${name}"`, {
 				argument: name,
 				reason: "unknown-argument",
@@ -1044,22 +1043,7 @@ export class Crust<
 	private _clone<Out = this>(nodeOverrides: Partial<CommandNode>): Out {
 		// SAFETY: the clone uses the same prototype and receives every instance field below.
 		const cloned = Object.create(Object.getPrototypeOf(this)) as this;
-		const effectiveFlags = { ...this._node.effectiveFlags };
-		const newNode: CommandNode = {
-			...this._node,
-			// Shallow copy collections so mutations don't affect the original
-			localFlags: { ...this._node.localFlags },
-			ownedFlags: { ...this._node.ownedFlags },
-			effectiveFlags,
-			flagSpellings: cloneFlagSpellings(this._node.flagSpellings, effectiveFlags),
-			subCommands: { ...this._node.subCommands },
-			contexts: [...this._node.contexts],
-			contextExtensionIds: [...this._node.contextExtensionIds],
-			extensions: [...this._node.extensions],
-			meta: { ...this._node.meta },
-			args: this._node.args ? [...this._node.args] : undefined,
-			...nodeOverrides,
-		};
+		const newNode: CommandNode = { ...cloneCommandNode(this._node), ...nodeOverrides };
 		cloned._node = newNode;
 		cloned._ancestorOwnedFlags = this._ancestorOwnedFlags;
 		/* oxlint-disable anti-slop/no-chained-type-assertions -- one runtime builder shape is re-parameterized after each matching mutation. */
@@ -1133,7 +1117,7 @@ export class Crust<
 	args<const NewA extends ArgsDef>(
 		...defs: NewA & AppendArgsChecks<A, NewA>
 	): AfterArgs<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result, NewA> {
-		const combined = [...(this._node.args ?? []), ...defs.map((definition) => ({ ...definition }))];
+		const combined = [...this._node.args, ...defs.map((definition) => ({ ...definition }))];
 		// Brands own literal tuples; this owns config-built defs, where a
 		// duplicate name silently discards a positional and a mid-tuple variadic
 		// swallows every later argument.
@@ -1372,7 +1356,7 @@ export class Crust<
 	 * calling Command Actions.
 	 */
 	async snapshot(): Promise<CommandSnapshot> {
-		return prepareInvocationSnapshot(this._node, materializeCommandDefinition);
+		return snapshotCommand(prepareInvocation(this._node, materializeCommandDefinition).rootNode);
 	}
 
 	/**
@@ -1412,7 +1396,7 @@ export class Crust<
 		const structuredInput = (args[0] ?? {}) as RunInputPayload;
 		// SAFETY: the public overloads constrain the second argument to invocation IO.
 		const io = args[1] as Partial<InvocationIO> | undefined;
-		const root = prepareInvocationRoot(this._node, materializeCommandDefinition);
+		const root = prepareInvocation(this._node, materializeCommandDefinition).rootNode;
 		const argv = serializeRunArgv(root, path, structuredInput);
 		// Programmatic calls preserve raw failures and never change process status.
 		return await runInvocation(this._node, argv, io, materializeCommandDefinition);

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -172,29 +172,6 @@ describe("command definitions", () => {
 		void rejectedForms;
 	});
 
-	it("clones annotations and isolates materializations across parents", async () => {
-		const annotation = Symbol("annotation");
-		const definition = defineCommand("one", { description: "Reusable" }, (command) => {
-			// SAFETY: this fixture attaches an ecosystem annotation to the runtime node.
-			// oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Crust's declared type omits the builder-only `.use()`, so the escape must pass through unknown.
-			Object.defineProperty((command as unknown as Crust)._node, annotation, {
-				value: "preserved",
-				enumerable: true,
-			});
-			return command;
-		});
-
-		const first = await new Crust("first").add(definition).snapshot();
-		const second = await new Crust("second").add(definition.as("two")).snapshot();
-
-		expect(Object.getOwnPropertyDescriptor(first.subCommands.one!, annotation)?.value).toBe(
-			"preserved",
-		);
-		expect(Object.getOwnPropertyDescriptor(second.subCommands.two!, annotation)?.value).toBe(
-			"preserved",
-		);
-	});
-
 	it("excludes parent local flags from added commands", async () => {
 		const definition = defineCommand("users", (command) => command.action(() => {}));
 		const app = new Crust("cli").flags({ name: "secret", type: "string" }).add(definition);

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -26,7 +26,10 @@ describe("buildCommandDocumentation", () => {
 	it("builds usage and arg tokens", async () => {
 		const model = await docs(
 			new Crust("app")
-				.args({ name: "file", required: true }, { name: "rest", variadic: true })
+				.args(
+					{ name: "file", type: "string", required: true },
+					{ name: "rest", type: "string", variadic: true },
+				)
 				.flags({ name: "verbose", type: "boolean" })
 				.action(() => {}),
 		);

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -40,7 +40,7 @@ export interface DocumentationArg {
 	 * with `...` appended when variadic — e.g. `"<file>"`, `"[files...]"`.
 	 */
 	readonly token: string;
-	/** Value type (`"string"`, `"number"`, …); `undefined` for schema/raw args. */
+	/** Value type (`"string"`, `"number"`, …); `undefined` for schema-backed args. */
 	readonly type?: CommandSnapshot["args"][number]["type"];
 	/** Human-readable description from the arg definition. */
 	readonly description?: string;

--- a/packages/core/src/command/extensions-install.ts
+++ b/packages/core/src/command/extensions-install.ts
@@ -3,7 +3,6 @@ import type { Extension } from "../api/extension.ts";
 import { CrustError } from "../errors.ts";
 import { defineExtensionId, type ExtensionId } from "../identity.ts";
 import { addFlagSpellingEntries, cloneFlagSpellings } from "../parsing/spellings.ts";
-import { isText } from "../sections.ts";
 import type { CommandSection, FlagDef, FlagsDef } from "../types.ts";
 import type { CommandDefinition } from "./crust.ts";
 import type { CommandNode } from "./node.ts";
@@ -102,7 +101,7 @@ export function cloneCommandNode(node: CommandNode): CommandNode {
 		ownedFlags: cloneFlags(node.ownedFlags),
 		effectiveFlags,
 		flagSpellings: cloneFlagSpellings(node.flagSpellings, effectiveFlags),
-		args: node.args ? node.args.map((def) => ({ ...def })) : undefined,
+		args: node.args.map((def) => ({ ...def })),
 		subCommands,
 		contexts: [...node.contexts],
 		contextExtensionIds: [...node.contextExtensionIds],
@@ -131,6 +130,10 @@ function hasId<T>(value: T): value is T & { readonly id?: unknown } {
 
 function isString<T>(value: T): value is T & string {
 	return typeof value === "string";
+}
+
+function isText<T>(value: T): value is T & string {
+	return typeof value === "string" && !!value.trim();
 }
 
 function parseExtensionId(consumer: unknown, owner: SectionOwner): ExtensionId {

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -25,7 +25,7 @@ import {
 } from "./extensions-install.ts";
 import type { CommandNode } from "./node.ts";
 import { resolveCommand } from "./router.ts";
-import { type CommandSnapshot, snapshotCommand } from "./snapshot.ts";
+import { snapshotCommand } from "./snapshot.ts";
 
 /** Terminal defaults: line-oriented writes to the process streams. */
 const DEFAULT_IO: InvocationIO = {
@@ -67,7 +67,7 @@ function freezeTree(node: CommandNode): void {
 	Object.freeze(node.contexts);
 	Object.freeze(node.contextExtensionIds);
 	Object.freeze(node.extensions);
-	if (node.args) Object.freeze(node.args);
+	Object.freeze(node.args);
 	for (const sub of Object.values(node.subCommands)) freezeTree(sub);
 	Object.freeze(node.subCommands);
 }
@@ -109,7 +109,7 @@ function applySectionsAndFreeze(
 }
 
 /** Clone, apply Extensions and sections, freeze, and cache ordinary invocation preparation. */
-function prepareInvocation(
+export function prepareInvocation(
 	node: CommandNode,
 	materializeCommandDefinition: MaterializeCommandDefinition,
 ): PreparedInvocation {
@@ -301,14 +301,6 @@ function hasInjectedIO(io: Partial<InvocationIO> | undefined): boolean {
 	return io !== undefined && Object.keys(io).length > 0;
 }
 
-/** Prepare the cached runtime command tree for structured programmatic serialization. */
-export function prepareInvocationRoot(
-	node: CommandNode,
-	materializeCommandDefinition: MaterializeCommandDefinition,
-): CommandNode {
-	return prepareInvocation(node, materializeCommandDefinition).rootNode;
-}
-
 /** Programmatic boundary: throw raw failures and leave process status untouched. */
 export async function runInvocation(
 	node: CommandNode,
@@ -423,13 +415,4 @@ export async function executeInvocation(
 	};
 
 	await (hasInjectedIO(options?.io) ? withAmbientTerminalIO(io, invoke) : invoke());
-}
-
-/** Prepare a frozen, validated snapshot without invoking a command action. */
-export async function prepareInvocationSnapshot(
-	node: CommandNode,
-	materializeCommandDefinition: MaterializeCommandDefinition,
-): Promise<CommandSnapshot> {
-	const prepared = prepareInvocation(node, materializeCommandDefinition);
-	return snapshotCommand(prepared.rootNode);
 }

--- a/packages/core/src/command/node.ts
+++ b/packages/core/src/command/node.ts
@@ -33,7 +33,7 @@ export interface CommandNode {
 	/** Cached canonical/short/alias table for the effective flags. */
 	flagSpellings: Map<string, FlagSpelling>;
 	/** Positional argument definitions */
-	args: ArgsDef | undefined;
+	args: ArgsDef;
 	/** Named subcommands keyed by name */
 	subCommands: Record<string, CommandNode>;
 	/** Context instances available to this command in provide order (construction order is pull-driven). */
@@ -64,7 +64,7 @@ export function createCommandNode(name: string): CommandNode {
 		ownedFlags: {},
 		effectiveFlags: {},
 		flagSpellings: new Map(),
-		args: undefined,
+		args: [],
 		subCommands: {},
 		contexts: [],
 		contextExtensionIds: [],

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -25,7 +25,7 @@ import type { CommandNode } from "./node.ts";
 export interface ArgSnapshot {
 	/** Argument name as defined, e.g. `"file"`. */
 	readonly name: string;
-	/** Value type (`"string"`, `"number"`, …); absent for schema/raw args. */
+	/** Value type (`"string"`, `"number"`, …); absent for schema-backed args. */
 	readonly type?: ValueType;
 	/** Human-readable description for help text. */
 	readonly description?: string;
@@ -176,21 +176,7 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 		subCommands[name] = snapshotCommand(sub);
 	}
 
-	// Enumerable symbol-keyed annotations (e.g. skills' command annotations)
-	// pass through so annotation-driven tooling can read them off snapshots.
-	// JSON/structuredClone ignore symbol keys, so serializability holds.
-	/* oxlint-disable anti-slop/no-unsafe-dictionary-type, anti-slop/no-chained-type-assertions -- open symbol annotations are owned by ecosystem packages and intentionally pass through unchanged. */
-	const annotations: Record<symbol, unknown> = {};
-	for (const sym of Object.getOwnPropertySymbols(node)) {
-		if (Object.getOwnPropertyDescriptor(node, sym)?.enumerable) {
-			// SAFETY: sym was enumerated from node and this open annotation value passes through unchanged.
-			annotations[sym] = (node as unknown as Record<symbol, unknown>)[sym];
-		}
-	}
-	/* oxlint-enable anti-slop/no-unsafe-dictionary-type, anti-slop/no-chained-type-assertions */
-
 	return Object.freeze({
-		...annotations,
 		meta: freezeCompact({
 			name: node.meta.name,
 			description: node.meta.description,
@@ -202,7 +188,7 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 			hidden: node.meta.hidden,
 		}),
 		hasAction: node.run !== undefined,
-		args: Object.freeze((node.args ?? []).map(snapshotArg)),
+		args: Object.freeze(node.args.map(snapshotArg)),
 		flags: Object.freeze(flags),
 		subCommands: Object.freeze(subCommands),
 	});

--- a/packages/core/src/parsing/parser.test.ts
+++ b/packages/core/src/parsing/parser.test.ts
@@ -896,30 +896,6 @@ describe("validateParsed", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
-// Schema-backed args with no parser type hint
-// ────────────────────────────────────────────────────────────────────────────
-
-describe("parseArgs — raw schema-backed args", () => {
-	it("keeps untyped positional args as raw strings", () => {
-		const cmd = makeNode({
-			meta: { name: "raw-arg" },
-			args: [{ name: "port" }],
-		});
-		const result = parseArgs(cmd, ["3000"]);
-		expect(result.args.port).toBe("3000");
-	});
-
-	it("keeps untyped variadic args as raw string arrays", () => {
-		const cmd = makeNode({
-			meta: { name: "raw-variadic" },
-			args: [{ name: "files", variadic: true }],
-		});
-		const result = parseArgs(cmd, ["a.ts", "b.ts"]);
-		expect(result.args.files).toEqual(["a.ts", "b.ts"]);
-	});
-});
-
-// ────────────────────────────────────────────────────────────────────────────
 // url / path / json built-in types
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/packages/core/src/parsing/parser.ts
+++ b/packages/core/src/parsing/parser.ts
@@ -151,6 +151,7 @@ function resolveDefault(def: ArgDef | FlagDef, label: string) {
 	// so an out-of-range default would silently reach the action.
 	if (choices) {
 		for (const v of Array.isArray(defaultValue) ? defaultValue : [defaultValue]) {
+			// oxlint-disable-next-line typescript/no-unnecessary-type-conversion -- runtime-configured definitions can violate the static string-default contract
 			validateChoice(String(v), choices, label);
 		}
 	}
@@ -286,25 +287,22 @@ function resolveAliases(
  * Handles coercion and default values.
  */
 function resolveFlags<F extends FlagsDef>(
-	flagsDef: F | undefined,
+	flagsDef: F,
 	tokens: ParseArgsToken[],
 	aliasToName: Record<string, string>,
 ): RawParsedFlags<F> {
 	const resolved: Record<string, ParsedFlagValue> = {};
+	const canonical = resolveAliases(tokens, aliasToName, flagsDef);
 
-	if (flagsDef) {
-		const canonical = resolveAliases(tokens, aliasToName, flagsDef);
+	for (const [name, def] of Object.entries(flagsDef)) {
+		const parsedValue = canonical[name];
 
-		for (const [name, def] of Object.entries(flagsDef)) {
-			const parsedValue = canonical[name];
-
-			if (parsedValue !== undefined) {
-				resolved[name] = coerceFlagValue(name, def, parsedValue);
-				continue;
-			}
-
-			resolved[name] = resolveDefault(def, `--${name}`);
+		if (parsedValue !== undefined) {
+			resolved[name] = coerceFlagValue(name, def, parsedValue);
+			continue;
 		}
+
+		resolved[name] = resolveDefault(def, `--${name}`);
 	}
 
 	// SAFETY: the loop writes exactly every key from flagsDef; mapped generic keys cannot be correlated at runtime.
@@ -315,11 +313,9 @@ function resolveFlags<F extends FlagsDef>(
  * Validate required flags against already-resolved flag values.
  */
 function validateRequiredFlags<F extends FlagsDef>(
-	flagsDef: F | undefined,
+	flagsDef: F,
 	resolvedFlags: RawParsedFlags<F>,
 ): void {
-	if (!flagsDef) return;
-
 	for (const [name, def] of Object.entries(flagsDef)) {
 		if (def.required === true && def.default === undefined) {
 			if (resolvedFlags[name] === undefined) {
@@ -341,21 +337,19 @@ interface ResolvedArgs<A extends ArgsDef> {
 	consumed: number;
 }
 
-function resolveArgs<A extends ArgsDef>(
-	argsDef: A | undefined,
-	positionals: string[],
-): ResolvedArgs<A> {
+function resolveArgs<A extends ArgsDef>(argsDef: A, positionals: string[]): ResolvedArgs<A> {
 	const resolved: Record<string, ParsedArgValue> = {};
 	let index = 0;
 
-	for (const def of argsDef ?? []) {
+	for (const def of argsDef) {
 		const { name, choices, parse } = def;
 		const label = `<${name}>`;
 
 		const coerceOne = (raw: string, i?: number) => {
+			if (def.schema) return raw;
 			if (choices) validateChoice(raw, choices, label);
 			if (parse) return invokeParse(parse, raw, label, i);
-			return def.type === undefined ? raw : coerceValue(raw, def.type, label);
+			return coerceValue(raw, def.type, label);
 		};
 
 		if (def.variadic) {
@@ -424,7 +418,7 @@ function validateNoNegateUsage(argv: string[], spellings: ReadonlyMap<string, Fl
  * @throws {CrustError} On unknown flags or type coercion failure
  */
 export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = FlagsDef>(
-	command: CommandNode & { args: A | undefined; effectiveFlags: F },
+	command: CommandNode & { args: A; effectiveFlags: F },
 	argv: string[],
 ): ParseResult<A, F> {
 	const argsDef = command.args;
@@ -498,7 +492,7 @@ export function parseArgs<A extends ArgsDef = ArgsDef, F extends FlagsDef = Flag
  * @throws {CrustError} On missing required args or flags
  */
 export function validateParsed<A extends ArgsDef = ArgsDef, F extends FlagsDef = FlagsDef>(
-	command: CommandNode & { args: A | undefined; effectiveFlags: F },
+	command: CommandNode & { args: A; effectiveFlags: F },
 	parsed: ParseResult<A, F>,
 ): void {
 	const argsDef = command.args;
@@ -515,21 +509,19 @@ export function validateParsed<A extends ArgsDef = ArgsDef, F extends FlagsDef =
 	}
 
 	// Re-validate args: check for required args that are undefined
-	if (argsDef) {
-		for (const def of argsDef) {
-			const { name } = def;
-			const label = `argument "<${name}>"`;
-			// SAFETY: name comes from the same argument definitions that produced this mapped result.
-			const value = args[name as keyof typeof args];
+	for (const def of argsDef) {
+		const { name } = def;
+		const label = `argument "<${name}>"`;
+		// SAFETY: name comes from the same argument definitions that produced this mapped result.
+		const value = args[name as keyof typeof args];
 
-			if (def.required === true && def.default === undefined) {
-				if (def.variadic) {
-					if (!Array.isArray(value) || value.length === 0) {
-						throw new CrustError("VALIDATION", `Missing required ${label}`);
-					}
-				} else if (value === undefined) {
+		if (def.required === true && def.default === undefined) {
+			if (def.variadic) {
+				if (!Array.isArray(value) || value.length === 0) {
 					throw new CrustError("VALIDATION", `Missing required ${label}`);
 				}
+			} else if (value === undefined) {
+				throw new CrustError("VALIDATION", `Missing required ${label}`);
 			}
 		}
 	}

--- a/packages/core/src/parsing/schema.ts
+++ b/packages/core/src/parsing/schema.ts
@@ -37,14 +37,14 @@ async function runSchema<S extends StandardSchema, Raw>(
  * @throws {CrustError} `VALIDATION` aggregating every schema issue
  */
 export async function applySchemas<A extends ArgsDef = ArgsDef, F extends FlagsDef = FlagsDef>(
-	node: CommandNode & { args: A | undefined; effectiveFlags: F },
+	node: CommandNode & { args: A; effectiveFlags: F },
 	parsed: ParseResult<A, F>,
 ): Promise<ValidatedInput<A, F>> {
 	const issues: ValidationIssue[] = [];
 	const args = new Map<string, unknown>(Object.entries(parsed.args));
 	const flags = new Map<string, unknown>(Object.entries(parsed.flags));
 
-	for (const def of node.args ?? []) {
+	for (const def of node.args) {
 		if (def.schema === undefined) continue;
 		const result = await runSchema(def.schema, args.get(def.name), ["args", def.name], issues);
 		if (result.ok) args.set(def.name, result.value);

--- a/packages/core/src/parsing/spellings.ts
+++ b/packages/core/src/parsing/spellings.ts
@@ -1,5 +1,5 @@
 import { CrustError } from "../errors.ts";
-import type { FlagDef, FlagsDef } from "../types.ts";
+import type { FlagDef, FlagsDef, NamedFlagDef } from "../types.ts";
 
 // Compile-time brands (FIX_EMPTY_SPELLING, FIX_NO_PREFIX) own literal
 // definitions; this guard owns the dynamic path (config-built flag defs).
@@ -45,7 +45,6 @@ export function assertDefinableFlag(name: string, def: FlagDef): void {
 
 export interface FlagSpelling {
 	canonicalName: string;
-	spelling: string;
 	def: FlagDef;
 	kind: "canonical" | "short" | "alias";
 	negatable: boolean;
@@ -71,13 +70,20 @@ export function addFlagSpellingEntries(
 		def,
 		negatable: isFlagNegatable(def),
 	} as const;
-	spellings.set(canonicalName, { ...entry, spelling: canonicalName, kind: "canonical" });
-	if (def.short) {
-		spellings.set(def.short, { ...entry, spelling: def.short, kind: "short" });
+	spellings.set(canonicalName, { ...entry, kind: "canonical" });
+	if (def.short) spellings.set(def.short, { ...entry, kind: "short" });
+	for (const alias of def.aliases ?? []) spellings.set(alias, { ...entry, kind: "alias" });
+}
+
+/** Convert named authoring definitions to the runtime flag record. */
+export function toFlagsRecord(definitions: readonly NamedFlagDef[]): FlagsDef {
+	const flags: FlagsDef = {};
+	for (const { name, ...flag } of definitions) {
+		// Validate before assignment: a `__proto__` key would change the record's prototype.
+		assertDefinableFlag(name, flag);
+		flags[name] = flag;
 	}
-	for (const alias of def.aliases ?? []) {
-		spellings.set(alias, { ...entry, spelling: alias, kind: "alias" });
-	}
+	return flags;
 }
 
 /** Clone a cached table while rebinding entries to cloned flag definitions. */

--- a/packages/core/src/sections.ts
+++ b/packages/core/src/sections.ts
@@ -2,10 +2,6 @@ import type { CommandSnapshot } from "./command/snapshot.ts";
 import type { ExtensionId } from "./identity.ts";
 import type { CommandSection } from "./types.ts";
 
-export function isText<T>(value: T): value is T & string {
-	return typeof value === "string" && !!value.trim();
-}
-
 /** Whether a command belongs in user-facing listings. */
 export function isListed(command: CommandSnapshot): boolean {
 	return command.meta.hidden !== true;

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -47,26 +47,6 @@ describe("InferArgs type inference", () => {
 		expect(val).toBeDefined();
 	});
 
-	it("narrows raw args (no type/schema) with literal choices", () => {
-		type Args = readonly [
-			{ name: "mode"; choices: readonly ["dev", "prod"] },
-			{ name: "env"; choices: readonly ["a", "b"]; default: "a" },
-			{ name: "tags"; choices: readonly ["x", "y"]; variadic: true },
-		];
-		type Result = InferArgs<Args>;
-		type _check = Expect<
-			Equal<
-				Result,
-				{
-					mode: "dev" | "prod" | undefined;
-					env: "a" | "b";
-					tags: ("x" | "y")[];
-				}
-			>
-		>;
-		expect(true).toBe(true);
-	});
-
 	it("schema args infer the schema output, untouched by choices narrowing", () => {
 		type Args = readonly [{ name: "url"; schema: StandardSchema<string | undefined, URL> }];
 		type Result = InferArgs<Args>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,8 +2,8 @@ import type { JsonValue } from "@crustjs/utils/json";
 import type { BaseValueType } from "@crustjs/utils/primitive";
 import type { InferOutput, StandardSchema } from "@crustjs/utils/schema";
 
-import type { Simplify } from "./api/context.ts";
 import type { ExtensionId } from "./identity.ts";
+import type { Simplify } from "./validation/shared.ts";
 
 /** Injectable output callbacks threaded through one invocation. */
 export interface InvocationIO {
@@ -168,16 +168,6 @@ interface JsonArgDef extends ArgDefBase {
 	parse?: never;
 }
 
-interface RawArgDef extends ArgDefBase {
-	/** Optional parser hint. Omit for raw schema-backed validation. */
-	type?: never;
-	/** Raw default value when the argument is not provided */
-	default?: unknown;
-	choices?: readonly string[];
-	/** Not supported on raw args — schema validators own the transform. */
-	parse?: never;
-}
-
 /**
  * A positional argument validated by a Standard Schema (exclusive mode).
  *
@@ -225,8 +215,7 @@ export type ArgDef =
 	| UrlArgDef
 	| PathArgDef
 	| JsonArgDef
-	| SchemaArgDef
-	| RawArgDef;
+	| SchemaArgDef;
 
 /** Ordered tuple of positional argument definitions */
 export type ArgsDef = readonly ArgDef[];
@@ -428,33 +417,18 @@ export type InferArgValue<A extends ArgDef> = A extends {
 	schema: infer S extends StandardSchema;
 }
 	? InferOutput<S>
-	: A extends { type: ValueType }
-		? A extends { variadic: true }
-			? ResolveBaseType<A>[]
-			: A extends { required: true }
+	: A extends { variadic: true }
+		? ResolveBaseType<A>[]
+		: A extends { required: true }
+			? ResolveBaseType<A>
+			: // Narrow on `default` presence, not its type. When `parse` is
+				// present the raw default is a string while `ResolveBaseType<A>`
+				// is the parsed return type, so a typed-default check would miss.
+				// ArgDef's discriminated interfaces already constrain the default
+				// shape at the call site.
+				A extends { default: unknown }
 				? ResolveBaseType<A>
-				: // Narrow on `default` presence, not its type. When `parse` is
-					// present the raw default is a string while `ResolveBaseType<A>`
-					// is the parsed return type, so a typed-default check would miss.
-					// ArgDef's discriminated interfaces already constrain the default
-					// shape at the call site.
-					A extends { default: unknown }
-					? ResolveBaseType<A>
-					: ResolveBaseType<A> | undefined
-		: // Raw args (no `type`, no `schema`) still enforce `choices` at parse
-			// time, so a literal tuple narrows the raw string token the same way.
-			// One ladder serves both raw variants: without choices the base is
-			// `unknown`, and `unknown | undefined` collapses back to `unknown`.
-			A extends { variadic: true }
-			? RawArgBase<A>[]
-			: A extends { required: true }
-				? RawArgBase<A>
-				: A extends { default: unknown }
-					? RawArgBase<A>
-					: RawArgBase<A> | undefined;
-
-/** Base type of a raw arg: the literal `choices` union when present, else `unknown`. */
-type RawArgBase<A> = A extends { choices: readonly (infer C extends string)[] } ? C : unknown;
+				: ResolveBaseType<A> | undefined;
 
 type DuplicateArgNames<
 	A extends readonly ArgDef[],
@@ -558,7 +532,7 @@ type InputBaseValue<D> = D extends { type: "boolean"; noNegate: true }
 					? string
 					: D extends { type: infer T extends ValueType }
 						? Resolve<T>
-						: string;
+						: never;
 
 type InputArgValue<D> = D extends { variadic: true } ? InputBaseValue<D>[] : InputBaseValue<D>;
 type InputFlagValue<D> = D extends { multiple: true } ? InputBaseValue<D>[] : InputBaseValue<D>;
@@ -685,8 +659,8 @@ export interface CommandMeta {
 	 * **Scope: commands only.** There is no analogous `hidden` field on
 	 * `FlagDef` or `ArgDef`; flags and positional arguments always surface
 	 * in help, completion, and man output. If you need a flag that does
-	 * not advertise itself, the workaround is to register it through a
-	 * extension's `setup()` hook without describing it (omit `description`),
+	 * not advertise itself, the workaround is to register it as an Extension
+	 * flags entry without a description (omit `description`),
 	 * which suppresses its description body but still lists the spelling
 	 * — there is intentionally no full hide mechanism at the flag layer.
 	 *

--- a/packages/core/src/validation/flags.brands.ts
+++ b/packages/core/src/validation/flags.brands.ts
@@ -231,7 +231,7 @@ type ValidateNoPrefixedFlags<F extends FlagsDef> = {
 // Context-owned flag validation (compile-time, per-instance granularity)
 // ────────────────────────────────────────────────────────────────────────────
 
-type ContextOwnedFlags<C> = C extends {
+export type ContextOwnedFlags<C> = C extends {
 	readonly _ownedFlags?: infer OF extends FlagsDef;
 }
 	? OF

--- a/packages/core/src/validation/shared.ts
+++ b/packages/core/src/validation/shared.ts
@@ -1,6 +1,11 @@
 // ────────────────────────────────────────────────────────────────────────────
-// Shared compile-time validation helpers (used by flag and arg validators)
+// Shared type helpers
 // ────────────────────────────────────────────────────────────────────────────
+
+export type Awaitable<T> = T | Promise<T>;
+export type Simplify<T> = { [K in keyof T]: T[K] };
+// Flat intersections keep chained composition at constant instantiation depth.
+export type MergeContext<A, B> = A & B;
 
 /**
  * Extract the narrowed canonical `name` literal from a definition.

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -17,7 +17,7 @@ export function makeNode<
 	flags?: F;
 	subCommands?: Record<string, CommandNode>;
 	run?: CommandAction;
-}): CommandNode & { args: A | undefined; effectiveFlags: F } {
+}): CommandNode & { args: A; effectiveFlags: F } {
 	// oxlint-disable-next-line anti-slop/no-runtime-typeof -- test fixtures intentionally accept either shorthand names or full metadata.
 	const meta = typeof config.meta === "string" ? { name: config.meta } : config.meta;
 	const node = createCommandNode(meta.name);
@@ -34,7 +34,7 @@ export function makeNode<
 	if (config.subCommands) node.subCommands = { ...config.subCommands };
 	if (config.run) node.run = config.run;
 	// SAFETY: the fixture copies config.args and config.flags into the returned node above.
-	return node as CommandNode & { args: A | undefined; effectiveFlags: F };
+	return node as CommandNode & { args: A; effectiveFlags: F };
 }
 
 export interface RunResult {

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -24,7 +24,7 @@ function makeNode(partial: Partial<CommandNode> & { name: string }): CommandNode
 		ownedFlags: partial.ownedFlags ?? {},
 		effectiveFlags: partial.effectiveFlags ?? flags,
 		flagSpellings: new Map(),
-		args: partial.args,
+		args: partial.args ?? [],
 		subCommands: partial.subCommands ?? {},
 		contexts: [],
 		contextExtensionIds: [],


### PR DESCRIPTION
Refactors Core's command preparation and internal data shapes to remove dead public surface and single-use indirection. Untyped positional definitions are removed in favor of an explicit core value `type` or Standard Schema, while the materializer dependency-injection seam remains intact to preserve acyclic command-module imports.

### Changes

- **@crustjs/core**
  - Remove the untyped positional argument variant and related inference/parser branches.
  - Inline single-use invocation preparation wrappers and reuse `cloneCommandNode` in builder cloning.
  - Normalize command args to an empty array and remove unreachable optional guards.
  - Remove unused flag spelling/context discriminant fields and symbol snapshot annotations.
  - Share named-flag conversion and context-owned flag type plumbing.
  - Move common type helpers to a leaf validation module to break a type-import cycle.
- **Docs**
  - Remove raw positional argument references and correct hidden-flag guidance.
- **Tests**
  - Remove dead raw-argument and symbol-annotation fixtures; update required-args fixtures.

### Notes

- The `MaterializeCommandDefinition` DI parameter was deliberately kept: it is what keeps `command/crust.ts` ↔ `command/invocation.ts` acyclic under the repo's `import/no-cycle` rule. The audit's "yagni" finding for it was wrong.
- Untyped positional arguments are a breaking removal; use `type` or `schema` instead.
- Changesets: `.changeset/remove-untyped-args.md` (`@crustjs/core`: minor).

### Stack
This PR is part of the codebase-audit refactor stack (bottom → top). Merge in order; each PR targets the one below it.
1. refactor/audit-01-tooling ([#329](https://github.com/chenxin-yan/crust/pull/329))
2. refactor/audit-02-tests ([#330](https://github.com/chenxin-yan/crust/pull/330))
3. refactor/audit-03-core-shrink ([#331](https://github.com/chenxin-yan/crust/pull/331)) **(this PR)**
4. refactor/audit-04-ext-shrink ([#332](https://github.com/chenxin-yan/crust/pull/332))
5. refactor/audit-05-ui-shrink ([#333](https://github.com/chenxin-yan/crust/pull/333))
6. refactor/audit-06-core-seams ([#334](https://github.com/chenxin-yan/crust/pull/334))
7. refactor/audit-07-docmodel-version ([#335](https://github.com/chenxin-yan/crust/pull/335))
8. refactor/audit-08-cli-seams ([#336](https://github.com/chenxin-yan/crust/pull/336))
9. refactor/audit-09-public-api ([#337](https://github.com/chenxin-yan/crust/pull/337))
10. refactor/audit-10-ui-seams ([#338](https://github.com/chenxin-yan/crust/pull/338))
11. refactor/audit-11-store-docs ([#339](https://github.com/chenxin-yan/crust/pull/339))

