### PR TITLE
refactor(crust): thread InvocationIO, plan-driven distribute, single target table

### DIFF
--- a/.changeset/thread-cli-invocation-io.md
+++ b/.changeset/thread-cli-invocation-io.md
@@ -1,0 +1,6 @@
+---
+"@crustjs/crust": patch
+"@crustjs/testing": patch
+---
+
+Route build and publish output through invocation IO, reuse build plans across distribution staging, and prevent captured executions from leaking their exit code to the process.

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -60,7 +60,7 @@ export type CapturedRun<Result = unknown> = {
 
 ## `captureExecute(app, argv)`
 
-Drive the terminal `execute()` path in-process. Unlike `captureRun()`, this exercises `execute()`'s returned exit-code protocol — `0` on success, `1` for rendered failures, `130` for `AbortError` cancellation — and the Extension `onError` rendering chain, so exit codes and rendered failure output are assertable without spawning a subprocess.
+Drive the terminal `execute()` path in-process. Unlike `captureRun()`, this exercises `execute()`'s returned exit-code protocol — `0` on success, `1` for rendered failures, `130` for `AbortError` cancellation — and the Extension `onError` rendering chain, so exit codes and rendered failure output are assertable without spawning a subprocess. The previous process exit code is restored after capture.
 
 ```ts
 import { captureExecute } from "@crustjs/testing";

--- a/bun.lock
+++ b/bun.lock
@@ -113,13 +113,14 @@
       "name": "@crustjs/crust",
       "version": "0.0.24",
       "bin": {
-        "crust": "dist/cli",
+        "crust": "dist/cli.js",
       },
       "devDependencies": {
         "@crustjs/config": "workspace:*",
         "@crustjs/core": "workspace:*",
         "@crustjs/extensions": "workspace:*",
         "@crustjs/style": "workspace:*",
+        "@crustjs/testing": "workspace:*",
         "@crustjs/utils": "workspace:*",
       },
     },

--- a/packages/crust/package.json
+++ b/packages/crust/package.json
@@ -41,6 +41,7 @@
 		"@crustjs/core": "workspace:*",
 		"@crustjs/extensions": "workspace:*",
 		"@crustjs/style": "workspace:*",
+		"@crustjs/testing": "workspace:*",
 		"@crustjs/config": "workspace:*",
 		"@crustjs/utils": "workspace:*"
 	},

--- a/packages/crust/src/cli.test.ts
+++ b/packages/crust/src/cli.test.ts
@@ -4,60 +4,17 @@
  * Tests the root crust command with the build subcommand wired up,
  * verifying help output, version output, subcommand help, and error handling.
  *
- * Uses `Crust.execute({ argv })` instead of the removed `runCommand`.
+ * Uses `captureExecute(app, argv)` to exercise and capture the terminal path.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+
+import { captureExecute } from "@crustjs/testing";
 
 import pkg from "../package.json";
 import { crustBase } from "./app.ts";
 import { buildCommand } from "./commands/build.ts";
 import { publishCommand } from "./commands/publish.ts";
-
-// ────────────────────────────────────────────────────────────────────────────
-// Test helpers — capture console output
-// ────────────────────────────────────────────────────────────────────────────
-
-let stdoutChunks: string[];
-let stderrChunks: string[];
-let originalLog: typeof console.log;
-let originalError: typeof console.error;
-let originalWarn: typeof console.warn;
-let originalExitCode: typeof process.exitCode;
-
-beforeEach(() => {
-	stdoutChunks = [];
-	stderrChunks = [];
-	originalLog = console.log;
-	originalError = console.error;
-	originalWarn = console.warn;
-	originalExitCode = process.exitCode;
-
-	console.log = (...args: unknown[]) => {
-		stdoutChunks.push(args.map(String).join(" "));
-	};
-	console.error = (...args: unknown[]) => {
-		stderrChunks.push(args.map(String).join(" "));
-	};
-	console.warn = (...args: unknown[]) => {
-		stderrChunks.push(args.map(String).join(" "));
-	};
-});
-
-afterEach(() => {
-	console.log = originalLog;
-	console.error = originalError;
-	console.warn = originalWarn;
-	process.exitCode = originalExitCode;
-});
-
-function getStdout(): string {
-	return stdoutChunks.join("\n");
-}
-
-function _getStderr(): string {
-	return stderrChunks.join("\n");
-}
 
 const expectedVersion = pkg.version;
 
@@ -73,8 +30,7 @@ function makeCrustApp() {
 describe("crust CLI entry point", () => {
 	describe("crust --help", () => {
 		it("should show help text with build and publish listed", async () => {
-			await makeCrustApp().execute({ argv: ["--help"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["--help"]);
 
 			expect(output).toContain("crust");
 			expect(output).toContain("CLI tooling for the Crust framework");
@@ -87,8 +43,7 @@ describe("crust CLI entry point", () => {
 		});
 
 		it("should show --help and --version in options", async () => {
-			await makeCrustApp().execute({ argv: ["--help"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["--help"]);
 
 			expect(output).toContain("--help");
 			expect(output).toContain("--version");
@@ -97,8 +52,7 @@ describe("crust CLI entry point", () => {
 		});
 
 		it("should show help with -h alias", async () => {
-			await makeCrustApp().execute({ argv: ["-h"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["-h"]);
 
 			expect(output).toContain("Usage:");
 			expect(output).toContain("Commands:");
@@ -107,15 +61,13 @@ describe("crust CLI entry point", () => {
 
 	describe("crust --version", () => {
 		it("should show version from package.json", async () => {
-			await makeCrustApp().execute({ argv: ["--version"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["--version"]);
 
 			expect(output).toContain(`crust v${expectedVersion}`);
 		});
 
 		it("should show version with -v alias", async () => {
-			await makeCrustApp().execute({ argv: ["-v"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["-v"]);
 
 			expect(output).toContain(`crust v${expectedVersion}`);
 		});
@@ -123,8 +75,7 @@ describe("crust CLI entry point", () => {
 
 	describe("crust (no args)", () => {
 		it("should show help when invoked without a subcommand", async () => {
-			await makeCrustApp().execute({ argv: [] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), []);
 
 			expect(output).toContain("Usage:");
 			expect(output).toContain("Commands:");
@@ -135,16 +86,14 @@ describe("crust CLI entry point", () => {
 
 	describe("crust unknown", () => {
 		it("shows root help for unknown input", async () => {
-			await makeCrustApp().execute({ argv: ["unknown"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["unknown"]);
 			expect(output).toContain("Usage:");
 			expect(output).toContain("build");
 			expect(output).toContain("publish");
 		});
 
 		it("shows root help for partial command input", async () => {
-			await makeCrustApp().execute({ argv: ["buil"] });
-			const output = getStdout();
+			const { stdout: output } = await captureExecute(makeCrustApp(), ["buil"]);
 			expect(output).toContain("Commands:");
 		});
 	});

--- a/packages/crust/src/commands/build.integration.test.ts
+++ b/packages/crust/src/commands/build.integration.test.ts
@@ -13,14 +13,11 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Crust } from "@crustjs/core";
+import { captureExecute } from "@crustjs/testing";
 import { runProcess } from "@crustjs/utils/process";
 
 import { buildCommand } from "../../src/commands/build.ts";
-import {
-	DENO_TARGET_INFO,
-	SUPPORTED_DENO_TARGETS,
-	TARGET_INFO,
-} from "../../src/utils/build-helpers.ts";
+import { BUN_TARGETS, DENO_TARGETS } from "../../src/utils/build-helpers.ts";
 import { hostTarget } from "../../tests/helpers.ts";
 
 function getHostBunTarget() {
@@ -29,9 +26,9 @@ function getHostBunTarget() {
 
 function getHostDenoTarget(): string | null {
 	const target = hostTarget();
-	const alias = target && TARGET_INFO[target].alias;
+	const alias = target && BUN_TARGETS.info[target].alias;
 	return (
-		SUPPORTED_DENO_TARGETS.find((candidate) => DENO_TARGET_INFO[candidate].alias === alias) ?? null
+		DENO_TARGETS.targets.find((candidate) => DENO_TARGETS.info[candidate].alias === alias) ?? null
 	);
 }
 
@@ -73,37 +70,24 @@ console.log("hello from crust build test");
 	it("builds a standalone executable for a single target", async () => {
 		process.cwd = () => tmpDir;
 
-		const logs: string[] = [];
-		const originalLog = console.log;
-		console.log = (...args: unknown[]) => {
-			logs.push(args.map(String).join(" "));
-		};
-
-		try {
-			const app = new Crust("test").add(buildCommand);
-			await app.execute({
-				argv: [
-					"build",
-					"--entry",
-					"src/cli.ts",
-					"--no-validate",
-					"--outfile",
-					join(tmpDir, "dist", "test-cli"),
-					"--target",
-					"bun-darwin-arm64",
-				],
-			});
-		} finally {
-			console.log = originalLog;
-		}
+		const { stdout } = await captureExecute(new Crust("test").add(buildCommand), [
+			"build",
+			"--entry",
+			"src/cli.ts",
+			"--no-validate",
+			"--outfile",
+			join(tmpDir, "dist", "test-cli"),
+			"--target",
+			"bun-darwin-arm64",
+		]);
 
 		// Verify the output binary exists
 		const outPath = join(tmpDir, "dist", "test-cli");
 		expect(existsSync(outPath)).toBe(true);
 
 		// Verify build progress messages were printed
-		expect(logs.some((l) => l.includes("Building"))).toBe(true);
-		expect(logs.some((l) => l.includes("Built successfully"))).toBe(true);
+		expect(stdout).toContain("Building");
+		expect(stdout).toContain("Built successfully");
 	});
 
 	// This test can only run when the host matches the build target (darwin-arm64).
@@ -127,60 +111,40 @@ console.log("hello from crust build test");
 	it("builds without --minify when --no-minify is passed", async () => {
 		process.cwd = () => tmpDir;
 
-		const logs: string[] = [];
-		const originalLog = console.log;
-		console.log = (...args: unknown[]) => {
-			logs.push(args.map(String).join(" "));
-		};
-
 		const outPath = join(tmpDir, "dist", "test-cli-no-minify");
-
-		try {
-			const app = new Crust("test").add(buildCommand);
-			await app.execute({
-				argv: [
-					"build",
-					"--entry",
-					"src/cli.ts",
-					"--outfile",
-					outPath,
-					"--no-validate",
-					"--no-minify",
-					"--target",
-					"bun-darwin-arm64",
-				],
-			});
-		} finally {
-			console.log = originalLog;
-		}
+		const { stdout } = await captureExecute(new Crust("test").add(buildCommand), [
+			"build",
+			"--entry",
+			"src/cli.ts",
+			"--outfile",
+			outPath,
+			"--no-validate",
+			"--no-minify",
+			"--target",
+			"bun-darwin-arm64",
+		]);
 
 		expect(existsSync(outPath)).toBe(true);
-		expect(logs.some((l) => l.includes("Built successfully"))).toBe(true);
+		expect(stdout).toContain("Built successfully");
 	});
 
 	it("uses package.json name for output when no --outfile or --name", async () => {
 		process.cwd = () => tmpDir;
 		mkdirSync(join(tmpDir, "dist"), { recursive: true });
 
-		const logs: string[] = [];
-		const originalLog = console.log;
-		console.log = (...args: unknown[]) => {
-			logs.push(args.map(String).join(" "));
-		};
-
-		try {
-			const app = new Crust("test").add(buildCommand);
-			await app.execute({
-				argv: ["build", "--entry", "src/cli.ts", "--no-validate", "--target", "bun-darwin-arm64"],
-			});
-		} finally {
-			console.log = originalLog;
-		}
+		const { stdout } = await captureExecute(new Crust("test").add(buildCommand), [
+			"build",
+			"--entry",
+			"src/cli.ts",
+			"--no-validate",
+			"--target",
+			"bun-darwin-arm64",
+		]);
 
 		// Single target without --outfile: uses dist/<package-name>
 		const expectedOut = resolve(tmpDir, "dist", "test-build-cli");
 		expect(existsSync(expectedOut)).toBe(true);
-		expect(logs.some((l) => l.includes(expectedOut))).toBe(true);
+		expect(stdout).toContain(expectedOut);
 	});
 
 	it.skipIf(getHostBunTarget() === null)(

--- a/packages/crust/src/commands/build.test.ts
+++ b/packages/crust/src/commands/build.test.ts
@@ -5,21 +5,17 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Crust } from "@crustjs/core";
+import { captureExecute } from "@crustjs/testing";
 
 const corePath = fileURLToPath(import.meta.resolve("@crustjs/core"));
 
 import type { BunTarget } from "../utils/build-helpers.ts";
 import {
-	DENO_TARGET_INFO,
-	getBinaryFilename,
-	getDenoBinaryFilename,
+	binaryFilename,
+	BUN_TARGETS,
+	DENO_TARGETS,
 	resolveBaseName,
-	resolveDenoTarget,
-	resolveDenoTargets,
-	resolveTarget,
-	SUPPORTED_DENO_TARGETS,
-	SUPPORTED_TARGETS,
-	TARGET_INFO,
+	resolveTargets,
 } from "../utils/build-helpers.ts";
 import {
 	buildCommand,
@@ -96,9 +92,6 @@ describe("planBuild", () => {
 	it("uses one parse-error policy for runtime and output-name resolution", () => {
 		writeFileSync(join(tmpDir, "package.json"), "not json");
 		expect(() => planBuild(baseFlags, tmpDir)).toThrow(`Failed to parse package.json in ${tmpDir}`);
-		expect(() => resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir)).toThrow(
-			`Failed to parse package.json in ${tmpDir}`,
-		);
 	});
 
 	for (const testCase of [
@@ -173,45 +166,48 @@ describe("planBuild", () => {
 
 describe("resolveTarget", () => {
 	it("accepts full Bun target names directly", () => {
-		for (const target of SUPPORTED_TARGETS) {
-			expect(resolveTarget(target)).toBe(target);
+		for (const target of BUN_TARGETS.targets) {
+			expect(resolveTargets(BUN_TARGETS, [target])[0]).toBe(target);
 		}
 	});
 
 	it("rejects every short alias with canonical-name guidance and a did-you-mean hint", () => {
-		for (const target of SUPPORTED_TARGETS) {
-			const alias = TARGET_INFO[target].alias;
-			expect(() => resolveTarget(alias)).toThrow(
+		for (const target of BUN_TARGETS.targets) {
+			const alias = BUN_TARGETS.info[target].alias;
+			expect(() => resolveTargets(BUN_TARGETS, [alias])).toThrow(
 				`Unknown target "${alias}". Targets must use canonical Bun names. Did you mean "${target}"?`,
 			);
-			expect(() => resolveTarget(alias)).toThrow(/Valid targets: bun-linux-x64-baseline/);
+			expect(() => resolveTargets(BUN_TARGETS, [alias])).toThrow(
+				/Valid targets: bun-linux-x64-baseline/,
+			);
 		}
 	});
 
 	it("throws on unknown target", () => {
-		expect(() => resolveTarget("linux-arm32")).toThrow(/Unknown target/);
+		expect(() => resolveTargets(BUN_TARGETS, ["linux-arm32"])).toThrow(/Unknown target/);
 	});
 });
 
 describe("resolveDenoTarget", () => {
 	it("accepts exactly the targets supported by deno compile", () => {
-		for (const target of SUPPORTED_DENO_TARGETS) expect(resolveDenoTarget(target)).toBe(target);
-		expect(resolveDenoTargets(undefined)).toEqual([...SUPPORTED_DENO_TARGETS]);
+		for (const target of DENO_TARGETS.targets)
+			expect(resolveTargets(DENO_TARGETS, [target])[0]).toBe(target);
+		expect(resolveTargets(DENO_TARGETS, undefined)).toEqual([...DENO_TARGETS.targets]);
 	});
 
 	it("guides aliases to canonical Deno target names", () => {
-		for (const target of SUPPORTED_DENO_TARGETS) {
-			expect(() => resolveDenoTarget(DENO_TARGET_INFO[target].alias)).toThrow(
+		for (const target of DENO_TARGETS.targets) {
+			expect(() => resolveTargets(DENO_TARGETS, [DENO_TARGETS.info[target].alias])).toThrow(
 				`Did you mean "${target}"?`,
 			);
 		}
 	});
 
 	it("uses Deno target names and the Windows executable extension", () => {
-		expect(getDenoBinaryFilename("cli", "x86_64-unknown-linux-gnu")).toBe(
+		expect(binaryFilename(DENO_TARGETS, "cli", "x86_64-unknown-linux-gnu")).toBe(
 			"cli-x86_64-unknown-linux-gnu",
 		);
-		expect(getDenoBinaryFilename("cli", "aarch64-pc-windows-msvc")).toBe(
+		expect(binaryFilename(DENO_TARGETS, "cli", "aarch64-pc-windows-msvc")).toBe(
 			"cli-aarch64-pc-windows-msvc.exe",
 		);
 	});
@@ -223,7 +219,7 @@ describe("resolveDenoTarget", () => {
 
 describe("resolveBaseName", () => {
 	it("uses --name when provided", () => {
-		expect(resolveBaseName("my-tool", "/test/src/cli.ts", "/test")).toBe("my-tool");
+		expect(resolveBaseName("my-tool", "/test/src/cli.ts", "/test", undefined)).toBe("my-tool");
 	});
 
 	describe("with package.json", () => {
@@ -238,24 +234,28 @@ describe("resolveBaseName", () => {
 		});
 
 		it("falls back to package.json name", () => {
-			writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "my-cli-app" }));
-			expect(resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir)).toBe("my-cli-app");
+			expect(
+				resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir, { name: "my-cli-app" }),
+			).toBe("my-cli-app");
 		});
 
 		it("strips scope prefix from package.json name", () => {
-			writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "@scope/my-cli" }));
-			expect(resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir)).toBe("my-cli");
+			expect(
+				resolveBaseName(undefined, join(tmpDir, "src/cli.ts"), tmpDir, { name: "@scope/my-cli" }),
+			).toBe("my-cli");
 		});
 	});
 
 	it("falls back to entry filename", () => {
-		expect(resolveBaseName(undefined, "/nonexistent/src/main.ts", "/nonexistent")).toBe("main");
+		expect(resolveBaseName(undefined, "/nonexistent/src/main.ts", "/nonexistent", undefined)).toBe(
+			"main",
+		);
 	});
 
 	it("strips file extension from entry filename", () => {
-		expect(resolveBaseName(undefined, "/nonexistent/src/app.cli.ts", "/nonexistent")).toBe(
-			"app.cli",
-		);
+		expect(
+			resolveBaseName(undefined, "/nonexistent/src/app.cli.ts", "/nonexistent", undefined),
+		).toBe("app.cli");
 	});
 });
 
@@ -265,17 +265,21 @@ describe("resolveBaseName", () => {
 
 describe("getBinaryFilename", () => {
 	it("returns <name>-<target> for non-Windows targets", () => {
-		expect(getBinaryFilename("my-cli", "bun-linux-x64-baseline")).toBe(
+		expect(binaryFilename(BUN_TARGETS, "my-cli", "bun-linux-x64-baseline")).toBe(
 			"my-cli-bun-linux-x64-baseline",
 		);
-		expect(getBinaryFilename("my-cli", "bun-darwin-arm64")).toBe("my-cli-bun-darwin-arm64");
+		expect(binaryFilename(BUN_TARGETS, "my-cli", "bun-darwin-arm64")).toBe(
+			"my-cli-bun-darwin-arm64",
+		);
 	});
 
 	it("appends .exe for Windows targets", () => {
-		expect(getBinaryFilename("my-cli", "bun-windows-x64-baseline")).toBe(
+		expect(binaryFilename(BUN_TARGETS, "my-cli", "bun-windows-x64-baseline")).toBe(
 			"my-cli-bun-windows-x64-baseline.exe",
 		);
-		expect(getBinaryFilename("my-cli", "bun-windows-arm64")).toBe("my-cli-bun-windows-arm64.exe");
+		expect(binaryFilename(BUN_TARGETS, "my-cli", "bun-windows-arm64")).toBe(
+			"my-cli-bun-windows-arm64.exe",
+		);
 	});
 });
 
@@ -285,12 +289,7 @@ describe("getBinaryFilename", () => {
 
 describe("generateResolverFor", () => {
 	it("maps all Unix targets to correct uname keys", () => {
-		const content = generateResolverFor(
-			"my-cli",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateResolverFor(BUN_TARGETS, "my-cli", BUN_TARGETS.targets);
 		expect(content).toContain("Linux-x86_64)");
 		expect(content).toContain("Linux-aarch64)");
 		expect(content).toContain("Darwin-x86_64)");
@@ -298,23 +297,13 @@ describe("generateResolverFor", () => {
 	});
 
 	it("excludes Windows targets from shell resolver", () => {
-		const content = generateResolverFor(
-			"my-cli",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateResolverFor(BUN_TARGETS, "my-cli", BUN_TARGETS.targets);
 		expect(content).not.toContain("Windows");
 		expect(content).not.toContain("bun-windows");
 	});
 
 	it("maps to correct binary filenames", () => {
-		const content = generateResolverFor(
-			"my-cli",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateResolverFor(BUN_TARGETS, "my-cli", BUN_TARGETS.targets);
 		expect(content).toContain('"my-cli-bun-linux-x64-baseline"');
 		expect(content).toContain('"my-cli-bun-linux-arm64"');
 		expect(content).toContain('"my-cli-bun-darwin-x64"');
@@ -323,7 +312,7 @@ describe("generateResolverFor", () => {
 
 	it("only includes targets that were built", () => {
 		const subset: BunTarget[] = ["bun-linux-x64-baseline", "bun-darwin-arm64"];
-		const content = generateResolverFor("my-cli", subset, TARGET_INFO, getBinaryFilename);
+		const content = generateResolverFor(BUN_TARGETS, "my-cli", subset);
 		expect(content).toContain("Linux-x86_64)");
 		expect(content).toContain("Darwin-arm64)");
 		// Should NOT contain platforms not in subset
@@ -332,12 +321,7 @@ describe("generateResolverFor", () => {
 	});
 
 	it("includes the base name in error messages", () => {
-		const content = generateResolverFor(
-			"my-tool",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateResolverFor(BUN_TARGETS, "my-tool", BUN_TARGETS.targets);
 		expect(content).toContain("[my-tool]");
 	});
 });
@@ -348,21 +332,11 @@ describe("generateResolverFor", () => {
 
 describe("Deno resolvers", () => {
 	it("maps Deno targets to their platform-specific filenames", () => {
-		const shell = generateResolverFor(
-			"my-cli",
-			SUPPORTED_DENO_TARGETS,
-			DENO_TARGET_INFO,
-			getDenoBinaryFilename,
-		);
+		const shell = generateResolverFor(DENO_TARGETS, "my-cli", DENO_TARGETS.targets);
 		expect(shell).toContain('Linux-x86_64) bin="my-cli-x86_64-unknown-linux-gnu"');
 		expect(shell).not.toContain("pc-windows-msvc");
 
-		const cmd = generateCmdResolverFor(
-			"my-cli",
-			SUPPORTED_DENO_TARGETS,
-			DENO_TARGET_INFO,
-			getDenoBinaryFilename,
-		);
+		const cmd = generateCmdResolverFor(DENO_TARGETS, "my-cli", DENO_TARGETS.targets);
 		expect(cmd).toContain("my-cli-x86_64-pc-windows-msvc.exe");
 		expect(cmd).toContain("my-cli-aarch64-pc-windows-msvc.exe");
 	});
@@ -370,39 +344,24 @@ describe("Deno resolvers", () => {
 
 describe("generateCmdResolverFor", () => {
 	it("references the correct Windows binary filename", () => {
-		const content = generateCmdResolverFor(
-			"my-cli",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateCmdResolverFor(BUN_TARGETS, "my-cli", BUN_TARGETS.targets);
 		expect(content).toContain("my-cli-bun-windows-x64-baseline.exe");
 		expect(content).toContain("my-cli-bun-windows-arm64.exe");
 	});
 
 	it("includes the base name in error messages", () => {
-		const content = generateCmdResolverFor(
-			"my-tool",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateCmdResolverFor(BUN_TARGETS, "my-tool", BUN_TARGETS.targets);
 		expect(content).toContain("[my-tool]");
 	});
 
 	it("generates error stub when no Windows targets built", () => {
 		const unixOnly: BunTarget[] = ["bun-linux-x64-baseline", "bun-darwin-arm64"];
-		const content = generateCmdResolverFor("my-cli", unixOnly, TARGET_INFO, getBinaryFilename);
+		const content = generateCmdResolverFor(BUN_TARGETS, "my-cli", unixOnly);
 		expect(content).toContain("No Windows binary was built");
 	});
 
 	it("uses CRLF line endings", () => {
-		const content = generateCmdResolverFor(
-			"my-cli",
-			SUPPORTED_TARGETS,
-			TARGET_INFO,
-			getBinaryFilename,
-		);
+		const content = generateCmdResolverFor(BUN_TARGETS, "my-cli", BUN_TARGETS.targets);
 		expect(content).toContain("\r\n");
 	});
 });
@@ -414,7 +373,7 @@ describe("writeResolver", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 		mkdirSync(tmpDir, { recursive: true });
 		try {
-			writeResolver(resolverPath, "my-cli", SUPPORTED_TARGETS, TARGET_INFO, getBinaryFilename);
+			writeResolver(BUN_TARGETS, resolverPath, "my-cli", BUN_TARGETS.targets);
 			expect(readFileSync(resolverPath, "utf8")).toContain("Linux-x86_64)");
 			expect(readFileSync(`${resolverPath}.cmd`, "utf8")).toContain(
 				"my-cli-bun-windows-x64-baseline.exe",
@@ -431,25 +390,15 @@ describe("writeResolver", () => {
 
 async function executeBuildError(name: string, argv: string[]): Promise<string> {
 	const originalCwd = process.cwd;
-	const originalLog = console.log;
-	const originalError = console.error;
 	const tmpDir = mkdtempSync(join(tmpdir(), `crust-${name}-`));
-	const errors: string[] = [];
 	rmSync(tmpDir, { recursive: true, force: true });
 	mkdirSync(join(tmpDir, "src"), { recursive: true });
 	writeFileSync(join(tmpDir, "src", "cli.ts"), "console.log('hi');");
 	process.cwd = () => tmpDir;
-	console.log = () => {};
-	console.error = (...args: unknown[]) => errors.push(args.map(String).join(" "));
 	try {
-		process.exitCode = 0;
-		await new Crust("test").add(buildCommand).execute({ argv: ["build", ...argv] });
-		return errors.join("\n");
+		return (await captureExecute(new Crust("test").add(buildCommand), ["build", ...argv])).stderr;
 	} finally {
-		process.exitCode = 0;
 		process.cwd = originalCwd;
-		console.log = originalLog;
-		console.error = originalError;
 		rmSync(tmpDir, { recursive: true, force: true });
 	}
 }
@@ -498,29 +447,19 @@ describe("buildCommand error handling", () => {
 
 		process.cwd = () => tmpDir;
 
-		const originalLog = console.log;
-		const originalError = console.error;
-		const errors: string[] = [];
-		console.log = () => {};
-		console.error = (...args: unknown[]) => {
-			errors.push(args.map(String).join(" "));
-		};
-
 		try {
-			process.exitCode = 0;
-			const app = new Crust("test").add(buildCommand);
+			const result = await captureExecute(new Crust("test").add(buildCommand), [
+				"build",
+				"--entry",
+				"nonexistent.ts",
+				"--target",
+				"bun-linux-x64-baseline",
+			]);
 
-			await app.execute({
-				argv: ["build", "--entry", "nonexistent.ts", "--target", "bun-linux-x64-baseline"],
-			});
-
-			expect(process.exitCode).toBe(1);
-			expect(errors.some((e) => /Entry file not found/.test(e))).toBe(true);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("Entry file not found");
 		} finally {
-			process.exitCode = 0;
 			process.cwd = originalCwd;
-			console.log = originalLog;
-			console.error = originalError;
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
@@ -533,29 +472,18 @@ describe("buildCommand error handling", () => {
 
 		process.cwd = () => tmpDir;
 
-		const originalLog = console.log;
-		const originalError = console.error;
-		const errors: string[] = [];
-		console.log = () => {};
-		console.error = (...args: unknown[]) => {
-			errors.push(args.map(String).join(" "));
-		};
-
 		try {
-			process.exitCode = 0;
-			const app = new Crust("test").add(buildCommand);
+			const result = await captureExecute(new Crust("test").add(buildCommand), [
+				"build",
+				"--outfile",
+				"./out",
+				"--no-validate",
+			]);
 
-			await app.execute({
-				argv: ["build", "--outfile", "./out", "--no-validate"],
-			});
-
-			expect(process.exitCode).toBe(1);
-			expect(errors.some((e) => /--outfile cannot be used/.test(e))).toBe(true);
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr).toContain("--outfile cannot be used");
 		} finally {
-			process.exitCode = 0;
 			process.cwd = originalCwd;
-			console.log = originalLog;
-			console.error = originalError;
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
@@ -573,30 +501,22 @@ describe("buildCommand error handling", () => {
 		);
 
 		process.cwd = () => tmpDir;
-		const originalLog = console.log;
-		console.log = () => {};
 
 		try {
-			process.exitCode = 0;
-			const app = new Crust("test").add(buildCommand);
-			await app.execute({
-				argv: [
-					"build",
-					"--entry",
-					"src/cli.ts",
-					"--target",
-					"bun-darwin-arm64",
-					"--outfile",
-					"./out/custom/cli",
-				],
-			});
+			const result = await captureExecute(new Crust("test").add(buildCommand), [
+				"build",
+				"--entry",
+				"src/cli.ts",
+				"--target",
+				"bun-darwin-arm64",
+				"--outfile",
+				"./out/custom/cli",
+			]);
 
-			expect(process.exitCode).toBe(0);
+			expect(result.exitCode).toBe(0);
 			expect(readFileSync(join(tmpDir, "out", "custom", "artifact.txt"), "utf-8")).toBe("built");
 		} finally {
-			process.exitCode = 0;
 			process.cwd = originalCwd;
-			console.log = originalLog;
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	}, 30_000);

--- a/packages/crust/src/commands/build.ts
+++ b/packages/crust/src/commands/build.ts
@@ -1,29 +1,28 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
-import { defineCommand } from "@crustjs/core";
+import { defineCommand, type InvocationIO } from "@crustjs/core";
 import { bold, cyan, dim, green } from "@crustjs/style";
 import { isJsonObject, type JsonValue } from "@crustjs/utils/json";
 
 import {
+	binaryFilename,
 	BUILD_RUNTIMES,
 	type BuildRuntime,
+	BUN_TARGETS,
 	type BunTarget,
-	DENO_TARGET_INFO,
+	DENO_TARGETS,
 	type DenoTarget,
 	execBuild,
 	execDenoBuild,
 	execNodeBuild,
-	getBinaryFilename,
-	getDenoBinaryFilename,
 	resolveBaseName,
-	resolveDenoTargets,
 	readUserPackageJson,
 	resolveTargets,
-	TARGET_INFO,
 	buildEntrypoint,
-	type ResolverTargetInfo,
+	type TargetTable,
 } from "../utils/build-helpers.ts";
+import { runDistributeBuild } from "../utils/distribute.ts";
 
 /**
  * Resolve the output file path for a single-target build.
@@ -97,16 +96,15 @@ function resolveBuildRuntimeFromPackageJson(
  * @returns The shell resolver script as a string
  */
 export function generateResolverFor<T extends string>(
+	table: TargetTable<T>,
 	baseName: string,
 	targets: readonly T[],
-	targetInfo: Record<T, ResolverTargetInfo>,
-	getFilename: (baseName: string, target: T) => string,
 ): string {
 	const caseEntries: string[] = [];
 	for (const target of targets) {
-		const info = targetInfo[target];
+		const info = table.info[target];
 		if (info.os === "win32") continue;
-		caseEntries.push(`\t${info.unameKey}) bin="${getFilename(baseName, target)}" ;;`);
+		caseEntries.push(`\t${info.unameKey}) bin="${binaryFilename(table, baseName, target)}" ;;`);
 	}
 	const caseBody = caseEntries.join("\n");
 
@@ -162,22 +160,23 @@ exec "$bin_path" "$@"
  * @returns The .cmd resolver script as a string
  */
 export function generateCmdResolverFor<T extends string>(
+	table: TargetTable<T>,
 	baseName: string,
 	targets: readonly T[],
-	targetInfo: Record<T, ResolverTargetInfo>,
-	getFilename: (baseName: string, target: T) => string,
 ): string {
-	const windowsTargets = targets.filter((target) => targetInfo[target].os === "win32");
+	const windowsTargets = targets.filter((target) => table.info[target].os === "win32");
 
 	if (windowsTargets.length === 0) {
 		return `@echo off\r\necho [${baseName}] No Windows binary was built for this package. >&2\r\nexit /b 1\r\n`;
 	}
 
-	const windowsX64Target = windowsTargets.find((target) => targetInfo[target].cpu === "x64");
-	const windowsArm64Target = windowsTargets.find((target) => targetInfo[target].cpu === "arm64");
+	const windowsX64Target = windowsTargets.find((target) => table.info[target].cpu === "x64");
+	const windowsArm64Target = windowsTargets.find((target) => table.info[target].cpu === "arm64");
 
-	const x64Filename = windowsX64Target ? getFilename(baseName, windowsX64Target) : "";
-	const arm64Filename = windowsArm64Target ? getFilename(baseName, windowsArm64Target) : "";
+	const x64Filename = windowsX64Target ? binaryFilename(table, baseName, windowsX64Target) : "";
+	const arm64Filename = windowsArm64Target
+		? binaryFilename(table, baseName, windowsArm64Target)
+		: "";
 
 	// Build architecture dispatch lines.
 	// CMD expands %var% at parse-time, so we cannot test a variable
@@ -239,19 +238,13 @@ if not exist "%bin_path%" (\r
  * @param targets - The list of targets that were built
  */
 export function writeResolver<T extends string>(
+	table: TargetTable<T>,
 	resolverPath: string,
 	baseName: string,
 	targets: readonly T[],
-	targetInfo: Record<T, ResolverTargetInfo>,
-	getFilename: (baseName: string, target: T) => string,
 ): void {
-	writeFileSync(resolverPath, generateResolverFor(baseName, targets, targetInfo, getFilename), {
-		mode: 0o755,
-	});
-	writeFileSync(
-		`${resolverPath}.cmd`,
-		generateCmdResolverFor(baseName, targets, targetInfo, getFilename),
-	);
+	writeFileSync(resolverPath, generateResolverFor(table, baseName, targets), { mode: 0o755 });
+	writeFileSync(`${resolverPath}.cmd`, generateCmdResolverFor(table, baseName, targets));
 }
 
 type BinaryOutput<T extends string> = { target: T; outfilePath: string };
@@ -279,27 +272,28 @@ async function buildBinaryOutputs<T extends string>(
 		resolver: ResolverPlan;
 	},
 	executor: BinaryExecutor<T>,
+	io: InvocationIO,
 ): Promise<void> {
 	if (plan.outputs.length === 1) {
 		const output = plan.outputs[0]!;
-		console.log(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(output.outfilePath)}...`);
+		io.stdout(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(output.outfilePath)}...`);
 		await executor.execute(plan.entryPath, output.outfilePath, output.target, plan.envFiles);
-		console.log(`${green("✓")} Built successfully: ${output.outfilePath}`);
+		io.stdout(`${green("✓")} Built successfully: ${output.outfilePath}`);
 		return;
 	}
 
-	console.log(`Building ${dim(plan.entryPath)} for ${bold(`${plan.outputs.length}`)} target(s)...`);
+	io.stdout(`Building ${dim(plan.entryPath)} for ${bold(`${plan.outputs.length}`)} target(s)...`);
 	for (const output of plan.outputs) {
-		console.log(`  ${cyan("→")} ${bold(output.target)}: ${dim(output.outfilePath)}`);
+		io.stdout(`  ${cyan("→")} ${bold(output.target)}: ${dim(output.outfilePath)}`);
 		await executor.execute(plan.entryPath, output.outfilePath, output.target, plan.envFiles);
 	}
 
 	const resolver = plan.resolver;
 	const targets = plan.outputs.map((output) => output.target);
 	executor.writeResolver(resolver.path, resolver.baseName, targets);
-	console.log(`\n${green("✓")} Built ${bold(`${plan.outputs.length}`)} target(s) successfully:`);
-	for (const output of plan.outputs) console.log(`  ${output.outfilePath}`);
-	console.log(`\n${dim("Resolver:")} ${resolver.path} ${dim(`(+ ${resolver.path}.cmd)`)}`);
+	io.stdout(`\n${green("✓")} Built ${bold(`${plan.outputs.length}`)} target(s) successfully:`);
+	for (const output of plan.outputs) io.stdout(`  ${output.outfilePath}`);
+	io.stdout(`\n${dim("Resolver:")} ${resolver.path} ${dim(`(+ ${resolver.path}.cmd)`)}`);
 }
 
 export function resolveEnvFilePaths(cwd: string, envFiles: string[] | undefined): string[] {
@@ -349,12 +343,9 @@ type BunBuildPlan = CommonBuildPlan &
 		| {
 				runtime: "bun";
 				mode: "package";
-				staging: {
-					entry: string;
-					name?: string;
-					targets: BunTarget[];
-					stageDir: string;
-				};
+				name?: string;
+				targets: BunTarget[];
+				stageDir: string;
 		  }
 		| {
 				runtime: "bun";
@@ -380,8 +371,8 @@ type NodeBuildPlan = CommonBuildPlan & {
 export type BuildPlan = BunBuildPlan | DenoBuildPlan | NodeBuildPlan;
 
 function planBinaryOutputs<T extends string>(options: {
+	table: TargetTable<T>;
 	targets: T[];
-	getFilename: (baseName: string, target: T) => string;
 	flags: BuildFlags;
 	cwd: string;
 	entryPath: string;
@@ -399,7 +390,7 @@ function planBinaryOutputs<T extends string>(options: {
 	};
 	if (options.targets.length === 1) {
 		const target = options.targets[0]!;
-		const ext = options.getFilename("x", target).endsWith(".exe") ? ".exe" : "";
+		const ext = options.table.info[target].os === "win32" ? ".exe" : "";
 		const resolved = resolveOutfile(
 			options.flags.outfile,
 			options.flags.name,
@@ -423,7 +414,7 @@ function planBinaryOutputs<T extends string>(options: {
 			outfilePath: resolve(
 				options.cwd,
 				options.flags.outdir,
-				options.getFilename(baseName, target),
+				binaryFilename(options.table, baseName, target),
 			),
 		})),
 		resolver,
@@ -509,7 +500,7 @@ export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
 		};
 	}
 	if (runtime === "bun") {
-		const targets = resolveTargets(flags.target);
+		const targets = resolveTargets(BUN_TARGETS, flags.target);
 		if (!flags.package && flags.outfile && targets.length > 1) {
 			throw new Error(
 				"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
@@ -520,12 +511,9 @@ export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
 				...common,
 				runtime,
 				mode: "package",
-				staging: {
-					entry: flags.entry,
-					...(flags.name === undefined ? {} : { name: flags.name }),
-					targets,
-					stageDir: resolve(cwd, flags["stage-dir"]),
-				},
+				...(flags.name === undefined ? {} : { name: flags.name }),
+				targets,
+				stageDir: resolve(cwd, flags["stage-dir"]),
 			};
 		}
 		return {
@@ -533,8 +521,8 @@ export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
 			runtime,
 			mode: "binary",
 			...planBinaryOutputs({
+				table: BUN_TARGETS,
 				targets,
-				getFilename: getBinaryFilename,
 				flags,
 				cwd,
 				entryPath,
@@ -543,7 +531,7 @@ export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
 		};
 	}
 
-	const targets = resolveDenoTargets(flags.target);
+	const targets = resolveTargets(DENO_TARGETS, flags.target);
 	if (flags.outfile && targets.length > 1) {
 		throw new Error(
 			"--outfile cannot be used when building for multiple targets.\n  Use --name to set the base binary name instead.",
@@ -554,8 +542,8 @@ export function planBuild(flags: BuildFlags, cwd: string): BuildPlan {
 		runtime,
 		mode: "binary",
 		...planBinaryOutputs({
+			table: DENO_TARGETS,
 			targets,
-			getFilename: getDenoBinaryFilename,
 			flags,
 			cwd,
 			entryPath,
@@ -673,49 +661,48 @@ export const buildCommand = defineCommand(
 					default: "dist/npm",
 				},
 			)
-			.action(async ({ flags }) => {
-				const plan = planBuild(flags, process.cwd());
-				for (const warning of plan.warnings) console.warn(warning);
+			.action(async ({ flags, stdout, stderr }) => {
+				const cwd = process.cwd();
+				const io = { stdout, stderr };
+				const plan = planBuild(flags, cwd);
+				for (const warning of plan.warnings) stderr(warning);
 				if (plan.validate) {
-					await buildEntrypoint(plan.entryPath, plan.outDir, plan.envFiles);
+					await buildEntrypoint(plan.entryPath, plan.outDir, plan.envFiles, io, cwd);
 				}
 
 				if (plan.runtime === "bun" && plan.mode === "package") {
-					const { runDistributeBuild } = await import("../utils/distribute.ts");
-					await runDistributeBuild({
-						cwd: plan.cwd,
-						entry: plan.staging.entry,
-						name: plan.staging.name,
-						stageDir: plan.staging.stageDir,
-						minify: plan.minify,
-						target: plan.staging.targets,
-						envFiles: plan.envFiles,
-						artifactOutDir: plan.validate ? plan.outDir : undefined,
-						userPackageJson: plan.userPackageJson,
-					});
+					await runDistributeBuild(plan, { io });
 					return;
 				}
 
 				if (plan.runtime === "node") {
-					console.log(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(plan.outfilePath)}...`);
-					await execNodeBuild(plan.entryPath, plan.outfilePath, plan.minify, plan.envFiles);
-					console.log(`${green("✓")} Built successfully: ${plan.outfilePath}`);
+					stdout(`Building ${dim(plan.entryPath)} ${cyan("→")} ${dim(plan.outfilePath)}...`);
+					await execNodeBuild(plan.entryPath, plan.outfilePath, plan.minify, plan.envFiles, cwd);
+					stdout(`${green("✓")} Built successfully: ${plan.outfilePath}`);
 					return;
 				}
 
 				if (plan.runtime === "bun") {
-					await buildBinaryOutputs(plan, {
-						execute: (entry, outfile, target, envFiles) =>
-							execBuild(entry, outfile, plan.minify, target, envFiles),
-						writeResolver: (path, baseName, targets) =>
-							writeResolver(path, baseName, targets, TARGET_INFO, getBinaryFilename),
-					});
+					await buildBinaryOutputs(
+						plan,
+						{
+							execute: (entry, outfile, target, envFiles) =>
+								execBuild(entry, outfile, plan.minify, target, envFiles, cwd),
+							writeResolver: (path, baseName, targets) =>
+								writeResolver(BUN_TARGETS, path, baseName, targets),
+						},
+						io,
+					);
 					return;
 				}
-				await buildBinaryOutputs(plan, {
-					execute: (entry, outfile, target) => execDenoBuild(entry, outfile, target),
-					writeResolver: (path, baseName, targets) =>
-						writeResolver(path, baseName, targets, DENO_TARGET_INFO, getDenoBinaryFilename),
-				});
+				await buildBinaryOutputs(
+					plan,
+					{
+						execute: (entry, outfile, target) => execDenoBuild(entry, outfile, target, cwd),
+						writeResolver: (path, baseName, targets) =>
+							writeResolver(DENO_TARGETS, path, baseName, targets),
+					},
+					io,
+				);
 			}),
 );

--- a/packages/crust/src/commands/publish.test.ts
+++ b/packages/crust/src/commands/publish.test.ts
@@ -135,6 +135,32 @@ describe("publish manifest validation", () => {
 		expect(spawnPublish).not.toHaveBeenCalled();
 	});
 
+	it("passes invocation IO to the publisher executor", async () => {
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+		const invocationIO = {
+			stdout: (text: string) => stdout.push(text),
+			stderr: (text: string) => stderr.push(text),
+		};
+
+		await publishStagedPackages(
+			manifest,
+			{
+				stageDir: tmpDir,
+				access: "public",
+				spawnPublish: async (_dir, _command, executorIO) => {
+					executorIO.stdout("registry stdout");
+					executorIO.stderr("registry stderr");
+					return 0;
+				},
+			},
+			invocationIO,
+		);
+
+		expect(stdout).toContain("registry stdout");
+		expect(stderr).toEqual(["registry stderr", "registry stderr", "registry stderr"]);
+	});
+
 	it("stops on first failed publish", async () => {
 		const calls: string[] = [];
 		const spawnPublish = mock(async (dir: string) => {

--- a/packages/crust/src/commands/publish.test.ts
+++ b/packages/crust/src/commands/publish.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../../src/commands/publish.ts";
 import type { DistributionManifest } from "../utils/distribute.ts";
 
+const io = { stdout: () => {}, stderr: () => {} };
+
 function writeStageFixture(tmpDir: string, manifest: DistributionManifest) {
 	mkdirSync(join(tmpDir, "root", "bin"), { recursive: true });
 	writeFileSync(
@@ -120,12 +122,16 @@ describe("publish manifest validation", () => {
 
 	it("supports dry-run without spawning bun publish", async () => {
 		const spawnPublish = mock(async () => 0);
-		await publishStagedPackages(manifest, {
-			stageDir: tmpDir,
-			access: "public",
-			dryRun: true,
-			spawnPublish,
-		});
+		await publishStagedPackages(
+			manifest,
+			{
+				stageDir: tmpDir,
+				access: "public",
+				dryRun: true,
+				spawnPublish,
+			},
+			io,
+		);
 		expect(spawnPublish).not.toHaveBeenCalled();
 	});
 
@@ -137,11 +143,15 @@ describe("publish manifest validation", () => {
 		});
 
 		await expect(
-			publishStagedPackages(manifest, {
-				stageDir: tmpDir,
-				access: "public",
-				spawnPublish,
-			}),
+			publishStagedPackages(
+				manifest,
+				{
+					stageDir: tmpDir,
+					access: "public",
+					spawnPublish,
+				},
+				io,
+			),
 		).rejects.toThrow(/linux-x64/);
 		expect(calls).toHaveLength(1);
 	});

--- a/packages/crust/src/commands/publish.ts
+++ b/packages/crust/src/commands/publish.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-import { defineCommand } from "@crustjs/core";
+import { defineCommand, type InvocationIO } from "@crustjs/core";
 import { bold, cyan, dim, green } from "@crustjs/style";
 import { runProcess } from "@crustjs/utils/process";
 
@@ -165,6 +165,7 @@ async function defaultSpawnPublish(dir: string, command: string[]): Promise<numb
 export async function publishStagedPackages(
 	manifest: DistributionManifest,
 	options: PublishOptions,
+	io: InvocationIO,
 ): Promise<void> {
 	if (options.verify !== false) {
 		validatePublishManifest(options.stageDir, manifest);
@@ -175,9 +176,9 @@ export async function publishStagedPackages(
 		tag: options.tag,
 		registry: options.registry,
 	});
-	console.log(`${dim("Publish order:")} ${manifest.publishOrder.join(" -> ")}`);
+	io.stdout(`${dim("Publish order:")} ${manifest.publishOrder.join(" -> ")}`);
 	for (const relativeDir of manifest.publishOrder) {
-		console.log(`  ${cyan("→")} ${relativeDir}: ${dim(command.join(" "))}`);
+		io.stdout(`  ${cyan("→")} ${relativeDir}: ${dim(command.join(" "))}`);
 	}
 
 	if (options.dryRun) {
@@ -188,14 +189,14 @@ export async function publishStagedPackages(
 
 	for (const relativeDir of manifest.publishOrder) {
 		const dir = join(options.stageDir, relativeDir);
-		console.log(`\nPublishing ${bold(relativeDir)} from ${dim(dir)}...`);
+		io.stdout(`\nPublishing ${bold(relativeDir)} from ${dim(dir)}...`);
 		const exitCode = await spawnPublish(dir, command);
 		if (exitCode !== 0) {
 			throw new Error(`bun publish failed for ${relativeDir} (${dir}) with exit code ${exitCode}`);
 		}
 	}
 
-	console.log(
+	io.stdout(
 		`\n${green("✓")} Published ${bold(String(manifest.publishOrder.length))} staged package(s).`,
 	);
 }
@@ -241,17 +242,22 @@ export const publishCommand = defineCommand(
 					description: "Override the registry passed to bun publish",
 				},
 			)
-			.action(async ({ flags }) => {
-				const stageDir = resolve(process.cwd(), flags["stage-dir"]);
+			.action(async ({ flags, stdout, stderr }) => {
+				const cwd = process.cwd();
+				const stageDir = resolve(cwd, flags["stage-dir"]);
 				const manifest = readPublishManifest(stageDir);
 
-				await publishStagedPackages(manifest, {
-					stageDir,
-					access: flags.access,
-					tag: flags.tag,
-					registry: flags.registry,
-					dryRun: flags["dry-run"],
-					verify: flags.verify,
-				});
+				await publishStagedPackages(
+					manifest,
+					{
+						stageDir,
+						access: flags.access,
+						tag: flags.tag,
+						registry: flags.registry,
+						dryRun: flags["dry-run"],
+						verify: flags.verify,
+					},
+					{ stdout, stderr },
+				);
 			}),
 );

--- a/packages/crust/src/commands/publish.ts
+++ b/packages/crust/src/commands/publish.ts
@@ -23,7 +23,7 @@ type PublishOptions = {
 	registry?: string;
 	dryRun?: boolean;
 	verify?: boolean;
-	spawnPublish?: (dir: string, command: string[]) => Promise<number>;
+	spawnPublish?: (dir: string, command: string[], io: InvocationIO) => Promise<number>;
 };
 
 export function readPublishManifest(stageDir: string): DistributionManifest {
@@ -149,15 +149,20 @@ export function buildPublishCommand(args: {
 	return command;
 }
 
-async function defaultSpawnPublish(dir: string, command: string[]): Promise<number> {
-	const { exitCode } = await runProcess(command[0]!, command.slice(1), {
+async function defaultSpawnPublish(
+	dir: string,
+	command: string[],
+	io: InvocationIO,
+): Promise<number> {
+	const { exitCode, stdout, stderr } = await runProcess(command[0]!, command.slice(1), {
 		cwd: dir,
 		env: {
 			...process.env,
 			BUN_BE_BUN: "1",
 		},
-		stdio: "inherit",
 	});
+	if (stdout) io.stdout(stdout.replace(/\r?\n$/, ""));
+	if (stderr) io.stderr(stderr.replace(/\r?\n$/, ""));
 
 	return exitCode ?? 1;
 }
@@ -190,7 +195,7 @@ export async function publishStagedPackages(
 	for (const relativeDir of manifest.publishOrder) {
 		const dir = join(options.stageDir, relativeDir);
 		io.stdout(`\nPublishing ${bold(relativeDir)} from ${dim(dir)}...`);
-		const exitCode = await spawnPublish(dir, command);
+		const exitCode = await spawnPublish(dir, command, io);
 		if (exitCode !== 0) {
 			throw new Error(`bun publish failed for ${relativeDir} (${dir}) with exit code ${exitCode}`);
 		}

--- a/packages/crust/src/utils/build-helpers.test.ts
+++ b/packages/crust/src/utils/build-helpers.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { buildEntrypoint } from "./build-helpers.ts";
 
 const coreUrl = import.meta.resolve("@crustjs/core");
+const io = { stdout: () => {}, stderr: () => {} };
 
 describe("buildEntrypoint", () => {
 	const tempDirs: string[] = [];
@@ -28,7 +29,7 @@ describe("buildEntrypoint", () => {
 				`await Bun.write(${JSON.stringify(trailingMarker)}, "ran");\n`,
 		);
 
-		const root = await buildEntrypoint(entry, join(directory, "dist"));
+		const root = await buildEntrypoint(entry, join(directory, "dist"), [], io, directory);
 
 		expect(root.meta).toMatchObject({ name: "fixture", description: "Fixture CLI" });
 		expect(root.hasAction).toBe(true);
@@ -48,7 +49,7 @@ describe("buildEntrypoint", () => {
 				`await app.execute();\n`,
 		);
 
-		const snapshot = await buildEntrypoint(entry, outDir);
+		const snapshot = await buildEntrypoint(entry, outDir, [], io, directory);
 
 		expect(snapshot.meta.name).toBe("fixture");
 		expect(await Bun.file(join(outDir, "artifact.txt")).text()).toBe("built");
@@ -101,9 +102,9 @@ describe("buildEntrypoint", () => {
 				`await new Crust("fixture").extend(broken).execute();\n`,
 		);
 
-		await expect(buildEntrypoint(entry, join(directory, "dist"))).rejects.toThrow(
-			'Extension "broken" build failed: disk full',
-		);
+		await expect(
+			buildEntrypoint(entry, join(directory, "dist"), [], io, directory),
+		).rejects.toThrow('Extension "broken" build failed: disk full');
 	});
 
 	it("explains when an entry exits without producing a snapshot", async () => {
@@ -112,9 +113,9 @@ describe("buildEntrypoint", () => {
 		const entry = join(directory, "cli.ts");
 		await writeFile(entry, "export {};\n");
 
-		await expect(buildEntrypoint(entry, join(directory, "dist"))).rejects.toThrow(
-			"Entry exited without producing a Command Snapshot",
-		);
+		await expect(
+			buildEntrypoint(entry, join(directory, "dist"), [], io, directory),
+		).rejects.toThrow("Entry exited without producing a Command Snapshot");
 	});
 
 	it("rethrows the entry's error when the subprocess exits non-zero", async () => {
@@ -123,9 +124,9 @@ describe("buildEntrypoint", () => {
 		const entry = join(directory, "cli.ts");
 		await writeFile(entry, `throw new Error("entry blew up before execute");\n`);
 
-		await expect(buildEntrypoint(entry, join(directory, "dist"))).rejects.toThrow(
-			"entry blew up before execute",
-		);
+		await expect(
+			buildEntrypoint(entry, join(directory, "dist"), [], io, directory),
+		).rejects.toThrow("entry blew up before execute");
 	});
 
 	it("explains when the snapshot file contains invalid JSON", async () => {
@@ -137,8 +138,8 @@ describe("buildEntrypoint", () => {
 			`await Bun.write(process.env.CRUST_INTERNAL_SNAPSHOT_PATH!, "not json");\n`,
 		);
 
-		await expect(buildEntrypoint(entry, join(directory, "dist"))).rejects.toThrow(
-			"Entry produced an invalid Command Snapshot",
-		);
+		await expect(
+			buildEntrypoint(entry, join(directory, "dist"), [], io, directory),
+		).rejects.toThrow("Entry produced an invalid Command Snapshot");
 	});
 });

--- a/packages/crust/src/utils/build-helpers.test.ts
+++ b/packages/crust/src/utils/build-helpers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -75,14 +75,9 @@ describe("buildEntrypoint", () => {
 				`await new Crust("demo", { description: "Demo" }).extend(skill({ distDir: ${JSON.stringify(source)} }), man()).execute();\n`,
 		);
 
-		// crust build runs from the project root; the entry subprocess inherits
-		// that cwd, so advertised sources relativize against the fixture project.
-		const cwdSpy = spyOn(process, "cwd").mockReturnValue(directory);
-		try {
-			await buildEntrypoint(entry, outDir);
-		} finally {
-			cwdSpy.mockRestore();
-		}
+		// Run the entry subprocess from the fixture project root so advertised
+		// sources are relative to that project.
+		await buildEntrypoint(entry, outDir, [], io, directory);
 
 		const manual = await Bun.file(join(outDir, "man", "demo.1")).text();
 		const packagedSkill = await Bun.file(join(outDir, "skills", "demo", "SKILL.md")).text();

--- a/packages/crust/src/utils/build-helpers.ts
+++ b/packages/crust/src/utils/build-helpers.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { text } from "node:stream/consumers";
 
+import type { InvocationIO } from "@crustjs/core";
 import { BUILD_OUT_DIR_ENV, type CommandSnapshot, SNAPSHOT_PATH_ENV } from "@crustjs/core/tooling";
 import { yellow } from "@crustjs/style";
 import { isErrnoException } from "@crustjs/utils/error";
@@ -19,13 +20,21 @@ import { runProcess, which } from "@crustjs/utils/process";
 export const BUILD_RUNTIMES = ["bun", "deno", "node"] as const;
 export type BuildRuntime = (typeof BUILD_RUNTIMES)[number];
 
-/**
- * All Bun compile targets supported by `crust build`.
- *
- * Uses baseline x64 variants for maximum CPU compatibility (Nehalem 2008+).
- * ARM64 targets have no baseline/modern distinction.
- */
-export const SUPPORTED_TARGETS = [
+export type TargetInfo = {
+	alias: string;
+	platformKey: string;
+	unameKey: string;
+	os: "linux" | "darwin" | "win32";
+	cpu: "x64" | "arm64";
+};
+
+export type TargetTable<T extends string> = {
+	runtime: "Bun" | "Deno";
+	targets: readonly T[];
+	info: Record<T, TargetInfo>;
+};
+
+const BUN_TARGET_NAMES = [
 	"bun-linux-x64-baseline",
 	"bun-linux-arm64",
 	"bun-darwin-x64",
@@ -34,77 +43,58 @@ export const SUPPORTED_TARGETS = [
 	"bun-windows-arm64",
 ] as const;
 
-export type BunTarget = (typeof SUPPORTED_TARGETS)[number];
+export type BunTarget = (typeof BUN_TARGET_NAMES)[number];
 
-/**
- * Consolidated metadata for every supported Bun compile target.
- *
- * Single source of truth for target metadata.
- */
-export type TargetInfo = {
-	/** Human-friendly alias (e.g. "linux-x64", "darwin-arm64") */
-	alias: string;
-	/** `process.platform`-`process.arch` key (e.g. "linux-x64", "win32-arm64") */
-	platformKey: string;
-	/** `uname -s`-`uname -m` key used by shell resolvers (e.g. "Linux-x86_64") */
-	unameKey: string;
-	/** npm `os` field value */
-	os: "linux" | "darwin" | "win32";
-	/** npm `cpu` field value */
-	cpu: "x64" | "arm64";
-};
+export const BUN_TARGETS = {
+	runtime: "Bun",
+	targets: BUN_TARGET_NAMES,
+	info: {
+		"bun-linux-x64-baseline": {
+			alias: "linux-x64",
+			platformKey: "linux-x64",
+			unameKey: "Linux-x86_64",
+			os: "linux",
+			cpu: "x64",
+		},
+		"bun-linux-arm64": {
+			alias: "linux-arm64",
+			platformKey: "linux-arm64",
+			unameKey: "Linux-aarch64",
+			os: "linux",
+			cpu: "arm64",
+		},
+		"bun-darwin-x64": {
+			alias: "darwin-x64",
+			platformKey: "darwin-x64",
+			unameKey: "Darwin-x86_64",
+			os: "darwin",
+			cpu: "x64",
+		},
+		"bun-darwin-arm64": {
+			alias: "darwin-arm64",
+			platformKey: "darwin-arm64",
+			unameKey: "Darwin-arm64",
+			os: "darwin",
+			cpu: "arm64",
+		},
+		"bun-windows-x64-baseline": {
+			alias: "windows-x64",
+			platformKey: "win32-x64",
+			unameKey: "Windows-x64",
+			os: "win32",
+			cpu: "x64",
+		},
+		"bun-windows-arm64": {
+			alias: "windows-arm64",
+			platformKey: "win32-arm64",
+			unameKey: "Windows-arm64",
+			os: "win32",
+			cpu: "arm64",
+		},
+	},
+} as const satisfies TargetTable<BunTarget>;
 
-export const TARGET_INFO = {
-	"bun-linux-x64-baseline": {
-		alias: "linux-x64",
-		platformKey: "linux-x64",
-		unameKey: "Linux-x86_64",
-		os: "linux",
-		cpu: "x64",
-	},
-	"bun-linux-arm64": {
-		alias: "linux-arm64",
-		platformKey: "linux-arm64",
-		unameKey: "Linux-aarch64",
-		os: "linux",
-		cpu: "arm64",
-	},
-	"bun-darwin-x64": {
-		alias: "darwin-x64",
-		platformKey: "darwin-x64",
-		unameKey: "Darwin-x86_64",
-		os: "darwin",
-		cpu: "x64",
-	},
-	"bun-darwin-arm64": {
-		alias: "darwin-arm64",
-		platformKey: "darwin-arm64",
-		unameKey: "Darwin-arm64",
-		os: "darwin",
-		cpu: "arm64",
-	},
-	"bun-windows-x64-baseline": {
-		alias: "windows-x64",
-		platformKey: "win32-x64",
-		unameKey: "Windows-x64",
-		os: "win32",
-		cpu: "x64",
-	},
-	"bun-windows-arm64": {
-		alias: "windows-arm64",
-		platformKey: "win32-arm64",
-		unameKey: "Windows-arm64",
-		os: "win32",
-		cpu: "arm64",
-	},
-} as const satisfies Record<BunTarget, TargetInfo>;
-
-/**
- * Deno 2.9 compile targets, verified against `deno compile --help`.
- * Keep this table separate from Bun's target namespace: the compilers use
- * different canonical strings even when they describe the same platform.
- */
-export const SUPPORTED_DENO_TARGETS = [
+const DENO_TARGET_NAMES = [
 	"x86_64-unknown-linux-gnu",
 	"aarch64-unknown-linux-gnu",
 	"x86_64-apple-darwin",
@@ -113,123 +103,87 @@ export const SUPPORTED_DENO_TARGETS = [
 	"aarch64-pc-windows-msvc",
 ] as const;
 
-export type DenoTarget = (typeof SUPPORTED_DENO_TARGETS)[number];
+export type DenoTarget = (typeof DENO_TARGET_NAMES)[number];
 
-/** Subset of target metadata the generated resolver scripts consume. */
-export type ResolverTargetInfo = Pick<TargetInfo, "unameKey" | "os" | "cpu">;
+export const DENO_TARGETS = {
+	runtime: "Deno",
+	targets: DENO_TARGET_NAMES,
+	info: {
+		"x86_64-unknown-linux-gnu": {
+			alias: "linux-x64",
+			platformKey: "linux-x64",
+			unameKey: "Linux-x86_64",
+			os: "linux",
+			cpu: "x64",
+		},
+		"aarch64-unknown-linux-gnu": {
+			alias: "linux-arm64",
+			platformKey: "linux-arm64",
+			unameKey: "Linux-aarch64",
+			os: "linux",
+			cpu: "arm64",
+		},
+		"x86_64-apple-darwin": {
+			alias: "darwin-x64",
+			platformKey: "darwin-x64",
+			unameKey: "Darwin-x86_64",
+			os: "darwin",
+			cpu: "x64",
+		},
+		"aarch64-apple-darwin": {
+			alias: "darwin-arm64",
+			platformKey: "darwin-arm64",
+			unameKey: "Darwin-arm64",
+			os: "darwin",
+			cpu: "arm64",
+		},
+		"x86_64-pc-windows-msvc": {
+			alias: "windows-x64",
+			platformKey: "win32-x64",
+			unameKey: "Windows-x64",
+			os: "win32",
+			cpu: "x64",
+		},
+		"aarch64-pc-windows-msvc": {
+			alias: "windows-arm64",
+			platformKey: "win32-arm64",
+			unameKey: "Windows-arm64",
+			os: "win32",
+			cpu: "arm64",
+		},
+	},
+} as const satisfies TargetTable<DenoTarget>;
 
-/** No platformKey: npm per-platform packaging (distribute.ts) is Bun-only. */
-type DenoTargetInfo = Omit<TargetInfo, "platformKey">;
+export function resolveTargets<T extends string>(
+	table: TargetTable<T>,
+	targetFlags: string[] | undefined,
+): T[] {
+	if (!targetFlags?.length) return [...table.targets];
 
-export const DENO_TARGET_INFO = {
-	"x86_64-unknown-linux-gnu": {
-		alias: "linux-x64",
-		unameKey: "Linux-x86_64",
-		os: "linux",
-		cpu: "x64",
-	},
-	"aarch64-unknown-linux-gnu": {
-		alias: "linux-arm64",
-		unameKey: "Linux-aarch64",
-		os: "linux",
-		cpu: "arm64",
-	},
-	"x86_64-apple-darwin": {
-		alias: "darwin-x64",
-		unameKey: "Darwin-x86_64",
-		os: "darwin",
-		cpu: "x64",
-	},
-	"aarch64-apple-darwin": {
-		alias: "darwin-arm64",
-		unameKey: "Darwin-arm64",
-		os: "darwin",
-		cpu: "arm64",
-	},
-	"x86_64-pc-windows-msvc": {
-		alias: "windows-x64",
-		unameKey: "Windows-x64",
-		os: "win32",
-		cpu: "x64",
-	},
-	"aarch64-pc-windows-msvc": {
-		alias: "windows-arm64",
-		unameKey: "Windows-arm64",
-		os: "win32",
-		cpu: "arm64",
-	},
-} as const satisfies Record<DenoTarget, DenoTargetInfo>;
+	return targetFlags.map((input) => {
+		const exact = table.targets.find((target) => target === input);
+		if (exact) return exact;
 
-/**
- * Resolve a canonical Bun target string to a supported compile target.
- *
- * @param input - User-provided canonical Bun target string
- * @returns The resolved Bun compile target
- * @throws {Error} If the target is not recognized
- */
-export function resolveTarget(input: string): BunTarget {
-	const exact = SUPPORTED_TARGETS.find((target) => target === input);
-	if (exact) return exact;
-
-	const canonical = SUPPORTED_TARGETS.find((target) => TARGET_INFO[target].alias === input);
-	const hint = canonical ? ` Did you mean "${canonical}"?` : "";
-	const validTargets = SUPPORTED_TARGETS.join(", ");
-	throw new Error(
-		`Unknown target "${input}". Targets must use canonical Bun names.${hint}\n  Valid targets: ${validTargets}`,
-	);
+		const canonical = table.targets.find((target) => table.info[target].alias === input);
+		const hint = canonical ? ` Did you mean "${canonical}"?` : "";
+		const runtime = table.runtime === "Bun" ? "" : `${table.runtime} `;
+		throw new Error(
+			`Unknown ${runtime}target "${input}". Targets must use canonical ${table.runtime} names.${hint}\n  Valid targets: ${table.targets.join(", ")}`,
+		);
+	});
 }
 
-/**
- * Resolve the list of Bun targets from flags.
- *
- * When no `--target` is provided, defaults to all supported targets.
- * When `--target` is provided, builds only the specified target(s).
- *
- * @param targetFlags - Values from repeatable --target flag
- * @returns Array of resolved BunTarget values
- */
-export function resolveTargets(targetFlags: string[] | undefined): BunTarget[] {
-	// No --target flags: build all platforms (default)
-	if (!targetFlags || targetFlags.length === 0) {
-		return [...SUPPORTED_TARGETS];
-	}
-
-	return targetFlags.map(resolveTarget);
+export function binaryFilename<T extends string>(
+	table: TargetTable<T>,
+	baseName: string,
+	target: T,
+): string {
+	return `${baseName}-${target}${table.info[target].os === "win32" ? ".exe" : ""}`;
 }
 
-export function resolveDenoTarget(input: string): DenoTarget {
-	const exact = SUPPORTED_DENO_TARGETS.find((target) => target === input);
-	if (exact) return exact;
-
-	const canonical = SUPPORTED_DENO_TARGETS.find(
-		(target) => DENO_TARGET_INFO[target].alias === input,
-	);
-	const hint = canonical ? ` Did you mean "${canonical}"?` : "";
-	throw new Error(
-		`Unknown Deno target "${input}". Targets must use canonical Deno names.${hint}\n  Valid targets: ${SUPPORTED_DENO_TARGETS.join(", ")}`,
-	);
-}
-
-export function resolveDenoTargets(targetFlags: string[] | undefined): DenoTarget[] {
-	return targetFlags?.length ? targetFlags.map(resolveDenoTarget) : [...SUPPORTED_DENO_TARGETS];
-}
-
-/**
- * Get the binary filename (basename only) for a given target.
- *
- * @param baseName - The base binary name
- * @param target - The Bun compile target
- * @returns The filename (e.g. "my-cli-bun-darwin-arm64" or "my-cli-bun-windows-x64-baseline.exe")
- */
-export function getBinaryFilename(baseName: string, target: BunTarget): string {
-	const isWindows = target.startsWith("bun-windows");
-	const ext = isWindows ? ".exe" : "";
-	return `${baseName}-${target}${ext}`;
-}
-
-export function getDenoBinaryFilename(baseName: string, target: DenoTarget): string {
-	const ext = DENO_TARGET_INFO[target].os === "win32" ? ".exe" : "";
-	return `${baseName}-${target}${ext}`;
+export function hostTarget<T extends string>(table: TargetTable<T>): T | null {
+	const platformKey = `${process.platform}-${process.arch}`;
+	return table.targets.find((target) => table.info[target].platformKey === platformKey) ?? null;
 }
 
 export function readUserPackageJson(cwd: string): JsonValue | undefined {
@@ -256,12 +210,11 @@ export function resolveBaseName(
 	name: string | undefined,
 	entry: string,
 	cwd: string,
-	packageJson?: JsonValue,
+	packageJson: JsonValue | undefined,
 ): string {
 	if (name) return name;
 
-	const pkgJson = packageJson ?? readUserPackageJson(cwd);
-	if (hasStringName(pkgJson)) return pkgJson.name.replace(/^@[^/]+\//, "");
+	if (hasStringName(packageJson)) return packageJson.name.replace(/^@[^/]+\//, "");
 
 	return basename(entry).replace(/\.[^.]+$/, "");
 }
@@ -322,12 +275,13 @@ export async function execBuild(
 	entryPath: string,
 	outfilePath: string,
 	minify: boolean,
-	target?: BunTarget,
-	envFiles: readonly string[] = [],
+	target: BunTarget | undefined,
+	envFiles: readonly string[],
+	cwd: string,
 ): Promise<void> {
 	const runner = resolveBunBuildRunner();
 	const args = createBunCompileArgs(entryPath, outfilePath, minify, target, envFiles);
-	await runBuildProcess(runner, args, outfilePath);
+	await runBuildProcess(runner, args, outfilePath, cwd);
 }
 
 function createBunCompileArgs(
@@ -398,10 +352,11 @@ async function runBuildProcess(
 	runner: BuildRunner,
 	args: readonly string[],
 	outfilePath: string,
+	cwd: string,
 ): Promise<void> {
 	const { exitCode, stdout, stderr } = await runProcess(runner.command, args, {
 		env: runner.env,
-		cwd: process.cwd(),
+		cwd,
 		stdio: "collect",
 	});
 
@@ -415,13 +370,15 @@ export async function execNodeBuild(
 	entryPath: string,
 	outfilePath: string,
 	minify: boolean,
-	envFiles: readonly string[] = [],
+	envFiles: readonly string[],
+	cwd: string,
 ): Promise<void> {
 	const runner = resolveBunBuildRunner();
 	await runBuildProcess(
 		runner,
 		createNodeBuildArgs(entryPath, outfilePath, minify, envFiles),
 		outfilePath,
+		cwd,
 	);
 
 	const output = await readFile(outfilePath, "utf8");
@@ -434,6 +391,7 @@ export async function execDenoBuild(
 	entryPath: string,
 	outfilePath: string,
 	target: DenoTarget,
+	cwd: string,
 ): Promise<void> {
 	const denoPath = which("deno");
 	if (!denoPath) {
@@ -445,6 +403,7 @@ export async function execDenoBuild(
 		{ command: denoPath, env: { ...process.env } },
 		createDenoCompileArgs(entryPath, outfilePath, target),
 		outfilePath,
+		cwd,
 	);
 }
 
@@ -464,7 +423,9 @@ const SNAPSHOT_TIMEOUT_MS = 30_000;
 export async function buildEntrypoint(
 	entryPath: string,
 	outDir: string,
-	envFiles: readonly string[] = [],
+	envFiles: readonly string[],
+	io: InvocationIO,
+	cwd: string,
 ): Promise<CommandSnapshot> {
 	const absoluteEntry = resolve(entryPath);
 	const snapshotDir = await mkdtemp(join(tmpdir(), "crust-snapshot-"));
@@ -479,7 +440,7 @@ export async function buildEntrypoint(
 				[BUILD_OUT_DIR_ENV]: resolve(outDir),
 				BUN_BE_BUN: "1",
 			},
-			cwd: process.cwd(),
+			cwd,
 			stdio: ["ignore", "ignore", "pipe"],
 			timeout: SNAPSHOT_TIMEOUT_MS,
 		});
@@ -516,7 +477,7 @@ export async function buildEntrypoint(
 						: line,
 				)
 				.join("\n");
-			process.stderr.write(`${styled}\n`);
+			io.stderr(styled);
 		}
 
 		let serialized: string;

--- a/packages/crust/src/utils/distribute.test.ts
+++ b/packages/crust/src/utils/distribute.test.ts
@@ -1,358 +1,207 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-import {
-	buildDistributionPlatformPackageJson,
-	buildDistributionRootPackageJson,
-	derivePlatformPackageName,
-	generateDistributionJsResolver,
-	getPackagePathSegment,
-	inferCommandName,
-	runDistributeBuild,
-} from "./distribute.ts";
+import type { JsonValue } from "@crustjs/utils/json";
 
-const corePath = fileURLToPath(import.meta.resolve("@crustjs/core"));
+import type { BunTarget } from "./build-helpers.ts";
+import { runDistributeBuild } from "./distribute.ts";
 
-describe("derivePlatformPackageName", () => {
-	it("suffixes unscoped package names", () => {
-		expect(derivePlatformPackageName("my-cli", "darwin-arm64")).toBe("my-cli-darwin-arm64");
-	});
+const io = { stdout: () => {}, stderr: () => {} };
 
-	it("suffixes scoped package names", () => {
-		expect(derivePlatformPackageName("@scope/my-cli", "linux-x64")).toBe("@scope/my-cli-linux-x64");
-	});
-});
+function createPlan(
+	cwd: string,
+	packageJson: JsonValue,
+	overrides: Partial<{
+		name: string;
+		targets: BunTarget[];
+		stageDir: string;
+		validate: boolean;
+		outDir: string;
+	}> = {},
+) {
+	return {
+		cwd,
+		entryPath: join(cwd, "src", "cli.ts"),
+		minify: true,
+		targets: ["bun-darwin-arm64"] satisfies BunTarget[],
+		stageDir: join(cwd, ".stage"),
+		envFiles: [],
+		validate: false,
+		outDir: join(cwd, "dist"),
+		userPackageJson: packageJson,
+		...overrides,
+	};
+}
 
-describe("inferCommandName", () => {
-	it("falls back to the resolved base name", () => {
-		expect(inferCommandName("my-cli", undefined, "my-cli")).toBe("my-cli");
-	});
+const fakeExecutor = async (
+	_entryPath: string,
+	outfilePath: string,
+	_minify: boolean,
+	_target: BunTarget,
+	_envFiles: readonly string[],
+	_cwd: string,
+) => {
+	writeFileSync(outfilePath, "fake binary\n");
+};
 
-	it("uses the single object bin key", () => {
-		expect(inferCommandName("my-cli", { crusty: "dist/cli" }, "my-cli")).toBe("crusty");
-	});
-
-	it("uses the unscoped package name for string bin shorthand", () => {
-		expect(inferCommandName("@scope/my-cli", "dist/cli", "ignored")).toBe("my-cli");
-	});
-
-	it("throws for multiple bin entries", () => {
-		expect(() =>
-			inferCommandName("my-cli", { one: "dist/one", two: "dist/two" }, "my-cli"),
-		).toThrow(/exactly one bin entry/);
-	});
-});
-
-describe("distribution manifest JSON builders", () => {
-	it("builds the root package optionalDependencies", () => {
-		const metadata = {
-			commandName: "crust",
-			rootPackageName: "@crustjs/crust",
-			version: "1.2.3",
-			baseName: "crust",
-			rootPackageJson: {
-				name: "@crustjs/crust",
-				version: "1.2.3",
-				description: "CLI tooling",
-				engines: { bun: ">=1.3.14" },
-			},
-		};
-		const targets = [
-			{
-				target: "bun-darwin-arm64" as const,
-				platformKey: "darwin-arm64" as const,
-				targetAlias: "darwin-arm64",
-				packageName: "@crustjs/crust-darwin-arm64",
-				packagePathSegment: "crust-darwin-arm64",
-				packageDir: "/tmp/darwin-arm64",
-				binaryRelativePath: "bin/crust-bun-darwin-arm64",
-				binaryFilename: "crust-bun-darwin-arm64",
-				os: "darwin" as const,
-				cpu: "arm64" as const,
-			},
-		];
-
-		expect(buildDistributionRootPackageJson(metadata, targets)).toEqual({
-			name: "@crustjs/crust",
-			version: "1.2.3",
-			type: "module",
-			description: "CLI tooling",
-			engines: { bun: ">=1.3.14" },
-			files: ["bin"],
-			bin: { crust: "bin/crust.js" },
-			optionalDependencies: {
-				"@crustjs/crust-darwin-arm64": "1.2.3",
-			},
-		});
-
-		expect(
-			buildDistributionRootPackageJson(metadata, targets, {
-				artifactDirs: ["man", "skills"],
-				manPages: ["crust.1"],
-			}),
-		).toEqual({
-			name: "@crustjs/crust",
-			version: "1.2.3",
-			type: "module",
-			description: "CLI tooling",
-			engines: { bun: ">=1.3.14" },
-			files: ["bin", "man", "skills"],
-			man: ["./man/crust.1"],
-			bin: { crust: "bin/crust.js" },
-			optionalDependencies: {
-				"@crustjs/crust-darwin-arm64": "1.2.3",
-			},
-		});
-	});
-
-	it("builds platform package metadata with os/cpu/bin", () => {
-		const metadata = {
-			commandName: "crust",
-			rootPackageName: "@crustjs/crust",
-			version: "1.2.3",
-			baseName: "crust",
-			rootPackageJson: {
-				name: "@crustjs/crust",
-				version: "1.2.3",
-				description: "CLI tooling",
-				engines: { bun: ">=1.3.14" },
-			},
-		};
-		const target = {
-			target: "bun-windows-arm64" as const,
-			platformKey: "win32-arm64" as const,
-			targetAlias: "windows-arm64",
-			packageName: "@crustjs/crust-windows-arm64",
-			packagePathSegment: "crust-windows-arm64",
-			packageDir: "/tmp/windows-arm64",
-			binaryRelativePath: "bin/crust-bun-windows-arm64.exe",
-			binaryFilename: "crust-bun-windows-arm64.exe",
-			os: "win32" as const,
-			cpu: "arm64" as const,
-		};
-
-		expect(buildDistributionPlatformPackageJson(metadata, target)).toEqual({
-			name: "@crustjs/crust-windows-arm64",
-			version: "1.2.3",
-			description: "CLI tooling",
-			engines: { bun: ">=1.3.14" },
-			files: ["bin"],
-			bin: { crust: "bin/crust-bun-windows-arm64.exe" },
-			os: ["win32"],
-			cpu: ["arm64"],
-		});
-	});
-});
-
-describe("getPackagePathSegment", () => {
-	it("returns the unscoped name for scoped packages", () => {
-		expect(getPackagePathSegment("@crustjs/crust-linux-x64")).toBe("crust-linux-x64");
-	});
-});
-
-describe("generateDistributionJsResolver", () => {
-	it("generates a JS resolver with fixed candidate probing", () => {
-		const launcher = generateDistributionJsResolver("crust", [
-			{
-				target: "bun-linux-x64-baseline",
-				platformKey: "linux-x64",
-				targetAlias: "linux-x64",
-				packageName: "@crustjs/crust-linux-x64",
-				packagePathSegment: "crust-linux-x64",
-				packageDir: "/tmp/linux-x64",
-				binaryRelativePath: "bin/crust-bun-linux-x64-baseline",
-				binaryFilename: "crust-bun-linux-x64-baseline",
-				os: "linux",
-				cpu: "x64",
-			},
-		]);
-
-		expect(launcher).toContain("#!/usr/bin/env node");
-		expect(launcher).toContain("process.platform");
-		expect(launcher).toContain("process.arch");
-		expect(launcher).toContain("const candidateOne = resolve(");
-		expect(launcher).toContain("const candidateTwo = resolve(");
-		expect(launcher).toContain('"packagePathSegment": "crust-linux-x64"');
-		expect(launcher).toContain('"packageName": "@crustjs/crust-linux-x64"');
-		expect(launcher).toContain('"binaryFilename": "crust-bun-linux-x64-baseline"');
-		expect(launcher).not.toContain('"targetAlias"');
-		expect(launcher).toContain("Missing platform package");
-		expect(launcher).toContain("optional dependencies are enabled");
-		expect(launcher).toContain("Supported platforms: linux-x64");
-		expect(launcher).toContain("try {");
-		expect(launcher).toContain("process.kill(process.pid, signal)");
-		expect(launcher).toContain("process.exit(1)");
-	});
-});
+function readJson<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf8")) as T;
+}
 
 describe("runDistributeBuild", () => {
-	const tmpDir = mkdtempSync(join(tmpdir(), "crust-distribute-validation-"));
-	const originalCwd = process.cwd;
+	const tmpDir = mkdtempSync(join(tmpdir(), "crust-distribute-"));
 
-	beforeAll(() => {
+	beforeEach(() => {
 		rmSync(tmpDir, { recursive: true, force: true });
 		mkdirSync(join(tmpDir, "src"), { recursive: true });
-		writeFileSync(join(tmpDir, "src", "cli.ts"), 'console.log("hello");\n');
+		writeFileSync(join(tmpDir, "src", "cli.ts"), "export {};\n");
 		writeFileSync(join(tmpDir, "LICENSE"), "test license\n");
 	});
 
-	afterAll(() => {
-		process.cwd = originalCwd;
-		rmSync(tmpDir, { recursive: true, force: true });
-	});
+	afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
 
-	it("writes a manifest file for a staged package", async () => {
-		writeFileSync(
-			join(tmpDir, "package.json"),
-			JSON.stringify({
-				name: "test-package-cli",
-				version: "0.1.0",
-				bin: {
-					"test-cli": "dist/cli",
-				},
-			}),
-		);
-		process.cwd = () => tmpDir;
-
-		await runDistributeBuild({
-			entry: "src/cli.ts",
-			minify: true,
-			target: ["bun-darwin-arm64"],
-			stageDir: ".stage",
-		});
-
-		const manifest = JSON.parse(readFileSync(join(tmpDir, ".stage", "manifest.json"), "utf-8")) as {
-			root: { dir: string; bin: string };
-			packages: Array<{ target: string; name: string }>;
-			publishOrder: string[];
+	it("stages manifests, package metadata, resolver, licenses, and fake binary outputs", async () => {
+		const packageJson = {
+			name: "@scope/test-package-cli",
+			version: "0.1.0",
+			description: "CLI tooling",
+			bin: { "test-cli": "dist/cli" },
 		};
-
-		expect(manifest.root.dir).toBe("root");
-		expect(manifest.root.bin).toBe("test-cli");
-		expect(manifest.packages).toHaveLength(1);
-		expect(manifest.packages[0]).toMatchObject({
-			target: "darwin-arm64",
-			name: "test-package-cli-darwin-arm64",
+		const plan = createPlan(tmpDir, packageJson, {
+			targets: ["bun-linux-x64-baseline", "bun-windows-arm64"],
 		});
-		expect(manifest.publishOrder).toEqual(["darwin-arm64", "root"]);
-		expect(readFileSync(join(tmpDir, ".stage", "root", "LICENSE"), "utf-8")).toBe("test license\n");
-		expect(readFileSync(join(tmpDir, ".stage", "darwin-arm64", "LICENSE"), "utf-8")).toBe(
-			"test license\n",
+		const outputs: string[] = [];
+
+		await runDistributeBuild(plan, {
+			io,
+			execute: async (...args) => {
+				outputs.push(args[1]);
+				await fakeExecutor(...args);
+			},
+		});
+
+		const manifest = readJson<{
+			root: { name: string; dir: string; bin: string };
+			packages: Array<{ target: string; name: string; bin: string }>;
+			publishOrder: string[];
+		}>(join(plan.stageDir, "manifest.json"));
+		expect(manifest.root).toEqual({
+			name: "@scope/test-package-cli",
+			dir: "root",
+			bin: "test-cli",
+		});
+		expect(manifest.packages).toEqual([
+			expect.objectContaining({
+				target: "linux-x64",
+				name: "@scope/test-package-cli-linux-x64",
+				bin: "bin/test-package-cli-bun-linux-x64-baseline",
+			}),
+			expect.objectContaining({
+				target: "windows-arm64",
+				name: "@scope/test-package-cli-windows-arm64",
+				bin: "bin/test-package-cli-bun-windows-arm64.exe",
+			}),
+		]);
+		expect(manifest.publishOrder).toEqual(["linux-x64", "windows-arm64", "root"]);
+
+		const rootPackage = readJson<{
+			files: string[];
+			bin: Record<string, string>;
+			optionalDependencies: Record<string, string>;
+		}>(join(plan.stageDir, "root", "package.json"));
+		expect(rootPackage.bin).toEqual({ "test-cli": "bin/test-cli.js" });
+		expect(rootPackage.optionalDependencies).toEqual({
+			"@scope/test-package-cli-linux-x64": "0.1.0",
+			"@scope/test-package-cli-windows-arm64": "0.1.0",
+		});
+		expect(readFileSync(join(plan.stageDir, "root", "bin", "test-cli.js"), "utf8")).toContain(
+			'"packagePathSegment": "test-package-cli-linux-x64"',
 		);
+		expect(readFileSync(join(plan.stageDir, "root", "LICENSE"), "utf8")).toBe("test license\n");
+		expect(outputs).toEqual([
+			join(plan.stageDir, "linux-x64", "bin", "test-package-cli-bun-linux-x64-baseline"),
+			join(plan.stageDir, "windows-arm64", "bin", "test-package-cli-bun-windows-arm64.exe"),
+		]);
 	});
 
-	it("copies common license filename variants", async () => {
+	it("uses string bin shorthand and copies common license variants", async () => {
 		rmSync(join(tmpDir, "LICENSE"));
 		writeFileSync(join(tmpDir, "LICENCE.md"), "variant license\n");
-		process.cwd = () => tmpDir;
-
-		await runDistributeBuild({
-			entry: "src/cli.ts",
-			minify: true,
-			target: ["bun-darwin-arm64"],
-			stageDir: ".stage",
+		const plan = createPlan(tmpDir, {
+			name: "@scope/my-cli",
+			version: "0.1.0",
+			bin: "dist/cli",
 		});
 
-		expect(readFileSync(join(tmpDir, ".stage", "root", "LICENCE.md"), "utf-8")).toBe(
-			"variant license\n",
+		await runDistributeBuild(plan, { io, execute: fakeExecutor });
+
+		const rootPackage = readJson<{ bin: Record<string, string> }>(
+			join(plan.stageDir, "root", "package.json"),
 		);
-		expect(readFileSync(join(tmpDir, ".stage", "darwin-arm64", "LICENCE.md"), "utf-8")).toBe(
+		expect(rootPackage.bin).toEqual({ "my-cli": "bin/my-cli.js" });
+		expect(readFileSync(join(plan.stageDir, "darwin-arm64", "LICENCE.md"), "utf8")).toBe(
 			"variant license\n",
 		);
 	});
-});
 
-describe("runDistributeBuild Extension artifact staging", () => {
-	const tmpDir = mkdtempSync(join(tmpdir(), "crust-distribute-artifacts-"));
-	const originalCwd = process.cwd;
-
-	afterAll(() => {
-		process.cwd = originalCwd;
-		rmSync(tmpDir, { recursive: true, force: true });
+	it("rejects multiple bin entries through staged package planning", async () => {
+		const plan = createPlan(tmpDir, {
+			name: "my-cli",
+			version: "0.1.0",
+			bin: { one: "dist/one", two: "dist/two" },
+		});
+		await expect(runDistributeBuild(plan, { io, execute: fakeExecutor })).rejects.toThrow(
+			/exactly one bin entry/,
+		);
 	});
 
-	it("stages artifact directories into the root and platform packages", async () => {
-		rmSync(tmpDir, { recursive: true, force: true });
-		mkdirSync(join(tmpDir, "src"), { recursive: true });
-		writeFileSync(
-			join(tmpDir, "src", "cli.ts"),
-			`import { Crust } from ${JSON.stringify(corePath)};
-const app = new Crust("x").action(() => {});
-await app.execute();
-`,
+	it("stages Extension artifact directories into root and platform packages", async () => {
+		const outDir = join(tmpDir, "dist");
+		mkdirSync(join(outDir, "man"), { recursive: true });
+		mkdirSync(join(outDir, "skills", "x"), { recursive: true });
+		writeFileSync(join(outDir, "man", "x.1"), ".Dd generated\n");
+		writeFileSync(join(outDir, "skills", "x", "SKILL.md"), "skill\n");
+		const plan = createPlan(
+			tmpDir,
+			{ name: "artifact-stage-cli", version: "0.1.0", bin: { cli: "dist/cli" } },
+			{ validate: true, outDir },
 		);
-		writeFileSync(
-			join(tmpDir, "package.json"),
-			JSON.stringify({
-				name: "artifact-stage-cli",
-				version: "0.1.0",
-				bin: { cli: "dist/cli" },
-			}),
-		);
-		process.cwd = () => tmpDir;
-		const artifactOutDir = join(tmpDir, "dist");
-		mkdirSync(join(artifactOutDir, "man"), { recursive: true });
-		mkdirSync(join(artifactOutDir, "skills", "x"), { recursive: true });
-		writeFileSync(join(artifactOutDir, "man", "x.1"), ".Dd generated\n");
-		writeFileSync(join(artifactOutDir, "skills", "x", "SKILL.md"), "skill\n");
 
-		await runDistributeBuild({
-			entry: "src/cli.ts",
-			minify: true,
-			target: ["bun-darwin-arm64"],
-			stageDir: ".stage",
-			artifactOutDir,
-		});
+		await runDistributeBuild(plan, { io, execute: fakeExecutor });
 
-		const rootPkg = JSON.parse(
-			readFileSync(join(tmpDir, ".stage", "root", "package.json"), "utf-8"),
-		) as { files: string[]; man: string[] };
-		expect(rootPkg.files).toEqual(["bin", "man", "skills"]);
-		expect(rootPkg.man).toEqual(["./man/x.1"]);
-		expect(readFileSync(join(tmpDir, ".stage", "root", "man", "x.1"), "utf-8")).toContain(".Dd");
-		expect(readFileSync(join(tmpDir, ".stage", "root", "skills", "x", "SKILL.md"), "utf-8")).toBe(
-			"skill\n",
+		const rootPackage = readJson<{ files: string[]; man: string[] }>(
+			join(plan.stageDir, "root", "package.json"),
 		);
+		expect(rootPackage.files).toEqual(["bin", "man", "skills"]);
+		expect(rootPackage.man).toEqual(["./man/x.1"]);
 		expect(
-			readFileSync(
-				join(tmpDir, ".stage", "darwin-arm64", "bin", "skills", "x", "SKILL.md"),
-				"utf-8",
-			),
+			readFileSync(join(plan.stageDir, "darwin-arm64", "bin", "skills", "x", "SKILL.md"), "utf8"),
 		).toBe("skill\n");
-		expect(readFileSync(join(artifactOutDir, "man", "x.1"), "utf-8")).toContain(".Dd");
 	});
 
-	it("rejects an artifact directory inside stage-dir", async () => {
-		process.cwd = () => tmpDir;
-		const artifactOutDir = join(tmpDir, ".stage", "artifacts");
-		mkdirSync(join(artifactOutDir, "man"), { recursive: true });
-
+	it("rejects artifacts inside stage-dir and the reserved bin directory", async () => {
+		const packageJson = { name: "artifact-stage-cli", version: "0.1.0" };
+		const stageDir = join(tmpDir, ".stage");
+		const nestedOutDir = join(stageDir, "artifacts");
+		mkdirSync(join(nestedOutDir, "man"), { recursive: true });
 		await expect(
-			runDistributeBuild({
-				entry: "src/cli.ts",
-				minify: true,
-				target: ["bun-darwin-arm64"],
-				stageDir: ".stage",
-				artifactOutDir,
-			}),
+			runDistributeBuild(
+				createPlan(tmpDir, packageJson, { stageDir, validate: true, outDir: nestedOutDir }),
+				{
+					io,
+					execute: fakeExecutor,
+				},
+			),
 		).rejects.toThrow("--stage-dir cannot contain the artifact output directory");
-	});
 
-	it("rejects a reserved bin artifact directory", async () => {
-		process.cwd = () => tmpDir;
-		const artifactOutDir = join(tmpDir, "dist-bin");
-		mkdirSync(join(artifactOutDir, "bin"), { recursive: true });
-
+		const outDir = join(tmpDir, "dist-bin");
+		mkdirSync(join(outDir, "bin"), { recursive: true });
 		await expect(
-			runDistributeBuild({
-				entry: "src/cli.ts",
-				minify: true,
-				target: ["bun-darwin-arm64"],
-				stageDir: ".stage",
-				artifactOutDir,
+			runDistributeBuild(createPlan(tmpDir, packageJson, { validate: true, outDir }), {
+				io,
+				execute: fakeExecutor,
 			}),
 		).rejects.toThrow('Artifact directory "bin"');
 	});

--- a/packages/crust/src/utils/distribute.test.ts
+++ b/packages/crust/src/utils/distribute.test.ts
@@ -116,9 +116,17 @@ describe("runDistributeBuild", () => {
 			"@scope/test-package-cli-linux-x64": "0.1.0",
 			"@scope/test-package-cli-windows-arm64": "0.1.0",
 		});
-		expect(readFileSync(join(plan.stageDir, "root", "bin", "test-cli.js"), "utf8")).toContain(
-			'"packagePathSegment": "test-package-cli-linux-x64"',
-		);
+		const resolver = readFileSync(join(plan.stageDir, "root", "bin", "test-cli.js"), "utf8");
+		expect(resolver).toContain('"packagePathSegment": "test-package-cli-linux-x64"');
+		expect(resolver).toContain("const candidateOne = resolve(");
+		expect(resolver).toContain("const candidateTwo = resolve(");
+		expect(resolver).toContain("Unsupported platform:");
+		expect(resolver).toContain("Supported platforms: linux-x64, windows-arm64");
+		expect(resolver).toContain("Missing platform package");
+		expect(resolver).toContain("optional dependencies are enabled");
+		expect(resolver).toContain('child.on("error"');
+		expect(resolver).toContain("process.kill(process.pid, signal)");
+		expect(resolver).toContain("process.exit(code ?? 0)");
 		expect(readFileSync(join(plan.stageDir, "root", "LICENSE"), "utf8")).toBe("test license\n");
 		expect(outputs).toEqual([
 			join(plan.stageDir, "linux-x64", "bin", "test-package-cli-bun-linux-x64-baseline"),

--- a/packages/crust/src/utils/distribute.ts
+++ b/packages/crust/src/utils/distribute.ts
@@ -9,18 +9,17 @@ import {
 } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
+import type { InvocationIO } from "@crustjs/core";
 import { bold, cyan, dim, green } from "@crustjs/style";
 import { isJsonObject, type JsonValue } from "@crustjs/utils/json";
 import { isWithin } from "@crustjs/utils/path";
 
 import {
+	binaryFilename,
+	BUN_TARGETS,
 	type BunTarget,
 	execBuild,
-	getBinaryFilename,
 	resolveBaseName,
-	resolveTargets,
-	readUserPackageJson,
-	TARGET_INFO,
 	type TargetInfo,
 } from "./build-helpers.ts";
 
@@ -40,7 +39,7 @@ const METADATA_KEYS = [
 
 type NpmOs = TargetInfo["os"];
 type NpmCpu = TargetInfo["cpu"];
-type PlatformKey = (typeof TARGET_INFO)[BunTarget]["platformKey"];
+type PlatformKey = (typeof BUN_TARGETS.info)[BunTarget]["platformKey"];
 type PublishPackageMetadata = {
 	name: string;
 	version: string;
@@ -133,7 +132,7 @@ function readPackageJson(cwd: string, packageJson: JsonValue | undefined): UserP
 	return packageJson as UserPackageJson;
 }
 
-export function derivePlatformPackageName(rootPackageName: string, targetAlias: string): string {
+function derivePlatformPackageName(rootPackageName: string, targetAlias: string): string {
 	const [scope, name] = rootPackageName.startsWith("@")
 		? rootPackageName.split("/")
 		: [undefined, rootPackageName];
@@ -141,7 +140,7 @@ export function derivePlatformPackageName(rootPackageName: string, targetAlias: 
 	return scope ? `${scope}/${suffixedName}` : suffixedName;
 }
 
-export function getPackagePathSegment(packageName: string): string {
+function getPackagePathSegment(packageName: string): string {
 	return packageName.startsWith("@") ? (packageName.split("/")[1] ?? packageName) : packageName;
 }
 
@@ -149,7 +148,7 @@ function isBinPath(bin: UserPackageJson["bin"]): bin is string {
 	return typeof bin === "string";
 }
 
-export function inferCommandName(
+function inferCommandName(
 	rootPackageName: string,
 	bin: UserPackageJson["bin"],
 	baseName: string,
@@ -175,7 +174,7 @@ export function inferCommandName(
 	return entry;
 }
 
-export function buildDistributionRootPackageJson(
+function buildDistributionRootPackageJson(
 	metadata: DistributionMetadata,
 	targets: readonly DistributionTarget[],
 	options?: { artifactDirs?: readonly string[]; manPages?: readonly string[] },
@@ -200,7 +199,7 @@ export function buildDistributionRootPackageJson(
 	return rootPackageJson;
 }
 
-export function buildDistributionPlatformPackageJson(
+function buildDistributionPlatformPackageJson(
 	metadata: DistributionMetadata,
 	target: DistributionTarget,
 ): PlatformPublishPackageJson {
@@ -276,11 +275,11 @@ function resolveDistributionTarget(
 	rootPackageName: string,
 	target: BunTarget,
 ): DistributionTarget {
-	const info = TARGET_INFO[target];
+	const info = BUN_TARGETS.info[target];
 	const packageName = derivePlatformPackageName(rootPackageName, info.alias);
 	validatePackageNameLength(packageName);
 
-	const binaryFilename = getBinaryFilename(baseName, target);
+	const filename = binaryFilename(BUN_TARGETS, baseName, target);
 	const packageDir = resolve(stageDir, info.alias);
 
 	return {
@@ -290,14 +289,14 @@ function resolveDistributionTarget(
 		packageName,
 		packagePathSegment: getPackagePathSegment(packageName),
 		packageDir,
-		binaryRelativePath: join("bin", binaryFilename),
-		binaryFilename,
+		binaryRelativePath: join("bin", filename),
+		binaryFilename: filename,
 		os: info.os,
 		cpu: info.cpu,
 	};
 }
 
-export function generateDistributionJsResolver(
+function generateDistributionJsResolver(
 	commandName: string,
 	targets: readonly DistributionTarget[],
 ): string {
@@ -490,51 +489,57 @@ function stageDistributionPackages(
 	writeDistributionManifest(stageDir, metadata, targets);
 }
 
-export async function runDistributeBuild(options: {
-	cwd?: string;
-	entry: string;
+type DistributeBuildPlan = {
+	cwd: string;
+	entryPath: string;
 	name?: string;
 	minify: boolean;
-	target?: string[];
+	targets: BunTarget[];
 	stageDir: string;
-	envFiles?: readonly string[];
-	/** Directory whose Extension-emitted artifact subdirectories are staged in the root package. */
-	artifactOutDir?: string;
-	/** Pre-read by build planning so package metadata is parsed once per build. */
-	userPackageJson?: JsonValue;
-}): Promise<void> {
-	const cwd = options.cwd ?? process.cwd();
-	const entryPath = resolve(cwd, options.entry);
+	envFiles: readonly string[];
+	validate: boolean;
+	outDir: string;
+	userPackageJson: JsonValue | undefined;
+};
 
-	if (!existsSync(entryPath)) {
-		throw new Error(
-			`Entry file not found: ${entryPath}\n  Specify a valid entry file with --entry <path>`,
-		);
-	}
+type DistributeExecutor = (
+	entryPath: string,
+	outfilePath: string,
+	minify: boolean,
+	target: BunTarget,
+	envFiles: readonly string[],
+	cwd: string,
+) => Promise<void>;
 
-	const stageDir = resolve(cwd, options.stageDir);
-	const targets = resolveTargets(options.target);
-	const userPackageJson = Object.hasOwn(options, "userPackageJson")
-		? options.userPackageJson
-		: readUserPackageJson(cwd);
-	const metadata = resolveDistributionMetadata(cwd, entryPath, options.name, userPackageJson);
-
-	const distributionTargets = targets.map((target) =>
-		resolveDistributionTarget(stageDir, metadata.baseName, metadata.rootPackageName, target),
+export async function runDistributeBuild(
+	plan: DistributeBuildPlan,
+	options: { io: InvocationIO; execute?: DistributeExecutor },
+): Promise<void> {
+	const metadata = resolveDistributionMetadata(
+		plan.cwd,
+		plan.entryPath,
+		plan.name,
+		plan.userPackageJson,
+	);
+	const distributionTargets = plan.targets.map((target) =>
+		resolveDistributionTarget(plan.stageDir, metadata.baseName, metadata.rootPackageName, target),
 	);
 
-	console.log(`Staging ${bold(`${targets.length}`)} distribution target(s) in ${dim(stageDir)}...`);
+	options.io.stdout(
+		`Staging ${bold(`${plan.targets.length}`)} distribution target(s) in ${dim(plan.stageDir)}...`,
+	);
 
-	const artifacts = collectArtifacts(options.artifactOutDir, stageDir);
-	stageDistributionPackages(cwd, stageDir, metadata, distributionTargets, {
+	const artifactOutDir = plan.validate ? plan.outDir : undefined;
+	const artifacts = collectArtifacts(artifactOutDir, plan.stageDir);
+	stageDistributionPackages(plan.cwd, plan.stageDir, metadata, distributionTargets, {
 		artifactDirs: artifacts.names,
 		manPages: artifacts.manPages,
 	});
 
-	if (options.artifactOutDir) {
-		const rootDir = join(stageDir, "root");
+	if (artifactOutDir) {
+		const rootDir = join(plan.stageDir, "root");
 		for (const name of artifacts.names) {
-			const artifactDir = join(options.artifactOutDir, name);
+			const artifactDir = join(artifactOutDir, name);
 			cpSync(artifactDir, join(rootDir, name), { recursive: true });
 			// Runtime source resolution (e.g. packaged skills) falls back to
 			// dirname(process.execPath), which is a platform package's bin dir — the
@@ -546,21 +551,29 @@ export async function runDistributeBuild(options: {
 		}
 	}
 
+	const execute = options.execute ?? execBuild;
 	for (const targetPackage of distributionTargets) {
 		const outfilePath = join(targetPackage.packageDir, targetPackage.binaryRelativePath);
-		console.log(`  ${cyan("→")} ${bold(targetPackage.targetAlias)}: ${dim(outfilePath)}`);
-		await execBuild(entryPath, outfilePath, options.minify, targetPackage.target, options.envFiles);
+		options.io.stdout(`  ${cyan("→")} ${bold(targetPackage.targetAlias)}: ${dim(outfilePath)}`);
+		await execute(
+			plan.entryPath,
+			outfilePath,
+			plan.minify,
+			targetPackage.target,
+			plan.envFiles,
+			plan.cwd,
+		);
 	}
 
-	const manifestPath = join(stageDir, "manifest.json");
-	console.log(
-		`\n${green("✓")} Staged ${bold(`${targets.length + 1}`)} npm package(s) successfully:`,
+	const manifestPath = join(plan.stageDir, "manifest.json");
+	options.io.stdout(
+		`\n${green("✓")} Staged ${bold(`${plan.targets.length + 1}`)} npm package(s) successfully:`,
 	);
-	console.log(`  ${join(stageDir, "root")}`);
+	options.io.stdout(`  ${join(plan.stageDir, "root")}`);
 	for (const targetPackage of distributionTargets) {
-		console.log(`  ${targetPackage.packageDir}`);
+		options.io.stdout(`  ${targetPackage.packageDir}`);
 	}
-	console.log(`\n${dim("Manifest:")} ${manifestPath}`);
+	options.io.stdout(`\n${dim("Manifest:")} ${manifestPath}`);
 }
 
 type CollectedArtifacts = { names: string[]; manPages: string[] };

--- a/packages/crust/tests/build.integration.test.ts
+++ b/packages/crust/tests/build.integration.test.ts
@@ -16,9 +16,9 @@ import { Crust } from "@crustjs/core";
 import { captureExecute } from "@crustjs/testing";
 import { runProcess } from "@crustjs/utils/process";
 
-import { buildCommand } from "../../src/commands/build.ts";
-import { BUN_TARGETS, DENO_TARGETS } from "../../src/utils/build-helpers.ts";
-import { hostTarget } from "../../tests/helpers.ts";
+import { buildCommand } from "../src/commands/build.ts";
+import { BUN_TARGETS, DENO_TARGETS } from "../src/utils/build-helpers.ts";
+import { hostTarget } from "./helpers.ts";
 
 function getHostBunTarget() {
 	return hostTarget();
@@ -38,7 +38,7 @@ function getHostDenoTarget(): string | null {
 
 describe("crust build integration — single target", () => {
 	const tmpDir = mkdtempSync(join(tmpdir(), "crust-build-integration-"));
-	const crustCliPath = resolve(import.meta.dir, "..", "cli.ts");
+	const crustCliPath = resolve(import.meta.dir, "..", "src", "cli.ts");
 	const corePath = fileURLToPath(import.meta.resolve("@crustjs/core"));
 	const originalCwd = process.cwd;
 

--- a/packages/crust/tests/helpers.ts
+++ b/packages/crust/tests/helpers.ts
@@ -1,8 +1,5 @@
-import { SUPPORTED_TARGETS, TARGET_INFO, type BunTarget } from "../src/utils/build-helpers.ts";
+import { BUN_TARGETS, hostTarget as resolveHostTarget } from "../src/utils/build-helpers.ts";
 
-export function hostTarget(): BunTarget | null {
-	const platformKey = `${process.platform}-${process.arch}`;
-	return (
-		SUPPORTED_TARGETS.find((target) => TARGET_INFO[target].platformKey === platformKey) ?? null
-	);
+export function hostTarget() {
+	return resolveHostTarget(BUN_TARGETS);
 }

--- a/packages/crust/tests/package-manager.smoke.test.ts
+++ b/packages/crust/tests/package-manager.smoke.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { Crust } from "@crustjs/core";
+import { captureExecute } from "@crustjs/testing";
 import { runProcess } from "@crustjs/utils/process";
 
 import { buildCommand } from "../src/commands/build.ts";
@@ -50,9 +51,16 @@ console.log(args.join(" ") || "resolver-ok");
 	const originalCwd = process.cwd;
 	process.cwd = () => sampleDir;
 	try {
-		await app.execute({
-			argv: ["build", "--package", "--target", target, "--stage-dir", "dist/npm", "--no-validate"],
-		});
+		const result = await captureExecute(app, [
+			"build",
+			"--package",
+			"--target",
+			target,
+			"--stage-dir",
+			"dist/npm",
+			"--no-validate",
+		]);
+		if (result.exitCode !== 0) throw new Error(result.stderr);
 	} finally {
 		process.cwd = originalCwd;
 	}

--- a/packages/crust/tests/package.integration.test.ts
+++ b/packages/crust/tests/package.integration.test.ts
@@ -12,10 +12,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Crust } from "@crustjs/core";
+import { captureExecute } from "@crustjs/testing";
 import { runProcess } from "@crustjs/utils/process";
 
 import { buildCommand } from "../src/commands/build.ts";
-import { TARGET_INFO } from "../src/utils/build-helpers.ts";
+import { BUN_TARGETS } from "../src/utils/build-helpers.ts";
 import { hostTarget } from "./helpers.ts";
 
 const tmpDir = mkdtempSync(join(tmpdir(), "crust-package-integration-"));
@@ -28,7 +29,7 @@ function readJson<T>(path: string): T {
 async function runBuild(argv: string[]) {
 	const app = new Crust("test").add(buildCommand);
 	process.cwd = () => tmpDir;
-	await app.execute({ argv: ["build", ...argv] });
+	return await captureExecute(app, ["build", ...argv]);
 }
 
 beforeAll(() => {
@@ -111,7 +112,7 @@ describe("crust build --package integration", () => {
 			const hostBunTarget = hostTarget();
 			const nodePath = Bun.which("node");
 			if (!hostBunTarget || !nodePath) return;
-			const hostAlias = TARGET_INFO[hostBunTarget].alias;
+			const hostAlias = BUN_TARGETS.info[hostBunTarget].alias;
 
 			await runBuild([
 				"--package",

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -243,39 +243,43 @@ describe("captureExecute", () => {
 		expect(result.stderr).toBe("custom: boom");
 	});
 
-	it("captures exit codes across overlapping captures", async () => {
-		const originalExitCode = process.exitCode;
-		try {
-			process.exitCode = 7;
+	it("restores the caller's exit code after overlapping failure and success captures", async () => {
+		process.exitCode = 7;
 
-			let releaseA!: () => void;
-			const gateA = new Promise<void>((resolve) => {
-				releaseA = resolve;
-			});
-			let releaseB!: () => void;
-			const gateB = new Promise<void>((resolve) => {
-				releaseB = resolve;
-			});
+		let releaseErrorRenderer!: () => void;
+		const errorRendererGate = new Promise<void>((resolve) => {
+			releaseErrorRenderer = resolve;
+		});
+		let releaseSuccess!: () => void;
+		const successGate = new Promise<void>((resolve) => {
+			releaseSuccess = resolve;
+		});
 
-			const appA = new Crust("test-cli").action(async () => {
-				await gateA;
-			});
-			const appB = new Crust("test-cli").action(async () => {
-				await gateB;
-			});
+		const delayedRenderer = defineExtension(defineExtensionId("delayed-renderer"), {
+			hooks: {
+				async onError() {
+					await errorRendererGate;
+					return true;
+				},
+			},
+		});
+		const failingApp = new Crust("test-cli").extend(delayedRenderer).action(() => {
+			throw new Error("boom");
+		});
+		const successfulApp = new Crust("test-cli").action(async () => {
+			await successGate;
+		});
 
-			const pendingA = captureExecute(appA, []);
-			await Bun.sleep(0);
-			const pendingB = captureExecute(appB, []);
-			await Bun.sleep(0);
+		const pendingFailure = captureExecute(failingApp, []);
+		await Bun.sleep(0);
+		expect(process.exitCode).toBe(1);
+		const pendingSuccess = captureExecute(successfulApp, []);
+		await Bun.sleep(0);
 
-			releaseA();
-			expect((await pendingA).exitCode).toBe(0);
-			releaseB();
-			expect((await pendingB).exitCode).toBe(0);
-			expect(process.exitCode).toBe(7);
-		} finally {
-			process.exitCode = originalExitCode;
-		}
+		releaseErrorRenderer();
+		expect((await pendingFailure).exitCode).toBe(1);
+		releaseSuccess();
+		expect((await pendingSuccess).exitCode).toBe(0);
+		expect(process.exitCode).toBe(7);
 	});
 });

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -203,7 +203,8 @@ describe("captureExecute", () => {
 		expect(result.exitCode).toBe(0);
 	});
 
-	it("captures exit code 1 and the rendered failure", async () => {
+	it("captures exit code 1 without leaking it to the process", async () => {
+		process.exitCode = 7;
 		const app = new Crust("test-cli").action(() => {
 			throw new Error("boom");
 		});
@@ -211,6 +212,7 @@ describe("captureExecute", () => {
 		const result = await captureExecute(app, []);
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain("boom");
+		expect(process.exitCode).toBe(7);
 	});
 
 	it("captures exit code 130 for AbortError cancellation", async () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -103,22 +103,28 @@ export async function captureExecute(
 ): Promise<CapturedExecute> {
 	const stdoutLines: string[] = [];
 	const stderrLines: string[] = [];
-	const exitCode = await app.execute({
-		argv: [...argv],
-		io: {
-			stdout: (text) => {
-				stdoutLines.push(text);
+	const originalExitCode = process.exitCode;
+	try {
+		const exitCode = await app.execute({
+			argv: [...argv],
+			io: {
+				stdout: (text) => {
+					stdoutLines.push(text);
+				},
+				stderr: (text) => {
+					stderrLines.push(text);
+				},
 			},
-			stderr: (text) => {
-				stderrLines.push(text);
-			},
-		},
-	});
-	return {
-		stdout: stdoutLines.join("\n"),
-		stderr: stderrLines.join("\n"),
-		exitCode,
-	};
+		});
+		return {
+			stdout: stdoutLines.join("\n"),
+			stderr: stderrLines.join("\n"),
+			exitCode,
+		};
+	} finally {
+		// Bun cannot clear a numeric exitCode back to undefined, so zero is the equivalent success state.
+		process.exitCode = originalExitCode ?? 0;
+	}
 }
 
 export interface InteractiveRun {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -92,6 +92,10 @@ export interface CapturedExecute {
 	readonly exitCode: number;
 }
 
+// Overlapping captures share process-global exit state, so only the outermost can restore it safely.
+let activeExecuteCaptures = 0;
+let exitCodeBeforeExecuteCaptures: typeof process.exitCode;
+
 /**
  * Drive the terminal `execute()` path in-process: exit-code protocol,
  * Extension `onError` rendering, and cancellation (130) are all observable
@@ -103,7 +107,8 @@ export async function captureExecute(
 ): Promise<CapturedExecute> {
 	const stdoutLines: string[] = [];
 	const stderrLines: string[] = [];
-	const originalExitCode = process.exitCode;
+	if (activeExecuteCaptures === 0) exitCodeBeforeExecuteCaptures = process.exitCode;
+	activeExecuteCaptures++;
 	try {
 		const exitCode = await app.execute({
 			argv: [...argv],
@@ -122,8 +127,11 @@ export async function captureExecute(
 			exitCode,
 		};
 	} finally {
-		// Bun cannot clear a numeric exitCode back to undefined, so zero is the equivalent success state.
-		process.exitCode = originalExitCode ?? 0;
+		activeExecuteCaptures--;
+		if (activeExecuteCaptures === 0) {
+			// Bun cannot clear a numeric exitCode back to undefined, so zero is the equivalent success state.
+			process.exitCode = exitCodeBeforeExecuteCaptures ?? 0;
+		}
 	}
 }
 

--- a/scripts/smoke-runtimes/smoke.mjs
+++ b/scripts/smoke-runtimes/smoke.mjs
@@ -29,7 +29,7 @@ const roots = {
 	skills: loadPackagedSkills,
 	store: createStore,
 	style: createStyle,
-	testing: testing.captureRun,
+	testing: testing.captureExecute,
 };
 for (const [name, value] of Object.entries(roots)) {
 	assert(value !== undefined, `Missing root export from @crustjs/${name}`);
@@ -79,18 +79,10 @@ try {
 	await rm(storeRoot, { recursive: true, force: true });
 }
 
-const stdout = [];
-const originalLog = console.log;
-console.log = (...values) => stdout.push(values.join(" "));
-try {
-	await new Crust("runtime-smoke")
-		.extend(help())
-		.action(() => {})
-		.execute({ argv: ["--help"] });
-} finally {
-	console.log = originalLog;
-}
-const output = stdout.join("\n");
+const { stdout: output } = await testing.captureExecute(
+	new Crust("runtime-smoke").extend(help()).action(() => {}),
+	["--help"],
+);
 assert(
 	output.includes("runtime-smoke") && output.includes("Usage:"),
 	`Sample CLI help output was incomplete:\n${output}`,
@@ -119,7 +111,7 @@ if (!isTTY()) {
 		assert(error instanceof NonInteractiveError, "expected NonInteractiveError");
 	}
 } else {
-	originalLog("runtime-smoke: skipping non-TTY assertion in an interactive terminal");
+	console.log("runtime-smoke: skipping non-TTY assertion in an interactive terminal");
 }
 
 assert(
@@ -127,4 +119,4 @@ assert(
 	"expected checkout to be a Git worktree",
 );
 
-originalLog(`runtime-smoke-ok (${Object.keys(roots).length} package roots)`);
+console.log(`runtime-smoke-ok (${Object.keys(roots).length} package roots)`);


### PR DESCRIPTION
Routes all Crust build and publish output through invocation IO while making distribution staging consume the already-validated build plan and consolidating Bun/Deno target behavior behind one table-driven implementation. Output text remains unchanged, while tests now use the shared terminal capture seam and distribution unit tests stage fake binary outputs instead of invoking real compilers.

### Changes

- **@crustjs/crust**
  - Thread `InvocationIO` and one action-level `cwd` through build, publish, distribution, and snapshot preparation.
  - Pass the validated build plan directly into distribution staging with an injectable executor.
  - Consolidate Bun and Deno target resolution, filenames, resolvers, and host lookup into generic target-table helpers.
  - Replace console/exit-code test patches with `captureExecute`; stage fake binaries in distribution unit tests.
- **@crustjs/testing**
  - Restore the caller's process exit status after `captureExecute`, with regression coverage.
- **runtime smoke**
  - Capture sample CLI help through `testing.captureExecute`.

### Notes

- Kept the explicit `BuildFlags` type because core does not publicly export `InferFlags`.
- Skipped a pure file split because the seam changes did not require one.
- Build/publish terminal text is byte-identical; warnings now correctly use invocation stderr.
- Added a patch changeset for `@crustjs/crust` and `@crustjs/testing`.
- The testing-package fix was approved after required error captures exposed leaked `process.exitCode` state.

### Stack
This PR is part of the codebase-audit refactor stack (bottom → top). Merge in order; each PR targets the one below it.
1. refactor/audit-01-tooling ([#329](https://github.com/chenxin-yan/crust/pull/329))
2. refactor/audit-02-tests ([#330](https://github.com/chenxin-yan/crust/pull/330))
3. refactor/audit-03-core-shrink ([#331](https://github.com/chenxin-yan/crust/pull/331))
4. refactor/audit-04-ext-shrink ([#332](https://github.com/chenxin-yan/crust/pull/332))
5. refactor/audit-05-ui-shrink ([#333](https://github.com/chenxin-yan/crust/pull/333))
6. refactor/audit-06-core-seams ([#334](https://github.com/chenxin-yan/crust/pull/334))
7. refactor/audit-07-docmodel-version ([#335](https://github.com/chenxin-yan/crust/pull/335))
8. refactor/audit-08-cli-seams ([#336](https://github.com/chenxin-yan/crust/pull/336)) **(this PR)**
9. refactor/audit-09-public-api ([#337](https://github.com/chenxin-yan/crust/pull/337))
10. refactor/audit-10-ui-seams ([#338](https://github.com/chenxin-yan/crust/pull/338))
11. refactor/audit-11-store-docs ([#339](https://github.com/chenxin-yan/crust/pull/339))
