### PR TITLE
refactor(style,prompts)!: public-API quick wins and missing type exports

### DIFF
--- a/.changeset/complete-prompt-kit.md
+++ b/.changeset/complete-prompt-kit.md
@@ -1,0 +1,8 @@
+---
+"@crustjs/prompts": minor
+---
+
+Complete the custom-prompt rendering kit and simplify its testing API.
+
+- Export the text, match, line, choice-list, and glyph rendering helpers used by built-in prompts.
+- Remove `pressKey()` from `@crustjs/prompts/testing` (breaking). Use the rendered prompt's `keys()` method for named and control keys, or `type()` for literal text.

--- a/.changeset/export-public-types.md
+++ b/.changeset/export-public-types.md
@@ -1,0 +1,12 @@
+---
+"@crustjs/core": patch
+"@crustjs/extensions": patch
+"@crustjs/man": patch
+"@crustjs/progress": patch
+"@crustjs/skills": patch
+"@crustjs/store": patch
+"@crustjs/style": patch
+"@crustjs/testing": patch
+---
+
+Expose and document the public types needed to name existing API signatures. `Crust._types` is now a supported type-level seam for accessing an application's inferred command types.

--- a/.changeset/simplify-style-surface.md
+++ b/.changeset/simplify-style-surface.md
@@ -1,0 +1,8 @@
+---
+"@crustjs/style": minor
+---
+
+Simplify dynamic colors and tables ahead of 1.0 (breaking).
+
+- `fg` and `bg` no longer accept a color-depth override argument. Use `createStyle({ overrides })` for deterministic output.
+- `TableOptions` no longer includes `minColumnWidth`, `cellPadding`, `separatorChar`, or `borderChar`; tables use their standard width, padding, separator, and border formatting.

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -155,6 +155,8 @@ type Path = CommandPath<Tree>; // e.g. readonly [] | readonly ["greet"]
 type GreetInput = RunInput<CommandShapeAt<(typeof app)["_types"]["shape"], readonly ["greet"]>>;
 ```
 
+`Crust._types` is a supported type-level seam for accessing an application's inferred flags, arguments, Contexts, command tree, and command shape; it has no runtime value.
+
 ## Parser boundary types
 
 `ParseResult<A, F>` is the syntax-parsed result before required-value and Standard Schema validation. Its generic `args` and `flags` preserve definition-specific raw value types; `ParsedArgValue` and `ParsedFlagValue` are the runtime-erased fallbacks for widened definitions. Its `excessArgs` holds positionals before `--` that no declared argument consumed (validation rejects them); its `rawArgs` holds tokens after `--`. `ValidatedInput<A, F>` is the validated boundary passed onward to Command Actions, with `InferArgs<A>` and `InferFlags<F>` applied.
@@ -331,4 +333,4 @@ Infers the syntax-parsed values from an Extension's named-definition array and e
 
 ## Error types
 
-See [Errors](/docs/api/errors) for `CrustError`, `CrustErrorCode`, `CrustErrorDetails`, `CrustErrorDetailsMap`, and the four detail interfaces.
+See [Errors](/docs/api/errors) for `CrustError`, `CrustErrorCode`, `CrustErrorDetails`, `CrustErrorDetailsMap`, `CrustErrorJson` (the serializable shape returned by `.toJSON()`), and the four detail interfaces.

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -69,6 +69,7 @@ Downstream commands and other Context setups call `await ctx.api`. See [Contexts
 | `CommandSection`                              | A titled documentation block with an optional consumer audience                    |
 | `CommandSectionInput`                         | Plain-text section (`title`, `body`) with an optional consumer audience            |
 | `SectionAudience`                             | Mutually exclusive `only`/`except` consumer lists on a section                     |
+| `SectionConsumer`                             | Extension identity or value exposing one at `.id`                                  |
 | `ExtensionId`                                 | Branded identity minted by `defineExtensionId()`                                   |
 | `ContextBag` / `FactoryValueOf`               | Lazy Context property bag and factory-value helper types                           |
 | [`RootCommandMeta`](/docs/api/crust)          | Root description, version, usage, and sections accepted by the `Crust` constructor |
@@ -154,6 +155,7 @@ Omitting `io` creates no new ambient scope, preserving native TTY detection and 
 | `CrustErrorCode`              | Four codes: `DEFINITION`, `PARSE`, `VALIDATION`, and `COMMAND_NOT_FOUND` |
 | `CrustErrorDetails<C>`        | Details selected by an error code                                        |
 | `CrustErrorDetailsMap`        | Mapping from each code to its details type                               |
+| `CrustErrorJson<C>`           | Serializable shape returned by `CrustError<C>.toJSON()`                  |
 | `DefinitionErrorDetails`      | Definition subject, name, and reason                                     |
 | `ParseErrorDetails`           | Flag, argument, value, and reason                                        |
 | `ValidationErrorDetails`      | Aggregated `{ message, path }` issues                                    |

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -34,7 +34,7 @@ The `postRun` hook checks for an update only after a Command Action completes su
 
 By default, notifier state is persisted at `stateDir(packageName)` using `@crustjs/store`; package names are URL-encoded for the state directory (`@scope/cli` → `%40scope%2Fcli`) so distinct packages never share state, and cached state from a different `registryUrl` is discarded. A fresh cached result is reused for 24 hours and duplicate notices for the same version are suppressed across sequential process invocations (best-effort: concurrent invocations may race and double-notice). A corrupt state file is treated as empty and repaired on the next successful check. Set `cache: false` to opt out, pass `cache: { intervalMs }` to tune the built-in cache interval, or provide a custom adapter to control persistence.
 
-By default, the notice reports only the available version. Configure `updateCommand` with a fixed string, a `{ scope: "global" | "local" }` object that generates a command for the detected package manager, or a callback receiving `{ packageName, packageManager }`. Set `updateDocsUrl` to link to update instructions. Automatic package-manager detection uses `npm_config_user_agent` when available, falling back to `npm_execpath` and the runtime executable name before defaulting to npm.
+By default, the notice reports only the available version. Configure `updateCommand` with a fixed string, a `{ scope: "global" | "local" }` object that generates a command for the detected package manager, or an exported `UpdateCommandResolver` callback receiving `{ packageName, packageManager }`. Set `updateDocsUrl` to link to update instructions. Automatic package-manager detection uses `npm_config_user_agent` when available, falling back to `npm_execpath` and the runtime executable name before defaulting to npm.
 
 ## Update command
 
@@ -101,7 +101,7 @@ The adapter reads and writes the exported `UpdateNotifierState` shape:
   name="UpdateNotifierState"
 />
 
-The package exports `UpdateNotifierCacheAdapter`, `UpdateNotifierCacheConfig`, `UpdateNotifierPackageManager`, and `UpdateNotifierState` alongside `UpdateNotifierOptions`.
+The package exports `UpdateCommandResolver`, `UpdateNotifierCacheAdapter`, `UpdateNotifierCacheConfig`, `UpdateNotifierPackageManager`, and `UpdateNotifierState` alongside `UpdateNotifierOptions`.
 
 ```ts
 import {

--- a/apps/docs/content/docs/modules/man.mdx
+++ b/apps/docs/content/docs/modules/man.mdx
@@ -24,7 +24,9 @@ import { man } from "@crustjs/man";
 const app = new Crust("my-cli").extend(man());
 ```
 
-`man()` writes `<outdir>/man/<name>.1`. Pass `man({ section: 5 })` to select another section and filename, and `man({ name: "my-tool" })` when the installed command name differs from the application name (for example, `crust build --name` or a diverging npm `bin` key). Extension presence is the source of intent; there is no `--man` build flag. `crust build --no-validate` skips all build hooks, including this one. Package builds stage the generated directory and populate npm `files` and `man` metadata.
+`man()` writes `<outdir>/man/<name>.1`. Pass `man({ section: 5 })` to select another section and filename, and `man({ name: "my-tool" })` when the installed command name differs from the application name (for example, `crust build --name` or a diverging npm `bin` key). Its options use the exported `ManOptions` type. The `man.id` static exposes the `crust:man` Extension identity for section filtering and integrations. Extension presence is the source of intent; there is no `--man` build flag. `crust build --no-validate` skips all build hooks, including this one. Package builds stage the generated directory and populate npm `files` and `man` metadata.
+
+<auto-type-table path="../../../../../packages/man/src/extension.ts" name="ManOptions" />
 
 ## `writeManPage(options)`
 

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -67,7 +67,9 @@ if (failed) {
 }
 ```
 
-`stop()` is idempotent; the default outcome is `"success"`. Calling it before `start()` still renders the final line. `SpinnerOutcome` is the union `"success" | "error"`.
+`stop()` is idempotent; the default outcome is `"success"`. Calling it before `start()` still renders the final line. The exported handle type is `SpinnerHandle`; `SpinnerOutcome` is the union `"success" | "error"`.
+
+<auto-type-table path="../../../../../packages/progress/src/spinner.ts" name="SpinnerHandle" />
 
 <auto-type-table
   path="../../../../../packages/progress/src/spinner.ts"

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -92,7 +92,19 @@ test("accepts a name", async () => {
 });
 ```
 
-Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey`, `pressKey`, and the types `Key`, `NamedKey`, `PromptTestIO`, and `RenderedPrompt`; `keys()` autocompletes named key names while still accepting `ctrl+<letter>` and single characters.
+Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, like the built-in prompt functions. For lower-level setup, `createPromptIO({ isTTY: false })` provides fake non-interactive streams for testing `default` fallbacks. The subpath also exports `encodeKey` and the types `Key`, `NamedKey`, `PromptTestIO`, and `RenderedPrompt`; `keys()` autocompletes named key names while still accepting `ctrl+<letter>` and single characters.
+
+## Building custom prompts
+
+The package root exports the renderer pieces used by the built-in prompts:
+
+- `renderTextWithCursor` renders editable text or its placeholder with a themed cursor.
+- `highlightMatches` applies the theme's match style to fuzzy-match indices.
+- `formatPromptLine` and `formatSubmitted` assemble active and submitted prompt lines.
+- `renderChoiceList` renders a scrolled choice viewport with overflow indicators.
+- `PREFIX_SYMBOL`, `PREFIX_SUBMITTED`, `CURSOR_INDICATOR`, `SCROLL_INDICATOR`, `CHECKBOX_CHECKED`, and `CHECKBOX_UNCHECKED` are the shared prompt glyphs.
+
+Use these with `runPrompt`, `submit`, `handleTextEdit`, and `fuzzyFilter` to build prompts that follow the built-in rendering conventions.
 
 ## Prompts
 

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -98,7 +98,7 @@ Custom prompt functions passed to `renderPrompt` must accept `(options, io?)`, l
 
 The package root exports the renderer pieces used by the built-in prompts:
 
-- `renderTextWithCursor` renders editable text or its placeholder with a themed cursor.
+- `renderTextWithCursor` renders editable text with a themed cursor, or a styled placeholder when empty.
 - `highlightMatches` applies the theme's match style to fuzzy-match indices.
 - `formatPromptLine` and `formatSubmitted` assemble active and submitted prompt lines.
 - `renderChoiceList` renders a scrolled choice viewport with overflow indicators.

--- a/apps/docs/content/docs/modules/skills.mdx
+++ b/apps/docs/content/docs/modules/skills.mdx
@@ -125,6 +125,20 @@ await uninstallSkill({ name: "my-cli" });
 
 <auto-type-table path="../../../../../packages/skills/src/types.ts" name="InstallSkillOptions" />
 
+### Public workflow types
+
+| Type                                             | Description                                                                |
+| ------------------------------------------------ | -------------------------------------------------------------------------- |
+| `PackagedSkill`                                  | Name, description, and source directory returned by `loadPackagedSkills()` |
+| `AgentClass`                                     | `"universal" \| "additional"` agent-layout category                        |
+| `Scope`                                          | `"global" \| "project"` installation scope                                 |
+| `InstallStatus`                                  | `"installed" \| "repaired" \| "up-to-date"` result status                  |
+| `UninstallStatus`                                | `"removed" \| "not-found"` result status                                   |
+| `SkillLinkStatus`                                | `"linked" \| "dangling" \| "conflict" \| "absent"` link-health status      |
+| `AgentResult` / `InstallSkillResult`             | Per-agent and aggregate results from `installSkill()`                      |
+| `UninstallSkillOptions` / `UninstallSkillResult` | Input and result shapes for `uninstallSkill()`                             |
+| `SkillStatusOptions` / `SkillStatusResult`       | Input and result shapes for `getSkillStatus()`                             |
+
 ## Command sections
 
 Add agent-facing guidance to a command's metadata. Each section is rendered as a Markdown heading and body in that command's generated documentation. Sections are shared with every renderer by default; pass the `skill` (`crust:skills`) factory for agent-only guidance:

--- a/apps/docs/content/docs/modules/store.mdx
+++ b/apps/docs/content/docs/modules/store.mdx
@@ -127,7 +127,7 @@ All four helpers follow XDG conventions on Linux and macOS, and Windows-native c
   `~/Library/...` paths.
 </Callout>
 
-The optional `env` parameter on each helper accepts a structural test environment (`platform`, `env`, and `homedir`) for deterministic testing without mutating `process.env`.
+The optional `env` parameter on each helper accepts the exported `PlatformEnv` structural test environment (`platform`, `env`, and `homedir`) for deterministic testing without mutating `process.env`.
 
 ### Multiple Stores
 
@@ -516,7 +516,7 @@ if (err instanceof CrustStoreError) {
 
 <auto-type-table path="../../../../../packages/store/src/types.ts" name="StoreValidatorIssue" />
 
-The package also exports `CreateStoreOptions`, `StoreUpdater`, `FieldsDef`, `InferStoreConfig`, `ValidationErrorDetails`, `StoreErrorCode`, `ValueType`, and the `CrustStoreError` class.
+The package also exports `CreateStoreOptions`, `StoreUpdater`, `FieldsDef`, `InferStoreConfig`, `PlatformEnv`, `ValidationErrorDetails`, `StoreErrorCode`, `ValueType`, and the `CrustStoreError` class.
 
 ## Design
 

--- a/apps/docs/content/docs/modules/style.mdx
+++ b/apps/docs/content/docs/modules/style.mdx
@@ -47,16 +47,18 @@ bold.red.bgYellow("chained"); // open left-to-right, close right-to-left
 
 ### Styles as values
 
-Chainables are plain `(text: StyleInput) => string` functions — passing a style around is just passing the chainable. `StyleInput` accepts stringifiable values plus `null` and `undefined`; nullish values become `""`, while other values are converted with `String(value)`. The narrower `StyleFn` type names the `(text: string) => string` callback contract; every chainable is assignable to it:
+Chainables are plain functions — passing a style around is just passing the chainable. `ChainableStyleFn` names the full callable, tagged-template, chaining, and `open`/`close` surface. `StyleInput` accepts stringifiable values plus `null` and `undefined`; nullish values become `""`, while other values are converted with `String(value)`. The narrower `StyleFn` type names the `(text: string) => string` callback contract; every chainable is assignable to it:
 
 ```ts
-import { style, type StyleFn } from "@crustjs/style";
+import { style, type ChainableStyleFn, type StyleFn } from "@crustjs/style";
+
+const accent: ChainableStyleFn = style.bold.red;
 
 function renderError(paint: StyleFn) {
   return paint("boom");
 }
 
-renderError(style.bold.red); // mode-aware, per-step NO_COLOR degradation
+renderError(accent); // mode-aware, per-step NO_COLOR degradation
 ```
 
 ## Dynamic colors
@@ -86,7 +88,7 @@ Output adapts to the resolved depth:
 | `"16"`        | 16-color ANSI  | Any other TTY                                                                            |
 | `"none"`      | Plain text     | Not a TTY, `NO_COLOR`, `FORCE_COLOR=0`, `TERM=dumb`, or `mode: "never"`                  |
 
-Inspect the resolved tier via `style.colorDepth` (live) or `instance.colorDepth` (frozen at creation).
+Inspect the resolved tier via `style.colorDepth` (live) or `instance.colorDepth` (frozen at creation). `colorsEnabled` reports whether color codes can be emitted, while `trueColorEnabled` reports whether the resolved depth is 24-bit.
 
 ## Color control
 
@@ -153,22 +155,22 @@ table(
 );
 ```
 
-`padStart` / `padEnd` / `center` measure visible width — unlike `String.prototype.padStart`, which counts code units and ANSI escapes. `table` supports per-column alignment, padding, separators, and styled cells. Headers define its column count, so extra row cells beyond the last header are dropped.
+`padStart` / `padEnd` / `center` measure visible width — unlike `String.prototype.padStart`, which counts code units and ANSI escapes. `table` supports per-column alignment and styled cells, using one space around each cell with `|` borders and `-` header separators. Headers define its column count, so extra row cells beyond the last header are dropped.
 
 Use the exported `stringWidth(text)` helper for ANSI-, CJK-, combining-mark-, and emoji-aware terminal width measurement.
 
 ## Reference
 
-| Group          | Exports                                                                                                                                                                                                                  |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Instances      | `style`, `createStyle(options?)`                                                                                                                                                                                         |
-| Chainables     | 7 modifiers, 16 foreground, 16 background (listed under [Styling](#styling))                                                                                                                                             |
-| Dynamic colors | `fg(text, input, depth?)`, `bg(text, input, depth?)`                                                                                                                                                                     |
-| Hyperlinks     | `link(text, url, options?)`                                                                                                                                                                                              |
-| Layout         | `padStart`, `padEnd`, `center`, `table`, `stringWidth`                                                                                                                                                                   |
-| Types          | `AnsiPair`, `ColorInput`, `ColorString`, `NamedColor`, `ColorMode`, `ColorDepth`, `StyleInput`, `StyleFn`, `StyleInstance`, `StyleOptions`, `CapabilityOverrides`, `HyperlinkOptions`, `TableOptions`, `ColumnAlignment` |
+| Group          | Exports                                                                                                                                                                                                                                      |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Instances      | `style`, `createStyle(options?)`                                                                                                                                                                                                             |
+| Chainables     | 7 modifiers, 16 foreground, 16 background (listed under [Styling](#styling))                                                                                                                                                                 |
+| Dynamic colors | `fg(text, input)`, `bg(text, input)`, plus chain-root `fg(input)` / `bg(input)`                                                                                                                                                              |
+| Hyperlinks     | `link(text, url, options?)`                                                                                                                                                                                                                  |
+| Layout         | `padStart`, `padEnd`, `center`, `table`, `stringWidth`                                                                                                                                                                                       |
+| Types          | `AnsiPair`, `ColorInput`, `ColorString`, `NamedColor`, `ColorMode`, `ColorDepth`, `StyleInput`, `StyleFn`, `ChainableStyleFn`, `StyleInstance`, `StyleOptions`, `CapabilityOverrides`, `HyperlinkOptions`, `TableOptions`, `ColumnAlignment` |
 
-Scalar types in prose: `ColorMode` is `"auto" | "always" | "never"`; `ColorDepth` is `"truecolor" | "256" | "16" | "none"`; `StyleInput` is `{ toString(): string } | null | undefined`; `StyleFn` is `(text: string) => string`; `ColumnAlignment` is `"left" | "right" | "center"`.
+Scalar types in prose: `ColorMode` is `"auto" | "always" | "never"`; `ColorDepth` is `"truecolor" | "256" | "16" | "none"`; `StyleInput` is `{ toString(): string } | null | undefined`; `StyleFn` is `(text: string) => string`; `ChainableStyleFn` is the type of every named chainable style export; `ColumnAlignment` is `"left" | "right" | "center"`.
 
 ```ts
 type ColorInput =

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -15,7 +15,7 @@ bun add -d @crustjs/testing
 
 `captureRun()` and `runInteractive()` accept a `Crust` application and infer its command tree. Their command path, argument object, and flag object are checked from the definitions added to that application. Misspelled command, argument, or flag names fail TypeScript checking and editor completion suggests valid names.
 
-`captureExecute()` instead accepts the structural `ExecutableApp` contract:
+`captureExecute()` instead accepts the structural `ExecutableApp` contract. Its `CaptureIO` option type is exported as `Partial<InvocationIO>`:
 
 ```ts
 interface ExecutableApp {

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -986,7 +986,7 @@ export class Crust<
 	CollisionSp extends CollisionSpellings = CollisionSpellings,
 	Result = void,
 > {
-	/** @internal — Phantom property exposing generic parameters for type-level testing */
+	/** Supported type-level seam exposing the application's inferred command types. */
 	declare readonly _types: {
 		flags: Flags;
 		args: A;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export type {
 	CommandNotFoundErrorDetails,
 	CrustErrorCode,
 	CrustErrorDetails,
+	CrustErrorJson,
 	CrustErrorDetailsMap,
 	DefinitionErrorDetails,
 	ParseErrorDetails,

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -6,6 +6,7 @@ export { help, renderHelp } from "./help.ts";
 export { noColor } from "./no-color.ts";
 export { updateNotifier } from "./update-notifier.ts";
 export type {
+	UpdateCommandResolver,
 	UpdateNotifierCacheAdapter,
 	UpdateNotifierCacheConfig,
 	UpdateNotifierPackageManager,

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -18,7 +18,7 @@ const UPDATE_NOTIFIER: ExtensionId = defineExtensionId("crust:update-notifier");
 
 export type UpdateNotifierPackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
-type UpdateCommandResolver = (info: {
+export type UpdateCommandResolver = (info: {
 	packageName: string;
 	packageManager: UpdateNotifierPackageManager;
 }) => string;

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -8,6 +8,12 @@ Interactive terminal prompts for the Crust CLI ecosystem.
 bun add @crustjs/prompts
 ```
 
+## Custom prompts
+
+The package root exports the built-in rendering pieces, including `renderTextWithCursor`, `highlightMatches`, `formatPromptLine`, `formatSubmitted`, `renderChoiceList`, and the shared prompt glyph constants.
+
+Test prompts through `@crustjs/prompts/testing`: call `prompt.type(text)` for literal text and `prompt.keys(...keys)` for named or control keys.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/prompts](https://crustjs.com/docs/modules/prompts)

--- a/packages/prompts/src/core/fuzzy.ts
+++ b/packages/prompts/src/core/fuzzy.ts
@@ -179,7 +179,7 @@ export function fuzzyFilter<T>(
 	return results;
 }
 
-/** @internal Apply the filter-match style to matched runs in a label. */
+/** Apply the filter-match style to matched runs in a label. */
 export function highlightMatches(
 	label: string,
 	indices: readonly number[],

--- a/packages/prompts/src/core/utils.ts
+++ b/packages/prompts/src/core/utils.ts
@@ -67,7 +67,7 @@ export function formatPromptLine(
 
 export const DEFAULT_MAX_VISIBLE = 10;
 
-/** @internal Render a scrollable list with viewport indicators. */
+/** Render a scrollable list with viewport indicators. */
 export function renderChoiceList<T>(
 	items: readonly T[],
 	scrollOffset: number,

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -7,6 +7,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 export type { FuzzyFilterResult, FuzzyMatchResult } from "./core/fuzzy.ts";
+export { highlightMatches } from "./core/fuzzy.ts";
 export type {
 	Choice,
 	ChoiceValue,
@@ -69,5 +70,14 @@ export { select } from "./prompts/select.ts";
 // ────────────────────────────────────────────────────────────────────────────
 
 export { fuzzyFilter, fuzzyMatch } from "./core/fuzzy.ts";
+export {
+	CHECKBOX_CHECKED,
+	CHECKBOX_UNCHECKED,
+	CURSOR_INDICATOR,
+	PREFIX_SUBMITTED,
+	PREFIX_SYMBOL,
+	SCROLL_INDICATOR,
+} from "./core/symbols.ts";
 export type { TextEditResult, TextEditState } from "./core/textEdit.ts";
-export { handleTextEdit } from "./core/textEdit.ts";
+export { handleTextEdit, renderTextWithCursor } from "./core/textEdit.ts";
+export { formatPromptLine, formatSubmitted, renderChoiceList } from "./core/utils.ts";

--- a/packages/prompts/src/prompts/confirm.test.ts
+++ b/packages/prompts/src/prompts/confirm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { confirm, type ConfirmOptions } from "./confirm.ts";
 import { nonTTYIO, tick } from "./test-helpers.ts";
 
@@ -13,7 +13,7 @@ describe("confirm — default value", () => {
 		const prompt = renderPrompt(confirm, { message: "Continue?" });
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(true);
@@ -26,7 +26,7 @@ describe("confirm — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -43,9 +43,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, left should toggle to false
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -56,9 +56,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, right should toggle to false
-		pressKey(prompt, "", { name: "right" });
+		prompt.keys("right");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -69,9 +69,9 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Default is true, tab should toggle to false
-		pressKey(prompt, "", { name: "tab" });
+		prompt.keys("tab");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -82,11 +82,11 @@ describe("confirm — toggle", () => {
 
 		await tick();
 		// Toggle twice — should be back to true
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "", { name: "right" });
+		prompt.keys("right");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(true);
@@ -105,9 +105,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "y");
+		prompt.type("y");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(true);
@@ -120,9 +120,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "Y", { name: "y", shift: true });
+		prompt.type("Y");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(true);
@@ -132,9 +132,9 @@ describe("confirm — shortcuts", () => {
 		const prompt = renderPrompt(confirm, { message: "Continue?" });
 
 		await tick();
-		pressKey(prompt, "n");
+		prompt.type("n");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -144,9 +144,9 @@ describe("confirm — shortcuts", () => {
 		const prompt = renderPrompt(confirm, { message: "Continue?" });
 
 		await tick();
-		pressKey(prompt, "N", { name: "n", shift: true });
+		prompt.type("N");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -159,9 +159,9 @@ describe("confirm — shortcuts", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "h", { name: "h" });
+		prompt.type("h");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(true);
@@ -171,9 +171,9 @@ describe("confirm — shortcuts", () => {
 		const prompt = renderPrompt(confirm, { message: "Continue?" });
 
 		await tick();
-		pressKey(prompt, "l", { name: "l" });
+		prompt.type("l");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(false);
@@ -196,7 +196,7 @@ describe("confirm — custom labels", () => {
 		expect(prompt.screen()).toContain("Agree");
 		expect(prompt.screen()).toContain("Decline");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -210,9 +210,9 @@ describe("confirm — custom labels", () => {
 
 		await tick();
 		// Toggle to true (Accept)
-		pressKey(prompt, "y");
+		prompt.type("y");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Accept");
@@ -230,7 +230,7 @@ describe("confirm — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Deploy to production?");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -238,9 +238,9 @@ describe("confirm — rendering", () => {
 		const prompt = renderPrompt(confirm, { message: "Continue?" });
 
 		await tick();
-		pressKey(prompt, "n");
+		prompt.type("n");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		// After submission, the selected answer should appear
@@ -262,7 +262,7 @@ describe("confirm — no message", () => {
 		expect(prompt.screen()).toContain("Yes");
 		expect(prompt.screen()).toContain("No");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe(true);
 	});
@@ -271,7 +271,7 @@ describe("confirm — no message", () => {
 		const prompt = renderPrompt(confirm, {});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Are you sure?");

--- a/packages/prompts/src/prompts/filter.test.ts
+++ b/packages/prompts/src/prompts/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { filter, type FilterOptions } from "./filter.ts";
 import { nonTTYIO, tick } from "./test-helpers.ts";
 
@@ -39,7 +39,7 @@ describe("filter — default value", () => {
 
 		await tick();
 		// Submit immediately — should select "Rust" (cursor at matching index)
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("Rust");
@@ -52,7 +52,7 @@ describe("filter — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("TypeScript");
@@ -66,7 +66,7 @@ describe("filter — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("TypeScript");
@@ -89,7 +89,7 @@ describe("filter — typing filters the list", () => {
 		expect(prompt.screen()).toContain("JavaScript");
 		expect(prompt.screen()).toContain("Rust");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -101,15 +101,15 @@ describe("filter — typing filters the list", () => {
 
 		await tick();
 		// Type "py" to filter
-		pressKey(prompt, "p", { name: "p" });
+		prompt.type("p");
 		await tick();
-		pressKey(prompt, "y", { name: "y" });
+		prompt.type("y");
 		await tick();
 
 		// "Python" should be visible, "Go" should not
 		expect(prompt.screen()).toContain("Python");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("Python");
 	});
@@ -122,23 +122,23 @@ describe("filter — typing filters the list", () => {
 
 		await tick();
 		// Type something that won't match anything
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
 
 		expect(prompt.screen()).toContain("No matches");
 
 		// Backspace to clear and get matches again, then submit
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -155,9 +155,9 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("beta");
@@ -170,13 +170,13 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("beta");
@@ -189,9 +189,9 @@ describe("filter — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("gamma");
@@ -205,27 +205,27 @@ describe("filter — navigation", () => {
 
 		await tick();
 		// Type something that won't match
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
-		pressKey(prompt, "z", { name: "z" });
+		prompt.type("z");
 		await tick();
 
 		// Navigation should be ignored (no crash)
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
 
 		// Clear query and submit
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -243,19 +243,19 @@ describe("filter — query editing", () => {
 
 		await tick();
 		// Type "ac"
-		pressKey(prompt, "a", { name: "a" });
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "c", { name: "c" });
+		prompt.type("c");
 		await tick();
 
 		// Move cursor left and insert "b" to make "abc"
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "b", { name: "b" });
+		prompt.type("b");
 		await tick();
 
 		// "abc" should now match
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("abc");
 	});
@@ -275,7 +275,7 @@ describe("filter — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Find a language");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -289,7 +289,7 @@ describe("filter — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Type to filter...");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -300,9 +300,9 @@ describe("filter — rendering", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("banana");
@@ -321,7 +321,7 @@ describe("filter — rendering", () => {
 		expect(prompt.screen()).toContain("Option A");
 		expect(prompt.screen()).toContain("Option B");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -345,7 +345,7 @@ describe("filter — viewport scrolling", () => {
 		expect(prompt.screen()).toContain("item-4");
 		expect(prompt.screen()).not.toContain("item-5");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -359,17 +359,17 @@ describe("filter — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
 
 		// item-3 should now be visible
 		expect(prompt.screen()).toContain("item-3");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("item-3");
 	});
@@ -390,7 +390,7 @@ describe("filter — no message", () => {
 		expect(prompt.screen()).not.toContain("undefined");
 		expect(prompt.screen()).toContain("apple");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("apple");
 	});
@@ -401,7 +401,7 @@ describe("filter — no message", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Search and select");

--- a/packages/prompts/src/prompts/input.test.ts
+++ b/packages/prompts/src/prompts/input.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { z } from "zod";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { input } from "./input.ts";
 import { nonTTYIO, tick, waitForScreen } from "./test-helpers.ts";
 
@@ -36,7 +36,7 @@ describe("input — interactive", () => {
 		expect(prompt.screen()).toContain("Your name?");
 
 		// Submit empty to resolve
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -49,7 +49,7 @@ describe("input — interactive", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Enter your name");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -64,7 +64,7 @@ describe("input — interactive", () => {
 		expect(prompt.screen()).toContain("World");
 		expect(prompt.screen()).not.toContain("(World)");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -79,7 +79,7 @@ describe("input — interactive", () => {
 		expect(prompt.screen()).toContain("Enter your name");
 		expect(prompt.screen()).toContain("(World)");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -87,13 +87,13 @@ describe("input — interactive", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A", { name: "a" });
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B", { name: "b" });
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "C", { name: "c" });
+		prompt.type("C");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ABC");
@@ -106,7 +106,7 @@ describe("input — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("DefaultName");
@@ -119,9 +119,9 @@ describe("input — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "X", { name: "x" });
+		prompt.type("X");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("X");
@@ -131,11 +131,11 @@ describe("input — interactive", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "O", { name: "o" });
+		prompt.type("O");
 		await tick();
-		pressKey(prompt, "K", { name: "k" });
+		prompt.type("K");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		// After submission, the confirmed value should appear in output
@@ -152,13 +152,13 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("A");
@@ -168,11 +168,11 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("A");
@@ -182,21 +182,21 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "C");
+		prompt.type("C");
 		await tick();
 		// Move cursor left to position before C
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
 		// Delete the character at cursor (B)
-		pressKey(prompt, "", { name: "delete" });
+		prompt.keys("delete");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("AC");
@@ -206,16 +206,16 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
 		// Move left, then type C — inserts before B
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "C");
+		prompt.type("C");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ACB");
@@ -225,20 +225,20 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
 		// Move left twice, then right once — cursor is between A and B
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "", { name: "left" });
+		prompt.keys("left");
 		await tick();
-		pressKey(prompt, "", { name: "right" });
+		prompt.keys("right");
 		await tick();
-		pressKey(prompt, "C");
+		prompt.type("C");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ACB");
@@ -248,15 +248,15 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "", { name: "home" });
+		prompt.keys("home");
 		await tick();
-		pressKey(prompt, "C");
+		prompt.type("C");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("CAB");
@@ -266,17 +266,17 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "", { name: "home" });
+		prompt.keys("home");
 		await tick();
-		pressKey(prompt, "", { name: "end" });
+		prompt.keys("end");
 		await tick();
-		pressKey(prompt, "C");
+		prompt.type("C");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ABC");
@@ -286,12 +286,12 @@ describe("input — keypress editing", () => {
 		const prompt = renderPrompt(input, { message: "Name?" });
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
 		// Ctrl+A should be ignored (not inserted)
-		pressKey(prompt, "a", { name: "a", ctrl: true });
+		prompt.keys("ctrl+a");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("A");
@@ -312,21 +312,21 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "a");
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "b");
+		prompt.type("b");
 		await tick();
 		// Try to submit invalid value
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		// Error should be displayed
 		expect(prompt.screen()).toContain("Must contain @");
 
 		// Now type valid input and resubmit
-		pressKey(prompt, "@");
+		prompt.type("@");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ab@");
@@ -344,18 +344,18 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
 		// Submit too-short value
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("Too short");
 
 		// Add more text and resubmit
-		pressKey(prompt, "B");
+		prompt.type("B");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("AB");
@@ -372,15 +372,15 @@ describe("input — validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "1");
+		prompt.type("1");
 		await tick();
-		pressKey(prompt, "2");
+		prompt.type("2");
 		await tick();
-		pressKey(prompt, "3");
+		prompt.type("3");
 		await tick();
-		pressKey(prompt, "4");
+		prompt.type("4");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("1234");
@@ -397,15 +397,15 @@ describe("input — validation", () => {
 
 		await tick();
 		// Submit empty — default is "" which should fail validation
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("Required");
 
 		// Type something and submit
-		pressKey(prompt, "X");
+		prompt.type("X");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("X");
@@ -424,9 +424,9 @@ describe("input — no message", () => {
 		expect(prompt.screen()).toContain("Enter a value");
 		expect(prompt.screen()).not.toContain("undefined");
 
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("A");
@@ -436,9 +436,9 @@ describe("input — no message", () => {
 		const prompt = renderPrompt(input, {});
 
 		await tick();
-		pressKey(prompt, "X");
+		prompt.type("X");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Enter a value");
@@ -496,13 +496,13 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
-		pressKey(prompt, "l");
+		prompt.type("l");
 		await tick();
-		pressKey(prompt, "i");
+		prompt.type("i");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("Ali");
@@ -515,11 +515,11 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "4");
+		prompt.type("4");
 		await tick();
-		pressKey(prompt, "2");
+		prompt.type("2");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(42);
@@ -532,20 +532,20 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "A");
+		prompt.type("A");
 		await tick();
 		// Submit too-short value
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("Too short");
 
 		// Add more characters and retry
-		pressKey(prompt, "l");
+		prompt.type("l");
 		await tick();
-		pressKey(prompt, "i");
+		prompt.type("i");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("Ali");
@@ -570,21 +570,21 @@ describe("input — schema validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "x");
+		prompt.type("x");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("Validation failed");
 
 		// Clear field, type valid value, submit
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "o");
+		prompt.type("o");
 		await tick();
-		pressKey(prompt, "k");
+		prompt.type("k");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ok");
@@ -608,11 +608,11 @@ describe("input — schema validation", () => {
 		const prompt = renderPrompt(input<string>, { message: "Word?", schema: emptyIssuesSchema });
 
 		await tick();
-		pressKey(prompt, "o");
+		prompt.type("o");
 		await tick();
-		pressKey(prompt, "k");
+		prompt.type("k");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("ok");
@@ -631,27 +631,27 @@ describe("input — schema validation", () => {
 		const prompt = renderPrompt(input<string>, { message: "Confirm?", schema: asyncSchema });
 
 		await tick();
-		pressKey(prompt, "n");
+		prompt.type("n");
 		await tick();
-		pressKey(prompt, "o");
+		prompt.type("o");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await waitForScreen(prompt, "must be yes");
 
 		expect(prompt.screen()).toContain("must be yes");
 
 		// Clear and type valid value
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "", { name: "backspace" });
+		prompt.keys("backspace");
 		await tick();
-		pressKey(prompt, "y");
+		prompt.type("y");
 		await tick();
-		pressKey(prompt, "e");
+		prompt.type("e");
 		await tick();
-		pressKey(prompt, "s");
+		prompt.type("s");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("yes");
@@ -723,7 +723,7 @@ describe("input — schema + interactive default", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(4000);
@@ -761,13 +761,13 @@ describe("input — callable Standard Schema", () => {
 		const prompt = renderPrompt(input<string>, { message: "Word?", schema: callable });
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 		expect(prompt.screen()).toContain("empty");
 
-		pressKey(prompt, "a");
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("[a]");

--- a/packages/prompts/src/prompts/multifilter.test.ts
+++ b/packages/prompts/src/prompts/multifilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { multifilter, type MultifilterOptions } from "./multifilter.ts";
 import { nonTTYIO, tick } from "./test-helpers.ts";
 
@@ -74,13 +74,13 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["alpha", "beta"]);
@@ -97,9 +97,9 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
 
 		const duplicateLines = prompt
@@ -108,7 +108,7 @@ describe("multifilter — interactive", () => {
 			.filter((line) => line.includes("duplicate"));
 		expect(duplicateLines.map((line) => line.includes("●"))).toEqual([false, true]);
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		expect(await prompt.answer).toEqual([value]);
 	});
 
@@ -121,7 +121,7 @@ describe("multifilter — interactive", () => {
 
 		await tick();
 		expect(prompt.screen()).toContain("●");
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["c"]);
@@ -138,9 +138,9 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		expect(await prompt.answer).toEqual([]);
 	});
@@ -153,14 +153,14 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("At least one");
 
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["x"]);
@@ -173,21 +173,21 @@ describe("multifilter — interactive", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "g", { name: "g" });
+		prompt.type("g");
 		await tick();
-		pressKey(prompt, "a", { name: "a" });
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "m", { name: "m" });
+		prompt.type("m");
 		await tick();
 
 		expect(prompt.screen()).toContain("gamma");
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["gamma"]);

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { multiselect, type MultiselectOptions } from "./multiselect.ts";
 import { nonTTYIO, tick } from "./test-helpers.ts";
 
@@ -39,7 +39,7 @@ describe("multiselect — default value", () => {
 
 		await tick();
 		// Submit immediately — should return pre-selected items
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["cheese", "mushrooms"]);
@@ -52,7 +52,7 @@ describe("multiselect — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual([]);
@@ -66,7 +66,7 @@ describe("multiselect — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["cheese"]);
@@ -86,9 +86,9 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Toggle first item on
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a"]);
@@ -103,9 +103,9 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Toggle first item off (it was pre-selected)
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual([]);
@@ -119,14 +119,14 @@ describe("multiselect — Space toggle", () => {
 
 		await tick();
 		// Select first item
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
 		// Move down and select second
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a", "b"]);
@@ -145,11 +145,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["b"]);
@@ -163,13 +163,13 @@ describe("multiselect — navigation", () => {
 
 		await tick();
 		// Move down to b, then up back to a
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a"]);
@@ -182,11 +182,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "j", { name: "j" });
+		prompt.type("j");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["b"]);
@@ -199,13 +199,13 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "k", { name: "k" });
+		prompt.type("k");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a"]);
@@ -218,11 +218,11 @@ describe("multiselect — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["c"]);
@@ -241,9 +241,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "a", { name: "a" });
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a", "b", "c"]);
@@ -257,9 +257,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "a", { name: "a" });
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual([]);
@@ -273,9 +273,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "a", { name: "a" });
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a", "b", "c"]);
@@ -289,9 +289,9 @@ describe("multiselect — toggle all / invert", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "i", { name: "i" });
+		prompt.type("i");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["b", "c"]);
@@ -312,16 +312,16 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Try to submit with nothing selected
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		// Error should be shown
 		expect(prompt.screen()).toContain("At least one item must be selected");
 
 		// Select something and submit
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a"]);
@@ -336,20 +336,20 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Select only 1 item
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		// Error should be shown
 		expect(prompt.screen()).toContain("Select at least 2 items");
 
 		// Select another item and submit
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a", "b"]);
@@ -364,16 +364,16 @@ describe("multiselect — validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		// Error should be shown
 		expect(prompt.screen()).toContain("Select at most 1 item");
 
 		// Deselect one and submit
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["b"]);
@@ -388,22 +388,22 @@ describe("multiselect — validation", () => {
 
 		await tick();
 		// Submit with nothing — triggers error
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 		expect(prompt.screen()).toContain("At least one item must be selected");
 
 		// Navigate — error should clear
 
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
 
 		// The error should no longer appear in new output
 		expect(prompt.screen()).not.toContain("At least one item must be selected");
 
 		// Select and submit
-		pressKey(prompt, " ", { name: "space" });
+		prompt.type(" ");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["b"]);
@@ -424,7 +424,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Select toppings");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -440,7 +440,7 @@ describe("multiselect — rendering", () => {
 		expect(prompt.screen()).toContain("gamma");
 		expect(prompt.screen()).toContain("○");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -454,7 +454,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("●");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -466,7 +466,7 @@ describe("multiselect — rendering", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		// After submit, should show comma-separated labels
@@ -485,7 +485,7 @@ describe("multiselect — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("recommended");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -508,7 +508,7 @@ describe("multiselect — viewport scrolling", () => {
 		expect(prompt.screen()).toContain("item-4");
 		expect(prompt.screen()).not.toContain("item-5");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -522,17 +522,17 @@ describe("multiselect — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
 
 		// item-3 should now be visible
 		expect(prompt.screen()).toContain("item-3");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -553,9 +553,9 @@ describe("multiselect — no message", () => {
 		expect(prompt.screen()).toContain("a");
 
 		// Select first item and submit
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toEqual(["a"]);
@@ -567,9 +567,9 @@ describe("multiselect — no message", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "space" });
+		prompt.keys("space");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Pick one or more");

--- a/packages/prompts/src/prompts/password.test.ts
+++ b/packages/prompts/src/prompts/password.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { z } from "zod";
 
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { password } from "./password.ts";
 import { nonTTYIO, tick, waitForScreen } from "./test-helpers.ts";
 
@@ -35,7 +35,7 @@ describe("password — masked rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Enter password:");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -43,11 +43,11 @@ describe("password — masked rendering", () => {
 		const prompt = renderPrompt(password, { message: "Password?" });
 
 		await tick();
-		pressKey(prompt, "a");
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "b");
+		prompt.type("b");
 		await tick();
-		pressKey(prompt, "c");
+		prompt.type("c");
 		await tick();
 
 		// Should see mask characters (***) but NOT the actual value "abc"
@@ -55,7 +55,7 @@ describe("password — masked rendering", () => {
 		// The actual characters should not appear in output
 		// (except potentially in keypress event data, not in rendered output)
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		// The actual value is returned, even though it was masked in display
 		expect(result).toBe("abc");
@@ -65,15 +65,15 @@ describe("password — masked rendering", () => {
 		const prompt = renderPrompt(password, { message: "Password?", mask: "●" });
 
 		await tick();
-		pressKey(prompt, "x");
+		prompt.type("x");
 		await tick();
-		pressKey(prompt, "y");
+		prompt.type("y");
 		await tick();
 
 		// Custom mask character should appear in output
 		expect(prompt.screen()).toContain("●");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("xy");
 	});
@@ -84,11 +84,11 @@ describe("password — masked rendering", () => {
 		await tick();
 		// Type a 10-character password
 		for (const ch of "abcdefghij") {
-			pressKey(prompt, ch);
+			prompt.type(ch);
 			await tick();
 		}
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 
 		// After submission, should show exactly 4 mask characters (SUBMITTED_MASK_LENGTH)
@@ -103,7 +103,7 @@ describe("password — masked rendering", () => {
 		// U+2502 (│) is the cursor character
 		expect(prompt.screen()).toContain("\u2502");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -122,22 +122,22 @@ describe("password — validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "a");
+		prompt.type("a");
 		await tick();
-		pressKey(prompt, "b");
+		prompt.type("b");
 		await tick();
 		// Try to submit invalid value (too short)
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await tick();
 
 		expect(prompt.screen()).toContain("Password must be at least 4 characters");
 
 		// Type more and resubmit
-		pressKey(prompt, "c");
+		prompt.type("c");
 		await tick();
-		pressKey(prompt, "d");
+		prompt.type("d");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("abcd");
@@ -156,13 +156,13 @@ describe("password — no message", () => {
 		expect(prompt.screen()).toContain("Enter a password");
 		expect(prompt.screen()).not.toContain("undefined");
 
-		pressKey(prompt, "s");
+		prompt.type("s");
 		await tick();
-		pressKey(prompt, "e");
+		prompt.type("e");
 		await tick();
-		pressKey(prompt, "c");
+		prompt.type("c");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("sec");
@@ -172,9 +172,9 @@ describe("password — no message", () => {
 		const prompt = renderPrompt(password, {});
 
 		await tick();
-		pressKey(prompt, "x");
+		prompt.type("x");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Enter a password");
@@ -224,15 +224,15 @@ describe("password — schema validation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "4");
+		prompt.type("4");
 		await tick();
-		pressKey(prompt, "2");
+		prompt.type("2");
 		await tick();
-		pressKey(prompt, "4");
+		prompt.type("4");
 		await tick();
-		pressKey(prompt, "2");
+		prompt.type("2");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(4242);
@@ -301,10 +301,10 @@ describe("password — secrecy", () => {
 
 		await tick();
 		for (const ch of SECRET) {
-			pressKey(prompt, ch);
+			prompt.type(ch);
 			await tick();
 		}
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 
 		expect(prompt.screen()).not.toContain(SECRET);
@@ -318,10 +318,10 @@ describe("password — secrecy", () => {
 
 		await tick();
 		for (const ch of SECRET) {
-			pressKey(prompt, ch);
+			prompt.type(ch);
 			await tick();
 		}
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		// Schema validation is async; a fixed tick races the error render on slow runners.
 		await waitForScreen(prompt, "too short");
 
@@ -330,14 +330,14 @@ describe("password — secrecy", () => {
 
 		// Resolve the prompt cleanly with a long-enough valid value.
 		for (let i = 0; i < SECRET.length; i++) {
-			pressKey(prompt, "", { name: "backspace" });
+			prompt.keys("backspace");
 			await tick();
 		}
 		for (const ch of "x".repeat(64)) {
-			pressKey(prompt, ch);
+			prompt.type(ch);
 			await tick();
 		}
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { createPrompts } from "../create-prompts.ts";
-import { pressKey, renderPrompt } from "../testing.ts";
+import { renderPrompt } from "../testing.ts";
 import { select, type SelectOptions } from "./select.ts";
 import { nonTTYIO, tick } from "./test-helpers.ts";
 
@@ -40,7 +40,7 @@ describe("select — default value", () => {
 
 		await tick();
 		// Submit immediately — should select "green" (cursor at index 1)
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("green");
@@ -53,7 +53,7 @@ describe("select — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("red");
@@ -67,7 +67,7 @@ describe("select — default value", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("red");
@@ -86,9 +86,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("b");
@@ -102,9 +102,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("a");
@@ -117,9 +117,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "j", { name: "j" });
+		prompt.type("j");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("b");
@@ -133,9 +133,9 @@ describe("select — navigation", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "k", { name: "k" });
+		prompt.type("k");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("b");
@@ -149,9 +149,9 @@ describe("select — navigation", () => {
 
 		await tick();
 		// Cursor at 0, up should wrap to index 2
-		pressKey(prompt, "", { name: "up" });
+		prompt.keys("up");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe("c");
@@ -173,9 +173,9 @@ describe("select — choice types", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		const result = await prompt.answer;
 		expect(result).toBe(443);
@@ -194,7 +194,7 @@ describe("select — choice types", () => {
 		// Verify hint text is rendered
 		expect(prompt.screen()).toContain("recommended");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -213,7 +213,7 @@ describe("select — rendering", () => {
 		await tick();
 		expect(prompt.screen()).toContain("Choose your favorite");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -228,7 +228,7 @@ describe("select — rendering", () => {
 		expect(prompt.screen()).toContain("beta");
 		expect(prompt.screen()).toContain("gamma");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -239,9 +239,9 @@ describe("select — rendering", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		// After submit, the selected label should appear in the output
@@ -261,7 +261,7 @@ describe("select — rendering", () => {
 		expect(prompt.screen()).toContain("Option A");
 		expect(prompt.screen()).toContain("Option B");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -285,7 +285,7 @@ describe("select — viewport scrolling", () => {
 		expect(prompt.screen()).toContain("item-4");
 		expect(prompt.screen()).not.toContain("item-5");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -300,7 +300,7 @@ describe("select — viewport scrolling", () => {
 		await tick();
 		expect(prompt.screen()).toContain("...");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 
@@ -314,17 +314,17 @@ describe("select — viewport scrolling", () => {
 
 		await tick();
 		// Move down 3 times to scroll past the initial viewport
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
-		pressKey(prompt, "", { name: "down" });
+		prompt.keys("down");
 		await tick();
 
 		// item-3 should now be visible
 		expect(prompt.screen()).toContain("item-3");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("item-3");
 	});
@@ -343,7 +343,7 @@ describe("select — viewport scrolling", () => {
 		const scrollLines = lines.filter((l) => l.trim() === "...");
 		expect(scrollLines.length).toBe(0);
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		await prompt.answer;
 	});
 });
@@ -363,7 +363,7 @@ describe("select — no message", () => {
 		expect(prompt.screen()).not.toContain("undefined");
 		expect(prompt.screen()).toContain("a");
 
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 		const result = await prompt.answer;
 		expect(result).toBe("a");
 	});
@@ -374,7 +374,7 @@ describe("select — no message", () => {
 		});
 
 		await tick();
-		pressKey(prompt, "", { name: "return" });
+		prompt.keys("return");
 
 		await prompt.answer;
 		expect(prompt.screen()).toContain("Pick an option");

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Writable } from "node:stream";
 import { stripVTControlCharacters } from "node:util";
 
-import type { KeypressEvent, PromptIO } from "./core/renderer.ts";
+import type { PromptIO } from "./core/renderer.ts";
 
 const namedKeys = {
 	return: "\r",
@@ -170,21 +170,6 @@ export interface RenderedPrompt<Answer> {
 	keys(...namedKeys: Key[]): void;
 	screen(): string;
 	readonly answer: Promise<Answer>;
-}
-
-/** Drive one keypress through a rendered prompt test harness. */
-export function pressKey(
-	prompt: Pick<RenderedPrompt<unknown>, "type" | "keys">,
-	char: string,
-	key?: Partial<Pick<KeypressEvent, "name" | "ctrl" | "meta" | "shift">>,
-): void {
-	if (key?.ctrl) {
-		prompt.keys(`ctrl+${key.name ?? char}`);
-	} else if (char === "") {
-		prompt.keys(key?.name ?? "");
-	} else {
-		prompt.type(char);
-	}
 }
 
 /** Run a prompt function against fake TTY streams and expose terminal-style controls. */

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -6,6 +6,7 @@
 export type { StoreErrorCode, ValidationErrorDetails } from "./errors.ts";
 export { CrustStoreError } from "./errors.ts";
 // Path
+export type { PlatformEnv } from "./path.ts";
 export { cacheDir, configDir, dataDir, stateDir } from "./path.ts";
 // Store
 export { createStore } from "./store.ts";

--- a/packages/style/README.md
+++ b/packages/style/README.md
@@ -8,6 +8,23 @@ Terminal styling foundation for the Crust CLI framework
 bun add @crustjs/style
 ```
 
+## Quick example
+
+```ts
+import { createStyle, fg, table } from "@crustjs/style";
+
+console.log(fg("brand", "#4fa83d"));
+console.log(table(["Name", "Age"], [["Ada", "36"]], { align: ["left", "right"] }));
+
+const deterministic = createStyle({
+	mode: "auto",
+	overrides: { isTTY: true, forceColor: "3" },
+});
+console.log(deterministic.fg("snapshot", "#4fa83d"));
+```
+
+`fg` and `bg` use the active style capabilities. Use `createStyle({ overrides })` when output must be deterministic.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/style](https://crustjs.com/docs/modules/style)

--- a/packages/style/src/blocks/tables.test.ts
+++ b/packages/style/src/blocks/tables.test.ts
@@ -86,46 +86,6 @@ describe("table", () => {
 		expect(lines[3]).toBe("| Bob   |  FAIL  |");
 	});
 
-	// ── Options ────────────────────────────────────────────────────────────
-
-	it("respects minColumnWidth", () => {
-		const result = table(["A", "B"], [["1", "2"]], { minColumnWidth: 5 });
-		const lines = result.split("\n");
-		// Columns should be at least 5 wide even though content is only 1 wide
-		expect(lines[0]).toBe("| A     | B     |");
-		expect(lines[1]).toBe("|-------|-------|");
-	});
-
-	it("respects custom cellPadding", () => {
-		const result = table(["A", "B"], [["1", "2"]], { cellPadding: 2 });
-		const lines = result.split("\n");
-		expect(lines[0]).toBe("|  A  |  B  |");
-		expect(lines[1]).toBe("|-----|-----|");
-		expect(lines[2]).toBe("|  1  |  2  |");
-	});
-
-	it("respects cellPadding of 0", () => {
-		const result = table(["A", "B"], [["1", "2"]], { cellPadding: 0 });
-		const lines = result.split("\n");
-		expect(lines[0]).toBe("|A|B|");
-		expect(lines[1]).toBe("|-|-|");
-		expect(lines[2]).toBe("|1|2|");
-	});
-
-	it("uses custom separator character", () => {
-		const result = table(["A"], [["1"]], { separatorChar: "=" });
-		const lines = result.split("\n");
-		expect(lines[1]).toBe("|===|");
-	});
-
-	it("uses custom border character", () => {
-		const result = table(["A"], [["1"]], { borderChar: ":" });
-		const lines = result.split("\n");
-		expect(lines[0]).toBe(": A :");
-		expect(lines[1]).toBe(":---:");
-		expect(lines[2]).toBe(": 1 :");
-	});
-
 	// ── ANSI Styled Content ────────────────────────────────────────────────
 
 	it("handles ANSI-styled header values", () => {

--- a/packages/style/src/blocks/tables.ts
+++ b/packages/style/src/blocks/tables.ts
@@ -24,35 +24,6 @@ export interface TableOptions {
 	 * left-aligned.
 	 */
 	align?: ColumnAlignment[];
-
-	/**
-	 * Minimum column width (in visible characters). Columns are always at
-	 * least as wide as their widest cell content regardless of this setting.
-	 *
-	 * @default 0
-	 */
-	minColumnWidth?: number;
-
-	/**
-	 * Padding (number of spaces) added to each side of every cell.
-	 *
-	 * @default 1
-	 */
-	cellPadding?: number;
-
-	/**
-	 * The character used for the horizontal separator line.
-	 *
-	 * @default "-"
-	 */
-	separatorChar?: string;
-
-	/**
-	 * The column separator character placed between cells.
-	 *
-	 * @default "|"
-	 */
-	borderChar?: string;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -62,9 +33,9 @@ export interface TableOptions {
 /**
  * Compute the maximum visible width for each column across headers and rows.
  */
-function computeColumnWidths(headers: string[], rows: string[][], minWidth: number): number[] {
+function computeColumnWidths(headers: string[], rows: string[][]): number[] {
 	const columnCount = headers.length;
-	const widths = Array<number>(columnCount).fill(minWidth);
+	const widths = Array<number>(columnCount).fill(0);
 
 	for (const row of [headers, ...rows]) {
 		for (let col = 0; col < columnCount; col++) {
@@ -93,39 +64,22 @@ function alignCell(value: string, width: number, alignment: ColumnAlignment): st
 /**
  * Format a single row of cells into a bordered row string.
  */
-function formatRow(
-	cells: string[],
-	columnWidths: number[],
-	alignments: ColumnAlignment[],
-	cellPadding: number,
-	borderChar: string,
-): string {
-	const pad = " ".repeat(cellPadding);
+function formatRow(cells: string[], columnWidths: number[], alignments: ColumnAlignment[]): string {
 	const formattedCells = columnWidths.map((width, col) => {
 		const cell = cells[col] ?? "";
 		const alignment = alignments[col] ?? "left";
-		const aligned = alignCell(cell, width, alignment);
-		return `${pad}${aligned}${pad}`;
+		return ` ${alignCell(cell, width, alignment)} `;
 	});
 
-	return `${borderChar}${formattedCells.join(borderChar)}${borderChar}`;
+	return `|${formattedCells.join("|")}|`;
 }
 
 /**
  * Generate a separator row using the given character.
  */
-function formatSeparator(
-	columnWidths: number[],
-	cellPadding: number,
-	separatorChar: string,
-	borderChar: string,
-): string {
-	const segments = columnWidths.map((width) => {
-		// Fill: column width + padding on both sides
-		return separatorChar.repeat(width + cellPadding * 2);
-	});
-
-	return `${borderChar}${segments.join(borderChar)}${borderChar}`;
+function formatSeparator(columnWidths: number[]): string {
+	const segments = columnWidths.map((width) => "-".repeat(width + 2));
+	return `|${segments.join("|")}|`;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -163,24 +117,19 @@ function formatSeparator(
  */
 export function table(headers: string[], rows: string[][], options?: TableOptions): string {
 	const alignments = options?.align ?? [];
-	const minColumnWidth = options?.minColumnWidth ?? 0;
-	const cellPadding = options?.cellPadding ?? 1;
-	const separatorChar = options?.separatorChar ?? "-";
-	const borderChar = options?.borderChar ?? "|";
-
-	const columnWidths = computeColumnWidths(headers, rows, minColumnWidth);
+	const columnWidths = computeColumnWidths(headers, rows);
 
 	const lines: string[] = [];
 
 	// Header row
-	lines.push(formatRow(headers, columnWidths, alignments, cellPadding, borderChar));
+	lines.push(formatRow(headers, columnWidths, alignments));
 
 	// Separator row
-	lines.push(formatSeparator(columnWidths, cellPadding, separatorChar, borderChar));
+	lines.push(formatSeparator(columnWidths));
 
 	// Data rows
 	for (const row of rows) {
-		lines.push(formatRow(row, columnWidths, alignments, cellPadding, borderChar));
+		lines.push(formatRow(row, columnWidths, alignments));
 	}
 
 	return lines.join("\n");

--- a/packages/style/src/dx.test.ts
+++ b/packages/style/src/dx.test.ts
@@ -13,7 +13,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
 import { linkCode } from "./hyperlinks.ts";
-import { bold, createStyle, red, style } from "./index.ts";
+import { bold, createStyle, fg, red, style } from "./index.ts";
 import { applyStyle } from "./styleEngine.ts";
 import { setEnv, snapshotEnv } from "./testEnv.ts";
 
@@ -194,8 +194,10 @@ describe("top-level chainables — full surface", () => {
 		expect(bold`hello ${42}!`).toBe("\x1b[1mhello 42!\x1b[22m");
 	});
 
-	it("top-level `bold.fg('#f00')('x')` chain root works", () => {
+	it("top-level dynamic colors support direct and chain-root calls", () => {
 		setEnv("FORCE_COLOR", "3");
+		expect(fg("x", "#ff0000")).toBe("\x1b[38;2;255;0;0mx\x1b[39m");
+		expect(fg("#ff0000")("x")).toBe("\x1b[38;2;255;0;0mx\x1b[39m");
 		expect(bold.fg("#ff0000")("x")).toBe("\x1b[1m\x1b[38;2;255;0;0mx\x1b[39m\x1b[22m");
 	});
 

--- a/packages/style/src/index.ts
+++ b/packages/style/src/index.ts
@@ -63,6 +63,7 @@ export { center, padEnd, padStart } from "./text/pad.ts";
 // Capability detection
 export type {
 	CapabilityOverrides,
+	ChainableStyleFn,
 	ColorDepth,
 	ColorInput,
 	ColorMode,

--- a/packages/style/src/runtimeExports.ts
+++ b/packages/style/src/runtimeExports.ts
@@ -2,9 +2,8 @@
 // Runtime Exports — Top-level color/modifier helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-import { bg as directBg, fg as directFg } from "./color.ts";
 import { style } from "./createStyle.ts";
-import type { ChainableStyleFn, ColorDepth, ColorInput, StyleInstance } from "./types.ts";
+import type { ChainableStyleFn, StyleInstance } from "./types.ts";
 
 export const black: ChainableStyleFn = style.black;
 export const red: ChainableStyleFn = style.red;
@@ -46,44 +45,5 @@ export const inverse: ChainableStyleFn = style.inverse;
 export const hidden: ChainableStyleFn = style.hidden;
 export const strikethrough: ChainableStyleFn = style.strikethrough;
 export const link: StyleInstance["link"] = style.link;
-
-/**
- * Apply a foreground color to `text`.
- *
- * Resolves the active color depth from the runtime style facade (respecting
- * `NO_COLOR`, `FORCE_COLOR`, and TTY detection) and emits the matching
- * terminal color format — truecolor, 256, 16, or none.
- *
- * @param text - The string to style. Empty input returns `""` after
- *   validating `input` (so invalid colors still throw).
- * @param input - Any {@link ColorInput} (named CSS color, hex, `rgb()`, or tuple).
- * @param depth - Optional override for the resolved color depth. When
- *   omitted, depth comes from the runtime style. Useful for deterministic
- *   output (e.g. tests, snapshots).
- * @returns The styled string with appropriate ANSI escape sequences.
- * @throws {TypeError} If `input` is not a recognized color.
- *
- * @example
- * ```ts
- * fg("error", "#ff0000");
- * fg("name", "rebeccapurple");
- * fg("deterministic", "#ff8800", "256"); // force 256-color
- * ```
- */
-export function fg(text: string, input: ColorInput, depth?: ColorDepth): string {
-	return depth === undefined ? style.fg(text, input) : directFg(text, input, depth);
-}
-
-/**
- * Apply a background color to `text`. Mirrors {@link fg} — see there for
- * details on `depth`, validation, and capability detection.
- *
- * @example
- * ```ts
- * bg("warning", "#ff8800");
- * bg("info", "rgb(0, 128, 255)", "16"); // force 16-color fallback
- * ```
- */
-export function bg(text: string, input: ColorInput, depth?: ColorDepth): string {
-	return depth === undefined ? style.bg(text, input) : directBg(text, input, depth);
-}
+export const fg: StyleInstance["fg"] = style.fg;
+export const bg: StyleInstance["bg"] = style.bg;


### PR DESCRIPTION
This refactor trims unused Style and Prompts surface while completing public type and custom-prompt exports that existing signatures require. Documentation and release notes now describe each supported seam and replacement.

### Changes

- **@crustjs/style**
  - Make top-level `fg`/`bg` use the chainable `StyleInstance` methods and remove their depth override.
  - Remove unused table width, padding, separator, and border options.
  - Export and document `ChainableStyleFn` and capability booleans.
- **@crustjs/prompts**
  - Remove `pressKey()` in favor of `type()`/`keys()` and migrate package tests.
  - Export and document custom-prompt rendering helpers and glyph constants.
- **@crustjs/core, @crustjs/extensions, @crustjs/store**
  - Export missing signature types and support `Crust._types` as a type-level seam.
  - Document `CrustErrorJson`, `UpdateCommandResolver`, `PlatformEnv`, and `SectionConsumer`.
- **@crustjs/progress, @crustjs/man, @crustjs/testing, @crustjs/skills**
  - Document existing public handle, option, capture, and workflow types; document `man.id`.

### Notes

- No items skipped.
- Breaking replacements: use `createStyle({ overrides })` instead of the `fg`/`bg` depth argument; use prompt `keys()`/`type()` instead of `pressKey()`.
- Added `simplify-style-surface`, `complete-prompt-kit`, and `export-public-types` changesets.

### Stack
This PR is part of the codebase-audit refactor stack (bottom → top). Merge in order; each PR targets the one below it.
1. refactor/audit-01-tooling ([#329](https://github.com/chenxin-yan/crust/pull/329))
2. refactor/audit-02-tests ([#330](https://github.com/chenxin-yan/crust/pull/330))
3. refactor/audit-03-core-shrink ([#331](https://github.com/chenxin-yan/crust/pull/331))
4. refactor/audit-04-ext-shrink ([#332](https://github.com/chenxin-yan/crust/pull/332))
5. refactor/audit-05-ui-shrink ([#333](https://github.com/chenxin-yan/crust/pull/333))
6. refactor/audit-06-core-seams ([#334](https://github.com/chenxin-yan/crust/pull/334))
7. refactor/audit-07-docmodel-version ([#335](https://github.com/chenxin-yan/crust/pull/335))
8. refactor/audit-08-cli-seams ([#336](https://github.com/chenxin-yan/crust/pull/336))
9. refactor/audit-09-public-api ([#337](https://github.com/chenxin-yan/crust/pull/337)) **(this PR)**
10. refactor/audit-10-ui-seams ([#338](https://github.com/chenxin-yan/crust/pull/338))
11. refactor/audit-11-store-docs ([#339](https://github.com/chenxin-yan/crust/pull/339))
