### PR TITLE
refactor(prompts,progress,style): one ambient IO scope, resolved-input isTTY, per-key capability overrides

### DIFF
--- a/.changeset/align-multiselect-default-cursor.md
+++ b/.changeset/align-multiselect-default-cursor.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/prompts": patch
+---
+
+Start multiselect prompts on the first default choice, matching multifilter, while sharing default selection and prompt short-circuit setup across prompt types.

--- a/.changeset/align-multiselect-default-cursor.md
+++ b/.changeset/align-multiselect-default-cursor.md
@@ -2,4 +2,4 @@
 "@crustjs/prompts": patch
 ---
 
-Start multiselect prompts on the first default choice, matching multifilter, while sharing default selection and prompt short-circuit setup across prompt types.
+Start multiselect prompts on the first default choice, matching multifilter, while preserving array-valued choices as scalar defaults in select and filter prompts.

--- a/.changeset/fallback-partial-style-overrides.md
+++ b/.changeset/fallback-partial-style-overrides.md
@@ -2,4 +2,4 @@
 "@crustjs/style": patch
 ---
 
-Make each omitted `CapabilityOverrides` property fall back to its matching runtime environment input instead of a partial override object clearing every unspecified capability.
+Make each omitted `CapabilityOverrides` property fall back to its matching runtime environment input, and expose dynamic-color chain pairs at the configured color depth.

--- a/.changeset/fallback-partial-style-overrides.md
+++ b/.changeset/fallback-partial-style-overrides.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/style": patch
+---
+
+Make each omitted `CapabilityOverrides` property fall back to its matching runtime environment input instead of a partial override object clearing every unspecified capability.

--- a/.changeset/fix-ambient-prompt-tty.md
+++ b/.changeset/fix-ambient-prompt-tty.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/prompts": patch
+---
+
+Make `isTTY()` and `assertTTY()` default to the resolved ambient prompt input instead of always reading `process.stdin`. `resolvePromptIO()` is now exported for custom prompt lifecycle checks.

--- a/.changeset/keep-style-chains-dynamic.md
+++ b/.changeset/keep-style-chains-dynamic.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/style": minor
+---
+
+Keep stored style sub-chains mode-aware: named and dynamic-color chains now respect terminal capability and color-depth changes when called instead of freezing them when the chain is created.

--- a/.changeset/unify-terminal-io-scope.md
+++ b/.changeset/unify-terminal-io-scope.md
@@ -1,0 +1,7 @@
+---
+"@crustjs/prompts": minor
+"@crustjs/progress": minor
+"@crustjs/testing": patch
+---
+
+Add `withTerminalIO()` to prompts and progress so prompts, spinners, and progress indicators share one ambient input/output scope. Existing `withPromptIO()` and `withProgressSink()` APIs remain as focused aliases, and `ProgressSink` now accepts writable-compatible outputs with optional TTY metadata.

--- a/apps/docs/content/docs/guide/testing.mdx
+++ b/apps/docs/content/docs/guide/testing.mdx
@@ -66,7 +66,7 @@ See [Contexts](/docs/guide/contexts#test-doubles).
 
 ## Test interactive commands
 
-Use `runInteractive()` when an action renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. Prompt frames and `ctx.stderr()` text share one stderr transcript, so `waitFor()` and `screen()` observe the same terminal output.
+Use `runInteractive()` when an action renders a built-in prompt. Its `type()` and `keys()` methods send terminal input. One ambient terminal-IO scope routes prompt frames, progress indicators, and `ctx.stderr()` text into the same transcript, so `waitFor()` and `screen()` observe the same terminal output. Application code can use either package's `withTerminalIO()` export; `withPromptIO()` and `withProgressSink()` remain focused aliases.
 
 ```ts
 import { expect, test } from "bun:test";

--- a/apps/docs/content/docs/modules/progress.mdx
+++ b/apps/docs/content/docs/modules/progress.mdx
@@ -184,22 +184,22 @@ The bare `progress`/`spinner` exports use `defaultTheme`. Resolution order: `def
 
 ## Output sinks
 
-Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a `ProgressSink` (`{ isTTY, write }`) receiving the rendered output — and `withProgressSink(sink, fn)` makes a sink ambiently available to every indicator created in `fn`'s async scope, mirroring `withPromptIO` in `@crustjs/prompts`. Resolution order: per-call `sink` option → ambient sink → ambient `InvocationIO` from `@crustjs/core` → `process.stderr`.
+Indicators write to `process.stderr` by default so piped `stdout` stays clean. Both `spinner()` and `progress()` accept a `sink` option — a writable-compatible `ProgressSink` with optional `isTTY` — and `withTerminalIO(io, fn)` makes input/output streams ambiently available to prompts and indicators in the same async scope. `withProgressSink(sink, fn)` remains an output-only alias. Resolution order: per-call `sink` option → ambient terminal output → `process.stderr`.
 
-When a Core invocation receives explicit `io`, its `stderr(text)` callback supplies the ambient fallback. The adapter is intentionally non-TTY: captured or redirected progress emits one static final line instead of cursor animation. Omitting invocation IO preserves native terminal detection.
+When a Core invocation receives explicit `io`, its `stderr(text)` callback supplies the ambient output through a line-buffering adapter shared with prompts. The adapter is intentionally non-TTY: captured or redirected progress emits one static final line instead of cursor animation. Omitting invocation IO preserves native terminal detection.
 
 ```ts
-import { type ProgressSink, spinner, withProgressSink } from "@crustjs/progress";
+import { type ProgressSink, spinner, withTerminalIO } from "@crustjs/progress";
 
 const sink: ProgressSink = {
   isTTY: false,
   write: (text) => transcript.push(text),
 };
 
-await withProgressSink(sink, () => deploy()); // spinners inside write their final lines to `sink` (no frames: isTTY is false)
+await withTerminalIO({ output: sink }, () => deploy()); // prompts and indicators share this output
 ```
 
-`runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses this ambient sink to render spinners onto its fake terminal screen.
+`runInteractive()` in [`@crustjs/testing`](/docs/modules/testing) uses one ambient terminal scope to render prompts and indicators onto its fake terminal screen.
 
 ## Non-interactive behavior
 

--- a/apps/docs/content/docs/modules/prompts.mdx
+++ b/apps/docs/content/docs/modules/prompts.mdx
@@ -53,18 +53,18 @@ const addons = await multifilter({
 
 ## Injecting IO
 
-Every prompt accepts an optional second `io` argument. Prompt input resolves from the explicit argument, the current `withPromptIO()` scope, then `process.stdin`. Prompt output adds one fallback before `process.stderr`: ambient `InvocationIO` supplied when `@crustjs/core` receives explicit invocation IO. Prompt UI therefore follows an injected Core `stderr(text)` callback instead of escaping to the process terminal.
+Every prompt accepts an optional second `io` argument. Input and output resolve from the explicit argument, the current `withTerminalIO()` scope, then `process.stdin` / `process.stderr`. `withPromptIO()` remains an output-compatible alias for prompt-focused code. The same ambient scope is shared with `@crustjs/progress`, so one scope can route prompts and indicators together.
 
-Only output is bridged. Core's line-oriented IO cannot supply an interactive input stream, so inject `PromptIO.input` explicitly (or use the testing helpers) when a test needs to drive a prompt. Per-call and `withPromptIO()` streams still take precedence over the Core bridge, and omitting invocation IO preserves the process-stream defaults.
+When `@crustjs/core` receives explicit invocation IO, its line-oriented `stderr(text)` callback is bridged into this scope as a non-TTY output. Core cannot supply an interactive input stream, so inject `PromptIO.input` explicitly (or use the testing helpers) when a test needs to drive a prompt. An existing terminal scope takes precedence over the Core bridge, and omitting invocation IO preserves the process-stream defaults.
 
 ```ts
-import { select, withPromptIO, type PromptIO } from "@crustjs/prompts";
+import { select, withTerminalIO, type PromptIO } from "@crustjs/prompts";
 
 declare const io: PromptIO;
 
 const choice = await select({ message: "Pick one", choices: ["a", "b"] }, io);
 
-const scopedChoice = await withPromptIO(io, () =>
+const scopedChoice = await withTerminalIO(io, () =>
   select({ message: "Pick one", choices: ["a", "b"] }),
 );
 ```
@@ -428,15 +428,17 @@ Only one prompt can be active per input or output stream. Prompts on fully disti
 
 ### Renderer
 
-| Export                | Description                                          |
-| --------------------- | ---------------------------------------------------- |
-| `runPrompt`           | Low-level prompt runner; accepts optional `PromptIO` |
-| `submit`              | Create a submit result to resolve a prompt           |
-| `assertTTY`           | Throw `NonInteractiveError` if stdin is not a TTY    |
-| `isTTY`               | Check whether an input stream is an interactive TTY  |
-| `withPromptIO`        | Scope prompt IO for nested async prompt calls        |
-| `PromptIO`            | Optional input/output streams for prompts            |
-| `NonInteractiveError` | Error thrown when a TTY is required but absent       |
+| Export                | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `runPrompt`           | Low-level prompt runner; accepts optional `PromptIO`               |
+| `submit`              | Create a submit result to resolve a prompt                         |
+| `assertTTY`           | Throw `NonInteractiveError` if the resolved input is not a TTY     |
+| `isTTY`               | Check whether the resolved or supplied input is an interactive TTY |
+| `resolvePromptIO`     | Resolve explicit, ambient, then process streams                    |
+| `withTerminalIO`      | Scope shared terminal IO for nested async UI calls                 |
+| `withPromptIO`        | Prompt-focused alias of `withTerminalIO`                           |
+| `PromptIO`            | Optional input/output streams for prompts                          |
+| `NonInteractiveError` | Error thrown when a TTY is required but absent                     |
 
 Ctrl+C cancellation rejects with a standard `DOMException` named `"AbortError"` — check `err.name === "AbortError"`.
 

--- a/apps/docs/content/docs/modules/style.mdx
+++ b/apps/docs/content/docs/modules/style.mdx
@@ -94,7 +94,7 @@ Inspect the resolved tier via `style.colorDepth` (live) or `instance.colorDepth`
 
 Two channels, one rule each:
 
-**The environment controls the default exports.** `style` and all named helpers re-resolve these standard variables on every call:
+**The environment controls the default exports.** `style`, named helpers, and stored chains re-resolve these standard variables on every call:
 
 | Variable                           | Effect                                                                                          |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -126,6 +126,8 @@ const t = createStyle({
   overrides: { isTTY: true, noColor: undefined, forceColor: undefined, colorTerm: "truecolor" },
 });
 ```
+
+Each `overrides` property replaces only its matching runtime input. Omitted properties continue to read `process.stdout` or `process.env`; set a property explicitly to `undefined` when a deterministic test must simulate an unset environment variable.
 
 ## Hyperlinks (OSC 8)
 
@@ -187,8 +189,6 @@ type ColorInput =
 <auto-type-table path="../../../../../packages/style/src/blocks/tables.ts" name="TableOptions" />
 
 ## Fine print
-
-**Capture semantics.** Top-level helpers and first-level properties (`style.bold`) are forwarders — they re-resolve the environment on every call. Deeper chains (`style.bold.red`) snapshot the resolved instance at access time (chalk/ansis parity). Capture the first level and chain at the call site when a reference must follow later env changes.
 
 **`open` / `close` for hot paths.** Every chainable exposes its raw ANSI codes (chalk/ansis parity) for manual composition in tight loops. They are static strings that bypass mode detection — check `style.enabled` first. Note `chain.open + text + chain.close` matches `chain(text)` byte-for-byte only when adjacent steps have distinct close codes; when steps share one (e.g. `bold` + `dim` both close with `\x1b[22m`), `chain(text)` re-opens the outer style after each inner close to prevent bleed. Use `chain(text)` for emission.
 

--- a/apps/docs/content/docs/modules/testing.mdx
+++ b/apps/docs/content/docs/modules/testing.mdx
@@ -93,7 +93,7 @@ run.keys("return");
 await run.done;
 ```
 
-`screen()` returns the ANSI-stripped terminal screen. Prompt frames, `ctx.stderr()` output, and `@crustjs/progress` indicators (routed via the ambient [`withProgressSink`](/docs/modules/progress#output-sinks) sink) all share that screen and the transcript scanned by `waitFor()`.
+`screen()` returns the ANSI-stripped terminal screen. One ambient [`withTerminalIO`](/docs/modules/progress#output-sinks) scope routes prompt frames, `ctx.stderr()` output, and `@crustjs/progress` indicators into that screen and the transcript scanned by `waitFor()`.
 
 The return type is `InteractiveRun`:
 

--- a/packages/progress/README.md
+++ b/packages/progress/README.md
@@ -1,6 +1,8 @@
 # @crustjs/progress
 
-Progress indicators for the Crust CLI ecosystem
+Progress indicators for the Crust CLI ecosystem.
+
+Use `withTerminalIO()` to share ambient input/output with `@crustjs/prompts`; `withProgressSink()` remains an output-only alias.
 
 ## Install
 

--- a/packages/progress/src/index.ts
+++ b/packages/progress/src/index.ts
@@ -12,7 +12,8 @@ export type {
 	SpinnerOutcome,
 	SpinnerSigintPolicy,
 	SpinnerType,
+	TerminalIO,
 } from "./spinner.ts";
-export { spinner, withProgressSink } from "./spinner.ts";
+export { spinner, withProgressSink, withTerminalIO } from "./spinner.ts";
 export { defaultTheme } from "./theme.ts";
 export type { PartialProgressTheme, ProgressTheme } from "./theme.ts";

--- a/packages/progress/src/spinner.ts
+++ b/packages/progress/src/spinner.ts
@@ -2,9 +2,12 @@
 // Spinner — Animated progress spinner for @crustjs/progress
 // ────────────────────────────────────────────────────────────────────────────
 
-import { AsyncLocalStorage } from "node:async_hooks";
-
-import { getAmbientTerminalIO } from "@crustjs/utils/terminal";
+import {
+	getTerminalIO,
+	type TerminalIO as SharedTerminalIO,
+	type TerminalOutput,
+	withTerminalIO as withSharedTerminalIO,
+} from "@crustjs/utils/terminal";
 
 import { defaultTheme } from "./theme.ts";
 import type { PartialProgressTheme, ProgressTheme } from "./theme.ts";
@@ -85,8 +88,7 @@ export interface SpinnerHandleOptions {
 	readonly sigint?: SpinnerSigintPolicy;
 	/**
 	 * Terminal sink receiving the rendered output. Resolution order:
-	 * this option → ambient {@link withProgressSink} sink → ambient invocation
-	 * IO → `process.stderr`.
+	 * this option → ambient {@link withTerminalIO} output → `process.stderr`.
 	 */
 	readonly sink?: ProgressSink;
 }
@@ -146,48 +148,27 @@ function renderFinal(
 	return erase ? ERASE_LINE + CURSOR_TO_START + line : line;
 }
 
-/** Terminal operations driven by spinners and progress indicators. */
-export interface ProgressSink {
-	readonly isTTY: boolean;
-	write: (text: string) => void;
+/** Terminal IO shared by prompts, spinners, and progress indicators. */
+export type TerminalIO = SharedTerminalIO;
+
+/** Writable-compatible output driven by spinners and progress indicators. */
+export type ProgressSink = TerminalOutput;
+
+/** Run a function with terminal streams available to UI created in its async scope. */
+export function withTerminalIO<T>(io: TerminalIO, fn: () => T): T {
+	return withSharedTerminalIO(io, fn);
 }
 
-const sinkStorage = new AsyncLocalStorage<ProgressSink>();
-
-/**
- * Run a function with a sink ambiently available to every spinner or
- * progress indicator created in its async scope (unless a per-call
- * `sink` option overrides it). Mirrors `withPromptIO` in
- * `@crustjs/prompts` — test harnesses and embedders redirect indicator
- * output without touching process globals.
- */
+/** Run a function with an ambient output sink for progress indicators. */
 export function withProgressSink<T>(sink: ProgressSink, fn: () => T): T {
-	return sinkStorage.run(sink, fn);
-}
-
-const processSink: ProgressSink = {
-	get isTTY() {
-		return process.stderr.isTTY ?? false;
-	},
-	write(text) {
-		process.stderr.write(text);
-	},
-};
-
-function ambientTerminalSink(): ProgressSink | undefined {
-	const io = getAmbientTerminalIO();
-	if (!io) return undefined;
-	return {
-		isTTY: false,
-		write: (text) => io.stderr(text.endsWith("\n") ? text.slice(0, -1) : text),
-	};
+	return withSharedTerminalIO({ output: sink }, fn);
 }
 
 /** Internal handle constructor shared by both `spinner()` modes and `progress()`. */
 export function createSpinnerHandle(options: SpinnerHandleOptions): SpinnerHandle {
-	const sink = options.sink ?? sinkStorage.getStore() ?? ambientTerminalSink() ?? processSink;
+	const sink = options.sink ?? getTerminalIO()?.output ?? process.stderr;
 	const theme = options.theme ? { ...defaultTheme, ...options.theme } : defaultTheme;
-	const isInteractive = sink.isTTY;
+	const isInteractive = sink.isTTY ?? false;
 	const { frames, interval } = resolveSpinner(options.spinner);
 	const sigint = options.sigint ?? "exit";
 

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -12,7 +12,7 @@ bun add @crustjs/prompts
 
 The package root exports the built-in rendering pieces, including `renderTextWithCursor`, `highlightMatches`, `formatPromptLine`, `formatSubmitted`, `renderChoiceList`, and the shared prompt glyph constants.
 
-Test prompts through `@crustjs/prompts/testing`: call `prompt.type(text)` for literal text and `prompt.keys(...keys)` for named or control keys.
+Test prompts through `@crustjs/prompts/testing`: call `prompt.type(text)` for literal text and `prompt.keys(...keys)` for named or control keys. Use `withTerminalIO()` to route prompts and `@crustjs/progress` indicators through one ambient input/output scope; `withPromptIO()` remains an alias.
 
 ## Documentation
 

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -1,19 +1,23 @@
 import type { FuzzyFilterResult } from "./fuzzy.ts";
 import { fuzzyFilter } from "./fuzzy.ts";
 import type { PromptIO } from "./renderer.ts";
-import { isTTY, resolvePromptIO } from "./renderer.ts";
+import { resolveShortCircuit } from "./shortCircuit.ts";
 import type { Choice } from "./types.ts";
 import type { NormalizedChoice } from "./utils.ts";
 import { calculateScrollOffset, DEFAULT_MAX_VISIBLE, normalizeChoices } from "./utils.ts";
 
-interface ListPromptOptions<T, Answer> {
+function isDefaultArray<T>(value: T | readonly T[] | undefined): value is readonly T[] {
+	return Array.isArray(value);
+}
+
+interface ListPromptOptions<T, Answer extends T | readonly T[]> {
 	readonly choices: readonly Choice<T>[];
 	readonly initial?: Answer;
 	readonly default?: Answer;
 	readonly maxVisible?: number;
 }
 
-type ListPromptSetup<T, Answer> =
+type ListPromptSetup<T, Answer extends T | readonly T[]> =
 	| { readonly shortCircuited: true; readonly value: Answer }
 	| {
 			readonly shortCircuited: false;
@@ -21,28 +25,32 @@ type ListPromptSetup<T, Answer> =
 			readonly maxVisible: number;
 			readonly cursor: number;
 			readonly scrollOffset: number;
+			readonly selected: ReadonlySet<number>;
 			readonly promptIO: Required<PromptIO>;
 	  };
 
 /** @internal Resolve the shared lifecycle and initial viewport for list prompts. */
-export function setupListPrompt<T, Answer>(
+export async function setupListPrompt<T, Answer extends T | readonly T[]>(
 	options: ListPromptOptions<T, Answer>,
 	io?: PromptIO,
-	defaultCursorValue?: T,
-	hasDefaultCursor: boolean = defaultCursorValue !== undefined,
-): ListPromptSetup<T, Answer> {
-	if (options.initial !== undefined) return { shortCircuited: true, value: options.initial };
-
-	const promptIO = resolvePromptIO(io);
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return { shortCircuited: true, value: options.default };
-	}
+): Promise<ListPromptSetup<T, Answer>> {
+	const shortCircuit = await resolveShortCircuit(options, io);
+	if (shortCircuit.shortCircuited) return shortCircuit;
 
 	const choices = normalizeChoices(options.choices);
 	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const defaultCursor = hasDefaultCursor
-		? choices.findIndex((choice) => choice.value === defaultCursorValue)
-		: -1;
+	const defaults = isDefaultArray<T>(options.default)
+		? options.default
+		: options.default === undefined
+			? []
+			: [options.default];
+	const selected = new Set(
+		defaults
+			.map((value) => choices.findIndex((choice) => choice.value === value))
+			.filter((index) => index !== -1),
+	);
+	const defaultCursor =
+		defaults.length === 0 ? -1 : choices.findIndex((choice) => choice.value === defaults[0]);
 	const cursor = defaultCursor === -1 ? 0 : defaultCursor;
 
 	return {
@@ -51,7 +59,8 @@ export function setupListPrompt<T, Answer>(
 		maxVisible,
 		cursor,
 		scrollOffset: calculateScrollOffset(cursor, 0, choices.length, maxVisible),
-		promptIO,
+		selected,
+		promptIO: shortCircuit.promptIO,
 	};
 }
 

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -6,10 +6,6 @@ import type { Choice } from "./types.ts";
 import type { NormalizedChoice } from "./utils.ts";
 import { calculateScrollOffset, DEFAULT_MAX_VISIBLE, normalizeChoices } from "./utils.ts";
 
-function isDefaultArray<T>(value: T | readonly T[] | undefined): value is readonly T[] {
-	return Array.isArray(value);
-}
-
 interface ListPromptOptions<T, Answer extends T | readonly T[]> {
 	readonly choices: readonly Choice<T>[];
 	readonly initial?: Answer;
@@ -32,6 +28,7 @@ type ListPromptSetup<T, Answer extends T | readonly T[]> =
 /** @internal Resolve the shared lifecycle and initial viewport for list prompts. */
 export async function setupListPrompt<T, Answer extends T | readonly T[]>(
 	options: ListPromptOptions<T, Answer>,
+	mode: "single" | "multiple",
 	io?: PromptIO,
 ): Promise<ListPromptSetup<T, Answer>> {
 	const shortCircuit = await resolveShortCircuit(options, io);
@@ -39,11 +36,13 @@ export async function setupListPrompt<T, Answer extends T | readonly T[]>(
 
 	const choices = normalizeChoices(options.choices);
 	const maxVisible = options.maxVisible ?? DEFAULT_MAX_VISIBLE;
-	const defaults = isDefaultArray<T>(options.default)
-		? options.default
-		: options.default === undefined
+	// SAFETY: The explicit mode disambiguates scalar array-valued T from multi-answer T[].
+	const defaults: readonly T[] =
+		options.default === undefined
 			? []
-			: [options.default];
+			: mode === "multiple"
+				? (options.default as readonly T[])
+				: [options.default as T];
 	const selected = new Set(
 		defaults
 			.map((value) => choices.findIndex((choice) => choice.value === value))

--- a/packages/prompts/src/core/renderer.test.ts
+++ b/packages/prompts/src/core/renderer.test.ts
@@ -6,6 +6,7 @@ import { withAmbientTerminalIO } from "@crustjs/utils/terminal";
 import { createPromptIO } from "../testing.ts";
 import {
 	assertTTY,
+	isTTY,
 	NonInteractiveError,
 	type PromptConfig,
 	resolvePromptIO,
@@ -65,6 +66,19 @@ describe("assertTTY", () => {
 		});
 
 		expect(() => assertTTY()).toThrow(NonInteractiveError);
+	});
+
+	it("uses the ambient prompt input by default", () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: true,
+			writable: true,
+			configurable: true,
+		});
+		const harness = createPromptIO({ isTTY: false });
+		withPromptIO(harness.io, () => {
+			expect(isTTY()).toBe(false);
+			expect(() => assertTTY()).toThrow(NonInteractiveError);
+		});
 	});
 
 	it("does not throw when stdin is a TTY", () => {

--- a/packages/prompts/src/core/renderer.ts
+++ b/packages/prompts/src/core/renderer.ts
@@ -2,13 +2,16 @@
 // Renderer — Core terminal rendering engine for @crustjs/prompts
 // ────────────────────────────────────────────────────────────────────────────
 
-import { AsyncLocalStorage } from "node:async_hooks";
 import * as readline from "node:readline";
-import type { Readable } from "node:stream";
-import { Writable } from "node:stream";
 
 import { stringWidth } from "@crustjs/style";
-import { getAmbientTerminalIO } from "@crustjs/utils/terminal";
+import {
+	getTerminalIO,
+	type TerminalIO,
+	type TerminalInput,
+	type TerminalOutput,
+	withTerminalIO as withSharedTerminalIO,
+} from "@crustjs/utils/terminal";
 
 import { defaultTheme } from "./theme.ts";
 import type { PartialPromptTheme, PromptTheme } from "./types.ts";
@@ -18,55 +21,30 @@ import type { PartialPromptTheme, PromptTheme } from "./types.ts";
 // ────────────────────────────────────────────────────────────────────────────
 
 /** A readable stream that can drive an interactive terminal prompt. */
-export type PromptInput = Readable & {
-	readonly isTTY?: boolean;
-	readonly isRaw?: boolean;
-	setRawMode?: (mode: boolean) => void;
-};
+export type PromptInput = TerminalInput;
 
-export type PromptOutput = Writable & {
-	readonly columns?: number;
-};
+/** A writable stream that receives prompt output. */
+export type PromptOutput = TerminalOutput;
 
 /** Streams used to render and receive input for a prompt. */
-export interface PromptIO {
-	readonly input?: PromptInput;
-	readonly output?: PromptOutput;
-}
+export type PromptIO = TerminalIO;
 
-const promptIOStorage = new AsyncLocalStorage<PromptIO>();
+/** Run a function with terminal streams available to UI created in its async scope. */
+export function withTerminalIO<T>(io: PromptIO, fn: () => T): T {
+	return withSharedTerminalIO(io, fn);
+}
 
 /** Run a function with prompt streams available to prompts created in its async scope. */
 export function withPromptIO<T>(io: PromptIO, fn: () => T): T {
-	return promptIOStorage.run(io, fn);
+	return withSharedTerminalIO(io, fn);
 }
 
-function ambientTerminalWritable(): PromptOutput | undefined {
-	const io = getAmbientTerminalIO();
-	if (!io) return undefined;
-
-	let pending = "";
-	return new Writable({
-		decodeStrings: false,
-		write(chunk, _encoding, callback) {
-			pending += chunk.toString();
-			let newline = pending.indexOf("\n");
-			while (newline !== -1) {
-				io.stderr(pending.slice(0, newline));
-				pending = pending.slice(newline + 1);
-				newline = pending.indexOf("\n");
-			}
-			callback();
-		},
-	});
-}
-
-/** Resolve explicit, prompt-scoped, invocation, then process-global streams. */
+/** Resolve explicit, ambient, then process-global streams. */
 export function resolvePromptIO(io?: PromptIO): Required<PromptIO> {
-	const ambient = promptIOStorage.getStore();
+	const ambient = getTerminalIO();
 	return {
 		input: io?.input ?? ambient?.input ?? process.stdin,
-		output: io?.output ?? ambient?.output ?? ambientTerminalWritable() ?? process.stderr,
+		output: io?.output ?? ambient?.output ?? process.stderr,
 	};
 }
 
@@ -198,18 +176,18 @@ export class NonInteractiveError extends Error {
 }
 
 /**
- * Check whether stdin is an interactive TTY.
- * @returns `true` if stdin is a TTY, `false` otherwise
+ * Check whether the resolved prompt input is an interactive TTY.
+ * @returns `true` if the input is a TTY, `false` otherwise
  */
-export function isTTY(input: Pick<PromptInput, "isTTY"> = process.stdin): boolean {
+export function isTTY(input: Pick<PromptInput, "isTTY"> = resolvePromptIO().input): boolean {
 	return !!input.isTTY;
 }
 
 /**
- * Check that stdin is an interactive TTY.
- * @throws {NonInteractiveError} when stdin is not a TTY
+ * Check that the resolved prompt input is an interactive TTY.
+ * @throws {NonInteractiveError} when the input is not a TTY
  */
-export function assertTTY(input: Pick<PromptInput, "isTTY"> = process.stdin): void {
+export function assertTTY(input: Pick<PromptInput, "isTTY"> = resolvePromptIO().input): void {
 	if (!isTTY(input)) {
 		throw new NonInteractiveError();
 	}
@@ -260,6 +238,8 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 	const { render, handleKey, initialState, renderSubmitted } = config;
 	const theme = config.theme ? { ...defaultTheme, ...config.theme } : defaultTheme;
 	const { input: stdin, output } = resolvePromptIO(io);
+	// SAFETY: readline's cursor helpers only call write(), which PromptOutput provides.
+	const readlineOutput = output as NodeJS.WritableStream;
 
 	return new Promise<T>((resolve, reject) => {
 		// Guard against concurrent prompts sharing an input stream.
@@ -304,9 +284,9 @@ export function runPrompt<S, T>(config: PromptConfig<S, T>, io?: PromptIO): Prom
 
 			// Erase previous frame
 			if (prevLineCount > 0) {
-				readline.cursorTo(output, 0);
-				readline.moveCursor(output, 0, -(prevLineCount - 1));
-				readline.clearScreenDown(output);
+				readline.cursorTo(readlineOutput, 0);
+				readline.moveCursor(readlineOutput, 0, -(prevLineCount - 1));
+				readline.clearScreenDown(readlineOutput);
 			}
 
 			output.write(content);

--- a/packages/prompts/src/core/shortCircuit.ts
+++ b/packages/prompts/src/core/shortCircuit.ts
@@ -1,0 +1,44 @@
+import type { PromptIO } from "./renderer.ts";
+import { isTTY, resolvePromptIO } from "./renderer.ts";
+
+type ShortCircuitOptions<Input> = {
+	readonly initial?: Input;
+	readonly default?: Input;
+};
+
+type ShortCircuitResult<Answer> =
+	| { readonly shortCircuited: true; readonly value: Answer }
+	| { readonly shortCircuited: false; readonly promptIO: Required<PromptIO> };
+
+/** @internal Resolve values that let a prompt answer without rendering. */
+export function resolveShortCircuit<Input>(
+	options: ShortCircuitOptions<Input>,
+	io?: PromptIO,
+): Promise<ShortCircuitResult<Input>>;
+export function resolveShortCircuit<Input, Answer>(
+	options: ShortCircuitOptions<Input>,
+	io: PromptIO | undefined,
+	parse: (value: Input, source: "initial" | "default") => Answer | Promise<Answer>,
+): Promise<ShortCircuitResult<Answer>>;
+export async function resolveShortCircuit<Input, Answer>(
+	options: ShortCircuitOptions<Input>,
+	io?: PromptIO,
+	parse?: (value: Input, source: "initial" | "default") => Answer | Promise<Answer>,
+): Promise<ShortCircuitResult<Input | Answer>> {
+	if (options.initial !== undefined) {
+		return {
+			shortCircuited: true,
+			value: parse ? await parse(options.initial, "initial") : options.initial,
+		};
+	}
+
+	const promptIO = resolvePromptIO(io);
+	if (!isTTY(promptIO.input) && options.default !== undefined) {
+		return {
+			shortCircuited: true,
+			value: parse ? await parse(options.default, "default") : options.default,
+		};
+	}
+
+	return { shortCircuited: false, promptIO };
+}

--- a/packages/prompts/src/core/validate.ts
+++ b/packages/prompts/src/core/validate.ts
@@ -2,12 +2,6 @@ import type { StandardSchema } from "@crustjs/utils/schema";
 
 import type { ValidateFn } from "./types.ts";
 
-type PromptInitialOptions<Output> = {
-	readonly schema?: StandardSchema<unknown, Output>;
-	readonly validate?: ValidateFn<string>;
-	readonly initial?: string;
-};
-
 export async function validateSubmitValue<Output>(
 	value: string,
 	schema: StandardSchema<unknown, Output> | undefined,
@@ -40,24 +34,4 @@ export async function parseShortCircuit<Output>(
 	if (!result.ok) throw new Error(`${source} value rejected by schema: ${result.error}`);
 	// SAFETY: a provided schema makes validateSubmitValue return only that schema's output.
 	return result.value as Output;
-}
-
-/** @internal Validate shared text-prompt options and resolve an initial value. */
-export async function resolvePromptInitial<Output>(
-	promptName: "input" | "password",
-	options: PromptInitialOptions<Output>,
-): Promise<
-	| { readonly shortCircuited: false }
-	| { readonly shortCircuited: true; readonly value: Output | string }
-> {
-	if (options.schema !== undefined && options.validate !== undefined) {
-		throw new Error(`${promptName}() cannot combine "schema" with "validate"`);
-	}
-	if (options.initial === undefined) return { shortCircuited: false };
-	return {
-		shortCircuited: true,
-		value: options.schema
-			? await parseShortCircuit(options.schema, options.initial, "initial")
-			: options.initial,
-	};
 }

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -41,9 +41,11 @@ export {
 	assertTTY,
 	isTTY,
 	NonInteractiveError,
+	resolvePromptIO,
 	runPrompt,
 	submit,
 	withPromptIO,
+	withTerminalIO,
 } from "./core/renderer.ts";
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/prompts/src/prompts/confirm.ts
+++ b/packages/prompts/src/prompts/confirm.ts
@@ -3,7 +3,8 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { KeypressEvent, PromptIO, SubmitResult } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt, submit } from "../core/renderer.ts";
+import { runPrompt, submit } from "../core/renderer.ts";
+import { resolveShortCircuit } from "../core/shortCircuit.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import type { PartialPromptTheme, PromptTheme } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
@@ -182,18 +183,9 @@ function renderSubmitted(
  * ```
  */
 export async function confirm(options: ConfirmOptions, io?: PromptIO): Promise<boolean> {
-	// Short-circuit: return initial value immediately without rendering
-	if (options.initial !== undefined) {
-		return options.initial;
-	}
-
-	const promptIO = resolvePromptIO(io);
-
-	// Non-interactive fallback: return default value when stdin is not a TTY
-	// Only triggers when user explicitly passed `default` (not the internal default of `true`)
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		return options.default;
-	}
+	const shortCircuit = await resolveShortCircuit(options, io);
+	if (shortCircuit.shortCircuited) return shortCircuit.value;
+	const { promptIO } = shortCircuit;
 
 	const activeLabel = options.active ?? "Yes";
 	const inactiveLabel = options.inactive ?? "No";

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -227,7 +227,7 @@ export function filter(
 ): Promise<string>;
 export function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T>;
 export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
-	const setup = setupListPrompt<T, T>(options, io, options.default);
+	const setup = await setupListPrompt<T, T>(options, io);
 	if (setup.shortCircuited) return setup.value;
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;

--- a/packages/prompts/src/prompts/filter.ts
+++ b/packages/prompts/src/prompts/filter.ts
@@ -227,7 +227,7 @@ export function filter(
 ): Promise<string>;
 export function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T>;
 export async function filter<T>(options: FilterOptions<T>, io?: PromptIO): Promise<T> {
-	const setup = await setupListPrompt<T, T>(options, io);
+	const setup = await setupListPrompt<T, T>(options, "single", io);
 	if (setup.shortCircuited) return setup.value;
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;

--- a/packages/prompts/src/prompts/input.ts
+++ b/packages/prompts/src/prompts/input.ts
@@ -5,7 +5,8 @@
 import type { StandardSchema } from "@crustjs/utils/schema";
 
 import type { PromptIO } from "../core/renderer.ts";
-import { isTTY, resolvePromptIO, runPrompt } from "../core/renderer.ts";
+import { runPrompt } from "../core/renderer.ts";
+import { resolveShortCircuit } from "../core/shortCircuit.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { createTextSubmitHandler, renderTextWithCursor } from "../core/textEdit.ts";
 import type { TextSubmitState } from "../core/textEdit.ts";
@@ -16,7 +17,7 @@ import type {
 	ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
-import { parseShortCircuit, resolvePromptInitial } from "../core/validate.ts";
+import { parseShortCircuit } from "../core/validate.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -176,16 +177,17 @@ export async function input<Output>(
 	options: InputOptions<Output> = {},
 	io?: PromptIO,
 ): Promise<Output | string> {
-	const initial = await resolvePromptInitial("input", options);
-	if (initial.shortCircuited) return initial.value;
-
-	const promptIO = resolvePromptIO(io);
-
-	// Non-interactive defaults also flow through the schema.
-	if (!isTTY(promptIO.input) && options.default !== undefined) {
-		if (options.schema) return parseShortCircuit(options.schema, options.default, "default");
-		return options.default;
+	if (options.schema !== undefined && options.validate !== undefined) {
+		throw new Error('input() cannot combine "schema" with "validate"');
 	}
+	const schema = options.schema;
+	const shortCircuit = schema
+		? await resolveShortCircuit(options, io, (value, source) =>
+				parseShortCircuit(schema, value, source),
+			)
+		: await resolveShortCircuit(options, io);
+	if (shortCircuit.shortCircuited) return shortCircuit.value;
+	const { promptIO } = shortCircuit;
 
 	const initialState: TextSubmitState = {
 		value: "",

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -260,7 +260,7 @@ export function multifilter(
 ): Promise<string[]>;
 export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
-	const setup = await setupListPrompt<T, readonly T[]>(options, io);
+	const setup = await setupListPrompt<T, readonly T[]>(options, "multiple", io);
 	if (setup.shortCircuited) return [...setup.value];
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset, selected } = setup;

--- a/packages/prompts/src/prompts/multifilter.ts
+++ b/packages/prompts/src/prompts/multifilter.ts
@@ -260,26 +260,11 @@ export function multifilter(
 ): Promise<string[]>;
 export function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multifilter<T>(options: MultifilterOptions<T>, io?: PromptIO): Promise<T[]> {
-	const setup = setupListPrompt<T, readonly T[]>(
-		options,
-		io,
-		options.default?.[0],
-		(options.default?.length ?? 0) > 0,
-	);
+	const setup = await setupListPrompt<T, readonly T[]>(options, io);
 	if (setup.shortCircuited) return [...setup.value];
 
-	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
+	const { choices, cursor, maxVisible, promptIO, scrollOffset, selected } = setup;
 	const results = fuzzyFilter("", choices);
-
-	const selected = new Set<number>();
-	if (options.default) {
-		for (const defaultValue of options.default) {
-			const idx = choices.findIndex((choice) => choice.value === defaultValue);
-			if (idx !== -1) {
-				selected.add(idx);
-			}
-		}
-	}
 
 	const initialState: MultifilterState<T> = {
 		query: "",
@@ -288,7 +273,7 @@ export async function multifilter<T>(options: MultifilterOptions<T>, io?: Prompt
 		results,
 		listCursor: cursor,
 		scrollOffset,
-		selected,
+		selected: new Set(selected),
 		error: null,
 	};
 

--- a/packages/prompts/src/prompts/multiselect.test.ts
+++ b/packages/prompts/src/prompts/multiselect.test.ts
@@ -45,6 +45,21 @@ describe("multiselect — default value", () => {
 		expect(result).toEqual(["cheese", "mushrooms"]);
 	});
 
+	it("positions the cursor on the first default value", async () => {
+		const prompt = renderPrompt(multiselect, {
+			message: "Select toppings",
+			choices: ["cheese", "pepperoni", "mushrooms"],
+			default: ["mushrooms"],
+		});
+
+		await tick();
+		prompt.keys("space");
+		await tick();
+		prompt.keys("return");
+
+		expect(await prompt.answer).toEqual([]);
+	});
+
 	it("returns empty array when no defaults and nothing selected", async () => {
 		const prompt = renderPrompt(multiselect, {
 			message: "Select toppings",

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -292,7 +292,7 @@ export function multiselect(
 ): Promise<string[]>;
 export function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
-	const setup = await setupListPrompt<T, readonly T[]>(options, io);
+	const setup = await setupListPrompt<T, readonly T[]>(options, "multiple", io);
 	if (setup.shortCircuited) return [...setup.value];
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset, selected } = setup;

--- a/packages/prompts/src/prompts/multiselect.ts
+++ b/packages/prompts/src/prompts/multiselect.ts
@@ -292,26 +292,15 @@ export function multiselect(
 ): Promise<string[]>;
 export function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]>;
 export async function multiselect<T>(options: MultiselectOptions<T>, io?: PromptIO): Promise<T[]> {
-	const setup = setupListPrompt<T, readonly T[]>(options, io);
+	const setup = await setupListPrompt<T, readonly T[]>(options, io);
 	if (setup.shortCircuited) return [...setup.value];
 
-	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;
-
-	// Pre-select items matching default values
-	const initialSelected = new Set<number>();
-	if (options.default) {
-		for (const defaultValue of options.default) {
-			const idx = choices.findIndex((c) => c.value === defaultValue);
-			if (idx !== -1) {
-				initialSelected.add(idx);
-			}
-		}
-	}
+	const { choices, cursor, maxVisible, promptIO, scrollOffset, selected } = setup;
 
 	const initialState: MultiselectState<T> = {
 		cursor,
 		choices,
-		selected: initialSelected,
+		selected: new Set(selected),
 		scrollOffset,
 		error: null,
 	};

--- a/packages/prompts/src/prompts/password.ts
+++ b/packages/prompts/src/prompts/password.ts
@@ -5,7 +5,8 @@
 import type { StandardSchema } from "@crustjs/utils/schema";
 
 import type { PromptIO } from "../core/renderer.ts";
-import { resolvePromptIO, runPrompt } from "../core/renderer.ts";
+import { runPrompt } from "../core/renderer.ts";
+import { resolveShortCircuit } from "../core/shortCircuit.ts";
 import { PREFIX_SUBMITTED, PREFIX_SYMBOL } from "../core/symbols.ts";
 import { createTextSubmitHandler, CURSOR_CHAR } from "../core/textEdit.ts";
 import type { TextSubmitState } from "../core/textEdit.ts";
@@ -16,7 +17,7 @@ import type {
 	ValidateFn,
 } from "../core/types.ts";
 import { formatPromptLine, formatSubmitted } from "../core/utils.ts";
-import { resolvePromptInitial } from "../core/validate.ts";
+import { parseShortCircuit } from "../core/validate.ts";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -167,10 +168,17 @@ export async function password<Output>(
 	options: PasswordOptions<Output> = {},
 	io?: PromptIO,
 ): Promise<Output | string> {
-	const initial = await resolvePromptInitial("password", options);
-	if (initial.shortCircuited) return initial.value;
-
-	const promptIO = resolvePromptIO(io);
+	if (options.schema !== undefined && options.validate !== undefined) {
+		throw new Error('password() cannot combine "schema" with "validate"');
+	}
+	const schema = options.schema;
+	const shortCircuit = schema
+		? await resolveShortCircuit(options, io, (value, source) =>
+				parseShortCircuit(schema, value, source),
+			)
+		: await resolveShortCircuit(options, io);
+	if (shortCircuit.shortCircuited) return shortCircuit.value;
+	const { promptIO } = shortCircuit;
 
 	const mask = options.mask ?? "*";
 

--- a/packages/prompts/src/prompts/select.test.ts
+++ b/packages/prompts/src/prompts/select.test.ts
@@ -46,6 +46,23 @@ describe("select — default value", () => {
 		expect(result).toBe("green");
 	});
 
+	it("preserves an array-valued choice as one default", async () => {
+		const defaultValue = ["green"] as const;
+		const prompt = renderPrompt(select, {
+			message: "Pick a color",
+			choices: [
+				{ label: "Red", value: ["red"] as const },
+				{ label: "Green", value: defaultValue },
+			],
+			default: defaultValue,
+		});
+
+		await tick();
+		prompt.keys("return");
+
+		expect(await prompt.answer).toBe(defaultValue);
+	});
+
 	it("defaults cursor to first item when no default is provided", async () => {
 		const prompt = renderPrompt(select, {
 			message: "Pick a color",

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -208,7 +208,7 @@ export function select(
 ): Promise<string>;
 export function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T>;
 export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
-	const setup = await setupListPrompt<T, T>(options, io);
+	const setup = await setupListPrompt<T, T>(options, "single", io);
 	if (setup.shortCircuited) return setup.value;
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;

--- a/packages/prompts/src/prompts/select.ts
+++ b/packages/prompts/src/prompts/select.ts
@@ -208,7 +208,7 @@ export function select(
 ): Promise<string>;
 export function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T>;
 export async function select<T>(options: SelectOptions<T>, io?: PromptIO): Promise<T> {
-	const setup = setupListPrompt<T, T>(options, io, options.default);
+	const setup = await setupListPrompt<T, T>(options, io);
 	if (setup.shortCircuited) return setup.value;
 
 	const { choices, cursor, maxVisible, promptIO, scrollOffset } = setup;

--- a/packages/prompts/src/testing.ts
+++ b/packages/prompts/src/testing.ts
@@ -152,7 +152,7 @@ export function createPromptIO({ isTTY = true }: { isTTY?: boolean } = {}): Prom
 				callback();
 			},
 		}),
-		{ columns: 80 },
+		{ columns: 80, isTTY },
 	);
 
 	return {

--- a/packages/style/README.md
+++ b/packages/style/README.md
@@ -23,7 +23,7 @@ const deterministic = createStyle({
 console.log(deterministic.fg("snapshot", "#4fa83d"));
 ```
 
-`fg` and `bg` use the active style capabilities. Use `createStyle({ overrides })` when output must be deterministic.
+`fg` and `bg` use the active style capabilities. Stored chains follow runtime capability changes. Use `createStyle({ overrides })` when output must be deterministic; each override only replaces its matching environment input.
 
 ## Documentation
 

--- a/packages/style/src/capability.test.ts
+++ b/packages/style/src/capability.test.ts
@@ -5,7 +5,7 @@ import { createStyle, style } from "./createStyle.ts";
 import { bold, red } from "./index.ts";
 import { snapshotEnv } from "./testEnv.ts";
 
-const restoreEnvVars = snapshotEnv("NO_COLOR", "FORCE_COLOR");
+const restoreEnvVars = snapshotEnv("NO_COLOR", "FORCE_COLOR", "COLORTERM", "TERM");
 const originalStdoutIsTTY = process.stdout.isTTY;
 
 /** Restore mutable runtime env (`NO_COLOR`, `FORCE_COLOR`, `isTTY`). */
@@ -23,6 +23,8 @@ beforeEach(() => {
 	// runners) must not leak in. afterEach still restores the ambient values.
 	delete process.env.NO_COLOR;
 	delete process.env.FORCE_COLOR;
+	delete process.env.COLORTERM;
+	delete process.env.TERM;
 });
 afterEach(restoreRuntimeEnv);
 
@@ -55,6 +57,11 @@ describe("resolveColorDepth", () => {
 	});
 
 	describe("`auto` mode", () => {
+		it("falls back to the environment for each omitted override", () => {
+			process.env.COLORTERM = "truecolor";
+			expect(resolveColorDepth("auto", { isTTY: true })).toBe("truecolor");
+		});
+
 		it('non-TTY → "none"', () => {
 			expect(
 				resolveColorDepth("auto", {

--- a/packages/style/src/capability.ts
+++ b/packages/style/src/capability.ts
@@ -8,13 +8,20 @@ import type { CapabilityOverrides, ColorDepth, ColorMode } from "./types.ts";
 // Internal helpers
 // ────────────────────────────────────────────────────────────────────────────
 
+function read<Key extends keyof CapabilityOverrides>(
+	overrides: CapabilityOverrides | undefined,
+	key: Key,
+	environment: CapabilityOverrides[Key],
+): CapabilityOverrides[Key] {
+	return overrides !== undefined && key in overrides ? overrides[key] : environment;
+}
+
 function readTTY(overrides: CapabilityOverrides | undefined): boolean {
-	const hasOverride = overrides !== undefined && "isTTY" in overrides;
-	return hasOverride ? (overrides.isTTY ?? false) : (process.stdout?.isTTY ?? false);
+	return read(overrides, "isTTY", process.stdout?.isTTY) ?? false;
 }
 
 function readForceColor(overrides: CapabilityOverrides | undefined): string | undefined {
-	return overrides !== undefined ? overrides.forceColor : process.env.FORCE_COLOR;
+	return read(overrides, "forceColor", process.env.FORCE_COLOR);
 }
 
 /** `FORCE_COLOR=0` / `FORCE_COLOR=false` mean "force off"; any other value forces on. */
@@ -113,8 +120,8 @@ export function resolveColorDepth(mode: ColorMode, overrides?: CapabilityOverrid
 	}
 
 	// auto mode
-	const colorTerm = overrides !== undefined ? overrides.colorTerm : process.env.COLORTERM;
-	const term = overrides !== undefined ? overrides.term : process.env.TERM;
+	const colorTerm = read(overrides, "colorTerm", process.env.COLORTERM);
+	const term = read(overrides, "term", process.env.TERM);
 
 	const forceColor = readForceColor(overrides);
 	if (forceColor !== undefined) {
@@ -132,7 +139,7 @@ export function resolveColorDepth(mode: ColorMode, overrides?: CapabilityOverrid
 		return "none";
 	}
 
-	const noColor = overrides !== undefined ? overrides.noColor : process.env.NO_COLOR;
+	const noColor = read(overrides, "noColor", process.env.NO_COLOR);
 	if (noColor !== undefined && noColor !== "") {
 		return "none";
 	}

--- a/packages/style/src/createStyle.test.ts
+++ b/packages/style/src/createStyle.test.ts
@@ -55,6 +55,13 @@ describe("createStyle — colorDepth introspection", () => {
 });
 
 describe("createStyle — fg/bg emit format matching colorDepth", () => {
+	it("exposes dynamic chain pairs at the configured depth", () => {
+		const chain = autoStyle({ term: "xterm-256color" }).fg("#ff0000");
+		expect(chain.open).toBe("\x1b[38;5;196m");
+		expect(`${chain.open}text${chain.close}`).toBe(chain("text"));
+		expect(createStyle({ mode: "never" }).fg("#ff0000").open).toBe("");
+	});
+
 	it('bg emits ansi-256 background when capability is "256"', () => {
 		const s = autoStyle({ term: "xterm-256color" });
 		const fgOpen = Bun.color("#00ff88", "ansi-256") as string;

--- a/packages/style/src/createStyle.ts
+++ b/packages/style/src/createStyle.ts
@@ -28,19 +28,21 @@ const dynamicColorKinds = [
 // Computed namespace access is safe because StyleMethodName contains only ANSI-pair exports.
 const styleMethodPairs = codes;
 
-// A single step in a chainable style. Either a registered method (looked
-// up by name in the style registry) or an ad-hoc `AnsiPair` produced by a
-// dynamic-color call like `style.bold.fg("#f00")`.
+// A single step in a chainable style: a registered method or a color
+// resolved against the active terminal depth when the chain is called.
 type ChainStep =
 	| { readonly kind: "named"; readonly name: StyleMethodName }
-	| { readonly kind: "pair"; readonly pair: AnsiPair };
+	| { readonly kind: "fg" | "bg"; readonly input: ColorInput };
 
 function stepIsModifier(step: ChainStep): boolean {
 	return step.kind === "named" && isModifierName(step.name);
 }
 
-function stepPair(step: ChainStep): AnsiPair {
-	return step.kind === "named" ? styleMethodPairs[step.name] : step.pair;
+function stepPair(step: ChainStep, colorDepth: ColorDepth): AnsiPair {
+	if (step.kind === "named") return styleMethodPairs[step.name];
+	return step.kind === "fg"
+		? fgPairAtDepth(step.input, colorDepth)
+		: bgPairAtDepth(step.input, colorDepth);
 }
 
 interface ResolvedStyleCapabilities {
@@ -66,7 +68,8 @@ function applyChain(
 		return result;
 	}
 
-	const { modifiersEnabled, colorsEnabled } = resolveCapabilities();
+	const capabilities = resolveCapabilities();
+	const { modifiersEnabled, colorsEnabled } = capabilities;
 	for (let i = steps.length - 1; i >= 0; i--) {
 		const step = steps[i];
 		if (step === undefined) {
@@ -75,7 +78,7 @@ function applyChain(
 		if (stepIsModifier(step) ? !modifiersEnabled : !colorsEnabled) {
 			continue;
 		}
-		result = applyStyle(result, stepPair(step));
+		result = applyStyle(result, stepPair(step, capabilities.colorDepth));
 	}
 
 	return result;
@@ -104,7 +107,7 @@ function buildChainableStyleFactory(
 			? "runtime"
 			: `${capabilities?.modifiersEnabled}|${capabilities?.colorDepth}`;
 		return `${mode}|${steps
-			.map((step) => (step.kind === "named" ? step.name : `~${step.pair.open}`))
+			.map((step) => (step.kind === "named" ? step.name : `~${stepPair(step, "truecolor").open}`))
 			.join("|")}`;
 	}
 
@@ -148,31 +151,21 @@ function buildChainableStyleFactory(
 				get() {
 					return createChainableStyle(
 						[...steps, { kind: "named", name }],
-						false,
-						capabilitiesForCall(),
+						dynamic,
+						fixedCapabilities,
 					);
 				},
 			});
 		}
 
-		// Dynamic-color chain methods resolve depth when the chain is extended.
+		// Dynamic-color chain methods validate now and resolve depth when called.
 		for (const [kind, pairAtDepth] of dynamicColorKinds) {
 			Object.defineProperty(styleFn, kind, {
 				configurable: false,
 				enumerable: true,
 				value: (input: ColorInput): ChainableStyleFn => {
-					const resolved = capabilitiesForCall();
-					return createChainableStyle(
-						[
-							...steps,
-							{
-								kind: "pair",
-								pair: pairAtDepth(input, resolved.colorDepth),
-							},
-						],
-						false,
-						resolved,
-					);
+					pairAtDepth(input, "truecolor");
+					return createChainableStyle([...steps, { kind, input }], dynamic, fixedCapabilities);
 				},
 				writable: false,
 			});
@@ -185,7 +178,7 @@ function buildChainableStyleFactory(
 		let open = "";
 		let close = "";
 		for (const step of steps) {
-			const pair = stepPair(step);
+			const pair = stepPair(step, "truecolor");
 			open += pair.open;
 			close = pair.close + close;
 		}
@@ -285,16 +278,8 @@ function createStyleInstance(options: StyleOptions | undefined, runtime: boolean
 			(...args: [input: ColorInput] | [text: string, input: ColorInput]) => {
 				const resolved = resolveCapabilities();
 				if (args.length === 1) {
-					return createChainableStyle(
-						[
-							{
-								kind: "pair",
-								pair: pairAtDepth(args[0], resolved.colorDepth),
-							},
-						],
-						false,
-						resolved,
-					);
+					pairAtDepth(args[0], "truecolor");
+					return createChainableStyle([{ kind, input: args[0] }], runtime, resolved);
 				}
 				return paint(args[0], args[1], resolved.colorDepth);
 			},

--- a/packages/style/src/createStyle.ts
+++ b/packages/style/src/createStyle.ts
@@ -178,7 +178,7 @@ function buildChainableStyleFactory(
 		let open = "";
 		let close = "";
 		for (const step of steps) {
-			const pair = stepPair(step, "truecolor");
+			const pair = stepPair(step, fixedCapabilities?.colorDepth ?? "truecolor");
 			open += pair.open;
 			close = pair.close + close;
 		}

--- a/packages/style/src/dx.test.ts
+++ b/packages/style/src/dx.test.ts
@@ -208,13 +208,12 @@ describe("top-level chainables — full surface", () => {
 });
 
 // ───────────────────────────────────────────────────────────────────────────
-// 8. Environment changes — capture semantics
+// 8. Environment changes — dynamic chains
 // ───────────────────────────────────────────────────────────────────────────
 //
-// Locks in H1 from the adversarial review: forwarders re-resolve the
-// environment; sub-chain captures snapshot (documented limitation).
+// Runtime facade chains re-resolve capabilities when called.
 
-describe("environment changes — capture semantics", () => {
+describe("environment changes — dynamic chains", () => {
 	const restoreEnv = snapshotEnv("FORCE_COLOR");
 	afterEach(restoreEnv);
 
@@ -234,15 +233,20 @@ describe("environment changes — capture semantics", () => {
 		expect(captured.red("x")).toBe("x");
 	});
 
-	it("sub-chain capture (`style.bold.red`) snapshots at access time", () => {
-		// This is documented behavior: capturing a deeper chain locks the
-		// resolved chainable to the runtime instance active at capture time.
-		// Matches chalk/ansis. To stay dynamic, capture the leaf only.
+	it("stored sub-chains re-resolve after an env flip", () => {
 		setEnv("FORCE_COLOR", "3");
-		const snapshot = style.bold.red;
+		const captured = style.bold.red;
+		expect(captured("x")).toBe("\x1b[1m\x1b[31mx\x1b[39m\x1b[22m");
 		setEnv("FORCE_COLOR", "0");
-		// snapshot is locked to the pre-flip instance: full color emitted.
-		expect(snapshot("x")).toBe("\x1b[1m\x1b[31mx\x1b[39m\x1b[22m");
+		expect(captured("x")).toBe("x");
+	});
+
+	it("stored dynamic-color chains re-resolve color depth", () => {
+		setEnv("FORCE_COLOR", "3");
+		const captured = style.bold.fg("#ff0000");
+		expect(captured("x")).toContain("\x1b[38;2;255;0;0m");
+		setEnv("FORCE_COLOR", "2");
+		expect(captured("x")).toContain("\x1b[38;5;196m");
 	});
 });
 

--- a/packages/style/src/types.ts
+++ b/packages/style/src/types.ts
@@ -42,9 +42,8 @@ export type ColorInput = ColorString | readonly [r: number, g: number, b: number
  *
  * The default `style` facade and top-level helpers always run in
  * `"auto"` mode — to influence them globally, set the standard
- * environment variables (`NO_COLOR`, `FORCE_COLOR`). The facade and helpers
- * re-resolve capabilities on every direct call; stored sub-chains capture them
- * when accessed (see {@link ChainableStyleFn}).
+ * environment variables (`NO_COLOR`, `FORCE_COLOR`). The facade and helpers,
+ * including stored sub-chains, re-resolve capabilities on every call.
  *
  * @example
  * ```ts
@@ -140,10 +139,8 @@ export type StyleMethodMap = {
  * Every chainable is simultaneously a function, a chain root, and an
  * ANSI pair. Chains compose `open` left-to-right and `close` right-to-left.
  *
- * On the default runtime facade, a first-level chainable such as `style.bold`
- * re-resolves terminal capabilities when called. Extending it freezes the
- * current capabilities, so a stored sub-chain such as `style.bold.red` keeps
- * the environment state from when the property was accessed.
+ * On the default runtime facade, stored chainables such as `style.bold.red`
+ * re-resolve terminal capabilities when called.
  *
  * To pass a style around as a value, pass the chainable itself — it is
  * already a `(text: string) => string` function (see {@link StyleFn}).

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -9,8 +9,7 @@ import type {
 	RunInputArguments,
 	RunOutcome,
 } from "@crustjs/core";
-import { type ProgressSink, withProgressSink } from "@crustjs/progress";
-import { withPromptIO } from "@crustjs/prompts";
+import { withTerminalIO } from "@crustjs/prompts";
 import { createPromptIO, type Key } from "@crustjs/prompts/testing";
 
 /** Structural io shape shared by `run()` and `execute()` captures. */
@@ -151,28 +150,18 @@ export function runInteractive<App extends AnyCrust, const Path extends CommandP
 ): InteractiveRun {
 	const harness = createPromptIO();
 	const output = harness.io.output;
-	// Spinners and progress indicators render onto the same fake terminal as
-	// prompts, so waitFor()/screen() observe them too.
-	const sink: ProgressSink = {
-		isTTY: true,
-		write: (text) => {
-			output.write(text);
-		},
-	};
 	const [input] = args;
 	// SAFETY: Path and input were constrained together by RunInputArguments above.
-	const done = withProgressSink(sink, () =>
-		withPromptIO(harness.io, () =>
-			app
-				.run(path as never, input as never, {
-					stdout: () => {},
-					stderr: (text) => {
-						// Line-oriented like core's console.error default.
-						output.write(`${text}\n`);
-					},
-				})
-				.then(() => {}),
-		),
+	const done = withTerminalIO(harness.io, () =>
+		app
+			.run(path as never, input as never, {
+				stdout: () => {},
+				stderr: (text) => {
+					// Line-oriented like core's console.error default.
+					output.write(`${text}\n`);
+				},
+			})
+			.then(() => {}),
 	);
 
 	// Observe settlement so waitFor can stop polling; the action also keeps an

--- a/packages/utils/src/terminal.test.ts
+++ b/packages/utils/src/terminal.test.ts
@@ -22,6 +22,20 @@ describe("ambient terminal IO", () => {
 		expect(getAmbientTerminalIO()).toBeUndefined();
 	});
 
+	it("shares ambient callback lookup across bundled module copies", async () => {
+		const first = (await import(
+			new URL("./terminal.ts?copy=first", import.meta.url).href
+		)) as typeof import("./terminal.ts");
+		const second = (await import(
+			new URL("./terminal.ts?copy=second", import.meta.url).href
+		)) as typeof import("./terminal.ts");
+		const io = { stdout: (_text: string) => {}, stderr: (_text: string) => {} };
+
+		first.withAmbientTerminalIO(io, () => {
+			expect(second.getAmbientTerminalIO()).toBe(io);
+		});
+	});
+
 	it("line-buffers callback output through the shared stream scope", () => {
 		const errors: string[] = [];
 		withAmbientTerminalIO({ stdout: () => {}, stderr: (text) => errors.push(text) }, () => {

--- a/packages/utils/src/terminal.test.ts
+++ b/packages/utils/src/terminal.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { getAmbientTerminalIO, withAmbientTerminalIO } from "./terminal.ts";
+import {
+	getAmbientTerminalIO,
+	getTerminalIO,
+	withAmbientTerminalIO,
+	withTerminalIO,
+} from "./terminal.ts";
 
 describe("ambient terminal IO", () => {
 	it("is absent outside a scope and available across async boundaries", async () => {
@@ -15,5 +20,25 @@ describe("ambient terminal IO", () => {
 			expect(getAmbientTerminalIO()).toBe(io);
 		});
 		expect(getAmbientTerminalIO()).toBeUndefined();
+	});
+
+	it("line-buffers callback output through the shared stream scope", () => {
+		const errors: string[] = [];
+		withAmbientTerminalIO({ stdout: () => {}, stderr: (text) => errors.push(text) }, () => {
+			const output = getTerminalIO()?.output;
+			output?.write("first");
+			output?.write(" line\nsecond\npartial");
+		});
+		expect(errors).toEqual(["first line", "second"]);
+	});
+
+	it("merges nested input and output scopes", () => {
+		const input = process.stdin;
+		const output = { write: (_text: string) => {} };
+		withTerminalIO({ input }, () => {
+			withTerminalIO({ output }, () => {
+				expect(getTerminalIO()).toEqual({ input, output });
+			});
+		});
 	});
 });

--- a/packages/utils/src/terminal.ts
+++ b/packages/utils/src/terminal.ts
@@ -29,14 +29,22 @@ export interface AmbientTerminalIO {
 }
 
 const STORAGE_KEY = Symbol.for("crustjs.terminal.io");
-// SAFETY: This intersection only declares the optional symbol slot read and initialized below.
+const AMBIENT_CALLBACKS_KEY = Symbol.for("crustjs.terminal.ambient-callbacks");
+// SAFETY: These intersections only declare the optional symbol slots read and initialized below.
 const globalWithStorage = globalThis as typeof globalThis & {
 	[key: symbol]: AsyncLocalStorage<TerminalIO> | undefined;
 };
+// SAFETY: This intersection only declares the optional symbol slot read and initialized below.
+const globalWithAmbientCallbacks = globalThis as typeof globalThis & {
+	[key: symbol]: WeakMap<TerminalOutput, AmbientTerminalIO> | undefined;
+};
 
-/** Bundled copies in Core, Prompts, and Progress share one process-wide storage instance. */
+/** Bundled copies in Core, Prompts, and Progress share process-wide terminal state. */
 const storage = (globalWithStorage[STORAGE_KEY] ??= new AsyncLocalStorage<TerminalIO>());
-const ambientCallbacks = new WeakMap<TerminalOutput, AmbientTerminalIO>();
+const ambientCallbacks = (globalWithAmbientCallbacks[AMBIENT_CALLBACKS_KEY] ??= new WeakMap<
+	TerminalOutput,
+	AmbientTerminalIO
+>());
 
 /** Run a function with terminal streams available in its async scope. */
 export function withTerminalIO<T>(io: TerminalIO, fn: () => T): T {

--- a/packages/utils/src/terminal.ts
+++ b/packages/utils/src/terminal.ts
@@ -1,29 +1,90 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { Readable } from "node:stream";
+import { Writable } from "node:stream";
 
-/** Line-oriented output callbacks ambiently available to terminal libraries. */
+/** A readable stream available to terminal libraries. */
+export type TerminalInput = Readable & {
+	readonly isTTY?: boolean;
+	readonly isRaw?: boolean;
+	setRawMode?: (mode: boolean) => void;
+};
+
+/** A writable-compatible output available to terminal libraries. */
+export interface TerminalOutput {
+	readonly isTTY?: boolean;
+	readonly columns?: number;
+	write(text: string): void;
+}
+
+/** Input and output streams available to terminal libraries. */
+export interface TerminalIO {
+	readonly input?: TerminalInput;
+	readonly output?: TerminalOutput;
+}
+
+/** Line-oriented output callbacks ambiently supplied by Core invocations. */
 export interface AmbientTerminalIO {
 	stdout: (text: string) => void;
 	stderr: (text: string) => void;
 }
 
-const STORAGE_KEY = Symbol.for("crustjs.terminal.ambient-io");
+const STORAGE_KEY = Symbol.for("crustjs.terminal.io");
 // SAFETY: This intersection only declares the optional symbol slot read and initialized below.
 const globalWithStorage = globalThis as typeof globalThis & {
-	[key: symbol]: AsyncLocalStorage<AmbientTerminalIO> | undefined;
+	[key: symbol]: AsyncLocalStorage<TerminalIO> | undefined;
 };
 
-/**
- * Bundled copies in Core, Prompts, and Progress must share one process-wide
- * storage instance. If the stored value shape changes, mint a new symbol key.
- */
-const storage = (globalWithStorage[STORAGE_KEY] ??= new AsyncLocalStorage<AmbientTerminalIO>());
+/** Bundled copies in Core, Prompts, and Progress share one process-wide storage instance. */
+const storage = (globalWithStorage[STORAGE_KEY] ??= new AsyncLocalStorage<TerminalIO>());
+const ambientCallbacks = new WeakMap<TerminalOutput, AmbientTerminalIO>();
 
-/** Run a function with line-oriented terminal output available in its async scope. */
-export function withAmbientTerminalIO<T>(io: AmbientTerminalIO, fn: () => T): T {
-	return storage.run(io, fn);
+/** Run a function with terminal streams available in its async scope. */
+export function withTerminalIO<T>(io: TerminalIO, fn: () => T): T {
+	const current = storage.getStore();
+	return storage.run(
+		{
+			input: io.input ?? current?.input,
+			output: io.output ?? current?.output,
+		},
+		fn,
+	);
 }
 
-/** Return the line-oriented terminal output in the current async scope, if any. */
-export function getAmbientTerminalIO(): AmbientTerminalIO | undefined {
+/** Return the terminal streams in the current async scope, if any. */
+export function getTerminalIO(): TerminalIO | undefined {
 	return storage.getStore();
+}
+
+function lineBufferedOutput(io: AmbientTerminalIO): TerminalOutput {
+	let pending = "";
+	const output = new Writable({
+		decodeStrings: false,
+		write(chunk, _encoding, callback) {
+			pending += chunk.toString();
+			let newline = pending.indexOf("\n");
+			while (newline !== -1) {
+				io.stderr(pending.slice(0, newline));
+				pending = pending.slice(newline + 1);
+				newline = pending.indexOf("\n");
+			}
+			callback();
+		},
+	});
+	ambientCallbacks.set(output, io);
+	return output;
+}
+
+/** Run a function with Core's line-oriented output bridged into the terminal stream scope. */
+export function withAmbientTerminalIO<T>(io: AmbientTerminalIO, fn: () => T): T {
+	const current = storage.getStore();
+	return withTerminalIO(
+		{ input: current?.input, output: current?.output ?? lineBufferedOutput(io) },
+		fn,
+	);
+}
+
+/** Return Core's line-oriented terminal output in the current async scope, if any. */
+export function getAmbientTerminalIO(): AmbientTerminalIO | undefined {
+	const output = storage.getStore()?.output;
+	return output === undefined ? undefined : ambientCallbacks.get(output);
 }


### PR DESCRIPTION
Unify terminal UI routing across prompts and progress, consolidate prompt startup behavior, and make style capability resolution consistently dynamic. Existing focused IO helpers remain available while the new shared scope lets embedders configure prompts and indicators once.

### Changes

- **@crustjs/prompts**
  - Add `withTerminalIO()` and export `resolvePromptIO()`; keep `withPromptIO()` as an alias.
  - Default TTY helpers to ambient resolved input.
  - Share prompt short-circuit setup and list default selection; align multiselect's initial cursor with multifilter.
- **@crustjs/progress**
  - Add `withTerminalIO()` and widen `ProgressSink` to writable-compatible output with optional terminal metadata.
  - Keep `withProgressSink()` as an output-only alias and use the shared line-buffered Core adapter.
- **@crustjs/testing**
  - Route `runInteractive()` prompts, indicators, and stderr through one ambient terminal scope.
- **@crustjs/style**
  - Resolve each omitted capability override from its matching runtime input.
  - Keep stored named and dynamic-color chains responsive to runtime capability changes.
- **Docs/tests**
  - Update package READMEs, module/guide docs, and focused regression coverage.

### Notes

- No items skipped.
- Behavior changes: multiselect initially highlights its first default; partial style overrides preserve unspecified environment capabilities; stored style chains remain mode-aware.
- Added five changesets covering prompts, progress, testing, and style behavior/API changes.

### Stack
This PR is part of the codebase-audit refactor stack (bottom → top). Merge in order; each PR targets the one below it.
1. refactor/audit-01-tooling ([#329](https://github.com/chenxin-yan/crust/pull/329))
2. refactor/audit-02-tests ([#330](https://github.com/chenxin-yan/crust/pull/330))
3. refactor/audit-03-core-shrink ([#331](https://github.com/chenxin-yan/crust/pull/331))
4. refactor/audit-04-ext-shrink ([#332](https://github.com/chenxin-yan/crust/pull/332))
5. refactor/audit-05-ui-shrink ([#333](https://github.com/chenxin-yan/crust/pull/333))
6. refactor/audit-06-core-seams ([#334](https://github.com/chenxin-yan/crust/pull/334))
7. refactor/audit-07-docmodel-version ([#335](https://github.com/chenxin-yan/crust/pull/335))
8. refactor/audit-08-cli-seams ([#336](https://github.com/chenxin-yan/crust/pull/336))
9. refactor/audit-09-public-api ([#337](https://github.com/chenxin-yan/crust/pull/337))
10. refactor/audit-10-ui-seams ([#338](https://github.com/chenxin-yan/crust/pull/338)) **(this PR)**
11. refactor/audit-11-store-docs ([#339](https://github.com/chenxin-yan/crust/pull/339))
