### PR TITLE
perf(core): reduce command registration map copying

### DIFF
--- a/.changeset/red-beers-accept.md
+++ b/.changeset/red-beers-accept.md
@@ -1,0 +1,5 @@
+---
+"@crustjs/core": patch
+---
+
+Reduce redundant child-map copying during command registration, accumulating variadic additions in one private map while preserving eager materialization and immutable builders.

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -901,13 +901,16 @@ export class Crust<
 		const effectiveFlags = { ...this._node.effectiveFlags };
 		const newNode: CommandNode = {
 			...this._node,
-			// Descendants are immutable builder values; sharing them keeps fluent updates O(1).
+			// Descendants are immutable builder values; sharing them avoids recursive clones.
 			localFlags: { ...this._node.localFlags },
 			ownedFlags: { ...this._node.ownedFlags },
 			effectiveFlags,
 			flagSpellings: cloneFlagSpellings(this._node.flagSpellings, effectiveFlags),
 			args: [...this._node.args],
-			subCommands: { ...this._node.subCommands },
+			// A supplied replacement wins even when explicitly undefined at runtime.
+			...(Object.hasOwn(nodeOverrides, "subCommands")
+				? {}
+				: { subCommands: { ...this._node.subCommands } }),
 			contexts: [...this._node.contexts],
 			extensions: [...this._node.extensions],
 			meta: { ...this._node.meta },
@@ -1092,15 +1095,9 @@ export class Crust<
 			ValidateDeclaredDeps<Ctx, Ds> &
 			ValidateDefinitionFlags<Ds, CollisionSp["extension"]>
 	): AfterAdd<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result, Ds> {
-		let result = this._clone<Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result>>(
-			{},
-		);
-		for (const definition of definitions) {
-			result = result._addDefinition(definition);
-		}
-		return result._clone<
+		return this._addDefinitions<
 			AfterAdd<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result, Ds>
-		>({});
+		>(definitions);
 	}
 
 	/**
@@ -1147,7 +1144,7 @@ export class Crust<
 		// SAFETY: the erased recipe still returns the builder it receives; materialization re-validates that at runtime.
 		const definition = define(name, recipe as unknown as CommandRecipe);
 		/* oxlint-enable anti-slop/no-chained-type-assertions */
-		return this._addDefinition(definition)._clone<
+		return this._addDefinitions<
 			AfterAdd<
 				Flags,
 				A,
@@ -1160,27 +1157,29 @@ export class Crust<
 				Result,
 				readonly [CommandDefinition<N, readonly [], ShapeOfBuilder<B>, DepsOfBuilder<B>>]
 			>
-		>({});
+		>([definition]);
 	}
 
-	private _addDefinition(
-		definition: CommandDefinition,
-	): Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result> {
-		// FIX_COMMAND_COLLISION owns literal names; this owns dynamic `.add()`,
-		// where a silent replacement makes the earlier command unreachable.
-		// Extension-contributed commands keep documented last-write-wins.
-		if (Object.hasOwn(this._node.subCommands, definition.name)) {
-			throw new CrustError(
-				"DEFINITION",
-				`Command name "${definition.name}" is already registered on this command`,
-				{ subject: "command", name: definition.name, reason: "command-collision" },
-			);
+	private _addDefinitions<Out>(definitions: readonly CommandDefinition[]): Out {
+		// Keep partial additions private if a duplicate or recipe throws. Every
+		// recipe inherits from the original parent, never from earlier siblings.
+		const subCommands = { ...this._node.subCommands };
+		for (const definition of definitions) {
+			// FIX_COMMAND_COLLISION owns literal names; this owns dynamic `.add()`,
+			// where a silent replacement makes the earlier command unreachable.
+			// Extension-contributed commands keep documented last-write-wins.
+			if (Object.hasOwn(subCommands, definition.name)) {
+				throw new CrustError(
+					"DEFINITION",
+					`Command name "${definition.name}" is already registered on this command`,
+					{ subject: "command", name: definition.name, reason: "command-collision" },
+				);
+			}
+			const childNode = materializeCommandDefinition(definition, this._node);
+			subCommands[definition.name] = childNode;
 		}
-		const childNode = materializeCommandDefinition(definition, this._node);
 
-		return this._clone<Crust<Flags, A, Ctx, Sibs, Sp, Tree, CtxFlags, CollisionSp, Result>>({
-			subCommands: { ...this._node.subCommands, [definition.name]: childNode },
-		});
+		return this._clone<Out>({ subCommands });
 	}
 
 	/**

--- a/packages/core/src/command/crust.ts
+++ b/packages/core/src/command/crust.ts
@@ -300,7 +300,6 @@ function materializeCommandDefinition(
 	});
 
 	const child = new Crust(name);
-	child._ancestorOwnedFlags = parent.ownedFlags;
 	for (const [flagName, def] of Object.entries(parent.ownedFlags)) {
 		registerFlag(child._node, flagName, def, "owned");
 	}
@@ -313,7 +312,10 @@ function materializeCommandDefinition(
 	/* oxlint-disable anti-slop/no-chained-type-assertions -- Crust's declared type omits the builder-only `.use()` (implemented on its prototype), so the cast must pass through unknown. */
 	const configured = internal.recipe(child as unknown as AnyCommandDefinitionBuilder);
 	/* oxlint-enable anti-slop/no-chained-type-assertions */
-	if (!(configured instanceof Crust) || configured._ancestorOwnedFlags !== parent.ownedFlags) {
+	if (
+		!(configured instanceof Crust) ||
+		configured._ancestorOwnedFlags !== child._ancestorOwnedFlags
+	) {
 		throw new CrustError(
 			"DEFINITION",
 			`${owner} definition must return the same command builder it received`,
@@ -853,7 +855,7 @@ export class Crust<
 	/** @internal */
 	_node: CommandNode;
 
-	/** @internal — Runtime identity anchor for the ancestor-owned flag carrier */
+	/** @internal — Recipe-builder lineage anchor, unique per materialization and preserved by clones */
 	_ancestorOwnedFlags: FlagsDef;
 
 	/**

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -207,23 +207,93 @@ describe("command definitions", () => {
 		);
 	});
 
-	it("adds multiple definitions in one variadic call", async () => {
+	it("keeps retained builders unchanged when a batch recipe throws", async () => {
+		const events: string[] = [];
+		const base = new Crust("cli");
+		const receiver = base.add(defineCommand("existing", (command) => command));
+		const first = defineCommand("first", (command) => {
+			events.push("first");
+			return command;
+		});
+		const failure = new Error("recipe failed");
+		const throwing = defineCommand("throwing", () => {
+			events.push("throwing");
+			throw failure;
+		});
+		const later = defineCommand("later", (command) => {
+			events.push("later");
+			return command;
+		});
+
+		expect(() => receiver.add(first, throwing, later)).toThrow(failure);
+		expect(events).toEqual(["first", "throwing"]);
+		expect(Object.keys(base._node.subCommands)).toEqual([]);
+		expect(Object.keys(receiver._node.subCommands)).toEqual(["existing"]);
+		expect(Object.keys((await receiver.snapshot()).subCommands)).toEqual(["existing"]);
+	});
+
+	it.each(["first", "existing"])(
+		"checks a batch duplicate of %s before its recipe and stops registration",
+		async (name: string) => {
+			const events: string[] = [];
+			const base = new Crust("cli");
+			const receiver = base.add(defineCommand("existing", (command) => command));
+			const first = defineCommand("first", (command) => {
+				events.push("first");
+				return command;
+			});
+			const duplicate = defineCommand(name, (command) => {
+				events.push("duplicate");
+				return command;
+			});
+			const later = defineCommand("later", (command) => {
+				events.push("later");
+				return command;
+			});
+
+			expect(() => receiver.add(first, duplicate, later)).toThrow(
+				expect.objectContaining({
+					code: "DEFINITION",
+					message: `Command name "${name}" is already registered on this command`,
+					details: { subject: "command", name, reason: "command-collision" },
+				}),
+			);
+			expect(events).toEqual(["first"]);
+			expect(Object.keys(base._node.subCommands)).toEqual([]);
+			expect(Object.keys(receiver._node.subCommands)).toEqual(["existing"]);
+			expect(Object.keys((await receiver.snapshot()).subCommands)).toEqual(["existing"]);
+		},
+	);
+
+	it("adds multiple definitions in argument order without mutating retained builders", async () => {
+		const configured: string[] = [];
 		const ran: string[] = [];
-		const build = defineCommand("build", (command) =>
-			command.action(() => {
+		const build = defineCommand("build", (command) => {
+			configured.push("build");
+			return command.action(() => {
 				ran.push("build");
-			}),
-		);
-		const publish = defineCommand("publish", (command) =>
-			command.action(() => {
+			});
+		});
+		const publish = defineCommand("publish", (command) => {
+			configured.push("publish");
+			return command.action(() => {
 				ran.push("publish");
-			}),
-		);
-		const app = new Crust("cli").add(build, publish);
+			});
+		});
+		const base = new Crust("cli");
+		const receiver = base.add(defineCommand("existing", (command) => command));
+		const app = receiver.add(build, publish);
+
+		expect(configured).toEqual(["build", "publish"]);
+		expect(Object.keys(base._node.subCommands)).toEqual([]);
+		expect(Object.keys(receiver._node.subCommands)).toEqual(["existing"]);
+		expect(Object.keys(app._node.subCommands)).toEqual(["existing", "build", "publish"]);
+		expect(app._node.subCommands).not.toBe(receiver._node.subCommands);
 
 		await app.run(["build"]);
 		await app.run(["publish"]);
 
 		expect(ran).toEqual(["build", "publish"]);
+		expect(configured).toEqual(["build", "publish"]);
 	});
 });

--- a/packages/core/src/command/definition.test.ts
+++ b/packages/core/src/command/definition.test.ts
@@ -5,7 +5,7 @@ import { defineContext } from "../api/context.ts";
 import { defineExtension } from "../api/extension.ts";
 import { defineFlag } from "../api/flags.ts";
 import { defineExtensionId } from "../identity.ts";
-import { Crust, defineCommand } from "./crust.ts";
+import { type CommandDefinitionBuilder, Crust, defineCommand } from "./crust.ts";
 
 describe("command definitions", () => {
 	it("stays inert and materializes each time it is added", async () => {
@@ -28,6 +28,39 @@ describe("command definitions", () => {
 		const unrelated = defineCommand("bad", () => new Crust("other") as never);
 
 		expect(() => new Crust("cli").add(unrelated)).toThrow(/same command builder/);
+	});
+
+	it("rejects a later batch recipe returning an earlier recipe's fluent builder", async () => {
+		const events: string[] = [];
+		let retained: CommandDefinitionBuilder<{ "from-first": { type: "boolean" } }, []> | undefined;
+		const base = new Crust("cli");
+		const receiver = base.add(defineCommand("existing", (command) => command));
+		const first = defineCommand("first", (command) => {
+			events.push("first");
+			retained = command.flags({ name: "from-first", type: "boolean" }).action(() => {});
+			return retained;
+		});
+		const second = defineCommand("second", () => {
+			events.push("second");
+			if (!retained) throw new Error("first recipe has not run");
+			return retained;
+		});
+		const later = defineCommand("later", (command) => {
+			events.push("later");
+			return command;
+		});
+
+		expect(() => receiver.add(first, second, later)).toThrow(
+			expect.objectContaining({
+				code: "DEFINITION",
+				message: 'Command "second" definition must return the same command builder it received',
+				details: { subject: "command", name: "second", reason: "foreign-command-builder" },
+			}),
+		);
+		expect(events).toEqual(["first", "second"]);
+		expect(Object.keys(base._node.subCommands)).toEqual([]);
+		expect(Object.keys(receiver._node.subCommands)).toEqual(["existing"]);
+		expect(Object.keys((await receiver.snapshot()).subCommands)).toEqual(["existing"]);
 	});
 
 	it("rejects Extensions registered inside command definitions", () => {


### PR DESCRIPTION
## Summary

Closes #351.

- Accumulate variadic command additions in one fresh private child map, then clone once. Single, batch and inline registration use the same duplicate check.
- Skip the discarded child-map copy when a clone receives an own-property replacement. Ordinary clones retain independent map ownership, and explicit override presence still wins over the old value.
- Preserve eager recipes, argument order, duplicate/error timing, original-parent inheritance and public signatures. Add missing failure/order/retained-builder regressions and a Core patch changeset.

No application migration, public API changes, snapshot optimization, permanent benchmark suite or general cold-start promise.

## Verification

Final sequential verification used Bun **1.4.2** with `TURBO_FORCE=true`. Every command exited **0**:

```sh
bun run test
bun run check:types
bun run check
bun test scripts/package-size-report.test.ts scripts/type-perf-report.test.ts scripts/editor-latency.test.ts
bun scripts/smoke-runtimes/smoke.mjs
node scripts/smoke-runtimes/smoke.mjs
deno run --allow-env --allow-read --allow-write --allow-run --config scripts/smoke-runtimes/deno.json scripts/smoke-runtimes/smoke.mjs
git diff --check
```

Package builds, tests, type checks and lint/format ran uncached. Builds include actual isolated declaration emission, not runtime tests alone.

The independent validator also passed all required gates on Bun 1.4.0, including forced uncached tests/types and 12 package builds with isolated declaration emission. That run reported 1,642 tests passed, seven existing skips and zero failures. Core passed 442 tests. Existing built-distribution smoke checks passed on Bun, Node 26.8.1 and Deno 2.9.5.

Seven existing skips cover Windows on Linux, four Fish-gated cases because Fish is unavailable, and two opt-in installation smoke tests. CI minimum versions were not tested locally. An initial supplemental scripts run raced another validation command rebuilding Core dist; the identical sequential rerun passed all 14 tests without source or consumer changes.

Dependency setup used a user-approved, one-command `bun install --frozen-lockfile --minimum-release-age 0` exception after four already-pinned docs dependencies hit the package-age guard. Neither lockfile nor policy configuration changed.

### Independent review

- Standards: no blocking findings. Optional repeated test setup was left explicit; pre-existing generic repetition is outside this change.
- Spec/correctness: no findings. Existing nested, Context, flag, Extension, snapshot, invocation, reserved-name and type/declaration coverage was reused.

## Ad-hoc before/after measurements

Baseline: `d9e121f23e3fcb0f29a0d480a3ccc7fe8d540bba`.
After: `200052325209d1980e6653ddb79d08b49ca4d855`, with registration source SHA-256 `4735d1009d24d7fdc96b2ec439f43113edff097af3ed46bac1311fa0b65d1372`.
Measurements preceded the commit. The measured tracked diff SHA-256 was `5dd3da1c93dc129f5e207292a84e8b5517d2e1efd6c03f30774d97ec3a5d477b`; source bytes were unchanged through measurement and publication.

Primary runtime: Bun 1.4.2, matching the repository pin. Python 3.13.15 drove synchronous process timing. Linux x86_64, AMD Ryzen 7 6800H, 8 cores/16 threads, approximately 27 GiB RAM; shared developer machine, no CPU pinning or fixed frequency. CPU boost enabled, no cgroup CPU/memory cap found in the active group/ancestors. Filesystem caches were warm, OS caches were not flushed, and unrelated host activity was not controlled.

Fixture: one new root with 10 or 1,000 flat, uniquely named, lightweight sibling commands. Recipes register the same no-op action, never invoked. No flags, arguments, Contexts, Extensions, snapshots or invocation work. Both revisions import their own Core source directly, not built distributions. Reusable definitions are prepared outside warmed timing; inline `.command()` necessarily creates definitions inside its timed call.

- Warmed construction: 20 unrecorded warmup batches, 31 measured batches. Each batch builds 100 trees at size 10 or three at size 1,000. Report the median of per-tree batch averages. Imports, fixture preparation and integrity assertions are outside this timer; allocation/GC within construction remains included.
- Fresh-process wall time: five warmup launches followed by 31 measured launches per source/shape/size. Python times process spawn through exit, including Bun initialization, source imports/transpilation, fixture setup, one construction and assertions. This is not cold-disk startup or a minimal production executable.
- Runs were sequential. Source order alternated, fresh-process fixture order rotated, and no concurrent builds/tests were launched during measurement. `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` disabled the shared transpiler disk cache.

All times are milliseconds, median [p10–p90] across 31 samples. Warmed samples are batch-normalized; fresh samples are individual launches.

### Warmed construction only

| Shape | Siblings | Before ms | After ms | Before / after |
|---|---:|---:|---:|---:|
| variadic | 10 | 0.019834 [0.016854–0.020693] | 0.011722 [0.011277–0.014813] | 1.69× |
| chained | 10 | 0.018271 [0.016069–0.019236] | 0.013332 [0.011412–0.013821] | 1.37× |
| inline | 10 | 0.017065 [0.015102–0.017789] | 0.015095 [0.012794–0.015577] | 1.13× |
| variadic | 1000 | 37.570577 [36.666365–38.128809] | 1.429271 [1.162625–1.671637] | 26.29× |
| chained | 1000 | 71.347358 [70.360697–73.015198] | 19.337265 [19.005619–20.183416] | 3.69× |
| inline | 1000 | 53.717247 [53.061159–54.161556] | 19.560766 [19.227998–20.696723] | 2.75× |

### Fresh-process wall time (warm filesystem caches)

| Shape | Siblings | Before ms | After ms | Before / after |
|---|---:|---:|---:|---:|
| variadic | 10 | 25.215729 [23.954708–26.410244] | 25.222421 [24.243104–25.814275] | 1.00× |
| chained | 10 | 25.172087 [24.205173–26.072374] | 24.529178 [23.988793–27.423816] | 1.03× |
| inline | 10 | 24.405994 [23.630803–25.795269] | 24.629938 [23.558336–26.031376] | 0.99× |
| variadic | 1000 | 74.472028 [72.936177–76.342496] | 29.125464 [27.835357–30.000443] | 2.56× |
| chained | 1000 | 111.214919 [109.108304–115.349520] | 57.572621 [54.218620–59.655852] | 1.93× |
| inline | 1000 | 93.933296 [91.955134–96.546591] | 58.367679 [56.526127–60.773732] | 1.61× |



At 1,000 siblings, variadic warmed construction was 37.571 → 1.429 ms; separate fresh-process wall time was 74.472 → 29.125 ms. At 10 siblings, fresh-process medians remained about 25 ms, with no demonstrated meaningful startup improvement.

Variadic sibling-map maintenance is now linear in batch size plus one copy of existing siblings. Chained `.add(one)` and inline `.command()` still copy their retained growing maps and remain quadratic. This complexity statement comes from the copying structure, not a fit to two measurements. These synthetic results do not establish production or cross-runtime speedups.

A supplementary complete run on the initially active Bun 1.4.0 found 1,000-child variadic medians of 36.844 → 1.458 ms warmed and 84.595 → 37.832 ms fresh. Both complete runs passed every fixture assertion and all 888 benchmark process launches exited 0. Node and Deno were smoke-tested, not benchmarked.

<details>
<summary>Complete scratch scripts and reproduction commands</summary>

No benchmark files are added to the repository. Save the three scripts below into a new scratch directory. The after worktree needs its normal local workspace dependency links, created by `bun install --frozen-lockfile`. The preparation script extracts the exact pinned baseline and creates baseline-local Utils/Config links without installing dependencies or modifying either source tree.

```sh
REPO=/path/to/checkout-at-200052325209d1980e6653ddb79d08b49ca4d855
E=$(mktemp -d /tmp/crust-351-reproduce.XXXXXX)
# Save prepare.py, bench.mjs and run.py below into "$E".
python3 "$E/prepare.py" "$REPO" > "$E/prepare.log"
# Put the installed Bun 1.4.2 executable first on PATH.
PATH=/path/to/bun-1.4.2/bin:$PATH python3 "$E/run.py" > "$E/run.log" 2>&1
python3 - "$E/results.json" <<'PY'
import json, statistics, sys
for mode, rows in json.load(open(sys.argv[1])).items():
    for r in rows:
        print(mode, r['label'], r['shape'], r['size'], statistics.median(r['ms']), 'ms')
PY
```

The local measured commands were `python3 "$E/prepare.py" "$REPO"`, `python3 "$E/run.py"` on Bun 1.4.0, then the same driver with the installed Bun 1.4.2 directory prepended to PATH. The first dataset was retained separately before the second run. `commands.json` records exact child argument arrays, exit status, elapsed time and stderr; `results.json` retains every sample. `sources.json`, `after.diff` and `validation.json` record the source identity and unchanged-source checks.

On a committed reproduction checkout, the preparation script records the new HEAD and an empty working diff instead of the original pre-commit diff hash. The pinned baseline and after source hash above identify the measured implementation.


### `prepare.py`

SHA-256: `d784a986bfad20c1f3bfffb082f442f02fbba2a8f702bd9a3208d3e8b3b1356b`

```python
#!/usr/bin/env python3
"""Extract the pinned baseline; do not change either Git worktree or index."""
import hashlib
import io
import json
from pathlib import Path
import subprocess
import sys
import tarfile

BASE = "d9e121f23e3fcb0f29a0d480a3ccc7fe8d540bba"
repo = Path(sys.argv[1]).resolve()
out = Path(__file__).resolve().parent
baseline = out / "baseline"

def git(*args):
    return subprocess.check_output(["git", "-C", str(repo), *args])

def digest(data):
    return hashlib.sha256(data).hexdigest()

def manifest(root):
    return {str(p.relative_to(root)): digest(p.read_bytes())
            for package in ("core", "utils", "config")
            for p in sorted((root / "packages" / package).rglob("*"))
            if p.is_file() and "node_modules" not in p.parts
            and "dist" not in p.parts and ".turbo" not in p.parts}

if baseline.exists():
    raise SystemExit(f"Refusing to overwrite {baseline}; use a fresh scratch directory")
archive = git("archive", "--format=tar", BASE)
(out / "baseline.tar").write_bytes(archive)
baseline.mkdir()
with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
    tar.extractall(baseline, filter="data")
links = baseline / "node_modules" / "@crustjs"
links.mkdir(parents=True)
for package in ("utils", "config"):
    (links / package).symlink_to(baseline / "packages" / package, target_is_directory=True)
patch = git("diff", "--binary", "--no-ext-diff", "HEAD", "--")
(out / "after.diff").write_bytes(patch)
untracked = git("ls-files", "--others", "--exclude-standard").decode().splitlines()
meta = {
    "baseline_revision": BASE,
    "baseline_archive_sha256": digest(archive),
    "after_repo": str(repo),
    "after_branch": git("branch", "--show-current").decode().strip(),
    "after_head": git("rev-parse", "HEAD").decode().strip(),
    "after_diff_command": "git diff --binary --no-ext-diff HEAD --",
    "after_diff_sha256": digest(patch),
    "after_status": git("status", "--porcelain=v1").decode(),
    "staged_files": git("diff", "--cached", "--name-only").decode().splitlines(),
    "untracked_sha256": {p: digest((repo / p).read_bytes()) for p in untracked},
    "sources": {"before": str(baseline), "after": str(repo)},
    "manifests": {"before": manifest(baseline), "after": manifest(repo)},
}
(out / "sources.json").write_text(json.dumps(meta, indent=2) + "\n")
print(json.dumps({k: v for k, v in meta.items() if k != "manifests"}, indent=2))
```

### `bench.mjs`

SHA-256: `99aa07f272b45bf9ac1bfe14f11fea9afc4af7d00f55c5886a2bf2c1201c157d`

```javascript
import assert from "node:assert/strict";
import { pathToFileURL } from "node:url";

const [root, shape, sizeText, mode, warmText = "20", samplesText = "31"] = process.argv.slice(2);
const size = Number(sizeText);
assert(["variadic", "chained", "inline"].includes(shape));
assert(["warm", "fresh"].includes(mode));
assert(Number.isInteger(size) && size > 0);
const { Crust, defineCommand } = await import(pathToFileURL(`${root}/packages/core/src/index.ts`).href);
const noop = () => {};
const recipe = (command) => command.action(noop);
const names = Array.from({ length: size }, (_, i) => `child-${i}`);
// Reusable definitions are setup, not warmed construction. Inline creates its
// definitions inside .command(); fresh-process timing includes all this setup.
const definitions = shape === "inline" ? [] : names.map((name) => defineCommand(name, recipe));
function construct() {
    let app = new Crust("bench");
    if (shape === "variadic") return app.add(...definitions);
    if (shape === "chained") {
        for (const definition of definitions) app = app.add(definition);
    } else {
        for (const name of names) app = app.command(name, recipe);
    }
    return app;
}
function verify(app) {
    assert.equal(Object.keys(app._node.subCommands).length, size);
    assert.equal(app._node.subCommands[names[0]].run, noop);
    assert.equal(app._node.subCommands[names.at(-1)].run, noop);
}
if (mode === "fresh") {
    verify(construct());
} else {
    const warmups = Number(warmText);
    const samples = Number(samplesText);
    const iterations = size <= 10 ? 100 : 3;
    let sink;
    function batch() {
        const start = performance.now();
        for (let i = 0; i < iterations; i++) sink = construct();
        const elapsed = performance.now() - start;
        verify(sink); // Outside timed region; no snapshots or invocation.
        return elapsed / iterations;
    }
    for (let i = 0; i < warmups; i++) batch();
    const ms = Array.from({ length: samples }, batch);
    console.log(JSON.stringify({ shape, size, warmups, samples, iterations, ms, runtime: Bun.version }));
}
```

### `run.py`

SHA-256: `dd15ef34f80e81dab3ff4f366015a773b1f6d33cc4bad0c763aa0b887a6760fd`

```python
#!/usr/bin/env python3
"""Sequential benchmark driver; Python's clock measures whole Bun processes."""
import datetime
import hashlib
import json
import os
from pathlib import Path
import resource
import shutil
import statistics
import subprocess
import time

out = Path(__file__).resolve().parent
meta = json.loads((out / "sources.json").read_text())
bun = shutil.which("bun")
assert bun, "Bun is required"
fixture = out / "bench.mjs"
env = dict(os.environ, BUN_RUNTIME_TRANSPILER_CACHE_PATH="0")
commands = []

def capture(argv):
    p = subprocess.run(argv, capture_output=True, text=True)
    return {"command": argv, "exit": p.returncode, "stdout": p.stdout, "stderr": p.stderr}

def environment():
    cg = Path("/proc/self/cgroup").read_text()
    limits = {}
    group = next(line.split(":", 2)[2] for line in cg.splitlines() if line.startswith("0::"))
    path = Path("/sys/fs/cgroup") / group.lstrip("/")
    while str(path).startswith("/sys/fs/cgroup"):
        for name in ("cpu.max", "memory.max", "cpuset.cpus.effective"):
            p = path / name
            limits[str(p)] = p.read_text().strip() if p.exists() else "unavailable"
        path = path.parent
    return {
        "utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
        "versions": [capture([bun, "--version"]), capture(["node", "--version"]), capture(["python3", "--version"])],
        "host": [capture(["uname", "-a"]), capture(["lscpu"]), capture(["free", "-h"]), capture(["uptime"])],
        "cpu_affinity": sorted(os.sched_getaffinity(0)),
        "cgroup": cg, "cgroup_limits": limits,
        "rlimits": {name: resource.getrlimit(getattr(resource, name)) for name in ("RLIMIT_AS", "RLIMIT_CPU", "RLIMIT_NOFILE")},
        "environment_overrides": {"BUN_RUNTIME_TRANSPILER_CACHE_PATH": "0"},
        "inherited_runtime_environment": {k: v for k, v in os.environ.items() if k.startswith(("BUN_", "NODE_", "JSC_"))},
    }

def invoke(label, shape, size, mode):
    argv = [bun, str(fixture), meta["sources"][label], shape, str(size), mode, "20", "31"]
    start = time.perf_counter_ns()
    p = subprocess.run(argv, cwd=out, env=env, capture_output=True, text=True, timeout=120)
    elapsed = (time.perf_counter_ns() - start) / 1e6
    commands.append({"argv": argv, "exit": p.returncode, "wall_ms": elapsed, "stderr": p.stderr})
    if p.returncode:
        (out / "failed-command.json").write_text(json.dumps(commands[-1], indent=2))
        raise RuntimeError(p.stderr)
    return elapsed, p.stdout

def unchanged():
    repo = meta["after_repo"]
    patch = subprocess.check_output(["git", "-C", repo, "diff", "--binary", "--no-ext-diff", "HEAD", "--"])
    assert hashlib.sha256(patch).hexdigest() == meta["after_diff_sha256"]
    for label, manifest in meta["manifests"].items():
        for relative, sha in manifest.items():
            assert hashlib.sha256((Path(meta["sources"][label]) / relative).read_bytes()).hexdigest() == sha, relative
    staged = subprocess.check_output(["git", "-C", repo, "diff", "--cached", "--name-only"]).decode().splitlines()
    assert staged == []
    return {"source_manifests_unchanged": True, "after_diff_unchanged": True, "staged_files": staged}

(out / "environment-start.json").write_text(json.dumps(environment(), indent=2) + "\n")
unchanged()
results = {"warm": [], "fresh": []}
cases = [(shape, size) for size in (10, 1000) for shape in ("variadic", "chained", "inline")]
for index, (shape, size) in enumerate(cases):
    labels = ("before", "after") if index % 2 == 0 else ("after", "before")
    for label in labels:
        _, stdout = invoke(label, shape, size, "warm")
        row = {"label": label, **json.loads(stdout)}
        results["warm"].append(row)
        (out / "results.json").write_text(json.dumps(results, indent=2) + "\n")
        print("warm", label, shape, size, statistics.median(row["ms"]), flush=True)
# Five untimed launches per source/shape/size prime filesystem caches; each
# measured launch still starts a fresh runtime, imports source and exits.
fresh = {(label, shape, size): [] for shape, size in cases for label in ("before", "after")}
for round_index in range(-5, 31):
    shift = round_index % len(cases)
    for shape, size in cases[shift:] + cases[:shift]:
        labels = ("before", "after") if round_index % 2 == 0 else ("after", "before")
        for label in labels:
            ms, _ = invoke(label, shape, size, "fresh")
            if round_index >= 0:
                fresh[label, shape, size].append(ms)
    print("fresh round", round_index, flush=True)
for (label, shape, size), ms in fresh.items():
    results["fresh"].append({"label": label, "shape": shape, "size": size, "warmups": 5, "samples": 31, "iterations": 1, "ms": ms})
(out / "results.json").write_text(json.dumps(results, indent=2) + "\n")
(out / "commands.json").write_text(json.dumps(commands, indent=2) + "\n")
(out / "environment-end.json").write_text(json.dumps(environment(), indent=2) + "\n")
(out / "validation.json").write_text(json.dumps(unchanged(), indent=2) + "\n")
for mode, rows in results.items():
    for row in rows:
        print(mode, row["label"], row["shape"], row["size"], f'{statistics.median(row["ms"]):.6f} ms')
```



</details>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

