### PR TITLE
feat(extensions): completion build hook and shell renderer exports

### DIFF
--- a/.changeset/completion-build-hook.md
+++ b/.changeset/completion-build-hook.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/extensions": minor
+---
+
+`completion()` contributes a build hook: `crust build` writes `<outdir>/completions/<bin>`, `_<bin>`, and `<bin>.fish`, and `crust build --package` stages the directory in the root npm package. Export `renderBashCompletion()`, `renderZshCompletion()`, `renderFishCompletion()`, and `CompletionRenderOptions` for custom pipelines. `binName` applies to both the runtime command and the build hook. All paths use the root command's version unless explicitly overridden, and require a version to be present.

--- a/.changeset/completion-build-hook.md
+++ b/.changeset/completion-build-hook.md
@@ -2,4 +2,4 @@
 "@crustjs/extensions": minor
 ---
 
-`completion()` contributes a build hook: `crust build` writes `<outdir>/completions/<bin>`, `_<bin>`, and `<bin>.fish`, and `crust build --package` stages the directory in the root npm package. Export `renderBashCompletion()`, `renderZshCompletion()`, `renderFishCompletion()`, and `CompletionRenderOptions` for custom pipelines. `binName` applies to both the runtime command and the build hook. All paths use the root command's version unless explicitly overridden, and require a version to be present.
+`completion()` contributes a build hook: `crust build` writes `<outdir>/completions/<bin>`, `_<bin>`, and `<bin>.fish`, and `crust build --package` stages the directory in the root npm package. Export `renderBashCompletion()`, `renderZshCompletion()`, `renderFishCompletion()`, and `CompletionRenderOptions` for custom pipelines. `binName` applies to both the runtime command and the build hook. All paths use the root command's version unless explicitly overridden, and require a version to be present. The build hook stages all scripts before replacing previous artifacts, preserving them if validation, rendering, or staging writes fail.

--- a/apps/docs/content/docs/modules/crust.mdx
+++ b/apps/docs/content/docs/modules/crust.mdx
@@ -34,6 +34,6 @@ The default `crust build` output is a raw binary and resolver script. Use it for
 
 ## Extension artifacts
 
-Registered Extensions own build artifacts. For example, [`man()`](/docs/modules/man) writes `<outdir>/man/<name>.1`, and [`skill()`](/docs/modules/skills) writes `<outdir>/skills`. No Extension-specific build flags are required. `--no-validate` skips snapshot preparation and all build hooks.
+Registered Extensions own build artifacts. For example, [`man()`](/docs/modules/man) writes `<outdir>/man/<name>.1`, [`skill()`](/docs/modules/skills) writes `<outdir>/skills`, and [`completion()`](/docs/modules/extensions/completion) writes `<outdir>/completions`. `crust build --package` ships these directories in the root npm package and includes them in npm `files`, with copies under each platform package's `bin/` directory. No Extension-specific build flags are required. `--no-validate` skips snapshot preparation and all build hooks.
 
 Install this package only as a development dependency; generated applications do not need it at runtime.

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -3,7 +3,7 @@ title: Completion
 description: Generate static shell completion scripts for bash, zsh, and fish.
 ---
 
-The completion Extension contributes a `completion <shell>` root command. It reads the final root Command Snapshot at invocation time and emits a self-contained script; generated scripts do not call back into the CLI on each completion.
+The completion Extension contributes a `completion <shell>` root command and a build hook. It reads the prepared root Command Snapshot and emits a self-contained script; generated scripts do not call back into the CLI on each completion.
 
 ## Usage
 
@@ -36,6 +36,11 @@ my-cli completion fish > ~/.config/fish/completions/my-cli.fish
 type CompletionShell = "bash" | "zsh" | "fish";
 
 const completion: ExtensionFactory<[options?: CompletionOptions]>;
+
+type CompletionRenderOptions = Pick<CompletionOptions, "binName" | "version">;
+function renderBashCompletion(root: CommandSnapshot, options?: CompletionRenderOptions): string;
+function renderZshCompletion(root: CommandSnapshot, options?: CompletionRenderOptions): string;
+function renderFishCompletion(root: CommandSnapshot, options?: CompletionRenderOptions): string;
 ```
 
 <auto-type-table
@@ -43,7 +48,9 @@ const completion: ExtensionFactory<[options?: CompletionOptions]>;
   name="CompletionOptions"
 />
 
-By default, generated headers use the root `CommandSnapshot.meta.version`; `CompletionOptions.version` remains an override. Invoking the command without either version reports a `DEFINITION` error.
+The pure renderers are exported from `@crustjs/extensions` for custom pipelines. Pass a root Command Snapshot prepared with `await app.snapshot()`; they return scripts without writing files.
+
+By default, generated headers use the root `CommandSnapshot.meta.version`; `CompletionOptions.version` remains an override. The runtime command, build hook, and pure renderers require one of these versions; omitting both throws a `DEFINITION` error (reported as an Extension build failure during builds).
 
 The positional `<shell>` accepts `bash`, `zsh`, or `fish`. With no `--output-dir`, the selected script is written through the invocation's stdout callback, so programmatic `run()` calls honor injected output. With `--output-dir <path>`, the Extension writes every supported shell using canonical filenames: `<bin>` for bash, `_<bin>` for zsh, and `<bin>.fish` for fish.
 
@@ -61,9 +68,21 @@ my-cli completion bash --output-dir completions/
 
 The Extension validates command, flag, argument, alias, choice, and binary identifiers before rendering. Unsafe identifiers throw instead of producing shell code with incorrect quoting.
 
-## Packaging
+## Build artifacts
 
-Generate all files during packaging when a target binary cannot run on the build host:
+With `completion()` registered, `crust build` writes all three shell files through its build hook:
+
+- `<outdir>/completions/<bin>` for bash
+- `<outdir>/completions/_<bin>` for zsh
+- `<outdir>/completions/<bin>.fish` for fish
+
+The hook replaces its owned `<outdir>/completions/` directory on each build so renamed binaries do not leave stale scripts. Runtime `--output-dir` preserves unrelated files in the supplied directory.
+
+`crust build --package` stages `completions/` in the root npm package and adds it to npm `files`; platform packages also receive a copy under `bin/completions/`. `--no-validate` skips the hook.
+
+The binary name defaults to the root command's `meta.name`. Set `completion({ binName: "installed-name" })` when `crust build --name` or the npm `bin` key installs the CLI under a different name; this applies to runtime output too. Build headers use the root `meta.version`, with `completion({ version })` as an override, just like runtime output.
+
+When not using `crust build`, generate all files with `--output-dir` during packaging:
 
 ```json
 {

--- a/apps/docs/content/docs/modules/extensions/completion.mdx
+++ b/apps/docs/content/docs/modules/extensions/completion.mdx
@@ -76,7 +76,7 @@ With `completion()` registered, `crust build` writes all three shell files throu
 - `<outdir>/completions/_<bin>` for zsh
 - `<outdir>/completions/<bin>.fish` for fish
 
-The hook replaces its owned `<outdir>/completions/` directory on each build so renamed binaries do not leave stale scripts. Runtime `--output-dir` preserves unrelated files in the supplied directory.
+The hook stages all three scripts before replacing its owned `<outdir>/completions/` directory, preserving previous artifacts if validation, rendering, or staging writes fail. Successful builds replace the directory so renamed binaries do not leave stale scripts. Runtime `--output-dir` preserves unrelated files in the supplied directory.
 
 `crust build --package` stages `completions/` in the root npm package and adds it to npm `files`; platform packages also receive a copy under `bin/completions/`. `--no-validate` skips the hook.
 

--- a/apps/docs/content/docs/modules/extensions/index.mdx
+++ b/apps/docs/content/docs/modules/extensions/index.mdx
@@ -43,16 +43,19 @@ await app.execute();
 
 ## Exports
 
-| Factory                                                               | Contribution                                      |
-| --------------------------------------------------------------------- | ------------------------------------------------- |
-| [`help()`](/docs/modules/extensions/help)                             | Recursive `--help` / `-h` flag and help rendering |
-| [`renderHelp(command, path?)`](/docs/modules/extensions/help)         | Render help text from a Command Snapshot          |
-| [`version(value?, options?)`](/docs/modules/extensions/version)       | Root-only `--version` / `-v` flag                 |
-| [`completion(options?)`](/docs/modules/extensions/completion)         | Static bash, zsh, and fish completion command     |
-| [`didYouMean(options?)`](/docs/modules/extensions/did-you-mean)       | `COMMAND_NOT_FOUND` presentation                  |
-| [`noColor()`](/docs/modules/extensions/no-color)                      | Recursive `--color` / `--no-color` flag           |
-| [`updateNotifier(options)`](/docs/modules/extensions/update-notifier) | Post-action npm update notice                     |
+| Export                                                                        | Contribution                                        |
+| ----------------------------------------------------------------------------- | --------------------------------------------------- |
+| [`help()`](/docs/modules/extensions/help)                                     | Recursive `--help` / `-h` flag and help rendering   |
+| [`renderHelp(command, path?)`](/docs/modules/extensions/help)                 | Render help text from a Command Snapshot            |
+| [`version(value?, options?)`](/docs/modules/extensions/version)               | Root-only `--version` / `-v` flag                   |
+| [`completion(options?)`](/docs/modules/extensions/completion)                 | Static shell completion command and build artifacts |
+| [`renderBashCompletion(root, options?)`](/docs/modules/extensions/completion) | Render bash completion from a Command Snapshot      |
+| [`renderZshCompletion(root, options?)`](/docs/modules/extensions/completion)  | Render zsh completion from a Command Snapshot       |
+| [`renderFishCompletion(root, options?)`](/docs/modules/extensions/completion) | Render fish completion from a Command Snapshot      |
+| [`didYouMean(options?)`](/docs/modules/extensions/did-you-mean)               | `COMMAND_NOT_FOUND` presentation                    |
+| [`noColor()`](/docs/modules/extensions/no-color)                              | Recursive `--color` / `--no-color` flag             |
+| [`updateNotifier(options)`](/docs/modules/extensions/update-notifier)         | Post-action npm update notice                       |
 
-These factories return plain `Extension` values. Contributions are application-wide and applied in `.extend()` registration order. Extension flag spellings must not collide with existing flags, including subcommand-local flags: `.extend()` and `.add()` reject statically known collisions at compile time (`FIX_ALIAS_COLLISION`), and dynamically assembled Extensions fail loud at prepare time. Provided Context names must not replace a Context already on the path (`FIX_DUPLICATE_CONTEXT` for statically known names). Colliding canonical command names use deterministic last-write-wins behavior. During routing, canonical command names beat aliases; among colliding aliases, the alias of the earliest-inserted sibling wins, so namespace custom Extension contributions to avoid accidental overrides.
+Extension factories return plain `Extension` values. Contributions are application-wide and applied in `.extend()` registration order. Extension flag spellings must not collide with existing flags, including subcommand-local flags: `.extend()` and `.add()` reject statically known collisions at compile time (`FIX_ALIAS_COLLISION`), and dynamically assembled Extensions fail loud at prepare time. Provided Context names must not replace a Context already on the path (`FIX_DUPLICATE_CONTEXT` for statically known names). Colliding canonical command names use deterministic last-write-wins behavior. During routing, canonical command names beat aliases; among colliding aliases, the alias of the earliest-inserted sibling wins, so namespace custom Extension contributions to avoid accidental overrides.
 
 Use [`defineExtension(id, config?)`](/docs/guide/extensions) from `@crustjs/core` to author a custom Extension; omitted config defaults to `{}`.

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -8,6 +8,61 @@ Official Extensions for the Crust CLI framework
 bun add @crustjs/extensions
 ```
 
+## Usage
+
+```ts
+import { Crust } from "@crustjs/core";
+import { completion, help } from "@crustjs/extensions";
+
+const app = new Crust("my-cli", { version: "1.2.3" })
+	.extend(help(), completion())
+	.action(({ stdout }) => stdout("Hello"));
+
+await app.execute();
+```
+
+`my-cli completion bash` prints a script. `crust build` generates Bash, Zsh,
+and Fish files in `<outdir>/completions/`; `crust build --package` stages them
+in the npm packages.
+
+## Exports
+
+Import all exports from `@crustjs/extensions`:
+
+- `help()`, `renderHelp()` — help flags and snapshot-based help rendering.
+- `version()` — root version flag.
+- `completion()` — shell completion command and build artifacts.
+- `renderBashCompletion()`, `renderZshCompletion()`, `renderFishCompletion()` —
+  pure renderers returning scripts from a root Command Snapshot.
+- `didYouMean()` — suggestions for unknown commands.
+- `noColor()` — color control flags.
+- `updateNotifier()` — npm update notices.
+
+Completion types: `CompletionOptions`, `CompletionShell`, and
+`CompletionRenderOptions` (the renderers' optional `binName` and `version` overrides).
+
+```ts
+import { Crust } from "@crustjs/core";
+import {
+	type CompletionRenderOptions,
+	renderBashCompletion,
+	renderFishCompletion,
+	renderZshCompletion,
+} from "@crustjs/extensions";
+
+const app = new Crust("my-cli", { version: "1.2.3" });
+const snapshot = await app.snapshot();
+const options: CompletionRenderOptions = { binName: "installed-name" };
+const bash = renderBashCompletion(snapshot, options);
+const zsh = renderZshCompletion(snapshot, options);
+const fish = renderFishCompletion(snapshot, options);
+```
+
+Renderers do not write files. Runtime output, build artifacts, and pure renderers
+use the root version unless overridden; omitting both versions throws.
+See the [completion reference](https://crustjs.com/docs/modules/extensions/completion)
+for filenames, installation, and build behavior.
+
 ## Documentation
 
 Full docs: [crustjs.com/docs/modules/extensions](https://crustjs.com/docs/modules/extensions)

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Crust, defineCommand } from "@crustjs/core";
 
-import { completion } from "./index.ts";
+import {
+	completion,
+	type CompletionRenderOptions,
+	renderBashCompletion,
+	renderFishCompletion,
+	renderZshCompletion,
+} from "../index.ts";
 
 let stdoutBuf: Buffer[];
 let processStdoutBuf: Buffer[];
@@ -207,6 +213,14 @@ describe("completion", () => {
 			expect(fish).toContain("complete -c 'mycli' -f");
 		});
 
+		it("preserves unrelated files in the user-owned output directory", async () => {
+			await writeFile(join(tmpDir, "other-cli"), "existing completion");
+			await buildCli().execute({
+				argv: ["completion", "bash", "--output-dir", tmpDir],
+			});
+			expect(await readFile(join(tmpDir, "other-cli"), "utf8")).toBe("existing completion");
+		});
+
 		it("writes nothing to stdout in --output-dir mode", async () => {
 			const app = buildCli();
 			await app.execute({
@@ -224,5 +238,114 @@ describe("completion", () => {
 			const entries = (await readdir(nested)).sort();
 			expect(entries).toEqual(["_mycli", "mycli", "mycli.fish"]);
 		});
+	});
+});
+
+describe("completion build hook", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "crust-completion-build-"));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("writes all three shell files under outDir/completions", async () => {
+		const snapshot = await buildCli().snapshot();
+		await completion().build?.({ snapshot, outDir: tmpDir });
+
+		expect(await readdir(tmpDir)).toEqual(["completions"]);
+		const dir = join(tmpDir, "completions");
+		expect((await readdir(dir)).sort()).toEqual(["_mycli", "mycli", "mycli.fish"]);
+		const bash = await readFile(join(dir, "mycli"), "utf8");
+		expect(bash).toContain("# completion script for mycli v1.2.3");
+		expect(bash).toContain("complete -o default -F _mycli 'mycli'");
+		expect(await readFile(join(dir, "_mycli"), "utf8")).toStartWith("#compdef mycli\n");
+		expect(await readFile(join(dir, "mycli.fish"), "utf8")).toContain("complete -c 'mycli' -f");
+	});
+
+	it("honors binName and version overrides at build time", async () => {
+		const snapshot = await buildCli().snapshot();
+		await completion({ binName: "my-tool", version: "2.0.0" }).build?.({
+			snapshot,
+			outDir: tmpDir,
+		});
+
+		const dir = join(tmpDir, "completions");
+		expect((await readdir(dir)).sort()).toEqual(["_my-tool", "my-tool", "my-tool.fish"]);
+		expect(await readFile(join(dir, "_my-tool"), "utf8")).toStartWith("#compdef my-tool\n");
+		expect(await readFile(join(dir, "my-tool"), "utf8")).toContain("my-tool v2.0.0");
+	});
+
+	it("removes stale completion files after a binary rename without touching sibling artifacts", async () => {
+		const snapshot = await buildCli().snapshot();
+		await writeFile(join(tmpDir, "other-artifact"), "preserved");
+		await completion().build?.({ snapshot, outDir: tmpDir });
+		await completion({ binName: "renamed" }).build?.({ snapshot, outDir: tmpDir });
+
+		expect((await readdir(join(tmpDir, "completions"))).sort()).toEqual([
+			"_renamed",
+			"renamed",
+			"renamed.fish",
+		]);
+		expect(await readFile(join(tmpDir, "other-artifact"), "utf8")).toBe("preserved");
+	});
+
+	it("rejects an unsafe binName before writing anything", async () => {
+		const snapshot = await buildCli().snapshot();
+		await expect(
+			completion({ binName: "../pwn" }).build?.({ snapshot, outDir: tmpDir }),
+		).rejects.toThrow(/invalid binName/);
+		expect(await readdir(tmpDir)).toEqual([]);
+	});
+
+	it("pure renderers match build and runtime files byte-for-byte", async () => {
+		const app = buildCli();
+		const snapshot = await app.snapshot();
+		const options: CompletionRenderOptions = { version: "1.2.3" };
+		await completion(options).build?.({ snapshot, outDir: tmpDir });
+		const runtimeDir = join(tmpDir, "runtime");
+		await app.execute({ argv: ["completion", "zsh", "--output-dir", runtimeDir] });
+
+		for (const [filename, render] of [
+			["mycli", renderBashCompletion],
+			["_mycli", renderZshCompletion],
+			["mycli.fish", renderFishCompletion],
+		] as const) {
+			const script = render(snapshot, options);
+			expect(script).toBe(await readFile(join(tmpDir, "completions", filename), "utf8"));
+			expect(script).toBe(await readFile(join(runtimeDir, filename), "utf8"));
+		}
+	});
+
+	it("rejects a missing version without writing files", async () => {
+		await expect(
+			completion().build?.({ snapshot: await new Crust("mycli").snapshot(), outDir: tmpDir }),
+		).rejects.toThrow("requires a version");
+		expect(await readdir(tmpDir)).toEqual([]);
+	});
+});
+
+describe("completion renderers", () => {
+	it("uses snapshot metadata by default and honors overrides", async () => {
+		const snapshot = await buildCli().snapshot();
+		expect(renderBashCompletion(snapshot)).toStartWith("# completion script for mycli v1.2.3");
+		expect(renderZshCompletion(snapshot)).toStartWith("#compdef mycli\n");
+		expect(renderFishCompletion(snapshot, { binName: "my-tool", version: "9.9.9" })).toStartWith(
+			"# completion script for my-tool v9.9.9",
+		);
+	});
+
+	it("validates names, requires a version, and sanitizes header text", async () => {
+		const snapshot = await new Crust("mycli").snapshot();
+		for (const render of [renderBashCompletion, renderZshCompletion, renderFishCompletion]) {
+			expect(() => render(snapshot, { binName: "../pwn", version: "1" })).toThrow(
+				/invalid binName/,
+			);
+			expect(() => render(snapshot)).toThrow("completion extension requires a version");
+			expect(render(snapshot, { version: "1\ninjected" })).not.toContain("\ninjected");
+		}
 	});
 });

--- a/packages/extensions/src/completion/index.test.ts
+++ b/packages/extensions/src/completion/index.test.ts
@@ -320,6 +320,23 @@ describe("completion build hook", () => {
 		}
 	});
 
+	it("preserves existing artifacts when a rebuild fails validation", async () => {
+		await completion().build?.({ snapshot: await buildCli().snapshot(), outDir: tmpDir });
+		const dir = join(tmpDir, "completions");
+		const filenames = (await readdir(dir)).sort();
+		const scripts = await Promise.all(filenames.map((name) => readFile(join(dir, name), "utf8")));
+
+		await expect(
+			completion().build?.({ snapshot: await new Crust("mycli").snapshot(), outDir: tmpDir }),
+		).rejects.toThrow("requires a version");
+
+		expect(await readdir(tmpDir)).toEqual(["completions"]);
+		expect((await readdir(dir)).sort()).toEqual(filenames);
+		expect(await Promise.all(filenames.map((name) => readFile(join(dir, name), "utf8")))).toEqual(
+			scripts,
+		);
+	});
+
 	it("rejects a missing version without writing files", async () => {
 		await expect(
 			completion().build?.({ snapshot: await new Crust("mycli").snapshot(), outDir: tmpDir }),

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import { join, resolve as resolvePath } from "node:path";
 
 import {
@@ -214,9 +214,17 @@ export const completion: ExtensionFactory<[options?: CompletionOptions]> = defin
 			commands: [completionCommand],
 			build: async ({ snapshot, outDir }) => {
 				const dir = join(outDir, "completions");
-				// The hook owns this directory; remove stale scripts after a binary rename.
-				await rm(dir, { recursive: true, force: true });
-				await writeCompletionFiles(dir, snapshot, options);
+				await mkdir(outDir, { recursive: true });
+				const stagedDir = await mkdtemp(join(outDir, ".completions-"));
+				try {
+					// Keep previous artifacts until validation, rendering, and writes succeed.
+					await writeCompletionFiles(stagedDir, snapshot, options);
+					// The hook owns this directory; remove stale scripts after a binary rename.
+					await rm(dir, { recursive: true, force: true });
+					await rename(stagedDir, dir);
+				} finally {
+					await rm(stagedDir, { recursive: true, force: true });
+				}
 			},
 		};
 	},

--- a/packages/extensions/src/completion/index.ts
+++ b/packages/extensions/src/completion/index.ts
@@ -1,8 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { resolve as resolvePath } from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join, resolve as resolvePath } from "node:path";
 
 import {
 	CrustError,
+	type CommandSnapshot,
 	type ExtensionFactory,
 	type ExtensionId,
 	defineCommand,
@@ -35,6 +36,8 @@ export interface CompletionOptions {
 	/**
 	 * Binary name embedded in generated scripts (the `complete -F` target,
 	 * the `#compdef` line, the `complete -c <bin>` rules).
+	 * Applies to the runtime command and build hook; set it when `crust build --name`
+	 * or the npm bin key installs the CLI under a different name.
 	 *
 	 * @default The root command's `meta.name`
 	 */
@@ -47,6 +50,9 @@ export interface CompletionOptions {
 	 */
 	version?: string;
 }
+
+/** Render inputs shared by the pure shell renderers. */
+export type CompletionRenderOptions = Pick<CompletionOptions, "binName" | "version">;
 
 /** Filename convention for each shell's drop-in completion file. */
 function filenameForShell(shell: CompletionShell, binName: string): string {
@@ -71,6 +77,73 @@ const SHELL_RENDERERS = {
 	fish: renderFish,
 } satisfies Record<CompletionShell, typeof renderBash>;
 
+function prepareRender(root: CommandSnapshot, options: CompletionRenderOptions) {
+	// Validate `binName` before emitting anything so misconfigured CLIs fail loudly.
+	// The walker also re-validates command/flag identifiers when it builds the spec.
+	const binName = assertSafeBinName(options.binName ?? root.meta.name);
+	const version = options.version ?? root.meta.version;
+	if (version === undefined) {
+		throw new CrustError(
+			"DEFINITION",
+			"The completion extension requires a version in new Crust(name, { version }) or completion({ version })",
+		);
+	}
+	// `version` flows into header comments only; strip control characters so it
+	// cannot break out of the comment line in the emitted script.
+	return {
+		spec: walkCommandNode(buildCommandDocumentation(root)),
+		binName,
+		version: sanitizeFreeText(version),
+	};
+}
+
+async function writeCompletionFiles(
+	dir: string,
+	root: CommandSnapshot,
+	options: CompletionRenderOptions,
+): Promise<void> {
+	const { spec, binName, version } = prepareRender(root, options);
+	await mkdir(dir, { recursive: true });
+	for (const shell of SUPPORTED_SHELLS) {
+		const filename = filenameForShell(shell, binName);
+		const script = SHELL_RENDERERS[shell](spec, binName, version);
+		await writeFile(join(dir, filename), script, "utf8");
+	}
+}
+
+function renderCompletionScript(
+	shell: CompletionShell,
+	root: CommandSnapshot,
+	options: CompletionRenderOptions = {},
+): string {
+	const { spec, binName, version } = prepareRender(root, options);
+	return SHELL_RENDERERS[shell](spec, binName, version);
+}
+
+/** Render a bash completion script from a prepared root Command Snapshot. */
+export function renderBashCompletion(
+	root: CommandSnapshot,
+	options?: CompletionRenderOptions,
+): string {
+	return renderCompletionScript("bash", root, options);
+}
+
+/** Render a zsh completion script from a prepared root Command Snapshot. */
+export function renderZshCompletion(
+	root: CommandSnapshot,
+	options?: CompletionRenderOptions,
+): string {
+	return renderCompletionScript("zsh", root, options);
+}
+
+/** Render a fish completion script from a prepared root Command Snapshot. */
+export function renderFishCompletion(
+	root: CommandSnapshot,
+	options?: CompletionRenderOptions,
+): string {
+	return renderCompletionScript("fish", root, options);
+}
+
 /**
  * Build an Extension that contributes a `completion <shell>` command
  * which emits a tab-completion script for bash, zsh, or fish.
@@ -92,6 +165,10 @@ const SHELL_RENDERERS = {
  *   is the artifact-generation path used by Homebrew, Nix, and similar
  *   distribution channels — distributors run it once at packaging time
  *   and the resulting files become drop-ins.
+ *
+ * **Build hook.** `crust build` writes the same three files under
+ * `<outDir>/completions/`; `--package` stages that directory. The binary name
+ * defaults to the snapshot's `meta.name`, unless `options.binName` is set.
  */
 export const completion: ExtensionFactory<[options?: CompletionOptions]> = defineExtension(
 	COMPLETION,
@@ -117,30 +194,11 @@ export const completion: ExtensionFactory<[options?: CompletionOptions]> = defin
 							"Write all supported shells' scripts into this directory instead of printing to stdout",
 					})
 					.action(async (context) => {
-						const rootCommand = context.rootCommand;
-						// Validate `binName` before emitting anything so misconfigured
-						// CLIs fail loudly. The walker also re-validates command/flag
-						// identifiers when it builds the spec.
-						const binName = assertSafeBinName(options.binName ?? rootCommand.meta.name);
-						const version = options.version ?? rootCommand.meta.version;
-						if (version === undefined) {
-							throw new CrustError(
-								"DEFINITION",
-								"The completion extension requires a version in new Crust(name, { version }) or completion({ version })",
-							);
-						}
-						// `version` flows into header comments only; sanitise to drop
-						// control characters (newlines especially) so they cannot break
-						// out of the comment line in the emitted script.
-						const safeVersion = sanitizeFreeText(version);
-
-						const { shell: requestedShell } = context.args;
-						const spec = walkCommandNode(buildCommandDocumentation(rootCommand));
 						const outputDir = context.flags["output-dir"];
-
 						if (outputDir === undefined) {
-							const script = SHELL_RENDERERS[requestedShell](spec, binName, safeVersion);
-							context.stdout(script);
+							context.stdout(
+								renderCompletionScript(context.args.shell, context.rootCommand, options),
+							);
 							return;
 						}
 
@@ -148,16 +206,18 @@ export const completion: ExtensionFactory<[options?: CompletionOptions]> = defin
 						// the packaging-time use case — distributors generate every
 						// supported file in one invocation regardless of which
 						// shell they nominally requested.
-						const targetDir = resolvePath(outputDir);
-						await mkdir(targetDir, { recursive: true });
-						for (const shell of SUPPORTED_SHELLS) {
-							const filename = filenameForShell(shell, binName);
-							const script = SHELL_RENDERERS[shell](spec, binName, safeVersion);
-							await writeFile(resolvePath(targetDir, filename), script, "utf8");
-						}
+						await writeCompletionFiles(resolvePath(outputDir), context.rootCommand, options);
 					}),
 		);
 
-		return { commands: [completionCommand] };
+		return {
+			commands: [completionCommand],
+			build: async ({ snapshot, outDir }) => {
+				const dir = join(outDir, "completions");
+				// The hook owns this directory; remove stale scripts after a binary rename.
+				await rm(dir, { recursive: true, force: true });
+				await writeCompletionFiles(dir, snapshot, options);
+			},
+		};
 	},
 );

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -1,5 +1,14 @@
-export { completion } from "./completion/index.ts";
-export type { CompletionOptions, CompletionShell } from "./completion/index.ts";
+export {
+	completion,
+	renderBashCompletion,
+	renderFishCompletion,
+	renderZshCompletion,
+} from "./completion/index.ts";
+export type {
+	CompletionOptions,
+	CompletionRenderOptions,
+	CompletionShell,
+} from "./completion/index.ts";
 export { didYouMean } from "./did-you-mean.ts";
 export type { DidYouMeanOptions } from "./did-you-mean.ts";
 export { help, renderHelp } from "./help.ts";


### PR DESCRIPTION
## Summary
- Add a completion build hook that writes bash, zsh, and fish scripts to `<outdir>/completions/`; package builds stage them in root and platform packages.
- Replace the hook-owned directory on rebuild to remove stale binary names; runtime `--output-dir` preserves unrelated files.
- Export snapshot-based `renderBashCompletion`, `renderZshCompletion`, `renderFishCompletion`, and `CompletionRenderOptions`.
- Share rendering and validation across runtime, build, and pure-renderer paths.
- Document packaged completions and include an extensions minor changeset.

## Compatibility
- Binary name defaults to snapshot metadata; `binName` overrides runtime and build output.
- A root version or explicit `version` override is required. Missing versions now fail validated builds when `completion()` is registered.
- `--no-validate` skips build hooks.

## Validation
- `bun test packages/extensions/src/completion/index.test.ts` (20 passed)
- `bun run check:fix`
- `bun run check`
- `bun run check:types`
- `bun run test`
- Regression coverage: stale-name cleanup, sibling/runtime-file preservation, missing version, unsafe names, and byte-for-byte renderer/runtime/build parity.

### Stack
1. #341 `feat/define-extension` → `main`
2. #342 `feat/completion-build-hook` → `feat/define-extension` **(this PR)**
3. #343 `refactor/run-structured-parse` → `feat/completion-build-hook`
