### PR TITLE
refactor(core,extensions,skills,man): documentation model owns sections; version single source of truth

### DIFF
--- a/.changeset/documentation-version-source.md
+++ b/.changeset/documentation-version-source.md
@@ -4,4 +4,4 @@
 "@crustjs/skills": minor
 ---
 
-Add command sections to the shared documentation model and export `formatDefault` from `@crustjs/core/tooling`. Root command metadata now carries the application version so version, completion, update-notifier, and skill generation can use one source of truth while extension options remain overrides. Skill link-operation results now report their effective scope.
+Add command sections to the shared documentation model and export `formatDefault` from `@crustjs/core/tooling`. Root command metadata now carries the application version so version, completion, update-notifier, and skill generation can use one source of truth while extension options remain overrides; reusable command configs reject root-only version metadata. Skill link-operation results now report their effective scope.

--- a/.changeset/documentation-version-source.md
+++ b/.changeset/documentation-version-source.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/core": minor
+"@crustjs/extensions": minor
+"@crustjs/skills": minor
+---
+
+Add command sections to the shared documentation model and export `formatDefault` from `@crustjs/core/tooling`. Root command metadata now carries the application version so version, completion, update-notifier, and skill generation can use one source of truth while extension options remain overrides. Skill link-operation results now report their effective scope.

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -74,7 +74,7 @@ defineCommand<const Name extends string>(
   recipe: (command: CommandDefinitionBuilder) => CommandDefinitionBuilder,
 ): CommandDefinition<Name>;
 
-interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
+interface CommandConfig extends Omit<CommandMeta, "name" | "sections" | "version"> {
   readonly sections?: readonly CommandSectionInput[];
 }
 
@@ -85,7 +85,7 @@ defineCommand<const Name extends string, const C extends CommandConfig>(
 ): CommandDefinition<Name, AliasesOf<C>>;
 ```
 
-Creates an inert reusable definition under a required name. Static `description`, `usage`, `aliases`, and `hidden` belong in `config`:
+Creates an inert reusable definition under a required name. Static `description`, `usage`, `aliases`, and `hidden` belong in `config`; application `version` belongs only in the root `Crust` constructor:
 
 ```ts
 const verbose = defineFlag("verbose", { type: "boolean" });

--- a/apps/docs/content/docs/api/crust.mdx
+++ b/apps/docs/content/docs/api/crust.mdx
@@ -114,7 +114,7 @@ The recipe does not execute when the definition is created. It executes once for
 ## Constructor
 
 ```ts
-type RootCommandMeta = Pick<CommandMeta, "description" | "usage"> & {
+type RootCommandMeta = Pick<CommandMeta, "description" | "version" | "usage"> & {
   readonly sections?: readonly CommandSectionInput[];
 };
 
@@ -133,11 +133,12 @@ class Crust<
 new Crust(name: string, meta?: RootCommandMeta)
 ```
 
-Creates a root command builder. Root metadata is declared at construction because aliases and hidden state only apply to subcommands. `sections` accepts the same ordered plain-text entries as subcommand metadata and is validated immediately.
+Creates a root command builder. Root metadata is declared at construction because aliases and hidden state only apply to subcommands. `version` is the application version exposed on `CommandSnapshot.meta.version` for Extensions and tooling. `sections` accepts the same ordered plain-text entries as subcommand metadata and is validated immediately.
 
 ```ts
 const app = new Crust("my-cli", {
   description: "Manage issues",
+  version: "1.2.3",
   usage: "my-cli <command>",
 });
 ```
@@ -251,7 +252,7 @@ Registers application-wide Extensions. Repeated calls accumulate in registration
 ```ts
 import { help, version } from "@crustjs/extensions";
 
-const app = new Crust("my-cli").extend(help(), version("1.2.3"));
+const app = new Crust("my-cli", { version: "1.2.3" }).extend(help(), version());
 ```
 
 Added definitions become ordinary command nodes before root Extensions prepare the application, so root Extensions apply to them. Extension-contributed definitions are materialized when the application prepares.

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -28,8 +28,9 @@ See [Types](/docs/api/types) for command definitions, Command Snapshots, Command
   The package root contains invocation-time authoring and execution APIs. `@crustjs/core/tooling`
   exports the supported `CommandSnapshot` type consumed by
   [`app.snapshot()`](/docs/api/crust#snapshot), plus build- and render-time helpers: `isListed()`,
-  `sectionsFor()`, `visibleSectionsFor()`, `formatDescription()`, the presentation-neutral
-  `buildCommandDocumentation()` model with its `CommandDocumentation`, `DocumentationArg`,
-  `DocumentationFlag`, and `UsageSegment` types, and the `SNAPSHOT_PATH_ENV` and `BUILD_OUT_DIR_ENV`
-  subprocess-protocol constants. These helpers move in lockstep with first-party tooling.
+  `sectionsFor()`, `visibleSectionsFor()`, `formatDefault()`, `formatDescription()`, the
+  presentation-neutral `buildCommandDocumentation()` model with its `CommandDocumentation`
+  (including unfiltered command sections), `DocumentationArg`, `DocumentationFlag`, and
+  `UsageSegment` types, and the `SNAPSHOT_PATH_ENV` and `BUILD_OUT_DIR_ENV` subprocess-protocol
+  constants. These helpers move in lockstep with first-party tooling.
 </Callout>

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -103,7 +103,7 @@ const target = defineArg("target", { type: "string", required: true });
 
 <auto-type-table path="../../../../../packages/core/src/types.ts" name="CommandMeta" />
 
-`sections` is an ordered list of plain-text `{ title, body }` entries, optionally scoped to renderer identities with `only` or `except` audiences. Declare it in the metadata passed to `new Crust()` or `defineCommand()`; help and man render the entries after their built-in sections. `hidden` removes a command from user-facing help, completion, man-page, typo-suggestion, and skill listings without disabling direct routing.
+`version` is the application version declared through `new Crust(name, { version })`; it is available on the root `CommandSnapshot.meta` for Extensions and tooling. `sections` is an ordered list of plain-text `{ title, body }` entries, optionally scoped to renderer identities with `only` or `except` audiences. Declare sections in the metadata passed to `new Crust()` or `defineCommand()`; help and man render them after their built-in sections. `hidden` removes a command from user-facing help, completion, man-page, typo-suggestion, and skill listings without disabling direct routing.
 
 ### `SectionConsumer`, `SectionAudience`, `CommandSectionInput`, and `CommandSection`
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -58,25 +58,25 @@ Downstream commands and other Context setups call `await ctx.api`. See [Contexts
 
 ## Definition types
 
-| Type                                          | Description                                                               |
-| --------------------------------------------- | ------------------------------------------------------------------------- |
-| `ArgDef`                                      | Core-value or Standard Schema positional argument definition              |
-| `ArgsDef`                                     | Readonly ordered argument definitions                                     |
-| [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                               |
-| [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                        |
-| [`CommandConfig`](/docs/api/crust)            | Static metadata for a reusable definition                                 |
-| `CommandMeta`                                 | Name, description, usage, sections, aliases, and visibility               |
-| `CommandSection`                              | A titled documentation block with an optional consumer audience           |
-| `CommandSectionInput`                         | Plain-text section (`title`, `body`) with an optional consumer audience   |
-| `SectionAudience`                             | Mutually exclusive `only`/`except` consumer lists on a section            |
-| `ExtensionId`                                 | Branded identity minted by `defineExtensionId()`                          |
-| `ContextBag` / `FactoryValueOf`               | Lazy Context property bag and factory-value helper types                  |
-| [`RootCommandMeta`](/docs/api/crust)          | Root description, usage, and sections accepted by the `Crust` constructor |
-| `FlagDef`                                     | Core-value or Standard Schema flag definition                             |
-| `FlagsDef`                                    | Flag-name-to-definition record                                            |
-| `NamedFlagDef`                                | Flag definition carrying its `name` (the `.flags()` input shape)          |
-| `UnnamedArgDef`                               | Argument definition without its `name` (the `defineArg` input)            |
-| `ValueType`                                   | String, number, boolean, URL, path, or JSON value literal                 |
+| Type                                          | Description                                                                        |
+| --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `ArgDef`                                      | Core-value or Standard Schema positional argument definition                       |
+| `ArgsDef`                                     | Readonly ordered argument definitions                                              |
+| [`CommandDefinition`](/docs/api/crust)        | Opaque inert command recipe                                                        |
+| [`CommandDefinitionBuilder`](/docs/api/crust) | Configure-only builder used by command definitions                                 |
+| [`CommandConfig`](/docs/api/crust)            | Static metadata for a reusable definition                                          |
+| `CommandMeta`                                 | Name, description, application version, usage, sections, aliases, and visibility   |
+| `CommandSection`                              | A titled documentation block with an optional consumer audience                    |
+| `CommandSectionInput`                         | Plain-text section (`title`, `body`) with an optional consumer audience            |
+| `SectionAudience`                             | Mutually exclusive `only`/`except` consumer lists on a section                     |
+| `ExtensionId`                                 | Branded identity minted by `defineExtensionId()`                                   |
+| `ContextBag` / `FactoryValueOf`               | Lazy Context property bag and factory-value helper types                           |
+| [`RootCommandMeta`](/docs/api/crust)          | Root description, version, usage, and sections accepted by the `Crust` constructor |
+| `FlagDef`                                     | Core-value or Standard Schema flag definition                                      |
+| `FlagsDef`                                    | Flag-name-to-definition record                                                     |
+| `NamedFlagDef`                                | Flag definition carrying its `name` (the `.flags()` input shape)                   |
+| `UnnamedArgDef`                               | Argument definition without its `name` (the `defineArg` input)                     |
+| `ValueType`                                   | String, number, boolean, URL, path, or JSON value literal                          |
 
 See [Types](/docs/api/types) for field-level definitions.
 
@@ -187,6 +187,6 @@ function collectWebSections(snapshot: CommandSnapshot) {
 
 Call `app.snapshot()` to prepare a frozen Command Snapshot for man-page, skill, and build generators. It materializes Extension contributions and command definitions and validates Extension-produced documentation sections without calling Command Actions. Command-authored sections are validated immediately by the constructor or `defineCommand()`. Authored and Extension-contributed documentation is available on each command under `meta.sections`.
 
-The package root contains invocation-time authoring and execution APIs. Build- and render-time helpers live under `@crustjs/core/tooling`, which exports the `CommandSnapshot` type plus `buildCommandDocumentation`, `formatDescription`, `isListed`, `sectionsFor`, `visibleSectionsFor`, its documentation model types, and the lockstep first-party subprocess protocol constants: `SNAPSHOT_PATH_ENV` for snapshot preparation, plus `BUILD_OUT_DIR_ENV`, which build tooling sets alongside it to run registered Extension `build` hooks in the app's process. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), visible children, argument tokens, and every accepted flag spelling. Except for the `CommandSnapshot` type consumed by `app.snapshot()`, helpers on this subpath are intended for first-party tooling that moves in lockstep with core.
+The package root contains invocation-time authoring and execution APIs. Build- and render-time helpers live under `@crustjs/core/tooling`, which exports the `CommandSnapshot` type plus `buildCommandDocumentation`, `formatDefault`, `formatDescription`, `isListed`, `sectionsFor`, `visibleSectionsFor`, its documentation model types, and the lockstep first-party subprocess protocol constants: `SNAPSHOT_PATH_ENV` for snapshot preparation, plus `BUILD_OUT_DIR_ENV`, which build tooling sets alongside it to run registered Extension `build` hooks in the app's process. `buildCommandDocumentation()` turns a Command Snapshot into a full, presentation-neutral tree with resolved usage (plain and as colorable segments), unfiltered `sections`, visible children, argument tokens, and every accepted flag spelling. `formatDefault()` applies the same default-value formatting used by `formatDescription()` and first-party renderers. Except for the `CommandSnapshot` type consumed by `app.snapshot()`, helpers on this subpath are intended for first-party tooling that moves in lockstep with core.
 
 Use [`@crustjs/extensions`](/docs/modules/extensions) for the official Extensions and [`@crustjs/crust`](/docs/modules/crust) as a development dependency for build tooling.

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -10,10 +10,9 @@ The completion Extension contributes a `completion <shell>` root command. It rea
 ```ts
 import { Crust, defineCommand } from "@crustjs/core";
 import { completion } from "@crustjs/extensions";
-import pkg from "../package.json";
 
-const app = new Crust("my-cli")
-  .extend(completion({ version: pkg.version }))
+const app = new Crust("my-cli", { version: "1.2.3" })
+  .extend(completion())
   .add(
     defineCommand("build", (command) =>
       command
@@ -43,6 +42,8 @@ const completion: ((options?: CompletionOptions) => Extension) & { readonly id: 
   path="../../../../../../packages/extensions/src/completion/index.ts"
   name="CompletionOptions"
 />
+
+By default, generated headers use the root `CommandSnapshot.meta.version`; `CompletionOptions.version` remains an override. Invoking the command without either version reports a `DEFINITION` error.
 
 The positional `<shell>` accepts `bash`, `zsh`, or `fish`. With no `--output-dir`, the selected script is written through the invocation's stdout callback, so programmatic `run()` calls honor injected output. With `--output-dir <path>`, the Extension writes every supported shell using canonical filenames: `<bin>` for bash, `_<bin>` for zsh, and `<bin>.fish` for fish.
 

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -27,14 +27,14 @@ import {
 } from "@crustjs/extensions";
 import pkg from "../package.json";
 
-const app = new Crust("my-cli")
+const app = new Crust("my-cli", { version: pkg.version })
   .extend(
     help(),
-    version(pkg.version),
+    version(),
     didYouMean(),
     noColor(),
-    completion({ version: pkg.version }),
-    updateNotifier({ packageName: pkg.name, currentVersion: pkg.version }),
+    completion(),
+    updateNotifier({ packageName: pkg.name }),
   )
   .action(({ stdout }) => stdout("Hello"));
 

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -10,13 +10,8 @@ import { Crust } from "@crustjs/core";
 import { updateNotifier } from "@crustjs/extensions";
 import pkg from "../package.json";
 
-const app = new Crust("my-cli")
-  .extend(
-    updateNotifier({
-      packageName: pkg.name,
-      currentVersion: pkg.version,
-    }),
-  )
+const app = new Crust("my-cli", { version: pkg.version })
+  .extend(updateNotifier({ packageName: pkg.name }))
   .action(({ stdout }) => stdout("Done"));
 
 await app.execute();
@@ -35,7 +30,7 @@ const updateNotifier: ((options: UpdateNotifierOptions) => Extension) & {
   name="UpdateNotifierOptions"
 />
 
-The `postRun` hook checks for an update only after a Command Action completes successfully. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written through the invocation's stderr callback (process stderr under `execute()`). Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
+The `postRun` hook checks for an update only after a Command Action completes successfully. It reads the root `CommandSnapshot.meta.version` by default; `currentVersion` remains an override. A successful action with neither version reports a `DEFINITION` error before any network or cache work. Network, registry, cache, and response failures are swallowed so the notifier does not fail a successful command. It does not check after `ctx.finish()` short-circuits such as `--help`. The notice is written through the invocation's stderr callback (process stderr under `execute()`). Version comparison follows SemVer precedence, so a stable release is considered newer than its prerelease.
 
 By default, notifier state is persisted at `stateDir(packageName)` using `@crustjs/store`; package names are URL-encoded for the state directory (`@scope/cli` → `%40scope%2Fcli`) so distinct packages never share state, and cached state from a different `registryUrl` is discarded. A fresh cached result is reused for 24 hours and duplicate notices for the same version are suppressed across sequential process invocations (best-effort: concurrent invocations may race and double-notice). A corrupt state file is treated as empty and repaired on the next successful check. Set `cache: false` to opt out, pass `cache: { intervalMs }` to tune the built-in cache interval, or provide a custom adapter to control persistence.
 
@@ -48,7 +43,6 @@ Generate the standard global update command for the detected package manager:
 ```ts
 updateNotifier({
   packageName: "my-cli",
-  currentVersion: "1.2.3",
   updateCommand: { scope: "global" },
 });
 ```
@@ -58,7 +52,6 @@ Use a fixed command or generate one from package information:
 ```ts
 updateNotifier({
   packageName: "my-cli",
-  currentVersion: "1.2.3",
   updateCommand: ({ packageName, packageManager }) => `${packageManager} run update-${packageName}`,
 });
 ```
@@ -68,10 +61,7 @@ updateNotifier({
 The built-in cache is enabled automatically; no setup is required:
 
 ```ts
-updateNotifier({
-  packageName: "my-cli",
-  currentVersion: "1.2.3",
-});
+updateNotifier({ packageName: "my-cli" });
 ```
 
 Tune the check interval while keeping the built-in persistence:
@@ -79,7 +69,6 @@ Tune the check interval while keeping the built-in persistence:
 ```ts
 updateNotifier({
   packageName: "my-cli",
-  currentVersion: "1.2.3",
   cache: { intervalMs: 60 * 60 * 1000 }, // 1 hour
 });
 ```
@@ -89,7 +78,6 @@ Disable all cache reads and writes when every invocation should check the regist
 ```ts
 updateNotifier({
   packageName: "my-cli",
-  currentVersion: "1.2.3",
   cache: false,
 });
 ```

--- a/apps/docs/content/docs/modules/extensions/version.mdx
+++ b/apps/docs/content/docs/modules/extensions/version.mdx
@@ -8,9 +8,8 @@ description: Add a root-only version flag.
 ```ts
 import { Crust } from "@crustjs/core";
 import { version } from "@crustjs/extensions";
-import pkg from "../package.json";
 
-const app = new Crust("my-cli").extend(version(pkg.version)).action(() => {});
+const app = new Crust("my-cli", { version: "1.2.3" }).extend(version()).action(() => {});
 
 await app.execute();
 ```
@@ -34,7 +33,7 @@ const version: ((value?: VersionValue, options?: VersionOptions) => Extension) &
 };
 ```
 
-The default value is `"0.0.0"`. Pass a function to resolve the version only when the flag is handled:
+With no value override, `version()` reads `CommandSnapshot.meta.version` from the root. If neither the root metadata nor an override provides a version, handling `--version` reports a `DEFINITION` error. Pass a function to resolve an override only when the flag is handled:
 
 ```ts
 const app = new Crust("my-cli").extend(version(() => process.env.APP_VERSION ?? "dev"));

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -53,7 +53,7 @@ Point the extension at the packaged skills directory with a package-relative fil
 import { Crust } from "@crustjs/core";
 import { skill } from "@crustjs/skills";
 
-export const app = new Crust("my-cli", { description: "My CLI" })
+export const app = new Crust("my-cli", { description: "My CLI", version: "1.2.3" })
   .extend(
     skill({
       distDir: new URL("../skills", import.meta.url),
@@ -63,7 +63,7 @@ export const app = new Crust("my-cli", { description: "My CLI" })
   .action(() => {});
 ```
 
-Each authored extra is copied into the build output next to the generated skill. An authored extra with the generated skill's name replaces that generated skill; duplicate names between authored extras remain an error. Use `name` and `description` to customize the generated skill, or `generated: false` to ship only authored `extras`; a build that would produce no skills at all is an error. `distDir` is only read at runtime, for discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
+The generated skill records the root `CommandSnapshot.meta.version` when present; the build hook never reads `package.json` from the working directory. Each authored extra is copied into the build output next to the generated skill. An authored extra with the generated skill's name replaces that generated skill; duplicate names between authored extras remain an error. Use `name` and `description` to customize the generated skill, or `generated: false` to ship only authored `extras`; a build that would produce no skills at all is an error. `distDir` is only read at runtime, for discovery and installation. Keep authored skill directories outside the build output; the build refuses an extra nested inside it.
 
 The extension registers `my-cli skill` and `my-cli skill update`. It also contributes an **Agent skills** section to root help and generated man pages. Each shipped skill is listed by name and description with its logical source path — relative to the working directory when the packaged directory is inside it, absolute otherwise — so agents can discover and load skills without installing them first. Run builds from the project root containing the packaged skills directory to keep absolute build-machine paths out of generated artifacts.
 
@@ -102,7 +102,7 @@ Additional agents are detected through a non-executing `PATH` lookup. The export
 | Universal  | `~/.agents/skills/<name>`         | `.agents/skills/<name>`           |
 | Additional | Agent-specific convention per CLI | Agent-specific convention per CLI |
 
-When the working directory is the home directory, project scope resolves to global scope.
+When the working directory is the home directory, project scope resolves to global scope. Every per-agent result from `installSkill()`, `getSkillStatus()`, and `uninstallSkill()` includes the effective `scope`, so callers can observe that remap.
 
 ## Low-level link operations
 

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -241,6 +241,7 @@ describe("command metadata", () => {
 	it("preserves root metadata through builder calls", async () => {
 		const app = new Crust("test", {
 			description: "A test command",
+			version: "1.2.3",
 			usage: "test [options]",
 		})
 			.flags({ name: "verbose", type: "boolean" })
@@ -250,6 +251,7 @@ describe("command metadata", () => {
 			meta: {
 				name: "test",
 				description: "A test command",
+				version: "1.2.3",
 				usage: "test [options]",
 			},
 			flags: { verbose: { type: "boolean" } },

--- a/packages/core/src/command/crust.test.ts
+++ b/packages/core/src/command/crust.test.ts
@@ -274,6 +274,19 @@ describe("command metadata", () => {
 			usage: "cli sub [options]",
 		});
 	});
+
+	it("keeps version metadata on the root command", async () => {
+		const app = new Crust("cli", { version: "1.0.0" }).add(
+			defineCommand(
+				"sub",
+				// @ts-expect-error -- application versions belong to the root constructor
+				{ version: "2.0.0" },
+				(command) => command,
+			),
+		);
+
+		expect((await app.snapshot()).subCommands.sub?.meta.version).toBeUndefined();
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -225,13 +225,13 @@ export type RunArguments<Shape extends CommandShape> = readonly [
 // ────────────────────────────────────────────────────────────────────────────
 
 /** Static configuration for a reusable command definition. */
-export interface CommandConfig extends Omit<CommandMeta, "name" | "sections"> {
+export interface CommandConfig extends Omit<CommandMeta, "name" | "sections" | "version"> {
 	/** Plain-text sections rendered after built-in command documentation. */
 	readonly sections?: readonly CommandSectionInput[];
 }
 
 /** Static metadata accepted by the root command constructor. */
-export type RootCommandMeta = Pick<CommandMeta, "description" | "usage"> & {
+export type RootCommandMeta = Pick<CommandMeta, "description" | "version" | "usage"> & {
 	/** Plain-text sections rendered after built-in command documentation. */
 	readonly sections?: readonly CommandSectionInput[];
 };
@@ -1005,7 +1005,7 @@ export class Crust<
 	 * Create a new root command builder.
 	 *
 	 * @param name - The command name.
-	 * @param meta - Optional root description, usage, and documentation sections.
+	 * @param meta - Optional root description, version, usage, and documentation sections.
 	 */
 	constructor(name: string, meta: RootCommandMeta = {}) {
 		// Runtime is the single home for this check: constructors cannot carry
@@ -1029,6 +1029,7 @@ export class Crust<
 		}
 		this._node = createCommandNode(name);
 		if (meta.description !== undefined) this._node.meta.description = meta.description;
+		if (meta.version !== undefined) this._node.meta.version = meta.version;
 		if (meta.usage !== undefined) this._node.meta.usage = meta.usage;
 		if (meta.sections !== undefined) {
 			this._node.meta.sections = validateCommandSections(name, meta.sections);

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -635,10 +635,10 @@ export function defineCommand(
 	maybeRecipe?: CommandRecipe,
 ): CommandDefinition {
 	const hasConfig = !isCommandRecipe(configOrRecipe);
-	const config: CommandConfig = hasConfig ? configOrRecipe : {};
+	const config: CommandConfig & { readonly version?: unknown } = hasConfig ? configOrRecipe : {};
 	const recipe = hasConfig ? maybeRecipe : configOrRecipe;
 	if (!recipe) throw new CrustError("DEFINITION", `Command "${name}" requires a recipe`);
-	const { sections, ...metaRest } = config;
+	const { sections, version: _rootVersion, ...metaRest } = config;
 	const meta: Omit<CommandMeta, "name"> = {
 		...metaRest,
 		...(config.aliases ? { aliases: [...config.aliases] } : {}),

--- a/packages/core/src/command/documentation.test.ts
+++ b/packages/core/src/command/documentation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { defineCommand } from "../index.ts";
 import { type AnyCrust, Crust } from "./crust.ts";
-import { buildCommandDocumentation, formatDescription } from "./documentation.ts";
+import { buildCommandDocumentation, formatDefault, formatDescription } from "./documentation.ts";
 
 async function docs(app: AnyCrust) {
 	return buildCommandDocumentation(await app.snapshot());
@@ -10,6 +10,8 @@ async function docs(app: AnyCrust) {
 
 describe("formatDescription", () => {
 	it("formats descriptions, defaults, and choices", () => {
+		expect(formatDefault(["json", "text"])).toBe("json, text");
+		expect(formatDefault("json")).toBe('"json"');
 		expect(formatDescription("Output", ["json", "text"], ["pretty", "compact"])).toBe(
 			"Output [default: json, text] [choices: pretty, compact]",
 		);
@@ -87,12 +89,23 @@ describe("buildCommandDocumentation", () => {
 		expect(model.flags[1]?.spellings).toEqual(["--help"]);
 	});
 
-	it("retains defaults and choices as renderer-neutral data", async () => {
+	it("retains defaults, choices, and unfiltered sections as renderer-neutral data", async () => {
 		const model = await docs(
-			new Crust("app")
+			new Crust("app", {
+				sections: [{ title: "Notes", body: "Root notes" }],
+			})
 				.flags({ name: "target", type: "string", default: "bun", choices: ["bun", "node"] })
+				.add(
+					defineCommand(
+						"child",
+						{ sections: [{ title: "Child notes", body: "Details" }] },
+						(command) => command,
+					),
+				)
 				.action(() => {}),
 		);
 		expect(model.flags[0]).toMatchObject({ default: "bun", choices: ["bun", "node"] });
+		expect(model.sections).toEqual([{ title: "Notes", body: "Root notes" }]);
+		expect(model.children[0]?.sections).toEqual([{ title: "Child notes", body: "Details" }]);
 	});
 });

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -1,9 +1,16 @@
 import { isListed } from "../sections.ts";
-import type { DeclaredDefault } from "../types.ts";
+import type { CommandSection, DeclaredDefault } from "../types.ts";
 import type { CommandSnapshot, FlagSnapshot } from "./snapshot.ts";
 
 function isNonFiniteNumber(value: DeclaredDefault): value is number {
 	return typeof value === "number" && !Number.isFinite(value);
+}
+
+/** Format a declared default value for command documentation. */
+export function formatDefault(value: DeclaredDefault): string {
+	if (isNonFiniteNumber(value)) return String(value);
+	if (Array.isArray(value)) return value.map(String).join(", ");
+	return JSON.stringify(value) ?? String(value);
 }
 
 /** Format a definition's description and optional default/choice annotations. */
@@ -15,12 +22,7 @@ export function formatDescription(
 ): string {
 	const parts = description ? [description] : [];
 	if (defaultValue !== undefined) {
-		const value = isNonFiniteNumber(defaultValue)
-			? String(defaultValue)
-			: Array.isArray(defaultValue)
-				? defaultValue.map(String).join(", ")
-				: JSON.stringify(defaultValue);
-		parts.push(formatAnnotation(`[default: ${value}]`));
+		parts.push(formatAnnotation(`[default: ${formatDefault(defaultValue)}]`));
 	}
 	if (choices?.length) parts.push(formatAnnotation(`[choices: ${choices.join(", ")}]`));
 	return parts.join(" ");
@@ -140,6 +142,8 @@ export interface CommandDocumentation {
 	readonly args: readonly DocumentationArg[];
 	/** Effective flags (Context-owned + local), in definition order. */
 	readonly flags: readonly DocumentationFlag[];
+	/** Unfiltered command-authored and Extension-contributed documentation sections. */
+	readonly sections: readonly CommandSection[];
 	/** Visible children only; hidden commands remain invocable but are not documentation. */
 	readonly children: readonly CommandDocumentation[];
 }
@@ -207,6 +211,7 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 		hasAction: command.hasAction,
 		args: Object.freeze(args),
 		flags: Object.freeze(flags),
+		sections: Object.freeze([...(command.meta.sections ?? [])]),
 		children: Object.freeze(children),
 	});
 }

--- a/packages/core/src/command/snapshot.ts
+++ b/packages/core/src/command/snapshot.ts
@@ -180,6 +180,7 @@ export function snapshotCommand(node: CommandNode): CommandSnapshot {
 		meta: freezeCompact({
 			name: node.meta.name,
 			description: node.meta.description,
+			version: node.meta.version,
 			usage: node.meta.usage,
 			sections: node.meta.sections
 				? Object.freeze(node.meta.sections.map((section) => Object.freeze({ ...section })))

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -7,7 +7,11 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 export { BUILD_OUT_DIR_ENV, SNAPSHOT_PATH_ENV } from "./command/invocation.ts";
-export { buildCommandDocumentation, formatDescription } from "./command/documentation.ts";
+export {
+	buildCommandDocumentation,
+	formatDefault,
+	formatDescription,
+} from "./command/documentation.ts";
 export type {
 	CommandDocumentation,
 	DocumentationArg,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -610,6 +610,8 @@ export interface CommandMeta {
 	name: string;
 	/** Human-readable description for help text */
 	description?: string;
+	/** Application version exposed to Extensions and tooling on the root command. */
+	version?: string;
 	/** Custom usage string (overrides auto-generated usage) */
 	usage?: string;
 	/** Plain-text sections rendered after built-in command documentation. */

--- a/packages/core/src/validation/commands.brands.ts
+++ b/packages/core/src/validation/commands.brands.ts
@@ -34,12 +34,19 @@ type AliasShapeErrors<Name extends string, C> =
 			: never
 		: never;
 
-/** Brand command config containing a statically known invalid alias. */
-export type ValidateCommandConfig<Name extends string, C> = string extends Name
+type AliasShapeBrand<Name extends string, C> = [AliasShapeErrors<Name, C>] extends [never]
 	? {}
-	: [AliasShapeErrors<Name, C>] extends [never]
-		? {}
-		: { readonly FIX_ALIAS_SHAPE: AliasShapeErrors<Name, C> };
+	: { readonly FIX_ALIAS_SHAPE: AliasShapeErrors<Name, C> };
+
+type RootVersionBrand<C> = "version" extends keyof C
+	? { readonly FIX_ROOT_VERSION: 'Command config "version" belongs on the root Crust constructor' }
+	: {};
+
+/** Brand command config containing statically known invalid metadata. */
+export type ValidateCommandConfig<Name extends string, C> = (string extends Name
+	? {}
+	: AliasShapeBrand<Name, C>) &
+	RootVersionBrand<C>;
 
 type EmptyNameError = { readonly FIX_EMPTY_NAME: "Command name must be a non-empty string" };
 

--- a/packages/extensions/src/completion/adversarial.test.ts
+++ b/packages/extensions/src/completion/adversarial.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Crust, defineCommand } from "@crustjs/core";
+import { buildCommandDocumentation } from "@crustjs/core/tooling";
 
 import { completion } from "./index.ts";
 import type { CompletionCommand } from "./spec.ts";
@@ -29,14 +30,14 @@ describe("walker · validation", () => {
 		const cli = new Crust("bad")
 			.add(defineCommand("two words", (c) => c.action(() => {})))
 			.action(() => {});
-		const snapshot = await cli.snapshot();
-		expect(() => walkCommandNode(snapshot)).toThrow(/invalid command name/);
+		const model = buildCommandDocumentation(await cli.snapshot());
+		expect(() => walkCommandNode(model)).toThrow(/invalid command name/);
 	});
 
 	it("rejects flag names with shell metacharacters", async () => {
 		const cli = new Crust("bad").flags({ name: "a;rm", type: "boolean" }).action(() => {});
-		const snapshot = await cli.snapshot();
-		expect(() => walkCommandNode(snapshot)).toThrow(/invalid flag name/);
+		const model = buildCommandDocumentation(await cli.snapshot());
+		expect(() => walkCommandNode(model)).toThrow(/invalid flag name/);
 	});
 
 	it("rejects choice values containing spaces", async () => {
@@ -47,15 +48,15 @@ describe("walker · validation", () => {
 				choices: ["a", "two words", "c"],
 			})
 			.action(() => {});
-		const snapshot = await cli.snapshot();
-		expect(() => walkCommandNode(snapshot)).toThrow(/unsupported choice value/);
+		const model = buildCommandDocumentation(await cli.snapshot());
+		expect(() => walkCommandNode(model)).toThrow(/unsupported choice value/);
 	});
 
 	it("strips control characters from descriptions instead of throwing", async () => {
 		const cli = new Crust("safe", {
 			description: "first line\nsecond line\rstill same line",
 		}).action(() => {});
-		const spec = walkCommandNode(await cli.snapshot());
+		const spec = walkCommandNode(buildCommandDocumentation(await cli.snapshot()));
 		// Newlines and CR collapse to spaces during normalisation.
 		expect(spec.description).toBe("first line second line still same line");
 		// And the value never contains a raw newline that could break

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -62,8 +62,8 @@ function getProcessStdout(): string {
 }
 
 function buildCli() {
-	return new Crust("mycli", { description: "Test CLI" })
-		.extend(completion({ version: "1.2.3" }))
+	return new Crust("mycli", { description: "Test CLI", version: "1.2.3" })
+		.extend(completion())
 		.add(
 			defineCommand("build", { description: "Build artifact" }, (cmd) =>
 				cmd
@@ -96,6 +96,21 @@ describe("completion", () => {
 			.action(() => {});
 		const root = await app.snapshot();
 		expect(Object.keys(root.subCommands)).toContain("shell-completion");
+	});
+
+	it("uses the explicit version option as an override", async () => {
+		const app = new Crust("mycli", { version: "1.2.3" })
+			.extend(completion({ version: "2.0.0" }))
+			.action(() => {});
+		await app.execute({ argv: ["completion", "bash"] });
+		expect(getStdout()).toStartWith("# completion script for mycli v2.0.0");
+	});
+
+	it("reports a missing version", async () => {
+		const app = new Crust("mycli").extend(completion()).action(() => {});
+		await app.execute({ argv: ["completion", "bash"] });
+		expect(stderrChunks.join("\n")).toContain("completion extension requires a version");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("`mycli completion bash` prints a bash script to stdout", async () => {

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -2,12 +2,14 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 
 import {
+	CrustError,
 	type Extension,
 	type ExtensionId,
 	defineCommand,
 	defineExtension,
 	defineExtensionId,
 } from "@crustjs/core";
+import { buildCommandDocumentation } from "@crustjs/core/tooling";
 
 import { assertSafeBinName, sanitizeFreeText } from "./escape.ts";
 import { renderBash } from "./templates/bash.ts";
@@ -39,10 +41,9 @@ export interface CompletionOptions {
 	binName?: string;
 	/**
 	 * Free-form version string embedded in generated script headers. The
-	 * walker does not parse it. Pass your `package.json` version when wiring
-	 * the extension.
+	 * walker does not parse it.
 	 *
-	 * @default "0.0.0"
+	 * @default The root command's `meta.version`
 	 */
 	version?: string;
 }
@@ -77,7 +78,7 @@ const SHELL_RENDERERS = {
  * **Strategy: pure-static.** The action walks the final root snapshot, so
  * registration order is irrelevant — any commands or recursive flags added
  * by other Extensions are visible by the time we generate the script. The
- * walker projects the root snapshot to a small completion model; per-shell
+ * walker projects Core's documentation model to a small completion model; per-shell
  * renderers turn that into a self-contained shell script with no runtime
  * callbacks.
  *
@@ -94,7 +95,6 @@ const SHELL_RENDERERS = {
  */
 function completionFactory(options: CompletionOptions = {}): Extension {
 	const subcommandName = options.command ?? "completion";
-	const version = options.version ?? "0.0.0";
 
 	const completionCommand = defineCommand(
 		subcommandName,
@@ -120,13 +120,20 @@ function completionFactory(options: CompletionOptions = {}): Extension {
 					// CLIs fail loudly. The walker also re-validates command/flag
 					// identifiers when it builds the spec.
 					const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
+					const version = options.version ?? rootCommand.meta.version;
+					if (version === undefined) {
+						throw new CrustError(
+							"DEFINITION",
+							"The completion extension requires a version in new Crust(name, { version }) or completion({ version })",
+						);
+					}
 					// `version` flows into header comments only; sanitise to drop
 					// control characters (newlines especially) so they cannot break
 					// out of the comment line in the emitted script.
 					const safeVersion = sanitizeFreeText(version);
 
 					const { shell: requestedShell } = context.args;
-					const spec = walkCommandNode(rootCommand);
+					const spec = walkCommandNode(buildCommandDocumentation(rootCommand));
 					const outputDir = context.flags["output-dir"];
 
 					if (outputDir === undefined) {

--- a/packages/extensions/src/completion/walker.test.ts
+++ b/packages/extensions/src/completion/walker.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "bun:test";
 
-import { Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
+import { type AnyCrust, Crust, defineCommand, defineContext, defineFlag } from "@crustjs/core";
+import { buildCommandDocumentation } from "@crustjs/core/tooling";
 
 import { walkCommandNode } from "./walker.ts";
 
+async function walk(app: AnyCrust) {
+	return walkCommandNode(buildCommandDocumentation(await app.snapshot()));
+}
+
 describe("walkCommandNode", () => {
 	it("walks a leaf command with no flags, args, or children", async () => {
-		const spec = walkCommandNode(
-			await new Crust("mycli", { description: "Top-level CLI" }).snapshot(),
-		);
+		const spec = await walk(new Crust("mycli", { description: "Top-level CLI" }));
 
 		expect(spec.name).toBe("mycli");
 		expect(spec.description).toBe("Top-level CLI");
@@ -23,7 +26,7 @@ describe("walkCommandNode", () => {
 			{ name: "name", type: "string", description: "Name to greet", aliases: ["nm"] },
 			{ name: "tag", type: "string", multiple: true },
 		);
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		const byName = Object.fromEntries(spec.flags.map((f) => [f.name, f]));
 
 		expect(byName.verbose).toEqual({
@@ -58,7 +61,7 @@ describe("walkCommandNode", () => {
 			.provide(auth())
 			.add(defineCommand("deploy", (command) => command.action(() => {})));
 
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		expect(spec.flags.map((flag) => flag.name)).toContain("api-key");
 		expect(spec.subCommands[0]?.flags.map((flag) => flag.name)).toContain("api-key");
 	});
@@ -68,7 +71,7 @@ describe("walkCommandNode", () => {
 			{ name: "input", type: "string", required: true, description: "Input file" },
 			{ name: "extra", type: "string", variadic: true },
 		);
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 
 		expect(spec.args).toEqual([
 			{
@@ -86,7 +89,7 @@ describe("walkCommandNode", () => {
 		const app = new Crust("mycli")
 			.flags({ name: "target", type: "string", choices: ["browser", "bun", "node"] })
 			.args({ name: "shell", type: "string", required: true, choices: ["bash", "zsh", "fish"] });
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		expect(spec.flags.find((f) => f.name === "target")?.choices).toEqual([
 			"browser",
 			"bun",
@@ -105,7 +108,7 @@ describe("walkCommandNode", () => {
 					command.flags({ name: "local", type: "boolean" }),
 				),
 			);
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		const childSpec = spec.subCommands[0];
 		if (!childSpec) throw new Error("missing child");
 		expect(childSpec.description).toBe("Child command");
@@ -121,7 +124,7 @@ describe("walkCommandNode", () => {
 				(command) => command,
 			),
 		);
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		expect(spec.subCommands.map((s) => s.name)).toEqual(["issue"]);
 		expect(spec.subCommands[0]?.aliases).toEqual(["issues", "i"]);
 	});
@@ -137,7 +140,7 @@ describe("walkCommandNode", () => {
 			.add(
 				defineCommand("kid", { description: `${ESC}[31mred kid${ESC}[0m` }, (command) => command),
 			);
-		const spec = walkCommandNode(await app.snapshot());
+		const spec = await walk(app);
 		expect(spec.description).toBe("colored desc");
 		expect(spec.flags[0]?.description).toBe("verbose");
 		expect(spec.flags[1]?.description).toBeUndefined();
@@ -153,9 +156,7 @@ describe("walkCommandNode — url/path/json valueCompletion", () => {
 			{ name: "out", type: "path" },
 			{ name: "config", type: "json" },
 		);
-		const by = Object.fromEntries(
-			walkCommandNode(await app.snapshot()).flags.map((f) => [f.name, f]),
-		);
+		const by = Object.fromEntries((await walk(app)).flags.map((f) => [f.name, f]));
 		expect(by.endpoint?.valueCompletion).toBe("none");
 		expect(by.out?.valueCompletion).toBe("files");
 		expect(by.config?.valueCompletion).toBe("none");
@@ -167,7 +168,7 @@ describe("walkCommandNode — url/path/json valueCompletion", () => {
 			{ name: "dst", type: "url" },
 			{ name: "cfg", type: "json" },
 		);
-		const [src, dst, cfg] = walkCommandNode(await app.snapshot()).args;
+		const [src, dst, cfg] = (await walk(app)).args;
 		expect(src?.valueCompletion).toBe("files");
 		expect(dst?.valueCompletion).toBe("none");
 		expect(cfg?.valueCompletion).toBe("none");

--- a/packages/extensions/src/completion/walker.ts
+++ b/packages/extensions/src/completion/walker.ts
@@ -1,7 +1,10 @@
 import { stripVTControlCharacters } from "node:util";
 
-import type { ArgSnapshot, CommandSnapshot, FlagSnapshot } from "@crustjs/core";
-import { isListed } from "@crustjs/core/tooling";
+import type {
+	CommandDocumentation,
+	DocumentationArg,
+	DocumentationFlag,
+} from "@crustjs/core/tooling";
 
 import { assertSafeChoiceValue, assertSafeIdentifier, sanitizeFreeText } from "./escape.ts";
 import type { CompletionArg, CompletionCommand, CompletionFlag } from "./spec.ts";
@@ -18,28 +21,23 @@ function normaliseDescription(value: string | undefined): string | undefined {
 }
 
 /**
- * Project a single `FlagDef` (keyed by `name` in the snapshot `flags`) onto a
- * `CompletionFlag`. The walker calls this for every entry of every visible
- * command's `flags` map so propagating flags surface at the right
- * depth.
+ * Project a single documentation flag onto a `CompletionFlag`.
  */
-function walkFlag(name: string, def: FlagSnapshot): CompletionFlag {
-	assertSafeIdentifier(name, "flag name");
-	const aliases = def.aliases?.filter((alias) => alias.length > 0);
-	if (aliases !== undefined) {
-		for (const alias of aliases) assertSafeIdentifier(alias, "flag alias");
-	}
+function walkFlag(def: DocumentationFlag): CompletionFlag {
+	assertSafeIdentifier(def.name, "flag name");
+	const aliases = def.aliases.filter((alias) => alias.length > 0);
+	for (const alias of aliases) assertSafeIdentifier(alias, "flag alias");
 	if (def.short !== undefined && def.short.length > 0) {
 		assertSafeIdentifier(def.short, "flag short alias");
 	}
 
 	const description = normaliseDescription(def.description);
 	const common = {
-		name,
+		name: def.name,
 		...(def.short !== undefined && def.short.length > 0 ? { short: def.short } : {}),
-		...(aliases !== undefined && aliases.length > 0 ? { aliases } : {}),
+		...(aliases.length > 0 ? { aliases } : {}),
 		...(description === undefined ? {} : { description }),
-		...(def.multiple === true ? { multiple: true as const } : {}),
+		...(def.multiple ? { multiple: true as const } : {}),
 		negatable: def.negatable,
 	};
 
@@ -72,14 +70,14 @@ function walkFlag(name: string, def: FlagSnapshot): CompletionFlag {
 	return { ...common, type: "string", takesValue: true };
 }
 
-/** Project a single `ArgDef` onto a `CompletionArg`. */
-function walkArg(def: ArgSnapshot): CompletionArg {
+/** Project a single documentation argument onto a `CompletionArg`. */
+function walkArg(def: DocumentationArg): CompletionArg {
 	assertSafeIdentifier(def.name, "arg name");
 	const description = normaliseDescription(def.description);
 	const common = {
 		name: def.name,
-		required: def.required === true,
-		variadic: def.variadic === true,
+		required: def.required,
+		variadic: def.variadic,
 		...(description === undefined ? {} : { description }),
 	};
 
@@ -101,48 +99,29 @@ function walkArg(def: ArgSnapshot): CompletionArg {
 }
 
 /**
- * Build a completion command from a `CommandSnapshot`, recursively filtering
- * hidden subcommands at every level.
+ * Build a completion command from the shared documentation model.
  */
-export function walkCommandNode(node: CommandSnapshot): CompletionCommand {
-	assertSafeIdentifier(node.meta.name, "command name");
-	const nodeAliases = node.meta.aliases;
-	if (nodeAliases !== undefined) {
-		for (const alias of nodeAliases) {
-			assertSafeIdentifier(alias, "command alias");
-		}
+export function walkCommandNode(node: CommandDocumentation): CompletionCommand {
+	assertSafeIdentifier(node.name, "command name");
+	for (const alias of node.aliases) {
+		assertSafeIdentifier(alias, "command alias");
 	}
-	const flags: CompletionFlag[] = [];
-	for (const [flagName, flagDef] of Object.entries(node.flags)) {
-		flags.push(walkFlag(flagName, flagDef));
-	}
-
-	const args: CompletionArg[] = [];
-	for (const argDef of node.args) {
-		args.push(walkArg(argDef));
-	}
-
-	const subCommands: CompletionCommand[] = [];
-	for (const subNode of Object.values(node.subCommands)) {
-		if (!isListed(subNode)) continue;
-		subCommands.push(walkCommandNode(subNode));
-	}
+	const flags = node.flags.map(walkFlag);
+	const args = node.args.map(walkArg);
+	const subCommands = node.children.map(walkCommandNode);
 
 	const result: CompletionCommand = {
-		name: node.meta.name,
+		name: node.name,
 		flags,
 		args,
 		subCommands,
 	};
 
-	const aliases = node.meta.aliases;
-	if (aliases !== undefined && aliases.length > 0) {
-		// `CommandMeta.aliases` is `readonly string[] | undefined`. Preserve
-		// readonly-ness; template code only needs to enumerate.
-		result.aliases = aliases;
+	if (node.aliases.length > 0) {
+		result.aliases = node.aliases;
 	}
 
-	const description = normaliseDescription(node.meta.description);
+	const description = normaliseDescription(node.description);
 	if (description !== undefined) {
 		result.description = description;
 	}

--- a/packages/extensions/src/extensions.test.ts
+++ b/packages/extensions/src/extensions.test.ts
@@ -614,12 +614,21 @@ describe("built-in extensions", () => {
 		expect(process.exitCode).toBeFalsy();
 	});
 
-	it("version extension handles --version", async () => {
-		const app = new Crust("app").extend(version("1.2.3")).action(() => {});
+	it("version extension handles --version from root metadata", async () => {
+		const app = new Crust("app", { version: "1.2.3" }).extend(version()).action(() => {});
 
 		await app.execute({ argv: ["--version"] });
 
 		expect(getStdout()).toContain("app v1.2.3");
+	});
+
+	it("version extension reports a missing version", async () => {
+		const app = new Crust("app").extend(version()).action(() => {});
+
+		await app.execute({ argv: ["--version"] });
+
+		expect(getStderr()).toContain("version extension requires a version");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("version extension handles -v alias", async () => {

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -94,7 +94,7 @@ export function renderHelp(command: CommandSnapshot, path?: readonly string[]): 
 	]) {
 		if (section.length > 0) lines.push("", ...section);
 	}
-	for (const section of sectionsFor(command.meta.sections, HELP)) {
+	for (const section of sectionsFor(model.sections, HELP)) {
 		lines.push(
 			"",
 			bold(cyan(`${section.title}:`)),

--- a/packages/extensions/src/update-notifier.test.ts
+++ b/packages/extensions/src/update-notifier.test.ts
@@ -1196,18 +1196,13 @@ describe("updateNotifier post-run hook", () => {
 	// ── Integration with Crust ──────────────────────────────────────────
 
 	describe("Crust.execute() integration", () => {
-		it("works as an extension passed to Crust.execute()", async () => {
+		it("uses the root metadata version with Crust.execute()", async () => {
 			const pkgName = uniquePackageName("runcommand");
 			mockRegistryResponse("5.0.0");
 
 			let commandExecuted = false;
-			const app = new Crust(pkgName, { description: "Test" })
-				.extend(
-					updateNotifier({
-						currentVersion: "1.0.0",
-						packageName: pkgName,
-					}),
-				)
+			const app = new Crust(pkgName, { description: "Test", version: "1.0.0" })
+				.extend(updateNotifier({ packageName: pkgName }))
 				.action(() => {
 					commandExecuted = true;
 				});
@@ -1217,6 +1212,18 @@ describe("updateNotifier post-run hook", () => {
 			expect(commandExecuted).toBe(true);
 			expect(getOutput()).toContain("Update available");
 			expect(getOutput()).toContain("5.0.0");
+		});
+
+		it("reports a missing application version", async () => {
+			const pkgName = uniquePackageName("missing-version");
+			const app = new Crust(pkgName)
+				.extend(updateNotifier({ packageName: pkgName }))
+				.action(() => {});
+
+			await app.execute({ argv: [] });
+
+			expect(getOutput()).toContain("update notifier extension requires a version");
+			expect(process.exitCode).toBe(1);
 		});
 
 		it("does not break command execution when registry is down", async () => {

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -5,6 +5,7 @@
 import { basename } from "node:path";
 
 import {
+	CrustError,
 	type Extension,
 	type ExtensionId,
 	defineExtension,
@@ -68,23 +69,16 @@ export interface UpdateNotifierCacheConfig {
  * ```ts
  * import { updateNotifier } from "@crustjs/extensions";
  *
- * updateNotifier({
- *   packageName: "my-cli",
- *   currentVersion: "1.2.3",
- * });
+ * updateNotifier({ packageName: "my-cli" });
  * ```
  */
 export interface UpdateNotifierOptions {
 	/**
-	 * The current version of the CLI package.
+	 * Override the current version of the CLI package.
 	 *
-	 * Typically sourced from `package.json`:
-	 * ```ts
-	 * import pkg from "../package.json";
-	 * updateNotifier({ packageName: pkg.name, currentVersion: pkg.version });
-	 * ```
+	 * @default The root command's `meta.version`
 	 */
-	currentVersion: string;
+	currentVersion?: string;
 
 	/**
 	 * The npm package name to check for updates.
@@ -418,17 +412,16 @@ function resolveUpdateCommand(
  * - The update notice is emitted *after* the command action completes.
  * - Duplicate notifications for the same version are suppressed.
  *
- * @param options - Extension configuration. `currentVersion` and `packageName` are required.
+ * @param options - Extension configuration. `packageName` is required.
  * @returns An Extension registered with `.extend()`.
  *
  * @example
  * ```ts
  * import { Crust } from "@crustjs/core";
  * import { updateNotifier } from "@crustjs/extensions";
- * import pkg from "../package.json";
  *
- * const app = new Crust("my-cli", { description: "My awesome CLI" })
- *   .extend(updateNotifier({ packageName: "my-cli", currentVersion: pkg.version }))
+ * const app = new Crust("my-cli", { description: "My awesome CLI", version: "1.2.3" })
+ *   .extend(updateNotifier({ packageName: "my-cli" }))
  *   .action(() => {
  *     console.log("Hello!");
  *   });
@@ -452,6 +445,14 @@ function updateNotifierFactory(options: UpdateNotifierOptions): Extension {
 		hooks: {
 			async postRun(context, outcome) {
 				if (outcome.status !== "completed") return;
+
+				const resolvedCurrentVersion = currentVersion ?? context.rootCommand.meta.version;
+				if (resolvedCurrentVersion === undefined) {
+					throw new CrustError(
+						"DEFINITION",
+						"The update notifier extension requires a version in new Crust(name, { version }) or currentVersion",
+					);
+				}
 
 				try {
 					let cacheAdapter: UpdateNotifierCacheAdapter = NO_CACHE_ADAPTER;
@@ -479,11 +480,11 @@ function updateNotifierFactory(options: UpdateNotifierOptions): Extension {
 						// Cache is still fresh — use cached version if available
 						if (
 							state.latestVersion &&
-							isNewerVersion(currentVersion, state.latestVersion) &&
+							isNewerVersion(resolvedCurrentVersion, state.latestVersion) &&
 							state.lastNotifiedVersion !== state.latestVersion
 						) {
 							emitUpdateNotice(
-								currentVersion,
+								resolvedCurrentVersion,
 								state.latestVersion,
 								resolvedUpdateCommand,
 								updateDocsUrl,
@@ -518,11 +519,11 @@ function updateNotifierFactory(options: UpdateNotifierOptions): Extension {
 
 					// ── Emit notice if newer and not already notified ─────────
 					if (
-						isNewerVersion(currentVersion, latestVersion) &&
+						isNewerVersion(resolvedCurrentVersion, latestVersion) &&
 						state.lastNotifiedVersion !== latestVersion
 					) {
 						emitUpdateNotice(
-							currentVersion,
+							resolvedCurrentVersion,
 							latestVersion,
 							resolvedUpdateCommand,
 							updateDocsUrl,

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -1,4 +1,5 @@
 import {
+	CrustError,
 	type Extension,
 	type ExtensionId,
 	type ExtensionContext,
@@ -21,10 +22,7 @@ export interface VersionOptions {
 	readonly format?: "plain" | ((version: string, context: ExtensionContext) => string);
 }
 
-function versionFactory(
-	versionValue: VersionValue = "0.0.0",
-	options: VersionOptions = {},
-): Extension {
+function versionFactory(versionValue?: VersionValue, options: VersionOptions = {}): Extension {
 	const { format } = options;
 
 	return defineExtension(VERSION, {
@@ -44,7 +42,14 @@ function versionFactory(
 				if (context.commandPath.length !== 1 || context.flags.version !== true) return;
 
 				// oxlint-disable-next-line anti-slop/no-runtime-typeof -- discriminating a typed options union.
-				const resolvedVersion = typeof versionValue === "function" ? versionValue() : versionValue;
+				const override = typeof versionValue === "function" ? versionValue() : versionValue;
+				const resolvedVersion = override ?? context.rootCommand.meta.version;
+				if (resolvedVersion === undefined) {
+					throw new CrustError(
+						"DEFINITION",
+						"The version extension requires a version in new Crust(name, { version }) or version(value)",
+					);
+				}
 				const line =
 					format === "plain"
 						? resolvedVersion

--- a/packages/man/src/mdoc.ts
+++ b/packages/man/src/mdoc.ts
@@ -3,7 +3,6 @@ import {
 	type CommandSnapshot,
 	formatDescription,
 	sectionsFor,
-	visibleSectionsFor,
 	type CommandDocumentation,
 	type DocumentationFlag,
 } from "@crustjs/core/tooling";
@@ -38,6 +37,24 @@ function commandLabel(command: CommandDocumentation): string {
 	return command.aliases.length === 0
 		? command.name
 		: `${command.name} (${command.aliases.join(", ")})`;
+}
+function commandSectionGroups(command: CommandDocumentation): readonly {
+	readonly path: readonly string[];
+	readonly sections: readonly CommandDocumentation["sections"][number][];
+}[] {
+	const groups: {
+		path: readonly string[];
+		sections: CommandDocumentation["sections"][number][];
+	}[] = [];
+	function visit(node: CommandDocumentation, path: readonly string[]): void {
+		const sections = [...sectionsFor(node.sections, MAN)];
+		if (sections.length > 0) groups.push({ path, sections });
+		for (const child of [...node.children].sort((a, b) => a.name.localeCompare(b.name))) {
+			visit(child, [...path, child.name]);
+		}
+	}
+	visit(command, []);
+	return groups;
 }
 function resolveDdLine(explicit?: string): string {
 	if (explicit) return explicit;
@@ -121,11 +138,11 @@ export function renderManPageMdoc(options: RenderManPageMdocOptions): string {
 		}
 		lines.push(".El");
 	}
-	for (const metadataSection of sectionsFor(root.meta.sections, MAN)) {
+	for (const metadataSection of sectionsFor(model.sections, MAN)) {
 		lines.push(`.Sh ${shTitle(metadataSection.title)}`);
 		for (const line of metadataSection.body.split("\n")) lines.push(escapeMdocBodyLine(line));
 	}
-	const commandSections = visibleSectionsFor(root, MAN).filter(({ path }) => path.length > 0);
+	const commandSections = commandSectionGroups(model).filter(({ path }) => path.length > 0);
 	if (commandSections.length > 0) {
 		lines.push(".Sh COMMANDS");
 		for (const group of commandSections) {

--- a/packages/skills/src/agents.ts
+++ b/packages/skills/src/agents.ts
@@ -374,9 +374,8 @@ export async function detectInstalledAgents(): Promise<AgentTarget[]> {
  * @internal
  */
 export function resolveAgentPath(agent: AgentTarget, scope: Scope, name: string): string {
-	const effectiveScope = resolveEffectiveScope(scope);
 	const cfg = AGENTS[agent];
-	if (effectiveScope === "project") {
+	if (scope === "project") {
 		return join(process.cwd(), cfg.projectSkillsDir, name);
 	}
 	return join(cfg.globalSkillsDir(homedir()), name);

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -142,12 +142,12 @@ describe("skill extension packaged directory", () => {
 		const extension = skill({ distDir: source, extras: [authored] });
 		const snapshot = await new Crust("demo", {
 			description: "Demo",
+			version: "9.9.9",
 			sections: [{ title: "Agent skills", body: "Application-authored agent guidance." }],
 		})
 			.extend(extension)
 			.snapshot();
 		const outDir = join(tempRoot, "dist");
-		await writeFile(join(tempRoot, "package.json"), '{"version":"9.9.9"}');
 
 		await withCwd(tempRoot, async () => {
 			await extension.build?.({ snapshot, outDir });
@@ -201,7 +201,7 @@ describe("skill extension packaged directory", () => {
 		const extension = skill({ distDir: source });
 		const snapshot = await new Crust("demo", { description: "Demo" }).extend(extension).snapshot();
 		const outDir = join(tempRoot, "dist");
-		await writeFile(join(tempRoot, "package.json"), "{}");
+		await writeFile(join(tempRoot, "package.json"), '{"version":"8.8.8"}');
 
 		await withCwd(tempRoot, async () => {
 			await extension.build!({ snapshot, outDir });

--- a/packages/skills/src/extension.test.ts
+++ b/packages/skills/src/extension.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	chmod,
 	lstat,
 	mkdir,
 	mkdtemp,
@@ -228,6 +229,81 @@ describe("skill extension packaged directory", () => {
 		expect((await lstat(target("demo"))).isSymbolicLink()).toBe(true);
 		expect((await lstat(target("guide"))).isSymbolicLink()).toBe(true);
 		expect(await readFile(join(target("demo"), "content.md"), "utf8")).toBe("demo\n");
+	});
+
+	it("normalizes home-directory scopes before repair and install grouping", async () => {
+		const source = await writeSource("demo");
+		for (const conflict of [
+			join(tempRoot, ".agents", "skills", "demo"),
+			join(tempRoot, ".trae", "skills", "demo"),
+		]) {
+			await mkdir(conflict, { recursive: true });
+			await writeFile(join(conflict, "manual.md"), "keep\n");
+		}
+		const binDir = join(tempRoot, "bin");
+		const traeBin = join(binDir, "trae");
+		await mkdir(binDir);
+		await writeFile(traeBin, "#!/bin/sh\nexit 0\n");
+		await chmod(traeBin, 0o755);
+
+		const script = join(tempRoot, "home-scope.ts");
+		await writeFile(
+			script,
+			`import { lstat } from "node:fs/promises";
+import { join } from "node:path";
+import { Crust } from ${JSON.stringify(import.meta.resolve("@crustjs/core"))};
+import { skill } from ${JSON.stringify(new URL("./extension.ts", import.meta.url).href)};
+
+const source = ${JSON.stringify(source)};
+const repairErrors: string[] = [];
+await new Crust("demo")
+  .extend(skill({ distDir: source }))
+  .action(() => {})
+  .execute({ argv: [], io: { stderr: (text) => repairErrors.push(text) } });
+
+await new Crust("demo")
+  .extend(skill({ distDir: source, autoUpdate: false }))
+  .action(() => {})
+  .execute({
+    argv: ["skill", "--all", "--scope", "project"],
+    io: { stderr: () => {} },
+  });
+
+let traeCnInstalled = false;
+try {
+  traeCnInstalled = (await lstat(join(process.cwd(), ".trae-cn", "skills", "demo"))).isSymbolicLink();
+} catch {}
+console.log("RESULT " + JSON.stringify({ repairErrors, traeCnInstalled }));
+`,
+		);
+		const proc = Bun.spawn([process.execPath, script], {
+			cwd: tempRoot,
+			env: {
+				...process.env,
+				HOME: tempRoot,
+				PATH: binDir,
+				XDG_CONFIG_HOME: join(tempRoot, ".config"),
+				CLAUDE_CONFIG_DIR: join(tempRoot, ".claude"),
+				VIBE_HOME: join(tempRoot, ".vibe"),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(exitCode, stderr).toBe(0);
+		const resultLine = stdout.match(/^RESULT (.+)$/m)?.[1];
+		expect(resultLine, stdout).toBeDefined();
+		const result = JSON.parse(resultLine!) as {
+			repairErrors: string[];
+			traeCnInstalled: boolean;
+		};
+		expect(result.repairErrors).toHaveLength(2);
+		expect(new Set(result.repairErrors).size).toBe(2);
+		expect(result.traeCnInstalled).toBe(true);
 	});
 
 	it("does not let --all overwrite an unowned agent directory", async () => {

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { join, relative } from "node:path";
 
 import {
 	type Extension,
@@ -13,7 +12,6 @@ import {
 import { spinner } from "@crustjs/progress";
 import { confirm, multiselect, select } from "@crustjs/prompts";
 import { bold, dim, yellow } from "@crustjs/style";
-import { isErrnoException } from "@crustjs/utils/error";
 import { isWithin } from "@crustjs/utils/path";
 
 import {
@@ -21,7 +19,6 @@ import {
 	detectInstalledAgents,
 	getAdditionalAgents,
 	getUniversalAgents,
-	resolveEffectiveScope,
 } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
 import {
@@ -70,12 +67,12 @@ async function repairInstalledSkill(
 	io: SkillIO,
 	report = false,
 ): Promise<void> {
-	const effectiveScope = resolveEffectiveScope(scope);
 	const status = await getSkillStatus({
 		name: packagedSkill.name,
 		sourceDir: packagedSkill.sourceDir,
 		scope,
 	});
+	const effectiveScope = status.agents[0]?.scope ?? scope;
 	for (const outputDir of new Set(
 		status.agents.filter((entry) => entry.status === "conflict").map((entry) => entry.outputDir),
 	)) {
@@ -133,7 +130,7 @@ async function autoRepairSkills(options: SkillOptions, io: SkillIO): Promise<voi
 	const configuredScopes: Scope[] = options.defaultScope
 		? [options.defaultScope]
 		: ["project", "global"];
-	const scopes = [...new Set(configuredScopes.map(resolveEffectiveScope))];
+	const scopes = [...new Set(configuredScopes)];
 	for (const packagedSkill of skills) {
 		for (const scope of scopes) {
 			try {
@@ -179,33 +176,11 @@ function formatSkillDocumentation(
 	}
 }
 
-function hasPackageVersion<Value>(value: Value): value is Value & { version: string } {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"version" in value &&
-		typeof value.version === "string"
-	);
-}
-
-async function readPackageVersion(): Promise<string | undefined> {
-	const path = resolve(process.cwd(), "package.json");
-	let content: string;
-	try {
-		content = await readFile(path, "utf8");
-	} catch (error) {
-		if (isErrnoException(error) && error.code === "ENOENT") return undefined;
-		throw error;
-	}
-	const manifest: unknown = JSON.parse(content);
-	return hasPackageVersion(manifest) && manifest.version.length > 0 ? manifest.version : undefined;
-}
-
 async function buildSkills(options: SkillOptions, context: ExtensionBuildContext): Promise<void> {
 	const { writeSkills, writeSkillsFromSnapshot } = await import("./build.ts");
 	const writeOptions = {
 		outDir: join(context.outDir, "skills"),
-		version: await readPackageVersion(),
+		version: context.snapshot.meta.version,
 		name: options.name,
 		description: options.description,
 		extras: options.extras,

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -19,6 +19,7 @@ import {
 	detectInstalledAgents,
 	getAdditionalAgents,
 	getUniversalAgents,
+	resolveEffectiveScope,
 } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
 import {
@@ -130,7 +131,7 @@ async function autoRepairSkills(options: SkillOptions, io: SkillIO): Promise<voi
 	const configuredScopes: Scope[] = options.defaultScope
 		? [options.defaultScope]
 		: ["project", "global"];
-	const scopes = [...new Set(configuredScopes)];
+	const scopes = [...new Set(configuredScopes.map(resolveEffectiveScope))];
 	for (const packagedSkill of skills) {
 		for (const scope of scopes) {
 			try {
@@ -225,12 +226,13 @@ async function reconcileSkill(opts: {
 	io: SkillIO;
 }): Promise<void> {
 	const { packagedSkill, scope, installAll, io } = opts;
+	const effectiveScope = resolveEffectiveScope(scope);
 	const detected = new Set(await detectInstalledAgents());
 	const universal = getUniversalAgents();
 	const status = await getSkillStatus({
 		name: packagedSkill.name,
 		sourceDir: packagedSkill.sourceDir,
-		scope,
+		scope: effectiveScope,
 	});
 	const statusMap = new Map(status.agents.map((entry) => [entry.agent, entry]));
 	const installed = new Set(
@@ -291,14 +293,14 @@ async function reconcileSkill(opts: {
 	}
 
 	if (toInstall.length > 0) {
-		const groups = groupAgentsByOutputDir(toInstall, scope, packagedSkill.name);
+		const groups = groupAgentsByOutputDir(toInstall, effectiveScope, packagedSkill.name);
 		const installedAgents: InstallSkillResult["agents"] = [];
 		for (const agents of groups.values()) {
 			const runInstall = (force?: boolean) =>
 				installSkill({
 					sourceDir: packagedSkill.sourceDir,
 					agents,
-					scope,
+					scope: effectiveScope,
 					force,
 				});
 			try {
@@ -344,7 +346,7 @@ async function reconcileSkill(opts: {
 				uninstallSkill({
 					name: packagedSkill.name,
 					agents: toUninstall,
-					scope,
+					scope: effectiveScope,
 				}),
 		});
 	}

--- a/packages/skills/src/generate.test.ts
+++ b/packages/skills/src/generate.test.ts
@@ -9,7 +9,7 @@ import {
 	symlink,
 	writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 import { SkillConflictError } from "./errors.ts";
@@ -57,11 +57,28 @@ async function projectInstall(sourceDir: string, force?: boolean) {
 }
 
 describe("symlink-only skill installation", () => {
+	it("reports the effective global scope when project scope is requested from home", async () => {
+		const name = "crust-effective-scope-test";
+		const sourceDir = await createSource(name);
+		const result = await withCwd(homedir(), () =>
+			getSkillStatus({ name, sourceDir, agents: ["codex"], scope: "project" }),
+		);
+
+		expect(result.agents[0]).toMatchObject({
+			outputDir: join(homedir(), ".agents", "skills", name),
+			scope: "global",
+		});
+	});
+
 	it("installs a relative project link", async () => {
 		const sourceDir = await createSource();
 		const installed = await projectInstall(sourceDir);
 
-		expect(installed.agents[0]).toMatchObject({ outputDir: outputDir(), status: "installed" });
+		expect(installed.agents[0]).toMatchObject({
+			outputDir: outputDir(),
+			scope: "project",
+			status: "installed",
+		});
 		expect(resolve(dirname(outputDir()), await readlink(outputDir()))).toBe(sourceDir);
 		expect(await readFile(join(outputDir(), "commands", "run.md"), "utf8")).toBe("run\n");
 	});
@@ -127,7 +144,7 @@ describe("symlink-only skill installation", () => {
 				}),
 			);
 
-		expect((await status()).agents[0]?.status).toBe("absent");
+		expect((await status()).agents[0]).toMatchObject({ scope: "project", status: "absent" });
 		await projectInstall(sourceDir);
 		expect((await status()).agents[0]?.status).toBe("linked");
 		await rm(sourceDir, { recursive: true });
@@ -144,7 +161,7 @@ describe("symlink-only skill installation", () => {
 		let result = await withCwd(tempRoot, () =>
 			uninstallSkill({ name: "demo", agents: ["claude-code"], scope: "project" }),
 		);
-		expect(result.agents[0]?.status).toBe("removed");
+		expect(result.agents[0]).toMatchObject({ scope: "project", status: "removed" });
 		await expect(lstat(outputDir())).rejects.toThrow();
 
 		await mkdir(outputDir(), { recursive: true });

--- a/packages/skills/src/generate.ts
+++ b/packages/skills/src/generate.ts
@@ -8,6 +8,7 @@ import {
 	detectInstalledAgents,
 	getUniversalAgents,
 	resolveAgentPath,
+	resolveEffectiveScope,
 } from "./agents.ts";
 import { SkillConflictError } from "./errors.ts";
 import { isOwnedSkillLink, skillLinkTarget } from "./link.ts";
@@ -109,7 +110,7 @@ export async function installSkill(options: InstallSkillOptions): Promise<Instal
 	}
 
 	const agents = options.agents ?? [...getUniversalAgents(), ...(await detectInstalledAgents())];
-	const scope = options.scope ?? "global";
+	const scope = resolveEffectiveScope(options.scope ?? "global");
 	const results: AgentResult[] = [];
 
 	for (const [outputDir, groupedAgents] of groupAgentsByOutputDir(agents, scope, source.name)) {
@@ -135,7 +136,7 @@ export async function installSkill(options: InstallSkillOptions): Promise<Instal
 		}
 
 		for (const agent of groupedAgents) {
-			results.push({ agent, outputDir, status });
+			results.push({ agent, outputDir, scope, status });
 		}
 	}
 
@@ -147,7 +148,7 @@ export async function uninstallSkill(
 	options: UninstallSkillOptions,
 ): Promise<UninstallSkillResult> {
 	const agents = options.agents ?? [...ALL_AGENTS];
-	const scope = options.scope ?? "global";
+	const scope = resolveEffectiveScope(options.scope ?? "global");
 	const results: UninstallSkillResult["agents"] = [];
 
 	for (const [outputDir, groupedAgents] of groupAgentsByOutputDir(agents, scope, options.name)) {
@@ -155,7 +156,7 @@ export async function uninstallSkill(
 		const removed = inspection.status === "owned";
 		if (removed) await unlink(outputDir);
 		for (const agent of groupedAgents) {
-			results.push({ agent, outputDir, status: removed ? "removed" : "not-found" });
+			results.push({ agent, outputDir, scope, status: removed ? "removed" : "not-found" });
 		}
 	}
 	return { agents: results };
@@ -164,7 +165,7 @@ export async function uninstallSkill(
 /** Reports the ownership and health of each requested agent-directory entry. */
 export async function getSkillStatus(options: SkillStatusOptions): Promise<SkillStatusResult> {
 	const agents = options.agents ?? [...ALL_AGENTS];
-	const scope = options.scope ?? "global";
+	const scope = resolveEffectiveScope(options.scope ?? "global");
 	const expectedSourceDir = resolveSourceDir(options.sourceDir);
 	const results: SkillStatusResult["agents"] = [];
 
@@ -176,7 +177,7 @@ export async function getSkillStatus(options: SkillStatusOptions): Promise<Skill
 					? "linked"
 					: "dangling"
 				: inspection.status;
-		for (const agent of groupedAgents) results.push({ agent, outputDir, status });
+		for (const agent of groupedAgents) results.push({ agent, outputDir, scope, status });
 	}
 	return { agents: results };
 }

--- a/packages/skills/src/link.ts
+++ b/packages/skills/src/link.ts
@@ -1,6 +1,5 @@
 import { dirname, relative } from "node:path";
 
-import { resolveEffectiveScope } from "./agents.ts";
 import type { Scope } from "./types.ts";
 
 /** Returns whether a symlink target carries Crust's skill ownership signature. */
@@ -10,7 +9,5 @@ export function isOwnedSkillLink(target: string, name: string): boolean {
 }
 
 export function skillLinkTarget(sourceDir: string, outputDir: string, scope: Scope): string {
-	return resolveEffectiveScope(scope) === "project"
-		? relative(dirname(outputDir), sourceDir)
-		: sourceDir;
+	return scope === "project" ? relative(dirname(outputDir), sourceDir) : sourceDir;
 }

--- a/packages/skills/src/manifest.test.ts
+++ b/packages/skills/src/manifest.test.ts
@@ -374,7 +374,7 @@ describe("buildManifest", () => {
 			expect(flag?.multiple).toBe(true);
 		});
 
-		it("serializes flag default values as strings", async () => {
+		it("formats flag defaults like core help", async () => {
 			const cmd = makeCommand({
 				meta: { name: "serve" },
 				flags: {
@@ -398,11 +398,11 @@ describe("buildManifest", () => {
 			const flagMap = Object.fromEntries(node.flags.map((f) => [f.name, f]));
 
 			expect(flagMap.port?.default).toBe("8080");
-			expect(flagMap.host?.default).toBe("localhost");
+			expect(flagMap.host?.default).toBe('"localhost"');
 			expect(flagMap.watch?.default).toBe("true");
 		});
 
-		it("serializes multiple flag array defaults as JSON", async () => {
+		it("formats multiple flag defaults as comma-separated values", async () => {
 			const cmd = makeCommand({
 				meta: { name: "build" },
 				flags: {
@@ -418,7 +418,7 @@ describe("buildManifest", () => {
 			const node = buildManifest(await snapshotFixture(cmd));
 			const [flag] = node.flags;
 
-			expect(flag?.default).toBe('["src/index.ts","src/cli.ts"]');
+			expect(flag?.default).toBe("src/index.ts, src/cli.ts");
 		});
 
 		it("omits description and default when not provided on flag", async () => {

--- a/packages/skills/src/manifest.ts
+++ b/packages/skills/src/manifest.ts
@@ -1,7 +1,7 @@
 import type { CommandSnapshot } from "@crustjs/core";
 import {
 	buildCommandDocumentation,
-	isListed,
+	formatDefault,
 	sectionsFor,
 	type CommandDocumentation,
 	type DocumentationArg,
@@ -13,40 +13,29 @@ import { SKILLS } from "./extension.ts";
 import type { ManifestArg, ManifestFlag, ManifestNode } from "./types.ts";
 
 export function buildManifest(command: CommandSnapshot): ManifestNode {
-	const rootName = normalizeName(command.meta.name);
-	if (
-		Object.values(command.subCommands).some(
-			(child) => isListed(child) && normalizeName(child.meta.name) === rootName,
-		)
-	) {
+	const model = buildCommandDocumentation(command);
+	const rootName = normalizeName(model.name);
+	if (model.children.some((child) => normalizeName(child.name) === rootName)) {
 		throw new Error(
 			`Cannot generate skills when a direct subcommand has the root command name "${rootName}".`,
 		);
 	}
-	return buildNode(buildCommandDocumentation(command), command);
+	return buildNode(model);
 }
-function buildNode(model: CommandDocumentation, source: CommandSnapshot): ManifestNode {
+function buildNode(model: CommandDocumentation): ManifestNode {
 	return {
 		name: normalizeName(model.name),
 		path: model.path.map(normalizeName),
 		description: model.description,
 		usage: model.usage,
-		sections: sectionsFor(source.meta.sections, SKILLS).map(({ title, body }) => ({
+		sections: sectionsFor(model.sections, SKILLS).map(({ title, body }) => ({
 			title,
 			body,
 		})),
 		runnable: model.hasAction,
 		args: model.args.map(normalizeArg),
 		flags: [...model.flags].sort((a, b) => a.name.localeCompare(b.name)).map(normalizeFlag),
-		children: [...model.children]
-			.sort((a, b) => a.name.localeCompare(b.name))
-			.map((child) => {
-				const snapshot = source.subCommands[child.name];
-				if (snapshot === undefined) {
-					throw new Error(`Missing command snapshot for documented child "${child.name}".`);
-				}
-				return buildNode(child, snapshot);
-			}),
+		children: [...model.children].sort((a, b) => a.name.localeCompare(b.name)).map(buildNode),
 	};
 }
 function normalizeName(raw: string): string {
@@ -78,6 +67,8 @@ function normalizeFlag(flag: DocumentationFlag): ManifestFlag {
 function manifestType(type: string | undefined): BaseValueType {
 	return type === "number" || type === "boolean" ? type : "string";
 }
-function serializeDefault<Value>(value: Value): string {
-	return Array.isArray(value) ? JSON.stringify(value) : String(value);
+type DocumentationDefault = DocumentationArg["default"];
+
+function serializeDefault(value: DocumentationDefault): string {
+	return formatDefault(value);
 }

--- a/packages/skills/src/reconcile.test.ts
+++ b/packages/skills/src/reconcile.test.ts
@@ -17,10 +17,16 @@ const choices: ReconcileChoice[] = [
 const universal = ["amp"] as const;
 
 const sharedStatuses: SkillStatusResult["agents"] = [
-	{ agent: "amp", outputDir: "/project/.agents/skills/demo", status: "linked" },
+	{
+		agent: "amp",
+		outputDir: "/project/.agents/skills/demo",
+		scope: "project",
+		status: "linked",
+	},
 	{
 		agent: "antigravity",
 		outputDir: "/project/.agents/skills/demo",
+		scope: "project",
 		status: "linked",
 	},
 ];

--- a/packages/skills/src/render.test.ts
+++ b/packages/skills/src/render.test.ts
@@ -380,7 +380,7 @@ describe("renderSkill", () => {
 				"`-v`, `--verbose`, `--debug`, `--no-verbose`, `--no-debug`",
 			);
 			expect(build?.content).toContain("`--target`");
-			expect(build?.content).toContain("Default: `dist`");
+			expect(build?.content).toContain('Default: `"dist"`');
 			expect(build?.content).toContain("| Yes |");
 		});
 

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -99,6 +99,8 @@ export type UninstallStatus = "removed" | "not-found";
 export interface AgentResult {
 	agent: AgentTarget;
 	outputDir: string;
+	/** Effective scope after remapping project scope at the home directory. */
+	scope: Scope;
 	status: InstallStatus;
 }
 
@@ -116,6 +118,7 @@ export interface UninstallSkillResult {
 	agents: Array<{
 		agent: AgentTarget;
 		outputDir: string;
+		scope: Scope;
 		status: UninstallStatus;
 	}>;
 }
@@ -134,6 +137,7 @@ export interface SkillStatusResult {
 	agents: Array<{
 		agent: AgentTarget;
 		outputDir: string;
+		scope: Scope;
 		status: SkillLinkStatus;
 	}>;
 }


### PR DESCRIPTION
Centralize command documentation sections and application version metadata so first-party renderers and Extensions consume shared Core models instead of parallel snapshot/configuration channels.

### Changes

- **@crustjs/core**
  - Add unfiltered `sections` to `CommandDocumentation`.
  - Export `formatDefault` from `@crustjs/core/tooling`.
  - Add root `version` metadata and preserve it in `CommandSnapshot.meta`.
- **@crustjs/extensions**
  - Read root metadata versions in version, completion, and update-notifier unless an option overrides it.
  - Report a `DEFINITION` error when version-dependent behavior runs without a configured version.
  - Feed completion generation from `CommandDocumentation`.
- **@crustjs/man**
  - Render root and nested command sections from the documentation tree.
- **@crustjs/skills**
  - Render sections and defaults from Core's documentation model.
  - Source generated skill versions from the root snapshot instead of cwd `package.json`.
  - Resolve home-directory scope remapping at public entry points and return effective scope.
- **Docs/tests**
  - Document constructor version metadata, tooling additions, Extension fallback/override behavior, and effective skill scopes.
  - Cover shared defaults, version fallback/errors, snapshot skill versions, completion model input, and scope visibility.

### Notes

- No items skipped.
- Skills string defaults are now JSON-quoted and array defaults comma-separated, matching `--help`.
- Added one minor changeset covering `@crustjs/core`, `@crustjs/extensions`, and `@crustjs/skills`.

### Stack
This PR is part of the codebase-audit refactor stack (bottom → top). Merge in order; each PR targets the one below it.
1. refactor/audit-01-tooling ([#329](https://github.com/chenxin-yan/crust/pull/329))
2. refactor/audit-02-tests ([#330](https://github.com/chenxin-yan/crust/pull/330))
3. refactor/audit-03-core-shrink ([#331](https://github.com/chenxin-yan/crust/pull/331))
4. refactor/audit-04-ext-shrink ([#332](https://github.com/chenxin-yan/crust/pull/332))
5. refactor/audit-05-ui-shrink ([#333](https://github.com/chenxin-yan/crust/pull/333))
6. refactor/audit-06-core-seams ([#334](https://github.com/chenxin-yan/crust/pull/334))
7. refactor/audit-07-docmodel-version ([#335](https://github.com/chenxin-yan/crust/pull/335)) **(this PR)**
8. refactor/audit-08-cli-seams ([#336](https://github.com/chenxin-yan/crust/pull/336))
9. refactor/audit-09-public-api ([#337](https://github.com/chenxin-yan/crust/pull/337))
10. refactor/audit-10-ui-seams ([#338](https://github.com/chenxin-yan/crust/pull/338))
11. refactor/audit-11-store-docs ([#339](https://github.com/chenxin-yan/crust/pull/339))
