### PR TITLE
feat(core): defineExtension(id, factory) form returns an ExtensionFactory with .id

### DIFF
--- a/.changeset/define-extension-factory-form.md
+++ b/.changeset/define-extension-factory-form.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Add the `defineExtension(id, factory)` form, which returns an `ExtensionFactory` with `.id`, and export the new `ExtensionFactory` type. Official extensions in `@crustjs/extensions`, `@crustjs/skills`, and `@crustjs/man` are migrated; their exported shapes are unchanged.

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -9,16 +9,17 @@ All exports on these pages come from `@crustjs/core`.
 
 ## Runtime API
 
-| Export                                                    | Description                                                        |
-| --------------------------------------------------------- | ------------------------------------------------------------------ |
-| [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary       |
-| [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.add()`     |
-| `defineContext(name, config?, setup)`                     | Define a named command dependency factory                          |
-| `defineExtension(id, config?)`                            | Define an application-wide Extension                               |
-| `defineExtensionId(id)`                                   | Mint a branded Extension identity from a non-empty, trimmed string |
-| `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition           |
-| `defineArg(name, definition)`                             | Define one named positional argument                               |
-| [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes           |
+| Export                                                    | Description                                                            |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`Crust`](/docs/api/crust)                                | Immutable, chainable command builder and invocation boundary           |
+| [`defineCommand(name, config?, recipe)`](/docs/api/crust) | Define a named, inert reusable command definition for `.add()`         |
+| `defineContext(name, config?, setup)`                     | Define a named command dependency factory                              |
+| `defineExtension(id, config?)`                            | Define an application-wide Extension                                   |
+| `defineExtension(id, factory)`                            | Build an Extension factory with `.id` from a config-returning callback |
+| `defineExtensionId(id)`                                   | Mint a branded Extension identity from a non-empty, trimmed string     |
+| `defineFlag(name, definition)`                            | Define one named flag, preserving its literal definition               |
+| `defineArg(name, definition)`                             | Define one named positional argument                                   |
+| [`CrustError`](/docs/api/errors)                          | Structured framework error with one of four stable codes               |
 
 ## Types
 

--- a/apps/docs/content/docs/api/types.mdx
+++ b/apps/docs/content/docs/api/types.mdx
@@ -278,6 +278,14 @@ The build context contains the frozen root Command Snapshot and the resolved abs
 
 `defineExtension(id, config?)` returns a frozen structural value; omitted config defaults to `{}`. Mint the branded `ExtensionId` with `defineExtensionId()`, which requires a non-empty, already-trimmed string.
 
+### `ExtensionFactory`
+
+| Type                          | Description                                                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `ExtensionFactory<Args = []>` | Callable Extension constructor with a readonly `id: ExtensionId`; valid as a `SectionConsumer` |
+
+`defineExtension(id, factory)` wraps a config-returning callback, preserving its parameters and inferring its flags, dependencies, providers, and commands. Each call follows the object form's normalization and freezing path. `ExtensionFactory<Args, Deps, Provides, Defs, Commands>` accepts optional contribution type parameters; their defaults erase contributions to `Extension`, keeping published annotations short. See [authoring an Extension](/docs/guide/extensions#author-an-extension).
+
 ### `ExtensionFlagDef`
 
 ```ts

--- a/apps/docs/content/docs/guide/extensions.mdx
+++ b/apps/docs/content/docs/guide/extensions.mdx
@@ -33,6 +33,31 @@ Two consequences of the root-only model:
 
 Official Extension identities use the `crust:` namespace, reserved by convention for official Crust identities (the prefix is not enforced at runtime). Third-party packages should namespace published Extension ids with their own prefix; application-local ids can remain plain.
 
+Packages that publish a configurable Extension factory use `defineExtension(id, factory)`. The callback returns config; each call builds a frozen Extension with normalized flags and the same id. The returned factory exposes a readonly `id`, so consumers can pass it to `only` or `except` without constructing an Extension. Every official Extension is exported this way.
+
+```ts
+import {
+  defineExtension,
+  defineExtensionId,
+  type ExtensionFactory,
+  type ExtensionId,
+} from "@crustjs/core";
+
+const DOCS: ExtensionId = defineExtensionId("acme:docs");
+interface DocsOptions {
+  readonly verbose?: boolean;
+}
+export const docs: ExtensionFactory<[options?: DocsOptions]> = defineExtension(
+  DOCS,
+  (options = {}) => ({
+    flags: [{ name: "verbose", type: "boolean", default: options.verbose }],
+  }),
+);
+// docs.id === DOCS; docs({ verbose: true }).id === DOCS
+```
+
+Authors not building with `isolatedDeclarations` can omit the annotation (`export const docs = defineExtension(DOCS, (options?: DocsOptions) => ({ … }))`) and get full inference.
+
 ## Owned flags and commands
 
 Extension flags are a readonly array of named definitions. Use `defineFlag()` values for ordinary recursive flags, or write a named definition inline. Extension flags default to `recursive: true`, which contributes them to every command. The documented way to set the Extension-only `recursive` option for a root-only flag is an inline definition:
@@ -104,7 +129,7 @@ const deploy = defineCommand(
 );
 ```
 
-A renderer exposes its identity on its factory. Render-time helpers are imported from `@crustjs/core/tooling`: a single-command renderer selects from that command with `sectionsFor()`, and a full-tree renderer uses `visibleSectionsFor(snapshot, consumer)`, which returns section-bearing visible commands in canonical path order, represents the root as `[]`, skips hidden command trees, and applies audience filtering. Section audiences accept the factory itself, such as `only: [help]`, while renderer integrations pass a branded `ExtensionId` such as `help.id`. Raw strings are not accepted, and core does not maintain a fixed list of identities.
+A renderer exposes its identity on its factory via `defineExtension(id, factory)`. Render-time helpers are imported from `@crustjs/core/tooling`: a single-command renderer selects from that command with `sectionsFor()`, and a full-tree renderer uses `visibleSectionsFor(snapshot, consumer)`, which returns section-bearing visible commands in canonical path order, represents the root as `[]`, skips hidden command trees, and applies audience filtering. Section audiences accept the factory itself, such as `only: [help]`, while renderer integrations pass a branded `ExtensionId` such as `help.id`. Raw strings are not accepted, and core does not maintain a fixed list of identities.
 
 ## Build hooks
 

--- a/apps/docs/content/docs/modules/core.mdx
+++ b/apps/docs/content/docs/modules/core.mdx
@@ -51,6 +51,7 @@ Downstream commands and other Context setups call `await ctx.api`. See [Contexts
 | [`defineCommand`](/docs/api/crust)    | Create a named, inert reusable command definition; its builder declares Context demand with variadic `.use()`                                                            |
 | `defineContext(name, config?, setup)` | Define a named Context factory with optional owned flags; setup receives its declared lazy Context bag and invocation I/O                                                |
 | `defineExtension(id, config?)`        | Define a frozen, application-wide Extension value; config defaults to `{}`                                                                                               |
+| `defineExtension(id, factory)`        | Build an Extension factory with `.id` from a config-returning callback                                                                                                   |
 | `defineExtensionId(id)`               | Mint a branded Extension identity from a non-empty, already-trimmed string                                                                                               |
 | `defineFlag(name, definition)`        | Define one named flag, preserving its literal definition                                                                                                                 |
 | `defineArg(name, definition)`         | Define one named positional argument, preserving its literal definition                                                                                                  |
@@ -134,19 +135,20 @@ Omitting `io` creates no new ambient scope, preserving native TTY detection and 
 
 ## Extension types
 
-| Type                           | Description                                                                 |
-| ------------------------------ | --------------------------------------------------------------------------- |
-| `Extension`                    | Identified frozen Extension value                                           |
-| `ExtensionBuildContext`        | Frozen root snapshot and resolved output directory for artifact generation  |
-| `ExtensionConfig`              | Owned flags, commands, section contributions, build generation, and hooks   |
-| `ExtensionFlagDef`             | Extension-owned flag with optional `recursive` scope                        |
-| `ExtensionContext`             | Readonly invocation view with inferred Extension-owned flags and `finish()` |
-| `ExtensionHooks`               | Typed `preRun`, `postRun`, and `onError` hook slots                         |
-| `InferExtensionFlags`          | Syntax-parsed values inferred from an Extension's contributed flags         |
-| `NamedExtensionFlagDef`        | Named Extension flag accepted by `ExtensionConfig.flags`                    |
-| `ExtensionSectionContribution` | Section contributed by an Extension to command documentation                |
-| `Finished`                     | Opaque token returned by `ExtensionContext.finish()`                        |
-| `InvocationOutcome`            | Completed, short-circuited, or failed invocation result                     |
+| Type                           | Description                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `Extension`                    | Identified frozen Extension value                                                                |
+| `ExtensionFactory<Args>`       | Callable Extension constructor with a readonly `.id`; short annotations erase contribution types |
+| `ExtensionBuildContext`        | Frozen root snapshot and resolved output directory for artifact generation                       |
+| `ExtensionConfig`              | Owned flags, commands, section contributions, build generation, and hooks                        |
+| `ExtensionFlagDef`             | Extension-owned flag with optional `recursive` scope                                             |
+| `ExtensionContext`             | Readonly invocation view with inferred Extension-owned flags and `finish()`                      |
+| `ExtensionHooks`               | Typed `preRun`, `postRun`, and `onError` hook slots                                              |
+| `InferExtensionFlags`          | Syntax-parsed values inferred from an Extension's contributed flags                              |
+| `NamedExtensionFlagDef`        | Named Extension flag accepted by `ExtensionConfig.flags`                                         |
+| `ExtensionSectionContribution` | Section contributed by an Extension to command documentation                                     |
+| `Finished`                     | Opaque token returned by `ExtensionContext.finish()`                                             |
+| `InvocationOutcome`            | Completed, short-circuited, or failed invocation result                                          |
 
 ## Error types
 
@@ -166,10 +168,15 @@ Omitting `io` creates no new ambient scope, preserving native TTY detection and 
 A command section without an audience is available to every renderer. Use `only` or `except` with section consumers to narrow it; the two fields are mutually exclusive. A `SectionConsumer` is either a branded `ExtensionId` or an Extension/factory object carrying one, so official renderers can be passed directly while custom renderers can use their minted id:
 
 ```ts
-import { defineExtensionId, type CommandSection, type CommandSnapshot } from "@crustjs/core";
+import {
+  defineExtensionId,
+  type CommandSection,
+  type CommandSnapshot,
+  type ExtensionId,
+} from "@crustjs/core";
 import { sectionsFor, visibleSectionsFor } from "@crustjs/core/tooling";
 
-export const WEB_DOCS = defineExtensionId("acme:web-docs");
+export const WEB_DOCS: ExtensionId = defineExtensionId("acme:web-docs");
 
 const sections: readonly CommandSection[] = [
   { title: "Overview", body: "Visible everywhere." },

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -35,7 +35,7 @@ my-cli completion fish > ~/.config/fish/completions/my-cli.fish
 ```ts
 type CompletionShell = "bash" | "zsh" | "fish";
 
-const completion: ((options?: CompletionOptions) => Extension) & { readonly id: ExtensionId };
+const completion: ExtensionFactory<[options?: CompletionOptions]>;
 ```
 
 <auto-type-table

--- a/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
+++ b/apps/docs/content/docs/modules/extensions/did-you-mean.mdx
@@ -26,7 +26,7 @@ Available commands: deploy
 ## Options
 
 ```ts
-const didYouMean: ((options?: DidYouMeanOptions) => Extension) & { readonly id: ExtensionId };
+const didYouMean: ExtensionFactory<[options?: DidYouMeanOptions]>;
 ```
 
 <auto-type-table

--- a/apps/docs/content/docs/modules/extensions/help.mdx
+++ b/apps/docs/content/docs/modules/extensions/help.mdx
@@ -21,7 +21,7 @@ my-cli deploy --help
 ```
 
 ```ts
-const help: (() => Extension) & { readonly id: ExtensionId };
+const help: ExtensionFactory;
 ```
 
 `help()` owns a recursive boolean `help` flag with short name `h`. Its `preRun` hook writes help through `ctx.stdout` and returns `ctx.finish()` when `--help` is present. A container command with no Command Action also displays help.

--- a/apps/docs/content/docs/modules/extensions/no-color.mdx
+++ b/apps/docs/content/docs/modules/extensions/no-color.mdx
@@ -13,7 +13,7 @@ await app.execute();
 ```
 
 ```ts
-const noColor: (() => Extension) & { readonly id: ExtensionId };
+const noColor: ExtensionFactory;
 ```
 
 `noColor()` owns a recursive boolean `color` flag. Crust's normal boolean negation provides both forms:

--- a/apps/docs/content/docs/modules/extensions/update-notifier.mdx
+++ b/apps/docs/content/docs/modules/extensions/update-notifier.mdx
@@ -20,9 +20,7 @@ await app.execute();
 ## API
 
 ```ts
-const updateNotifier: ((options: UpdateNotifierOptions) => Extension) & {
-  readonly id: ExtensionId;
-};
+const updateNotifier: ExtensionFactory<[options: UpdateNotifierOptions]>;
 ```
 
 <auto-type-table

--- a/apps/docs/content/docs/modules/extensions/version.mdx
+++ b/apps/docs/content/docs/modules/extensions/version.mdx
@@ -28,9 +28,7 @@ interface VersionOptions {
   format?: "plain" | ((version: string, context: ExtensionContext) => string);
 }
 
-const version: ((value?: VersionValue, options?: VersionOptions) => Extension) & {
-  readonly id: ExtensionId;
-};
+const version: ExtensionFactory<[versionValue?: VersionValue, options?: VersionOptions]>;
 ```
 
 With no value override, `version()` reads `CommandSnapshot.meta.version` from the root. If neither the root metadata nor an override provides a version, handling `--version` reports a `DEFINITION` error. Pass a function to resolve an override only when the flag is handled:

--- a/docs/adr/0001-isolated-declarations.md
+++ b/docs/adr/0001-isolated-declarations.md
@@ -1,0 +1,33 @@
+# ADR 0001: Keep isolated declarations for package builds
+
+Status: accepted
+
+## Context
+
+Packages publish bundled declarations built by tsdown. The private, unpublished
+`@crustjs/utils` sources must be inlined into each consuming package's `.d.ts`,
+not left as imports; root `tsdown.config.ts` enforces this through `deps.onlyImport`.
+
+With `isolatedDeclarations: true`, tsdown emits declarations per file through
+oxc-transform, including those private sources. Disabling the flag switches to
+the tsgo program-based fallback, which fails on both core and store with
+`tsgo did not generate dts file for packages/utils/src/*.ts`.
+
+The observed TS7 per-package timings were 88ms with isolated declarations versus
+137ms without. Speed is secondary to successfully bundling private declarations.
+
+## Decision
+
+Keep `isolatedDeclarations: true` in `packages/config/tsconfig.base.json`.
+Keep the existing crust/create-crust opt-outs: those CLI packages publish no types.
+
+## Consequences
+
+Exported call-initialized values need explicit annotations (`export const x: T = call()`).
+This annotation tax affects 42 sites at the time of this decision, including the
+official Extension factories, which use `ExtensionFactory<Args>` to preserve their
+published signatures without exposing private constructor functions.
+
+Authors not using isolated declarations can omit those annotations and retain
+full inference. Reconsider the flag if tsdown's program-based emitter can reliably
+bundle unpublished workspace sources; removing annotations alone is not sufficient.

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -14,6 +14,9 @@
 		"verbatimModuleSyntax": true,
 		"noEmit": true,
 		"declaration": true,
+		// tsdown's per-file oxc-transform declaration emit lets deps.onlyImport inline private
+		// @crustjs/utils sources; the tsgo program fallback fails to emit their .d.ts files.
+		// See docs/adr/0001-isolated-declarations.md; speed is secondary.
 		"isolatedDeclarations": true,
 
 		// Best practices

--- a/packages/core/src/api/extension.test.ts
+++ b/packages/core/src/api/extension.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Equal, Expect } from "../../tests/helpers.ts";
+import {
+	Crust,
+	defineCommand,
+	defineContext,
+	defineExtension,
+	defineExtensionId,
+	type Extension,
+} from "../index.ts";
+
+describe("defineExtension", () => {
+	const HELP = defineExtensionId("acme:help");
+	const help = defineExtension(HELP, (options: { readonly verbose?: boolean } = {}) => ({
+		flags: [{ name: "verbose", type: "boolean", default: options.verbose ?? false }],
+	}));
+
+	it("exposes the identity and builds frozen, normalized Extensions with default options", () => {
+		expect(help.id).toBe(HELP);
+		const extension = help();
+		expect(extension.id).toBe(HELP);
+		expect(Object.isFrozen(extension)).toBe(true);
+		expect(Object.isFrozen(extension.uses)).toBe(true);
+		expect(extension.flags?.verbose?.default).toBe(false);
+		expect(help({ verbose: true }).flags?.verbose?.default).toBe(true);
+		type _args = Expect<Equal<Parameters<typeof help>, [options?: { readonly verbose?: boolean }]>>;
+	});
+
+	it("passes required options through on each call", () => {
+		const prefix = defineExtension(HELP, (options: { prefix: string }) => ({
+			flags: [{ name: "prefix", type: "string", default: options.prefix }],
+		}));
+		type _args = Expect<Equal<Parameters<typeof prefix>, [options: { prefix: string }]>>;
+		expect(prefix({ prefix: "first" }).flags?.prefix?.default).toBe("first");
+		expect(prefix({ prefix: "second" }).flags?.prefix?.default).toBe("second");
+	});
+
+	it("accepts the factory as a section consumer", async () => {
+		const app = new Crust("help", {
+			sections: [{ title: "Examples", body: "help --verbose", only: [help] }],
+		});
+		expect((await app.snapshot()).meta.sections?.[0]?.only).toEqual([HELP]);
+	});
+
+	it("infers flags, dependencies, providers, and commands from the callback", () => {
+		const logger = defineContext("logger", () => ({ info: () => {} }));
+		const provided = logger();
+		const command = defineCommand("docs", (cmd) => cmd.action(() => "docs"));
+		const logging = defineExtension(HELP, () => ({
+			uses: [logger],
+			provides: [provided],
+			commands: [command],
+			flags: [{ name: "verbose", type: "boolean" }],
+			hooks: {
+				async postRun({ ctx, flags }) {
+					(await ctx.logger).info();
+					type _flag = Expect<Equal<typeof flags.verbose, boolean | undefined>>;
+				},
+			},
+		}));
+		type _shape = Expect<
+			Equal<
+				ReturnType<typeof logging>,
+				Extension<
+					{ logger: { info: () => void } },
+					readonly [typeof provided],
+					readonly [{ readonly name: "verbose"; readonly type: "boolean" }],
+					readonly [typeof command]
+				>
+			>
+		>;
+		expect(logging().commands).toEqual([command]);
+	});
+
+	it("keeps the object and omitted-config forms unchanged", () => {
+		const extension = defineExtension(HELP, {
+			flags: [{ name: "verbose", type: "boolean", default: false }],
+		});
+		expect<Extension>(extension).toEqual(help());
+		expect(Object.isFrozen(extension)).toBe(true);
+		expect(defineExtension(HELP)).toEqual({ id: HELP, uses: [] });
+	});
+});

--- a/packages/core/src/api/extension.ts
+++ b/packages/core/src/api/extension.ts
@@ -300,12 +300,55 @@ export type ExtensionsProvidesOutput<Es extends readonly Extension<any, any>[]> 
 		? ExtensionProvidesOutput<H> & ExtensionsProvidesOutput<T>
 		: {};
 
+/** A callable Extension constructor whose identity is also a section consumer. */
+export type ExtensionFactory<
+	Args extends readonly unknown[] = [],
+	Deps extends ContextMap = ContextMap,
+	Provides extends readonly ContextInstance[] = readonly ContextInstance[],
+	Defs extends readonly NamedExtensionFlagDef[] = readonly NamedExtensionFlagDef[],
+	Commands extends readonly CommandDefinition<any, any, any, any>[] = readonly CommandDefinition<
+		any,
+		any,
+		any,
+		any
+	>[],
+> = ((...args: Args) => Extension<Deps, Provides, Defs, Commands>) & { readonly id: ExtensionId };
+
+type ErasedExtensionFactory = (...args: any[]) => ExtensionConfig;
+
+function isExtensionFactory(
+	value: ExtensionConfig | ErasedExtensionFactory,
+): value is ErasedExtensionFactory {
+	return typeof value === "function";
+}
+
 /**
- * Define an Extension.
+ * Define an Extension, or a factory that builds one from config on each call.
  *
  * Extensions apply to the whole application and own the flags and commands
- * they contribute.
+ * they contribute. Factories expose the same identity for section audiences.
  */
+export function defineExtension<
+	Args extends readonly unknown[],
+	const Defs extends readonly NamedExtensionFlagDef[] = [],
+	const Uses extends readonly AnyContextFactory[] = [],
+	const Provides extends readonly ContextInstance[] = [],
+	const Commands extends readonly CommandDefinition<any, any, any, any>[] = [],
+>(
+	id: ExtensionId,
+	factory: (
+		...args: Args
+	) => ExtensionConfig<Defs, Uses, Provides, Commands> &
+		ValidateExtensionConfig<Defs, Provides, Commands>,
+): ExtensionFactory<
+	Args,
+	ContextDependencies<Uses> &
+		ContextsDependencies<Provides> &
+		CommandDefinitionsDependencies<Commands>,
+	Provides,
+	Defs,
+	Commands
+>;
 export function defineExtension<
 	const Defs extends readonly NamedExtensionFlagDef[] = [],
 	const Uses extends readonly AnyContextFactory[] = [],
@@ -313,8 +356,8 @@ export function defineExtension<
 	const Commands extends readonly CommandDefinition<any, any, any, any>[] = [],
 >(
 	id: ExtensionId,
-	config: ExtensionConfig<Defs, Uses, Provides, Commands> &
-		ValidateExtensionConfig<Defs, Provides, Commands> = {},
+	config?: ExtensionConfig<Defs, Uses, Provides, Commands> &
+		ValidateExtensionConfig<Defs, Provides, Commands>,
 ): Extension<
 	ContextDependencies<Uses> &
 		ContextsDependencies<Provides> &
@@ -322,21 +365,21 @@ export function defineExtension<
 	Provides,
 	Defs,
 	Commands
-> {
+>;
+export function defineExtension(
+	id: ExtensionId,
+	config: ExtensionConfig | ErasedExtensionFactory = {},
+): Extension | ExtensionFactory<any[]> {
+	if (isExtensionFactory(config)) {
+		return Object.assign((...args: any[]) => defineExtension(id, config(...args)), { id });
+	}
 	const ownedFlags = toFlagsRecord(config.flags ?? []);
 
-	// SAFETY: the runtime registry erases Defs after this function contextually typed every hook.
+	// SAFETY: the runtime registry erases Defs after the overloads contextually typed every hook.
 	return Object.freeze({
 		...config,
 		uses: Object.freeze([...(config.uses ?? [])]),
 		id,
 		...(config.flags === undefined ? {} : { flags: ownedFlags }),
-	}) as Extension<
-		ContextDependencies<Uses> &
-			ContextsDependencies<Provides> &
-			CommandDefinitionsDependencies<Commands>,
-		Provides,
-		Defs,
-		Commands
-	>;
+	}) as Extension;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export { defineContext } from "./api/context.ts";
 export type {
 	Extension,
+	ExtensionFactory,
 	ExtensionBuildContext,
 	ExtensionConfig,
 	ExtensionContext,

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -3,7 +3,7 @@ import { resolve as resolvePath } from "node:path";
 
 import {
 	CrustError,
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	defineCommand,
 	defineExtension,
@@ -93,73 +93,71 @@ const SHELL_RENDERERS = {
  *   distribution channels — distributors run it once at packaging time
  *   and the resulting files become drop-ins.
  */
-function completionFactory(options: CompletionOptions = {}): Extension {
-	const subcommandName = options.command ?? "completion";
+export const completion: ExtensionFactory<[options?: CompletionOptions]> = defineExtension(
+	COMPLETION,
+	(options = {}) => {
+		const subcommandName = options.command ?? "completion";
 
-	const completionCommand = defineCommand(
-		subcommandName,
-		{ description: "Generate shell tab-completion scripts" },
-		(cmd) =>
-			cmd
-				.args({
-					name: "shell",
-					type: "string",
-					required: true,
-					description: "Shell to generate completion for",
-					choices: SUPPORTED_SHELLS,
-				})
-				.flags({
-					name: "output-dir",
-					type: "string",
-					description:
-						"Write all supported shells' scripts into this directory instead of printing to stdout",
-				})
-				.action(async (context) => {
-					const rootCommand = context.rootCommand;
-					// Validate `binName` before emitting anything so misconfigured
-					// CLIs fail loudly. The walker also re-validates command/flag
-					// identifiers when it builds the spec.
-					const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
-					const version = options.version ?? rootCommand.meta.version;
-					if (version === undefined) {
-						throw new CrustError(
-							"DEFINITION",
-							"The completion extension requires a version in new Crust(name, { version }) or completion({ version })",
-						);
-					}
-					// `version` flows into header comments only; sanitise to drop
-					// control characters (newlines especially) so they cannot break
-					// out of the comment line in the emitted script.
-					const safeVersion = sanitizeFreeText(version);
+		const completionCommand = defineCommand(
+			subcommandName,
+			{ description: "Generate shell tab-completion scripts" },
+			(cmd) =>
+				cmd
+					.args({
+						name: "shell",
+						type: "string",
+						required: true,
+						description: "Shell to generate completion for",
+						choices: SUPPORTED_SHELLS,
+					})
+					.flags({
+						name: "output-dir",
+						type: "string",
+						description:
+							"Write all supported shells' scripts into this directory instead of printing to stdout",
+					})
+					.action(async (context) => {
+						const rootCommand = context.rootCommand;
+						// Validate `binName` before emitting anything so misconfigured
+						// CLIs fail loudly. The walker also re-validates command/flag
+						// identifiers when it builds the spec.
+						const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
+						const version = options.version ?? rootCommand.meta.version;
+						if (version === undefined) {
+							throw new CrustError(
+								"DEFINITION",
+								"The completion extension requires a version in new Crust(name, { version }) or completion({ version })",
+							);
+						}
+						// `version` flows into header comments only; sanitise to drop
+						// control characters (newlines especially) so they cannot break
+						// out of the comment line in the emitted script.
+						const safeVersion = sanitizeFreeText(version);
 
-					const { shell: requestedShell } = context.args;
-					const spec = walkCommandNode(buildCommandDocumentation(rootCommand));
-					const outputDir = context.flags["output-dir"];
+						const { shell: requestedShell } = context.args;
+						const spec = walkCommandNode(buildCommandDocumentation(rootCommand));
+						const outputDir = context.flags["output-dir"];
 
-					if (outputDir === undefined) {
-						const script = SHELL_RENDERERS[requestedShell](spec, binName, safeVersion);
-						context.stdout(script);
-						return;
-					}
+						if (outputDir === undefined) {
+							const script = SHELL_RENDERERS[requestedShell](spec, binName, safeVersion);
+							context.stdout(script);
+							return;
+						}
 
-					// File path: write **all** supported shells. This matches
-					// the packaging-time use case — distributors generate every
-					// supported file in one invocation regardless of which
-					// shell they nominally requested.
-					const targetDir = resolvePath(outputDir);
-					await mkdir(targetDir, { recursive: true });
-					for (const shell of SUPPORTED_SHELLS) {
-						const filename = filenameForShell(shell, binName);
-						const script = SHELL_RENDERERS[shell](spec, binName, safeVersion);
-						await writeFile(resolvePath(targetDir, filename), script, "utf8");
-					}
-				}),
-	);
+						// File path: write **all** supported shells. This matches
+						// the packaging-time use case — distributors generate every
+						// supported file in one invocation regardless of which
+						// shell they nominally requested.
+						const targetDir = resolvePath(outputDir);
+						await mkdir(targetDir, { recursive: true });
+						for (const shell of SUPPORTED_SHELLS) {
+							const filename = filenameForShell(shell, binName);
+							const script = SHELL_RENDERERS[shell](spec, binName, safeVersion);
+							await writeFile(resolvePath(targetDir, filename), script, "utf8");
+						}
+					}),
+		);
 
-	return defineExtension(COMPLETION, { commands: [completionCommand] });
-}
-
-export const completion: typeof completionFactory & { readonly id: ExtensionId } = Object.assign(
-	completionFactory,
-	{ id: COMPLETION },
+		return { commands: [completionCommand] };
+	},
 );

--- a/packages/extensions/src/did-you-mean.ts
+++ b/packages/extensions/src/did-you-mean.ts
@@ -1,7 +1,7 @@
 import {
 	type CommandSnapshot,
 	CrustError,
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	defineExtension,
 	defineExtensionId,
@@ -104,41 +104,39 @@ function findSuggestions(
 		.map(([name]) => name);
 }
 
-function didYouMeanFactory(options: DidYouMeanOptions = {}): Extension {
-	const mode = options.mode ?? "error";
+export const didYouMean: ExtensionFactory<[options?: DidYouMeanOptions]> = defineExtension(
+	DID_YOU_MEAN,
+	(options = {}) => {
+		const mode = options.mode ?? "error";
 
-	return defineExtension(DID_YOU_MEAN, {
-		hooks: {
-			onError(error, context) {
-				if (!(error instanceof CrustError) || !error.is("COMMAND_NOT_FOUND")) return;
+		return {
+			hooks: {
+				onError(error, context) {
+					if (!(error instanceof CrustError) || !error.is("COMMAND_NOT_FOUND")) return;
 
-				const details = error.details;
-				const suggestions = findSuggestions(details.input, details.parentCommand.subCommands);
+					const details = error.details;
+					const suggestions = findSuggestions(details.input, details.parentCommand.subCommands);
 
-				let message = `Unknown command "${details.input}".`;
-				if (suggestions.length > 0) {
-					message += ` Did you mean "${suggestions[0]}"?`;
-				}
+					let message = `Unknown command "${details.input}".`;
+					if (suggestions.length > 0) {
+						message += ` Did you mean "${suggestions[0]}"?`;
+					}
 
-				if (mode === "help") {
-					context.stdout(message);
-					context.stdout("");
-					context.stdout(renderHelp(details.parentCommand, details.commandPath));
+					if (mode === "help") {
+						context.stdout(message);
+						context.stdout("");
+						context.stdout(renderHelp(details.parentCommand, details.commandPath));
+						return true;
+					}
+
+					if (details.available.length > 0) {
+						message += `\n\nAvailable commands: ${details.available.join(", ")}`;
+					}
+					context.stderr(message);
+					// Core preserves the nonzero exit code — rendering only here.
 					return true;
-				}
-
-				if (details.available.length > 0) {
-					message += `\n\nAvailable commands: ${details.available.join(", ")}`;
-				}
-				context.stderr(message);
-				// Core preserves the nonzero exit code — rendering only here.
-				return true;
+				},
 			},
-		},
-	});
-}
-
-export const didYouMean: typeof didYouMeanFactory & { readonly id: ExtensionId } = Object.assign(
-	didYouMeanFactory,
-	{ id: DID_YOU_MEAN },
+		};
+	},
 );

--- a/packages/extensions/src/help.ts
+++ b/packages/extensions/src/help.ts
@@ -1,6 +1,6 @@
 import {
 	type CommandSnapshot,
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	defineExtension,
 	defineExtensionId,
@@ -104,21 +104,13 @@ export function renderHelp(command: CommandSnapshot, path?: readonly string[]): 
 	return lines.join("\n");
 }
 
-function helpFactory(): Extension {
-	return defineExtension(HELP, {
-		flags: [
-			{ name: "help", type: "boolean", short: "h", noNegate: true, description: "Show help" },
-		],
-		hooks: {
-			preRun(context) {
-				if (context.flags.help !== true && context.command.hasAction) return;
-				context.stdout(renderHelp(context.command, context.commandPath));
-				return context.finish();
-			},
+export const help: ExtensionFactory = defineExtension(HELP, () => ({
+	flags: [{ name: "help", type: "boolean", short: "h", noNegate: true, description: "Show help" }],
+	hooks: {
+		preRun(context) {
+			if (context.flags.help !== true && context.command.hasAction) return;
+			context.stdout(renderHelp(context.command, context.commandPath));
+			return context.finish();
 		},
-	});
-}
-
-export const help: typeof helpFactory & { readonly id: ExtensionId } = Object.assign(helpFactory, {
-	id: HELP,
-});
+	},
+}));

--- a/packages/extensions/src/no-color.ts
+++ b/packages/extensions/src/no-color.ts
@@ -1,5 +1,5 @@
 import {
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	type ExtensionContext,
 	defineExtension,
@@ -36,55 +36,48 @@ let baseForceColor: string | undefined;
 let baseNoColor: string | undefined;
 const colorRuns = new WeakMap<ExtensionContext, true>();
 
-function noColorFactory(): Extension {
-	return defineExtension(NO_COLOR, {
-		flags: [
-			{
-				name: "color",
-				type: "boolean",
-				description: "Enable colored output",
-			},
-		],
-		hooks: {
-			preRun(context) {
-				const flagValue = context.flags.color;
-				if (flagValue !== true && flagValue !== false) return;
-
-				if (activeRuns === 0) {
-					baseForceColor = process.env.FORCE_COLOR;
-					baseNoColor = process.env.NO_COLOR;
-				}
-				activeRuns++;
-				colorRuns.set(context, true);
-
-				if (flagValue) {
-					delete process.env.NO_COLOR;
-					process.env.FORCE_COLOR = "3";
-				} else {
-					delete process.env.FORCE_COLOR;
-					process.env.NO_COLOR = "1";
-				}
-			},
-			postRun(context) {
-				if (!colorRuns.has(context)) return;
-				colorRuns.delete(context);
-				activeRuns--;
-				// ponytail: opposing overlapping runs share process.env and are last-writer-wins;
-				// ambient env restored once all runs finish. If a consumer needs per-invocation
-				// color correctness, implement fail-fast (reject opposing overlap in preRun) —
-				// do not serialize (nested execute() deadlocks).
-				if (activeRuns === 0) {
-					if (baseForceColor === undefined) delete process.env.FORCE_COLOR;
-					else process.env.FORCE_COLOR = baseForceColor;
-					if (baseNoColor === undefined) delete process.env.NO_COLOR;
-					else process.env.NO_COLOR = baseNoColor;
-				}
-			},
+export const noColor: ExtensionFactory = defineExtension(NO_COLOR, () => ({
+	flags: [
+		{
+			name: "color",
+			type: "boolean",
+			description: "Enable colored output",
 		},
-	});
-}
+	],
+	hooks: {
+		preRun(context) {
+			const flagValue = context.flags.color;
+			if (flagValue !== true && flagValue !== false) return;
 
-export const noColor: typeof noColorFactory & { readonly id: ExtensionId } = Object.assign(
-	noColorFactory,
-	{ id: NO_COLOR },
-);
+			if (activeRuns === 0) {
+				baseForceColor = process.env.FORCE_COLOR;
+				baseNoColor = process.env.NO_COLOR;
+			}
+			activeRuns++;
+			colorRuns.set(context, true);
+
+			if (flagValue) {
+				delete process.env.NO_COLOR;
+				process.env.FORCE_COLOR = "3";
+			} else {
+				delete process.env.FORCE_COLOR;
+				process.env.NO_COLOR = "1";
+			}
+		},
+		postRun(context) {
+			if (!colorRuns.has(context)) return;
+			colorRuns.delete(context);
+			activeRuns--;
+			// ponytail: opposing overlapping runs share process.env and are last-writer-wins;
+			// ambient env restored once all runs finish. If a consumer needs per-invocation
+			// color correctness, implement fail-fast (reject opposing overlap in preRun) —
+			// do not serialize (nested execute() deadlocks).
+			if (activeRuns === 0) {
+				if (baseForceColor === undefined) delete process.env.FORCE_COLOR;
+				else process.env.FORCE_COLOR = baseForceColor;
+				if (baseNoColor === undefined) delete process.env.NO_COLOR;
+				else process.env.NO_COLOR = baseNoColor;
+			}
+		},
+	},
+}));

--- a/packages/extensions/src/update-notifier.ts
+++ b/packages/extensions/src/update-notifier.ts
@@ -6,7 +6,7 @@ import { basename } from "node:path";
 
 import {
 	CrustError,
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	defineExtension,
 	defineExtensionId,
@@ -429,118 +429,121 @@ function resolveUpdateCommand(
  * await app.execute();
  * ```
  */
-function updateNotifierFactory(options: UpdateNotifierOptions): Extension {
-	const {
-		currentVersion,
-		packageName,
-		timeoutMs = DEFAULT_TIMEOUT_MS,
-		registryUrl = DEFAULT_REGISTRY_URL,
-		updateCommand,
-		updateDocsUrl,
-		cache,
-	} = options;
-	const intervalMs = (cache === false ? undefined : cache?.intervalMs) ?? DEFAULT_INTERVAL_MS;
+export const updateNotifier: ExtensionFactory<[options: UpdateNotifierOptions]> = defineExtension(
+	UPDATE_NOTIFIER,
+	(options) => {
+		const {
+			currentVersion,
+			packageName,
+			timeoutMs = DEFAULT_TIMEOUT_MS,
+			registryUrl = DEFAULT_REGISTRY_URL,
+			updateCommand,
+			updateDocsUrl,
+			cache,
+		} = options;
+		const intervalMs = (cache === false ? undefined : cache?.intervalMs) ?? DEFAULT_INTERVAL_MS;
 
-	return defineExtension(UPDATE_NOTIFIER, {
-		hooks: {
-			async postRun(context, outcome) {
-				if (outcome.status !== "completed") return;
+		return {
+			hooks: {
+				async postRun(context, outcome) {
+					if (outcome.status !== "completed") return;
 
-				const resolvedCurrentVersion = currentVersion ?? context.rootCommand.meta.version;
-				if (resolvedCurrentVersion === undefined) {
-					throw new CrustError(
-						"DEFINITION",
-						"The update notifier extension requires a version in new Crust(name, { version }) or currentVersion",
-					);
-				}
-
-				try {
-					let cacheAdapter: UpdateNotifierCacheAdapter = NO_CACHE_ADAPTER;
-					if (cache !== false) {
-						if (cache?.adapter) {
-							cacheAdapter = cache.adapter;
-						} else {
-							cacheAdapter = await createStoreCacheAdapter(packageName, registryUrl);
-						}
+					const resolvedCurrentVersion = currentVersion ?? context.rootCommand.meta.version;
+					if (resolvedCurrentVersion === undefined) {
+						throw new CrustError(
+							"DEFINITION",
+							"The update notifier extension requires a version in new Crust(name, { version }) or currentVersion",
+						);
 					}
 
-					// Corrupt/unreadable cache (e.g. CrustStoreError PARSE) reads as empty
-					// so the next successful write repairs the file instead of permanently
-					// disabling the notifier.
-					const state = normalizeNotifierState(await cacheAdapter.read().catch(() => null));
-					const resolvedUpdateCommand = resolveUpdateCommand(packageName, updateCommand);
+					try {
+						let cacheAdapter: UpdateNotifierCacheAdapter = NO_CACHE_ADAPTER;
+						if (cache !== false) {
+							if (cache?.adapter) {
+								cacheAdapter = cache.adapter;
+							} else {
+								cacheAdapter = await createStoreCacheAdapter(packageName, registryUrl);
+							}
+						}
 
-					// ── Cache gate: skip network if within interval ──────────
-					const now = Date.now();
-					const elapsed = now - state.lastCheckedAt;
+						// Corrupt/unreadable cache (e.g. CrustStoreError PARSE) reads as empty
+						// so the next successful write repairs the file instead of permanently
+						// disabling the notifier.
+						const state = normalizeNotifierState(await cacheAdapter.read().catch(() => null));
+						const resolvedUpdateCommand = resolveUpdateCommand(packageName, updateCommand);
 
-					// Negative elapsed (clock rollback, corrupt future timestamp) is
-					// treated as stale so the refetch rewrites lastCheckedAt.
-					if (cache !== false && elapsed >= 0 && elapsed < intervalMs) {
-						// Cache is still fresh — use cached version if available
+						// ── Cache gate: skip network if within interval ──────────
+						const now = Date.now();
+						const elapsed = now - state.lastCheckedAt;
+
+						// Negative elapsed (clock rollback, corrupt future timestamp) is
+						// treated as stale so the refetch rewrites lastCheckedAt.
+						if (cache !== false && elapsed >= 0 && elapsed < intervalMs) {
+							// Cache is still fresh — use cached version if available
+							if (
+								state.latestVersion &&
+								isNewerVersion(resolvedCurrentVersion, state.latestVersion) &&
+								state.lastNotifiedVersion !== state.latestVersion
+							) {
+								emitUpdateNotice(
+									resolvedCurrentVersion,
+									state.latestVersion,
+									resolvedUpdateCommand,
+									updateDocsUrl,
+									context.stderr,
+								);
+								await cacheAdapter.write({
+									...state,
+									lastNotifiedVersion: state.latestVersion,
+								});
+							}
+							return;
+						}
+
+						// ── Network check: fetch latest version ──────────────────
+						const latestVersion = await fetchLatestVersion(packageName, registryUrl, timeoutMs);
+
+						if (latestVersion === null) {
+							// Soft failure — update timestamp to avoid retrying too soon
+							await cacheAdapter.write({
+								...state,
+								lastCheckedAt: now,
+							});
+							return;
+						}
+
+						// ── Persist fetched version and timestamp ─────────────────
+						const nextState: UpdateNotifierState = {
+							...state,
+							lastCheckedAt: now,
+							latestVersion,
+						};
+
+						// ── Emit notice if newer and not already notified ─────────
 						if (
-							state.latestVersion &&
-							isNewerVersion(resolvedCurrentVersion, state.latestVersion) &&
-							state.lastNotifiedVersion !== state.latestVersion
+							isNewerVersion(resolvedCurrentVersion, latestVersion) &&
+							state.lastNotifiedVersion !== latestVersion
 						) {
 							emitUpdateNotice(
 								resolvedCurrentVersion,
-								state.latestVersion,
+								latestVersion,
 								resolvedUpdateCommand,
 								updateDocsUrl,
 								context.stderr,
 							);
-							await cacheAdapter.write({
-								...state,
-								lastNotifiedVersion: state.latestVersion,
-							});
+							nextState.lastNotifiedVersion = latestVersion;
 						}
-						return;
+
+						await cacheAdapter.write(nextState);
+					} catch {
+						// All notifier internal errors are silently swallowed.
+						// The extension must never affect command exit codes or output.
 					}
-
-					// ── Network check: fetch latest version ──────────────────
-					const latestVersion = await fetchLatestVersion(packageName, registryUrl, timeoutMs);
-
-					if (latestVersion === null) {
-						// Soft failure — update timestamp to avoid retrying too soon
-						await cacheAdapter.write({
-							...state,
-							lastCheckedAt: now,
-						});
-						return;
-					}
-
-					// ── Persist fetched version and timestamp ─────────────────
-					const nextState: UpdateNotifierState = {
-						...state,
-						lastCheckedAt: now,
-						latestVersion,
-					};
-
-					// ── Emit notice if newer and not already notified ─────────
-					if (
-						isNewerVersion(resolvedCurrentVersion, latestVersion) &&
-						state.lastNotifiedVersion !== latestVersion
-					) {
-						emitUpdateNotice(
-							resolvedCurrentVersion,
-							latestVersion,
-							resolvedUpdateCommand,
-							updateDocsUrl,
-							context.stderr,
-						);
-						nextState.lastNotifiedVersion = latestVersion;
-					}
-
-					await cacheAdapter.write(nextState);
-				} catch {
-					// All notifier internal errors are silently swallowed.
-					// The extension must never affect command exit codes or output.
-				}
+				},
 			},
-		},
-	});
-}
+		};
+	},
+);
 
 // ────────────────────────────────────────────────────────────────────────────
 // Internal — Update notice output
@@ -595,6 +598,3 @@ function emitUpdateNotice(
 
 	stderr(lines.join("\n"));
 }
-
-export const updateNotifier: typeof updateNotifierFactory & { readonly id: ExtensionId } =
-	Object.assign(updateNotifierFactory, { id: UPDATE_NOTIFIER });

--- a/packages/extensions/src/version.ts
+++ b/packages/extensions/src/version.ts
@@ -1,6 +1,6 @@
 import {
 	CrustError,
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	type ExtensionContext,
 	defineExtension,
@@ -22,48 +22,44 @@ export interface VersionOptions {
 	readonly format?: "plain" | ((version: string, context: ExtensionContext) => string);
 }
 
-function versionFactory(versionValue?: VersionValue, options: VersionOptions = {}): Extension {
-	const { format } = options;
+export const version: ExtensionFactory<[versionValue?: VersionValue, options?: VersionOptions]> =
+	defineExtension(VERSION, (versionValue, options = {}) => {
+		const { format } = options;
 
-	return defineExtension(VERSION, {
-		flags: [
-			{
-				name: "version",
-				type: "boolean",
-				short: "v",
-				noNegate: true,
-				description: "Show version number",
-				recursive: false,
-			},
-		],
-		hooks: {
-			preRun(context) {
-				// Root invocation with --version only
-				if (context.commandPath.length !== 1 || context.flags.version !== true) return;
+		return {
+			flags: [
+				{
+					name: "version",
+					type: "boolean",
+					short: "v",
+					noNegate: true,
+					description: "Show version number",
+					recursive: false,
+				},
+			],
+			hooks: {
+				preRun(context) {
+					// Root invocation with --version only
+					if (context.commandPath.length !== 1 || context.flags.version !== true) return;
 
-				// oxlint-disable-next-line anti-slop/no-runtime-typeof -- discriminating a typed options union.
-				const override = typeof versionValue === "function" ? versionValue() : versionValue;
-				const resolvedVersion = override ?? context.rootCommand.meta.version;
-				if (resolvedVersion === undefined) {
-					throw new CrustError(
-						"DEFINITION",
-						"The version extension requires a version in new Crust(name, { version }) or version(value)",
-					);
-				}
-				const line =
-					format === "plain"
-						? resolvedVersion
-						: format
-							? format(resolvedVersion, context)
-							: `${context.rootCommand.meta.name} v${resolvedVersion}`;
-				context.stdout(line);
-				return context.finish();
+					// oxlint-disable-next-line anti-slop/no-runtime-typeof -- discriminating a typed options union.
+					const override = typeof versionValue === "function" ? versionValue() : versionValue;
+					const resolvedVersion = override ?? context.rootCommand.meta.version;
+					if (resolvedVersion === undefined) {
+						throw new CrustError(
+							"DEFINITION",
+							"The version extension requires a version in new Crust(name, { version }) or version(value)",
+						);
+					}
+					const line =
+						format === "plain"
+							? resolvedVersion
+							: format
+								? format(resolvedVersion, context)
+								: `${context.rootCommand.meta.name} v${resolvedVersion}`;
+					context.stdout(line);
+					return context.finish();
+				},
 			},
-		},
+		};
 	});
-}
-
-export const version: typeof versionFactory & { readonly id: ExtensionId } = Object.assign(
-	versionFactory,
-	{ id: VERSION },
-);

--- a/packages/man/src/extension.ts
+++ b/packages/man/src/extension.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import {
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	defineExtension,
 	defineExtensionId,
@@ -21,22 +21,21 @@ export interface ManOptions {
 }
 
 /** Adds build-time mdoc generation for the application. */
-function manFactory(options: ManOptions = {}): Extension {
-	const section = options.section ?? 1;
-	return defineExtension(MAN, {
-		async build({ snapshot, outDir }) {
-			const { writeManPage } = await import("./write-man-page.ts");
-			const name = options.name ?? snapshot.meta.name;
-			await writeManPage({
-				root: snapshot,
-				name,
-				section,
-				outfile: join(outDir, "man", `${name}.${section}`),
-			});
-		},
-	});
-}
-
-export const man: typeof manFactory & { readonly id: ExtensionId } = Object.assign(manFactory, {
-	id: MAN,
-});
+export const man: ExtensionFactory<[options?: ManOptions]> = defineExtension(
+	MAN,
+	(options = {}) => {
+		const section = options.section ?? 1;
+		return {
+			async build({ snapshot, outDir }) {
+				const { writeManPage } = await import("./write-man-page.ts");
+				const name = options.name ?? snapshot.meta.name;
+				await writeManPage({
+					root: snapshot,
+					name,
+					section,
+					outfile: join(outDir, "man", `${name}.${section}`),
+				});
+			},
+		};
+	},
+);

--- a/packages/skills/src/extension.ts
+++ b/packages/skills/src/extension.ts
@@ -1,7 +1,7 @@
 import { join, relative } from "node:path";
 
 import {
-	type Extension,
+	type ExtensionFactory,
 	type ExtensionId,
 	type ExtensionBuildContext,
 	type InvocationIO,
@@ -190,33 +190,31 @@ async function buildSkills(options: SkillOptions, context: ExtensionBuildContext
 	else await writeSkillsFromSnapshot(context.snapshot, writeOptions);
 }
 
-function skillFactory(options: SkillOptions): Extension {
-	const commandName = options.command ?? DEFAULT_SKILL_COMMAND_NAME;
-	return defineExtension(SKILLS, {
-		commands: [buildSkillCommand(commandName, options)],
-		// Skills are loaded when a snapshot is prepared, not at construction, so
-		// help and man pages reflect the packaged directory as it exists at render time.
-		sections: (snapshot) => [
-			{
-				command: [],
-				title: SKILLS_SECTION_TITLE,
-				body: formatSkillDocumentation(options.distDir, commandName, snapshot.meta.name),
-				except: [SKILLS],
+export const skill: ExtensionFactory<[options: SkillOptions]> = defineExtension(
+	SKILLS,
+	(options) => {
+		const commandName = options.command ?? DEFAULT_SKILL_COMMAND_NAME;
+		return {
+			commands: [buildSkillCommand(commandName, options)],
+			// Skills are loaded when a snapshot is prepared, not at construction, so
+			// help and man pages reflect the packaged directory as it exists at render time.
+			sections: (snapshot) => [
+				{
+					command: [],
+					title: SKILLS_SECTION_TITLE,
+					body: formatSkillDocumentation(options.distDir, commandName, snapshot.meta.name),
+					except: [SKILLS],
+				},
+			],
+			build: (context) => buildSkills(options, context),
+			hooks: {
+				async preRun(context) {
+					if (context.commandPath[1] === commandName || options.autoUpdate === false) return;
+					await autoRepairSkills(options, context);
+				},
 			},
-		],
-		build: (context) => buildSkills(options, context),
-		hooks: {
-			async preRun(context) {
-				if (context.commandPath[1] === commandName || options.autoUpdate === false) return;
-				await autoRepairSkills(options, context);
-			},
-		},
-	});
-}
-
-export const skill: typeof skillFactory & { readonly id: ExtensionId } = Object.assign(
-	skillFactory,
-	{ id: SKILLS },
+		};
+	},
 );
 
 async function reconcileSkill(opts: {


### PR DESCRIPTION
Replace the separate Extension factory helper with a second `defineExtension(id, factory)` form. The callback returns config; each invocation builds a frozen, normalized Extension with the factory's identity.

### Changes

- **@crustjs/core:** Add the factory overload and exported `ExtensionFactory` type; preserve inferred flags, dependencies, providers, commands, and object-form validation. Cover identity, options, section consumers, inference, and object-form behavior.
- **@crustjs/extensions:** Inline all six official factories into annotated one-call definitions.
- **@crustjs/skills / @crustjs/man:** Migrate skill and man without changing their call signatures.
- **Docs / config:** Update authoring/API references, group the two defineExtension forms, align official factory signature references with ExtensionFactory, and document isolated declarations in ADR 0001 and the shared tsconfig.

### Notes

- Published factory annotations remain necessary for `isolatedDeclarations`; authors without that flag can omit them for full inference.
- ADR 0001 records why per-file declaration emit is required to inline private utils sources; speed is secondary.
- Includes a core patch changeset; no CHANGELOG edits.
- Before/after declaration builds and compiler comparisons confirm no official exported shape changes; only intersection spelling/imports differ.
- `check:fix`, `check`, `check:types`, and `test` pass. The guide example also compiles with isolated declarations.

### Stack
1. #341 `feat/define-extension` → `main` **(this PR)**
2. #342 `feat/completion-build-hook` → `feat/define-extension`
3. #343 `refactor/run-structured-parse` → `feat/completion-build-hook`

