### PR TITLE
chore: adopt three upstream anti-slop rules and record plugin provenance

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -47,6 +47,7 @@
 		"promise/no-multiple-resolved": "error",
 		"typescript/no-import-type-side-effects": "error",
 		"oxc/bad-bitwise-operator": "error",
+		"oxc/no-accumulating-spread": "error",
 
 		"typescript/no-floating-promises": "error",
 		"typescript/no-misused-promises": "error",
@@ -57,15 +58,18 @@
 
 		"promise/always-return": "off",
 
+		"anti-slop/no-array-filter-map": "error",
 		"anti-slop/no-chained-type-assertions": "error",
 		"anti-slop/no-known-value-widening": "error",
 		"anti-slop/no-module-mocking": "error",
 		"anti-slop/no-object-parameters": "error",
+		"anti-slop/no-reduce-accumulator-copy": "error",
 		"anti-slop/no-runtime-typeof": ["error", { "allowInTypeGuards": true }],
 		"anti-slop/no-unknown-parameters": ["error", { "allowInBoundaryFunctions": true }],
 		"anti-slop/no-unknown-returns": "error",
 		"anti-slop/no-unknown-type-aliases": "error",
 		"anti-slop/no-unsafe-dictionary-type": "error",
+		"anti-slop/no-widen-then-assert": "error",
 		"anti-slop/require-safety-comment-for-type-assertion": "error"
 	},
 	"ignorePatterns": [

--- a/apps/docs/src/routes/index.tsx
+++ b/apps/docs/src/routes/index.tsx
@@ -175,7 +175,7 @@ const MODULES: Array<{
   },
 ];
 
-const PUBLISHED_PACKAGES = MODULES.filter((m) => !m.upcoming).map((m) => m.pkg);
+const PUBLISHED_PACKAGES = MODULES.flatMap((m) => (m.upcoming ? [] : [m.pkg]));
 
 type ReleaseChannel = "alpha" | "beta";
 

--- a/packages/core/src/command/documentation.ts
+++ b/packages/core/src/command/documentation.ts
@@ -185,9 +185,9 @@ function buildNode(command: CommandSnapshot, path: readonly string[]): CommandDo
 			variadic: arg.variadic === true,
 		}),
 	);
-	const children = Object.entries(command.subCommands)
-		.filter(([, child]) => isListed(child))
-		.map(([name, child]) => buildNode(child, [...path, name]));
+	const children = Object.entries(command.subCommands).flatMap(([name, child]) =>
+		isListed(child) ? [buildNode(child, [...path, name])] : [],
+	);
 	const flags = documentationFlags(command.flags);
 	const usageSegments: UsageSegment[] = command.meta.usage
 		? [{ kind: "custom", text: command.meta.usage }]

--- a/packages/core/src/command/extensions-install.ts
+++ b/packages/core/src/command/extensions-install.ts
@@ -192,9 +192,9 @@ export function installExtensionContexts(
 	const cloned = cloneCommandNode(node);
 	// ponytail: O(n²) includes over an already-deduped list, fine for handfuls of extensions.
 	const kept = new Set(
-		extensions
-			.filter((e) => !reRegisteredIds.has(e.id) && node.extensions.includes(e))
-			.map((e) => e.id),
+		extensions.flatMap((e) =>
+			!reRegisteredIds.has(e.id) && node.extensions.includes(e) ? [e.id] : [],
+		),
 	);
 	const prune = (target: CommandNode): void => {
 		target.contexts = target.contexts.filter(

--- a/packages/core/src/command/invocation.ts
+++ b/packages/core/src/command/invocation.ts
@@ -157,9 +157,9 @@ function resolveStructuredInput(
 		const parentCommand = snapshotCommand(route.command);
 		throw new CrustError("COMMAND_NOT_FOUND", `Unknown command "${candidate}".`, {
 			input: candidate,
-			available: Object.entries(parentCommand.subCommands)
-				.filter(([, child]) => isListed(child))
-				.map(([name]) => name),
+			available: Object.entries(parentCommand.subCommands).flatMap(([name, child]) =>
+				isListed(child) ? [name] : [],
+			),
 			commandPath: route.commandPath,
 			parentCommand,
 		});

--- a/packages/core/src/command/router.ts
+++ b/packages/core/src/command/router.ts
@@ -218,9 +218,9 @@ export function resolveCommand(command: CommandNode, argv: string[]): CommandRou
 		const parentCommand = snapshotCommand(current);
 		throw new CrustError("COMMAND_NOT_FOUND", `Unknown command "${candidate}".`, {
 			input: candidate,
-			available: Object.entries(parentCommand.subCommands)
-				.filter(([, child]) => isListed(child))
-				.map(([name]) => name),
+			available: Object.entries(parentCommand.subCommands).flatMap(([name, child]) =>
+				isListed(child) ? [name] : [],
+			),
 			commandPath: [...path],
 			parentCommand,
 		});

--- a/packages/prompts/src/core/list.ts
+++ b/packages/prompts/src/core/list.ts
@@ -44,9 +44,10 @@ export async function setupListPrompt<T, Answer extends T | readonly T[]>(
 				? (options.default as readonly T[])
 				: [options.default as T];
 	const selected = new Set(
-		defaults
-			.map((value) => choices.findIndex((choice) => choice.value === value))
-			.filter((index) => index !== -1),
+		defaults.flatMap((value) => {
+			const index = choices.findIndex((choice) => choice.value === value);
+			return index === -1 ? [] : [index];
+		}),
 	);
 	const defaultCursor =
 		defaults.length === 0 ? -1 : choices.findIndex((choice) => choice.value === defaults[0]);

--- a/packages/skills/src/reconcile.ts
+++ b/packages/skills/src/reconcile.ts
@@ -28,9 +28,9 @@ export function planReconcile(options: {
 	readonly universal: readonly AgentTarget[];
 }): ReconcilePlan {
 	const { statusMap, choices, selected, universal } = options;
-	const installed = [...statusMap.values()]
-		.filter((entry) => entry.status === "linked" || entry.status === "dangling")
-		.map((entry) => entry.agent);
+	const installed = [...statusMap.values()].flatMap((entry) =>
+		entry.status === "linked" || entry.status === "dangling" ? [entry.agent] : [],
+	);
 	const toInstall = selected.filter((agent) => statusMap.get(agent)?.status !== "linked");
 	const keptDirs = new Set(selected.map((agent) => statusMap.get(agent)?.outputDir));
 	const toUninstall = installed.filter(

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -1,0 +1,48 @@
+# Upstream provenance
+
+Vendored from <https://github.com/dmmulroy/anti-slop> (`src/` → this directory). The
+upstream project is designed to be vendored and forked; this copy is owned here and
+diverges deliberately.
+
+|                            | Revision                        |
+| -------------------------- | ------------------------------- |
+| Base (original copy, #308) | `6d53855` (2026-08-18)          |
+| Reviewed through           | `c44ef22` (2026-09-10, v0.1.2+) |
+
+## Adopted from `c44ef22`
+
+- `rules/no-array-filter-map` + `shared/array-method`
+- `rules/no-reduce-accumulator-copy` (paired with native `oxc/no-accumulating-spread`)
+- `rules/no-widen-then-assert`
+
+## Local deviations (keep on future updates)
+
+- `no-module-mocking`: also detects Bun `mock.module` (`bun:test`) and Jest `setMock`;
+  resolves namespace imports.
+- `no-unknown-parameters`: local `allowInBoundaryFunctions` option.
+- Helpers split into `shared/{parameters,scope,type-aliases}.ts`; upstream later grew an
+  identical `shared/scope.ts` and a `shared/type-alias-resolution.ts`.
+- Formatted with repo `oxfmt` (tabs); linted by the repo config including these rules,
+  so upstream's `x as unknown as T` double-casts are rewritten.
+- Tests run under Node's test runner (`bun test` cannot host Oxlint `RuleTester`).
+
+## Intentionally not vendored
+
+- Upstream's 2026-08-31 semantic fixes to the ten original rules: measured zero
+  enforcement change on this repo; not worth a three-way merge into customized files.
+- `require-readable-spacing` (+ vendored eslint-stylistic): formatting is `oxfmt`'s job.
+- `no-shape-in-symbol-names`: `CommandShape`/`CommandShapeAt`/`_types.shape` are public,
+  documented API.
+- `no-conditional-empty-object-spread`: `...(cond ? { k } : {})` is the accepted idiom here.
+- `no-reflect-apply` / `no-reflect-get`: covered by `eslint/no-restricted-properties`.
+- `effect/*`: no Effect dependency.
+
+## Updating
+
+```bash
+git clone https://github.com/dmmulroy/anti-slop .agent-sources/anti-slop   # git-excluded
+git -C .agent-sources/anti-slop diff c44ef22..HEAD -- src/
+```
+
+Port reviewed changes by hand; do not overwrite this directory. Bump "Reviewed through"
+and extend the lists above.

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -20,6 +20,11 @@ diverges deliberately.
 - `no-module-mocking`: also detects Bun `mock.module` (`bun:test`) and Jest `setMock`;
   resolves namespace imports.
 - `no-unknown-parameters`: local `allowInBoundaryFunctions` option.
+- `shared/array-method`: `isKnownArrayExpression` also accepts unshadowed `Object.entries/keys/values`
+  and `Array.from` results, so `Object.entries(x).filter().map()` is flagged; `isGlobalOwner` lives
+  here instead of inside `no-reduce-accumulator-copy`.
+- `no-widen-then-assert`: `Record`/`Readonly`/`PropertyKey` are only treated as built-ins when the
+  file does not declare or import its own binding (reuses `createTypeEnvironment`).
 - Helpers split into `shared/{parameters,scope,type-aliases}.ts`; upstream later grew an
   identical `shared/scope.ts` and a `shared/type-alias-resolution.ts`.
 - Formatted with repo `oxfmt` (tabs); linted by the repo config including these rules,

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -24,7 +24,8 @@ diverges deliberately.
   and `Array.from` results, so `Object.entries(x).filter().map()` is flagged; `isGlobalOwner` lives
   here instead of inside `no-reduce-accumulator-copy`.
 - `no-widen-then-assert`: `Record`/`Readonly`/`PropertyKey` are only treated as built-ins when the
-  file does not declare or import its own binding (reuses `createTypeEnvironment`).
+  file does not declare or import its own module-level binding; non-generic module-level aliases
+  are followed, so `type Payload = unknown` widens like `unknown` (reuses `createTypeEnvironment`).
 - Helpers split into `shared/{parameters,scope,type-aliases}.ts`; upstream later grew an
   identical `shared/scope.ts` and a `shared/type-alias-resolution.ts`.
 - Formatted with repo `oxfmt` (tabs); linted by the repo config including these rules,

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -21,11 +21,13 @@ diverges deliberately.
   resolves namespace imports.
 - `no-unknown-parameters`: local `allowInBoundaryFunctions` option.
 - `shared/array-method`: `isKnownArrayExpression` also accepts unshadowed `Object.entries/keys/values`
-  and `Array.from` results, so `Object.entries(x).filter().map()` is flagged; `isGlobalOwner` lives
-  here instead of inside `no-reduce-accumulator-copy`.
+  and `Array.from` results and `x as T[]` assertions, so `Object.entries(x).filter().map()` and
+  `(load() as User[]).filter().map()` are flagged; `isGlobalOwner` lives here instead of inside
+  `no-reduce-accumulator-copy`.
 - `no-widen-then-assert`: `Record`/`Readonly`/`PropertyKey` are only treated as built-ins when the
-  file does not declare or import its own module-level binding; non-generic module-level aliases
-  are followed, so `type Payload = unknown` widens like `unknown` (reuses `createTypeEnvironment`).
+  file does not declare or import its own module-level binding; non-generic aliases are followed
+  (respecting type-parameter and block-level shadowing), so `type Payload = unknown` widens like
+  `unknown` (reuses `createTypeEnvironment`).
 - Helpers split into `shared/{parameters,scope,type-aliases}.ts`; upstream later grew an
   identical `shared/scope.ts` and a `shared/type-alias-resolution.ts`.
 - Formatted with repo `oxfmt` (tabs); linted by the repo config including these rules,

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,29 +1,35 @@
 import { eslintCompatPlugin } from "@oxlint/plugins";
 
+import { noArrayFilterMapRule } from "./rules/no-array-filter-map.ts";
 import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
 import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
 import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
 import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReduceAccumulatorCopyRule } from "./rules/no-reduce-accumulator-copy.ts";
 import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
 import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
 import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
 import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
 import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
 import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
 
 /** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
 const antiSlopPlugin = eslintCompatPlugin({
 	meta: { name: "anti-slop" },
 	rules: {
+		"no-array-filter-map": noArrayFilterMapRule,
 		"no-chained-type-assertions": noChainedTypeAssertionsRule,
 		"no-known-value-widening": noKnownValueWideningRule,
 		"no-module-mocking": noModuleMockingRule,
 		"no-object-parameters": noObjectParametersRule,
+		"no-reduce-accumulator-copy": noReduceAccumulatorCopyRule,
 		"no-runtime-typeof": noRuntimeTypeofRule,
 		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
 		"no-unknown-parameters": noUnknownParametersRule,
 		"no-unknown-returns": noUnknownReturnsRule,
 		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
 		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
 	},
 });

--- a/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
@@ -1,0 +1,62 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noArrayFilterMapRule } from "./no-array-filter-map.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "arrayFilterMap" };
+
+tester.run("anti-slop/no-array-filter-map", noArrayFilterMapRule, {
+	valid: [
+		"const users = []; users.values().filter(active).map(email).toArray();",
+		"const users = []; users.values().map(email).filter(Boolean).toArray();",
+		"Iterator.from(users).filter(active).map(email).toArray();",
+		"function collect(users: IteratorObject<User>) { return users.filter(active).map(email).toArray(); }",
+		"const users = []; users.flatMap(user => user.active ? [user.email] : []);",
+		"const users = []; users.map(email); users.filter(active);",
+		"const users = []; users.map(email).map(normalize);",
+		"const users = []; users.filter(active).filter(verified);",
+		"const custom = { filter() { return this; }, map() {} }; custom.filter(active).map(email);",
+		"function collect(unknownReceiver) { return unknownReceiver.filter(active).map(email); }",
+		"const users = fetchUsers(); users.filter(active).map(email);",
+		"const users = []; function collect(users) { return users.filter(active).map(email); }",
+		"let users = []; users = iterator; users.filter(active).map(email);",
+		"const users = []; users[method](active).map(email);",
+		"const first = second; const second = first; first.filter(active).map(email);",
+	],
+	invalid: [
+		{ code: "[].filter(active).map(email);", errors: [error] },
+		{
+			code: "[].map(user => user.active ? user.email : undefined).filter(email => email !== undefined);",
+			errors: [error],
+		},
+		{ code: "const users = []; users.map(email).filter(Boolean);", errors: [error] },
+		{
+			code: "const users = []; const alias = users; alias.filter(active).map(email);",
+			errors: [error],
+		},
+		{
+			code: "function collect(users: User[]) { return users.filter(active).map(email); }",
+			errors: [error],
+		},
+		{
+			code: "function collect(users: readonly User[]) { return users.map(email).filter(present); }",
+			errors: [error],
+		},
+		{
+			code: "function collect(users: ReadonlyArray<User>) { return users.filter(active).map(email); }",
+			errors: [error],
+		},
+		{
+			code: "function collect(users: Array<User>) { return users.filter(active).map(email); }",
+			errors: [error],
+		},
+		{ code: "const users = [] as const; users['filter'](active)['map'](email);", errors: [error] },
+		{ code: "const users = []; (users.filter(active)!).map(email);", errors: [error] },
+		{ code: "const users = []; users?.filter(active)?.map(email);", errors: [error] },
+		{ code: "const users = []; users.slice().filter(active).map(email);", errors: [error] },
+		{
+			code: "const users = []; users.filter(active).map(email).filter(Boolean);",
+			errors: [error, error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
@@ -23,6 +23,7 @@ tester.run("anti-slop/no-array-filter-map", noArrayFilterMapRule, {
 		"let users = []; users = iterator; users.filter(active).map(email);",
 		"const users = []; users[method](active).map(email);",
 		"const first = second; const second = first; first.filter(active).map(email);",
+		"(fetchUsers() as unknown).filter(active).map(email);",
 	],
 	invalid: [
 		{ code: "[].filter(active).map(email);", errors: [error] },
@@ -57,6 +58,12 @@ tester.run("anti-slop/no-array-filter-map", noArrayFilterMapRule, {
 		{ code: "const users = []; (users.filter(active)!).map(email);", errors: [error] },
 		{ code: "const users = []; users?.filter(active)?.map(email);", errors: [error] },
 		{ code: "const users = []; users.slice().filter(active).map(email);", errors: [error] },
+		{ code: "(fetchUsers() as User[]).filter(active).map(email);", errors: [error] },
+		{
+			code: "const users = fetchUsers() as readonly User[]; users.filter(active).map(email);",
+			errors: [error],
+		},
+		{ code: "(<User[]>fetchUsers())!.filter(active).map(email);", errors: [error] },
 		{
 			code: "const users = []; users.filter(active).map(email).filter(Boolean);",
 			errors: [error, error],

--- a/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-array-filter-map.test.ts
@@ -18,6 +18,7 @@ tester.run("anti-slop/no-array-filter-map", noArrayFilterMapRule, {
 		"const custom = { filter() { return this; }, map() {} }; custom.filter(active).map(email);",
 		"function collect(unknownReceiver) { return unknownReceiver.filter(active).map(email); }",
 		"const users = fetchUsers(); users.filter(active).map(email);",
+		"const Object = { entries: () => custom }; Object.entries(users).filter(active).map(email);",
 		"const users = []; function collect(users) { return users.filter(active).map(email); }",
 		"let users = []; users = iterator; users.filter(active).map(email);",
 		"const users = []; users[method](active).map(email);",
@@ -25,6 +26,8 @@ tester.run("anti-slop/no-array-filter-map", noArrayFilterMapRule, {
 	],
 	invalid: [
 		{ code: "[].filter(active).map(email);", errors: [error] },
+		{ code: "Object.entries(users).filter(active).map(email);", errors: [error] },
+		{ code: "Array.from(users).map(email).filter(Boolean);", errors: [error] },
 		{
 			code: "[].map(user => user.active ? user.email : undefined).filter(email => email !== undefined);",
 			errors: [error],

--- a/tools/oxlint/anti-slop/rules/no-array-filter-map.ts
+++ b/tools/oxlint/anti-slop/rules/no-array-filter-map.ts
@@ -1,0 +1,40 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	arrayMethodTarget,
+	isKnownArrayExpression,
+	unwrapArrayExpression,
+} from "../shared/array-method.ts";
+
+/** Reject eager array filter/map pipelines; lazy iterator helpers remain allowed. */
+export const noArrayFilterMapRule = defineRule({
+	meta: {
+		type: "suggestion",
+		docs: {
+			description:
+				"Disallow adjacent array filter/map passes in favor of lazy iterator helpers or a single transformation.",
+		},
+		messages: {
+			arrayFilterMap:
+				"Avoid consecutive array `{{first}}` and `{{second}}` passes. Prefer `.values().{{first}}(...).{{second}}(...).toArray()` where iterator helpers are supported, or a single `flatMap`/mutating reducer. Preserve callback ordering, indexes, and filtering semantics.",
+		},
+	},
+	createOnce(context) {
+		return {
+			CallExpression(node) {
+				const outer = arrayMethodTarget(node.callee);
+				if (outer === null || (outer.name !== "map" && outer.name !== "filter")) return;
+				const innerCall = unwrapArrayExpression(outer.object);
+				if (innerCall.type !== "CallExpression") return;
+				const inner = arrayMethodTarget(innerCall.callee);
+				if (inner === null || inner.name !== (outer.name === "map" ? "filter" : "map")) return;
+				if (!isKnownArrayExpression(context.sourceCode, inner.object)) return;
+				context.report({
+					node,
+					messageId: "arrayFilterMap",
+					data: { first: inner.name, second: outer.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.test.ts
@@ -1,0 +1,97 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noReduceAccumulatorCopyRule } from "./no-reduce-accumulator-copy.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "accumulatorCopy" };
+
+tester.run("anti-slop/no-reduce-accumulator-copy", noReduceAccumulatorCopyRule, {
+	valid: [
+		"items.reduce((acc, item) => { acc.push(item); return acc; }, []);",
+		"items.reduce((acc, item) => Object.assign(acc, item), {});",
+		"items.reduce((acc, item) => Object.assign(acc, acc, item), {});",
+		"items.reduce((acc, item) => { acc[item.id] = { ...item }; return acc; }, {});",
+		"items.reduce((acc, item) => { acc.push(Object.assign({}, item)); return acc; }, []);",
+		"items.reduce((acc, item) => { acc.push(item.slice()); return acc; }, []);",
+		"items.reduce((acc, item) => acc.concat(item), '');",
+		"items.reduce((acc, item) => acc.concat(item), customCollection);",
+		"function copy(acc) { return Object.assign({}, acc); }",
+		"items.map((acc, item) => Object.assign({}, acc));",
+		"items.reduce((acc, item) => { function copy(acc) { return Object.assign({}, acc); } return acc; }, {});",
+		"items.reduce((acc, item) => { const snapshot = () => Object.assign({}, acc); return acc; }, {});",
+		"items.reduce((acc, item) => { { const acc = {}; Object.assign({}, acc); } return acc; }, {});",
+		"const Object = custom; items.reduce((acc, item) => Object.assign({}, acc), {});",
+		"function run(Object) { return items.reduce((acc, item) => Object.assign({}, acc), {}); }",
+		"const Array = custom; items.reduce((acc, item) => Array.from(acc), []);",
+		"items.reduce((acc, item) => { let alias = acc; alias = item; return Object.assign({}, alias); }, {});",
+		"items.reduce((acc, item) => [...acc, item], []);", // Owned by the native rule.
+		"items.reduce((acc, item) => ({ ...acc, [item.id]: item }), {});",
+	],
+	invalid: [
+		{
+			code: "items.reduce((acc, item) => Object.assign({}, acc, { [item.id]: item }), {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduceRight((acc, item) => Object.assign({}, acc, item), {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item, index, array) => Object.assign({}, acc, item), {});",
+			errors: [error],
+		},
+		{ code: "items.reduce(acc => Object.assign({}, acc), {});", errors: [error] },
+		{
+			code: "items.reduce(function (acc, item) { return Object.assign({}, item, acc); }, {});",
+			errors: [error],
+		},
+		{
+			code: "items['reduce'](((acc, item) => Object['assign']({}, acc, item)), {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc = {}, item) => Object.assign({}, acc, item), {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => { const alias = acc; return Object.assign({}, alias, item); }, {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => Object.assign({}, acc as State, item), {});",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => { const next = Object.assign({}, acc); next[item.id] = item; return next; }, {});",
+			errors: [error],
+		},
+		{ code: "items.reduce((acc, item) => acc.concat([item]), []);", errors: [error] },
+		{
+			code: "items.reduceRight((acc, item, index) => acc['concat']([item]), [] as Item[]);",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => { const next = acc.slice(); next.push(item); return next; }, []);",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => { const alias = acc; return alias.concat(item); }, []);",
+			errors: [error],
+		},
+		{
+			code: "const initial = []; items.reduce((acc, item) => acc.concat(item), initial);",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => { const next = Array.from(acc); next.push(item); return next; }, []);",
+			errors: [error],
+		},
+		{
+			code: "items.reduce((acc, item) => acc.toSpliced(acc.length, 0, item), []);",
+			errors: [error],
+		},
+		{ code: "items.reduce((acc, item) => acc.toSorted(), []);", errors: [error] },
+		{ code: "items.reduce((acc, item) => acc.toReversed(), []);", errors: [error] },
+		{ code: "items.reduce((acc, item) => acc.with(0, item), []);", errors: [error] },
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
@@ -1,0 +1,132 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, SourceCode, Variable } from "@oxlint/plugins";
+
+import {
+	arrayMethodTarget,
+	isKnownArrayExpression,
+	resolveArrayBinding,
+	unwrapArrayExpression,
+} from "../shared/array-method.ts";
+
+function enclosingReducer(node: ESTree.Node) {
+	let parent = node.parent;
+	while (parent !== null) {
+		if (parent.type === "FunctionDeclaration") return null;
+		if (parent.type === "ArrowFunctionExpression" || parent.type === "FunctionExpression") {
+			const callback = parent;
+			let owner: ESTree.Node | null = callback.parent;
+			while (owner !== null && unwrapArrayExpression(owner) === callback) owner = owner.parent;
+			if (owner?.type !== "CallExpression") return null;
+			const method = arrayMethodTarget(owner.callee);
+			const firstArgument = owner.arguments[0];
+			if (
+				method === null ||
+				(method.name !== "reduce" && method.name !== "reduceRight") ||
+				owner.arguments.length > 2 ||
+				firstArgument === undefined ||
+				unwrapArrayExpression(firstArgument) !== callback
+			)
+				return null;
+			const firstParameter = callback.params[0];
+			const accumulator =
+				firstParameter?.type === "AssignmentPattern" ? firstParameter.left : firstParameter;
+			if (accumulator?.type !== "Identifier") return null;
+			return { callback, accumulator, initialValue: owner.arguments[1] };
+		}
+		parent = parent.parent;
+	}
+	return null;
+}
+
+function referencesAccumulator(
+	sourceCode: SourceCode,
+	node: ESTree.Node,
+	accumulator: Variable,
+	visited = new Set<Variable>(),
+): boolean {
+	const variable = resolveArrayBinding(sourceCode, node);
+	if (variable === null || visited.has(variable)) return false;
+	if (variable === accumulator) return true;
+	visited.add(variable);
+	if (variable.references.some((reference) => reference.isWrite() && !reference.init)) return false;
+	for (const definition of variable.defs) {
+		if (
+			definition.type === "Variable" &&
+			definition.node.type === "VariableDeclarator" &&
+			definition.node.id.type === "Identifier" &&
+			definition.node.init !== null &&
+			definition.node.parent.type === "VariableDeclaration" &&
+			definition.node.parent.kind === "const"
+		) {
+			return referencesAccumulator(sourceCode, definition.node.init, accumulator, visited);
+		}
+	}
+	return false;
+}
+
+function isGlobalCopyOwner(sourceCode: SourceCode, node: ESTree.Node, name: string): boolean {
+	node = unwrapArrayExpression(node);
+	if (node.type !== "Identifier" || node.name !== name) return false;
+	const variable = resolveArrayBinding(sourceCode, node);
+	return variable === null || variable.defs.length === 0;
+}
+
+/** Reject non-spread copies of reducer accumulators; pair with oxc/no-accumulating-spread. */
+export const noReduceAccumulatorCopyRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow copying growing reducer accumulators with Object.assign, Array.from, or array copy methods.",
+		},
+		messages: {
+			accumulatorCopy:
+				"Do not copy the reducer accumulator on every iteration; growing copies can cause quadratic work. Mutate a fresh, locally owned accumulator and return it, or use an iterator pipeline/flatMap.",
+		},
+	},
+	createOnce(context) {
+		return {
+			CallExpression(node) {
+				const method = arrayMethodTarget(node.callee);
+				if (method === null) return;
+				const reducer = enclosingReducer(node);
+				if (reducer === null) return;
+				const accumulator = context.sourceCode
+					.getDeclaredVariables(reducer.callback)
+					.find((variable) =>
+						variable.identifiers.some(
+							(identifier) => identifier.start === reducer.accumulator.start,
+						),
+					);
+				if (accumulator === undefined) return;
+				const isAccumulator = (expression: ESTree.Node) =>
+					referencesAccumulator(context.sourceCode, expression, accumulator);
+				let copiesAccumulator = false;
+				if (
+					method.name === "assign" &&
+					isGlobalCopyOwner(context.sourceCode, method.object, "Object")
+				) {
+					const target = node.arguments[0];
+					copiesAccumulator =
+						target !== undefined &&
+						unwrapArrayExpression(target).type === "ObjectExpression" &&
+						node.arguments.slice(1).some(isAccumulator);
+				} else if (
+					method.name === "from" &&
+					isGlobalCopyOwner(context.sourceCode, method.object, "Array")
+				) {
+					const source = node.arguments[0];
+					copiesAccumulator = source !== undefined && isAccumulator(source);
+				} else if (
+					["concat", "slice", "toSpliced", "toSorted", "toReversed", "with"].includes(method.name)
+				) {
+					const initialValue = reducer.initialValue;
+					const arrayAccumulator =
+						initialValue !== undefined && isKnownArrayExpression(context.sourceCode, initialValue);
+					copiesAccumulator = arrayAccumulator && isAccumulator(method.object);
+				}
+				if (copiesAccumulator) context.report({ node, messageId: "accumulatorCopy" });
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
@@ -3,6 +3,7 @@ import type { ESTree, SourceCode, Variable } from "@oxlint/plugins";
 
 import {
 	arrayMethodTarget,
+	isGlobalOwner,
 	isKnownArrayExpression,
 	resolveArrayBinding,
 	unwrapArrayExpression,
@@ -64,13 +65,6 @@ function referencesAccumulator(
 	return false;
 }
 
-function isGlobalCopyOwner(sourceCode: SourceCode, node: ESTree.Node, name: string): boolean {
-	node = unwrapArrayExpression(node);
-	if (node.type !== "Identifier" || node.name !== name) return false;
-	const variable = resolveArrayBinding(sourceCode, node);
-	return variable === null || variable.defs.length === 0;
-}
-
 /** Reject non-spread copies of reducer accumulators; pair with oxc/no-accumulating-spread. */
 export const noReduceAccumulatorCopyRule = defineRule({
 	meta: {
@@ -104,7 +98,7 @@ export const noReduceAccumulatorCopyRule = defineRule({
 				let copiesAccumulator = false;
 				if (
 					method.name === "assign" &&
-					isGlobalCopyOwner(context.sourceCode, method.object, "Object")
+					isGlobalOwner(context.sourceCode, method.object, "Object")
 				) {
 					const target = node.arguments[0];
 					copiesAccumulator =
@@ -113,7 +107,7 @@ export const noReduceAccumulatorCopyRule = defineRule({
 						node.arguments.slice(1).some(isAccumulator);
 				} else if (
 					method.name === "from" &&
-					isGlobalCopyOwner(context.sourceCode, method.object, "Array")
+					isGlobalOwner(context.sourceCode, method.object, "Array")
 				) {
 					const source = node.arguments[0];
 					copiesAccumulator = source !== undefined && isAccumulator(source);

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
@@ -1,0 +1,19 @@
+import { RuleTester } from "oxlint/plugins-dev";
+
+import { noWidenThenAssertRule } from "./no-widen-then-assert.ts";
+
+const tester = new RuleTester({ languageOptions: { parserOptions: { lang: "ts" } } });
+const error = { messageId: "widenThenAssert" };
+
+tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
+	valid: [
+		"const source = { id: 'first' }; const widened: unknown = source;",
+		"declare const input: unknown; const parsed = input as { readonly id: string };",
+	],
+	invalid: [
+		{
+			code: "const source = { id: 'second' }; const widened: unknown = source; const parsed = widened as { readonly id: string };",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
@@ -11,6 +11,8 @@ tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
 		"type Record<K, V> = { key: K; value: V }; const source = { id: 'first' }; const widened: Record<string, unknown> = source; const asserted = widened as { id: string };",
 		"import { Readonly } from './local'; const source = { id: 'first' }; const widened: Readonly<Record<string, unknown>> = source; const asserted = widened as { id: string };",
 		"declare const input: unknown; const parsed = input as { readonly id: string };",
+		"type Payload = unknown; declare const source: Payload; const widened: unknown = source; const parsed = widened as { id: string };",
+		"type Payload<T> = T; const source = { id: 'first' }; const widened: Payload<unknown> = source; const parsed = widened as { id: string };",
 	],
 	invalid: [
 		{
@@ -19,6 +21,14 @@ tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
 		},
 		{
 			code: "const source = { id: 'second' }; const widened: Readonly<Record<string, unknown>> = source; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			code: "type Payload = unknown; const source = { id: 'second' }; const widened: Payload = source; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			code: "type Dict = Record<string, unknown>; type Payload = Dict; const source = { id: 'second' }; const widened: Payload = source; const parsed = widened as { id: string };",
 			errors: [error],
 		},
 	],

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
@@ -13,6 +13,8 @@ tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
 		"declare const input: unknown; const parsed = input as { readonly id: string };",
 		"type Payload = unknown; declare const source: Payload; const widened: unknown = source; const parsed = widened as { id: string };",
 		"type Payload<T> = T; const source = { id: 'first' }; const widened: Payload<unknown> = source; const parsed = widened as { id: string };",
+		"type Payload = unknown; function run() { type Payload = string; const source = { id: 'first' }; const widened: Payload = source; const parsed = widened as { id: string }; }",
+		"type Payload = unknown; function run<Payload>() { const source = { id: 'first' }; const widened: Payload = source; const parsed = widened as { id: string }; }",
 	],
 	invalid: [
 		{
@@ -29,6 +31,10 @@ tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
 		},
 		{
 			code: "type Dict = Record<string, unknown>; type Payload = Dict; const source = { id: 'second' }; const widened: Payload = source; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			code: "type Payload = string; function run() { type Payload = unknown; const source = { id: 'second' }; const widened: Payload = source; const parsed = widened as { id: string }; }",
 			errors: [error],
 		},
 	],

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.test.ts
@@ -8,11 +8,17 @@ const error = { messageId: "widenThenAssert" };
 tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
 	valid: [
 		"const source = { id: 'first' }; const widened: unknown = source;",
+		"type Record<K, V> = { key: K; value: V }; const source = { id: 'first' }; const widened: Record<string, unknown> = source; const asserted = widened as { id: string };",
+		"import { Readonly } from './local'; const source = { id: 'first' }; const widened: Readonly<Record<string, unknown>> = source; const asserted = widened as { id: string };",
 		"declare const input: unknown; const parsed = input as { readonly id: string };",
 	],
 	invalid: [
 		{
 			code: "const source = { id: 'second' }; const widened: unknown = source; const parsed = widened as { readonly id: string };",
+			errors: [error],
+		},
+		{
+			code: "const source = { id: 'second' }; const widened: Readonly<Record<string, unknown>> = source; const parsed = widened as { id: string };",
 			errors: [error],
 		},
 	],

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+	readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+	"ArrowFunctionExpression",
+	"FunctionDeclaration",
+	"FunctionExpression",
+	"TSDeclareFunction",
+	"TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (current.type === "ParenthesizedExpression") current = current.expression;
+	return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+	return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+	const unwrapped = unwrapTypeParentheses(type);
+	return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+	const unwrapped = unwrapTypeParentheses(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+	return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+	const unwrapped = unwrapTypeParentheses(type);
+
+	if (unwrapped.type === "TSTypeReference") {
+		if (typeReferenceName(unwrapped) === "Readonly") {
+			const [inner] = unwrapped.typeArguments?.params ?? [];
+			return inner !== undefined && isBroadRecordType(inner);
+		}
+
+		if (typeReferenceName(unwrapped) !== "Record") return false;
+		const parameters = unwrapped.typeArguments?.params ?? [];
+		return (
+			parameters.length === 2 &&
+			parameters[0] !== undefined &&
+			parameters[1] !== undefined &&
+			isBroadRecordKeyType(parameters[0]) &&
+			isUnknownOrAnyType(parameters[1])
+		);
+	}
+
+	if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+	const [member] = unwrapped.members;
+	const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+	return (
+		member?.type === "TSIndexSignature" &&
+		member.parameters.length === 1 &&
+		parameter !== undefined &&
+		isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+		isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+	const unwrapped = unwrapTypeParentheses(type);
+	if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+	node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+	return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+	expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+	const unwrapped = unwrapExpressionParentheses(expression);
+	return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+		? unwrapped
+		: null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+	return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+	sourceText: string,
+	left: ESTree.TSType | null,
+	right: ESTree.TSType,
+): boolean {
+	return (
+		left !== null &&
+		normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+			normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+	);
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+	const unwrapped = unwrapTypeParentheses(type);
+	switch (unwrapped.type) {
+		case "TSArrayType":
+		case "TSConstructorType":
+		case "TSFunctionType":
+		case "TSMappedType":
+		case "TSObjectKeyword":
+		case "TSTupleType":
+			return true;
+		case "TSTypeLiteral":
+			return unwrapped.members.length > 0;
+		case "TSIntersectionType":
+			return unwrapped.types.every(isDefinitelyObjectType);
+		case "TSTypeOperator":
+			return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+		default:
+			return false;
+	}
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+	const unwrapped = unwrapTypeParentheses(type);
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return false;
+	if (typeReferenceName(unwrapped) === "Readonly") {
+		const [inner] = unwrapped.typeArguments?.params ?? [];
+		return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+	}
+	if (typeReferenceName(unwrapped) !== "Record") return false;
+
+	const parameters = unwrapped.typeArguments?.params ?? [];
+	return (
+		parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+	);
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+	let current = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (functionBoundaryTypes.has(current.type)) return current;
+		current = current.parent;
+	}
+	return null;
+}
+
+function resolvedVariableForIdentifier(
+	scopes: readonly {
+		readonly references: readonly {
+			readonly identifier: ESTree.Node;
+			readonly resolved: Variable | null;
+		}[];
+	}[],
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	for (const scope of scopes) {
+		const reference = scope.references.find(
+			(candidate) =>
+				candidate.identifier.start === identifier.start &&
+				candidate.identifier.end === identifier.end,
+		);
+		if (reference !== undefined) return reference.resolved;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	for (const definition of variable.defs) {
+		if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+			return definition.node;
+		}
+	}
+	return null;
+}
+
+function knownValueEvidence(
+	expression: ESTree.Expression,
+	scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+	boundary: ESTree.Node | null,
+	visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+	const unwrapped = unwrapExpressionParentheses(expression);
+
+	if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+		if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+		return { type: unwrapped.typeAnnotation };
+	}
+
+	if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+		return { type: null };
+	}
+
+	if (
+		unwrapped.type === "ArrayExpression" ||
+		unwrapped.type === "ArrowFunctionExpression" ||
+		unwrapped.type === "ClassExpression" ||
+		unwrapped.type === "FunctionExpression" ||
+		unwrapped.type === "NewExpression" ||
+		unwrapped.type === "ObjectExpression"
+	) {
+		return { type: null };
+	}
+
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return null;
+
+	const annotatedIdentifier = variable.identifiers.find(
+		(identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+	);
+	const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+	if (annotation !== undefined && annotatedIdentifier !== undefined) {
+		if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+			return null;
+		}
+		return { type: annotation };
+	}
+
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.parent.type !== "VariableDeclaration" ||
+		declarator.parent.kind !== "const" ||
+		declarator.init === null ||
+		variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+		functionBoundary(declarator) !== boundary
+	) {
+		return null;
+	}
+
+	return knownValueEvidence(
+		declarator.init,
+		scopes,
+		boundary,
+		new Set([...visitedVariables, variable]),
+	);
+}
+
+function widenedBinding(
+	variable: Variable,
+	scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+	readonly broadKind: BroadTypeKind;
+	readonly evidence: KnownValueEvidence;
+	readonly declaredAt: number;
+	readonly boundary: ESTree.Node | null;
+} | null {
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.parent.type !== "VariableDeclaration" ||
+		declarator.parent.kind !== "const" ||
+		declarator.id.type !== "Identifier" ||
+		declarator.init === null ||
+		variable.references.some((reference) => reference.isWrite() && !reference.init)
+	) {
+		return null;
+	}
+
+	const boundary = functionBoundary(declarator);
+	const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+	const initializerAssertion = assertionFromExpression(declarator.init);
+	const initializerBroadKind =
+		initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+	const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+	const broadKind = declaredBroadKind ?? initializerBroadKind;
+	if (broadKind === null) return null;
+
+	const originalExpression =
+		initializerAssertion !== null && initializerBroadKind !== null
+			? assertedExpression(initializerAssertion)
+			: declarator.init;
+	const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+	return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+	sourceText: string,
+	broadKind: BroadTypeKind,
+	evidence: KnownValueEvidence,
+	assertedType: ESTree.TSType,
+): boolean {
+	if (broadTypeKind(assertedType) !== null) return false;
+	if (broadKind === "top") return true;
+	if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+	if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+	return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+		},
+		messages: {
+			widenThenAssert:
+				'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+		},
+	},
+	createOnce(context) {
+		let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+		const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+			const expression = assertedExpression(node);
+			if (expression.type !== "Identifier") return;
+
+			const variable = resolvedVariableForIdentifier(scopes, expression);
+			if (variable === null) return;
+			const widened = widenedBinding(variable, scopes);
+			if (
+				widened === null ||
+				node.start <= widened.declaredAt ||
+				functionBoundary(node) !== widened.boundary ||
+				!assertionIsNarrower(
+					context.sourceCode.text,
+					widened.broadKind,
+					widened.evidence,
+					node.typeAnnotation,
+				)
+			) {
+				return;
+			}
+
+			context.report({
+				node,
+				messageId: "widenThenAssert",
+				data: { name: expression.name },
+			});
+		};
+
+		return {
+			Program() {
+				scopes = context.sourceCode.scopeManager.scopes;
+			},
+			TSAsExpression: checkAssertion,
+			TSTypeAssertion: checkAssertion,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -2,6 +2,7 @@ import { defineRule } from "@oxlint/plugins";
 import type { ESTree, Variable } from "@oxlint/plugins";
 
 import { createTypeEnvironment } from "../shared/dictionary-types.ts";
+import { lexicalTypeParameterNames } from "../shared/lexical-type-parameters.ts";
 
 type BroadTypeKind = "top" | "object" | "record";
 
@@ -32,6 +33,32 @@ function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
 // Refreshed per file in `Program`; every caller compares against built-in utility names.
 let shadowedBuiltIns: ReadonlySet<string> = new Set();
 let typeAliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration> = new Map();
+let visitorKeys: Readonly<Record<string, readonly string[]>> = {};
+
+/** Non-generic alias visible at `reference`; type parameters and block-level declarations shadow the module map. */
+function visibleAlias(
+	reference: ESTree.TSTypeReference,
+	name: string,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(reference, visitorKeys).has(name)) return null;
+	for (let current = reference.parent; current !== null; current = current.parent) {
+		if (current.type === "Program") break;
+		if (current.type !== "BlockStatement") continue;
+		for (const statement of current.body) {
+			if (statement.type === "TSTypeAliasDeclaration" && statement.id.name === name)
+				return statement;
+			if (
+				(statement.type === "TSInterfaceDeclaration" ||
+					statement.type === "TSEnumDeclaration" ||
+					statement.type === "ClassDeclaration") &&
+				statement.id?.name === name
+			) {
+				return null;
+			}
+		}
+	}
+	return typeAliases.get(name) ?? null;
+}
 
 /** Name of a built-in type reference, or null when the file declares/imports its own binding. */
 function typeReferenceName(type: ESTree.TSTypeReference): string | null {
@@ -100,9 +127,9 @@ function broadTypeKind(
 	// `type Payload = unknown` is as broad as `unknown`; follow non-generic module-level aliases.
 	if (unwrapped.type !== "TSTypeReference" || unwrapped.typeName.type !== "Identifier") return null;
 	const name = unwrapped.typeName.name;
-	const alias = typeAliases.get(name);
+	const alias = visibleAlias(unwrapped, name);
 	if (
-		alias === undefined ||
+		alias === null ||
 		(alias.typeParameters !== null && alias.typeParameters !== undefined) ||
 		unwrapped.typeArguments?.params.length ||
 		visitedAliases.has(name)
@@ -385,6 +412,7 @@ export const noWidenThenAssertRule = defineRule({
 				const environment = createTypeEnvironment(node);
 				shadowedBuiltIns = environment.shadowedBuiltIns;
 				typeAliases = environment.aliases;
+				visitorKeys = context.sourceCode.visitorKeys;
 			},
 			TSAsExpression: checkAssertion,
 			TSTypeAssertion: checkAssertion,

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,6 +1,8 @@
 import { defineRule } from "@oxlint/plugins";
 import type { ESTree, Variable } from "@oxlint/plugins";
 
+import { createTypeEnvironment } from "../shared/dictionary-types.ts";
+
 type BroadTypeKind = "top" | "object" | "record";
 
 type KnownValueEvidence = {
@@ -27,8 +29,13 @@ function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
 	return current;
 }
 
+// Refreshed per file in `Program`; every caller compares against built-in utility names.
+let shadowedBuiltIns: ReadonlySet<string> = new Set();
+
+/** Name of a built-in type reference, or null when the file declares/imports its own binding. */
 function typeReferenceName(type: ESTree.TSTypeReference): string | null {
-	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+	if (type.typeName.type !== "Identifier") return null;
+	return shadowedBuiltIns.has(type.typeName.name) ? null : type.typeName.name;
 }
 
 function isUnknownOrAnyType(type: ESTree.TSType): boolean {
@@ -356,8 +363,9 @@ export const noWidenThenAssertRule = defineRule({
 		};
 
 		return {
-			Program() {
+			Program(node) {
 				scopes = context.sourceCode.scopeManager.scopes;
+				shadowedBuiltIns = createTypeEnvironment(node).shadowedBuiltIns;
 			},
 			TSAsExpression: checkAssertion,
 			TSTypeAssertion: checkAssertion,

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -31,6 +31,7 @@ function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
 
 // Refreshed per file in `Program`; every caller compares against built-in utility names.
 let shadowedBuiltIns: ReadonlySet<string> = new Set();
+let typeAliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration> = new Map();
 
 /** Name of a built-in type reference, or null when the file declares/imports its own binding. */
 function typeReferenceName(type: ESTree.TSTypeReference): string | null {
@@ -88,11 +89,27 @@ function isBroadRecordType(type: ESTree.TSType): boolean {
 	);
 }
 
-function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+function broadTypeKind(
+	type: ESTree.TSType,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): BroadTypeKind | null {
 	const unwrapped = unwrapTypeParentheses(type);
 	if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
 	if (unwrapped.type === "TSObjectKeyword") return "object";
-	return isBroadRecordType(unwrapped) ? "record" : null;
+	if (isBroadRecordType(unwrapped)) return "record";
+	// `type Payload = unknown` is as broad as `unknown`; follow non-generic module-level aliases.
+	if (unwrapped.type !== "TSTypeReference" || unwrapped.typeName.type !== "Identifier") return null;
+	const name = unwrapped.typeName.name;
+	const alias = typeAliases.get(name);
+	if (
+		alias === undefined ||
+		(alias.typeParameters !== null && alias.typeParameters !== undefined) ||
+		unwrapped.typeArguments?.params.length ||
+		visitedAliases.has(name)
+	) {
+		return null;
+	}
+	return broadTypeKind(alias.typeAnnotation, new Set([...visitedAliases, name]));
 }
 
 function assertedExpression(
@@ -365,7 +382,9 @@ export const noWidenThenAssertRule = defineRule({
 		return {
 			Program(node) {
 				scopes = context.sourceCode.scopeManager.scopes;
-				shadowedBuiltIns = createTypeEnvironment(node).shadowedBuiltIns;
+				const environment = createTypeEnvironment(node);
+				shadowedBuiltIns = environment.shadowedBuiltIns;
+				typeAliases = environment.aliases;
 			},
 			TSAsExpression: checkAssertion,
 			TSTypeAssertion: checkAssertion,

--- a/tools/oxlint/anti-slop/shared/array-method.ts
+++ b/tools/oxlint/anti-slop/shared/array-method.ts
@@ -4,18 +4,20 @@ function isString(value: unknown): value is string {
 	return typeof value === "string";
 }
 
-/** Unwrap syntax-only wrappers when inspecting array methods and accumulator references. */
-export function unwrapArrayExpression(node: ESTree.Node): ESTree.Node {
-	while (
-		node.type === "ParenthesizedExpression" ||
+function unwrapOnce(node: ESTree.Node): ESTree.Node | null {
+	return node.type === "ParenthesizedExpression" ||
 		node.type === "ChainExpression" ||
 		node.type === "TSAsExpression" ||
 		node.type === "TSTypeAssertion" ||
 		node.type === "TSNonNullExpression" ||
 		node.type === "TSSatisfiesExpression"
-	) {
-		node = node.expression;
-	}
+		? node.expression
+		: null;
+}
+
+/** Unwrap syntax-only wrappers when inspecting array methods and accumulator references. */
+export function unwrapArrayExpression(node: ESTree.Node): ESTree.Node {
+	for (let inner = unwrapOnce(node); inner !== null; inner = unwrapOnce(node)) node = inner;
 	return node;
 }
 
@@ -83,6 +85,15 @@ export function isKnownArrayExpression(
 	node: ESTree.Node,
 	visited = new Set<Variable>(),
 ): boolean {
+	// `loadUsers() as User[]` is explicit array evidence even though the callee is unknown.
+	for (let current: ESTree.Node | null = node; current !== null; current = unwrapOnce(current)) {
+		if (
+			(current.type === "TSAsExpression" || current.type === "TSTypeAssertion") &&
+			isArrayAnnotation(current.typeAnnotation)
+		) {
+			return true;
+		}
+	}
 	node = unwrapArrayExpression(node);
 	if (node.type === "ArrayExpression") return true;
 	if (node.type === "CallExpression") {

--- a/tools/oxlint/anti-slop/shared/array-method.ts
+++ b/tools/oxlint/anti-slop/shared/array-method.ts
@@ -1,0 +1,111 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}
+
+/** Unwrap syntax-only wrappers when inspecting array methods and accumulator references. */
+export function unwrapArrayExpression(node: ESTree.Node): ESTree.Node {
+	while (
+		node.type === "ParenthesizedExpression" ||
+		node.type === "ChainExpression" ||
+		node.type === "TSAsExpression" ||
+		node.type === "TSTypeAssertion" ||
+		node.type === "TSNonNullExpression" ||
+		node.type === "TSSatisfiesExpression"
+	) {
+		node = node.expression;
+	}
+	return node;
+}
+
+/** Resolve a local binding by scope, not by identifier spelling. */
+export function resolveArrayBinding(sourceCode: SourceCode, node: ESTree.Node): Variable | null {
+	node = unwrapArrayExpression(node);
+	if (node.type !== "Identifier") return null;
+	let scope: Scope | null = sourceCode.getScope(node);
+	while (scope !== null) {
+		const variable = scope.set.get(node.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+/** Read static method names, including computed string literals, without evaluating expressions. */
+export function arrayMethodTarget(
+	node: ESTree.Node,
+): { readonly name: string; readonly object: ESTree.Node } | null {
+	node = unwrapArrayExpression(node);
+	if (node.type !== "MemberExpression") return null;
+	const property = node.property;
+	if (!node.computed && property.type === "Identifier") {
+		return { name: property.name, object: node.object };
+	}
+	if (node.computed && property.type === "Literal" && isString(property.value)) {
+		return { name: property.value, object: node.object };
+	}
+	return null;
+}
+
+function isArrayAnnotation(type: ESTree.TSType): boolean {
+	if (type.type === "TSArrayType" || type.type === "TSTupleType") return true;
+	if (type.type === "TSParenthesizedType") return isArrayAnnotation(type.typeAnnotation);
+	if (type.type === "TSTypeOperator" && type.operator === "readonly") {
+		return isArrayAnnotation(type.typeAnnotation);
+	}
+	return (
+		type.type === "TSTypeReference" &&
+		type.typeName.type === "Identifier" &&
+		(type.typeName.name === "Array" || type.typeName.name === "ReadonlyArray")
+	);
+}
+
+/** Recognize local array evidence; unknown receivers and iterator pipelines are deliberately excluded. */
+export function isKnownArrayExpression(
+	sourceCode: SourceCode,
+	node: ESTree.Node,
+	visited = new Set<Variable>(),
+): boolean {
+	node = unwrapArrayExpression(node);
+	if (node.type === "ArrayExpression") return true;
+	if (node.type === "CallExpression") {
+		const method = arrayMethodTarget(node.callee);
+		return (
+			method !== null &&
+			[
+				"map",
+				"filter",
+				"flatMap",
+				"slice",
+				"concat",
+				"toSorted",
+				"toReversed",
+				"toSpliced",
+			].includes(method.name) &&
+			isKnownArrayExpression(sourceCode, method.object, visited)
+		);
+	}
+	if (node.type !== "Identifier") return false;
+	const variable = resolveArrayBinding(sourceCode, node);
+	if (variable === null || visited.has(variable)) return false;
+	visited.add(variable);
+	if (variable.references.some((reference) => reference.isWrite() && !reference.init)) return false;
+	for (const identifier of variable.identifiers) {
+		const annotation = identifier.typeAnnotation?.typeAnnotation;
+		if (annotation !== undefined) return isArrayAnnotation(annotation);
+	}
+	for (const definition of variable.defs) {
+		if (
+			definition.type === "Variable" &&
+			definition.node.type === "VariableDeclarator" &&
+			definition.node.id.type === "Identifier" &&
+			definition.node.init !== null &&
+			definition.node.parent.type === "VariableDeclaration" &&
+			definition.node.parent.kind === "const"
+		) {
+			return isKnownArrayExpression(sourceCode, definition.node.init, visited);
+		}
+	}
+	return false;
+}

--- a/tools/oxlint/anti-slop/shared/array-method.ts
+++ b/tools/oxlint/anti-slop/shared/array-method.ts
@@ -61,6 +61,22 @@ function isArrayAnnotation(type: ESTree.TSType): boolean {
 	);
 }
 
+/** Static factories whose result is always an array: method name → owning global. */
+const ARRAY_FACTORIES: ReadonlyMap<string, string> = new Map([
+	["entries", "Object"],
+	["keys", "Object"],
+	["values", "Object"],
+	["from", "Array"],
+]);
+
+/** True when `node` is the unshadowed global binding `name` (e.g. `Object`, `Array`). */
+export function isGlobalOwner(sourceCode: SourceCode, node: ESTree.Node, name: string): boolean {
+	node = unwrapArrayExpression(node);
+	if (node.type !== "Identifier" || node.name !== name) return false;
+	const variable = resolveArrayBinding(sourceCode, node);
+	return variable === null || variable.defs.length === 0;
+}
+
 /** Recognize local array evidence; unknown receivers and iterator pipelines are deliberately excluded. */
 export function isKnownArrayExpression(
 	sourceCode: SourceCode,
@@ -71,8 +87,10 @@ export function isKnownArrayExpression(
 	if (node.type === "ArrayExpression") return true;
 	if (node.type === "CallExpression") {
 		const method = arrayMethodTarget(node.callee);
+		if (method === null) return false;
+		const owner = ARRAY_FACTORIES.get(method.name);
+		if (owner !== undefined && isGlobalOwner(sourceCode, method.object, owner)) return true;
 		return (
-			method !== null &&
 			[
 				"map",
 				"filter",
@@ -82,8 +100,7 @@ export function isKnownArrayExpression(
 				"toSorted",
 				"toReversed",
 				"toSpliced",
-			].includes(method.name) &&
-			isKnownArrayExpression(sourceCode, method.object, visited)
+			].includes(method.name) && isKnownArrayExpression(sourceCode, method.object, visited)
 		);
 	}
 	if (node.type !== "Identifier") return false;

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -16,6 +16,7 @@ function collectInferTypeParameterNames(
 	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
 	const untypedNode: unknown = node;
 	// SAFETY: visitor keys only name ESTree child-node fields for this node kind.
+	// oxlint-disable-next-line anti-slop/no-widen-then-assert -- ESTree node interfaces have no index signature; this is the generic child-walk boundary.
 	const record = untypedNode as Readonly<
 		Record<string, ESTree.Node | readonly ESTree.Node[] | null | undefined>
 	>;


### PR DESCRIPTION
## What

Reviews upstream [dmmulroy/anti-slop](https://github.com/dmmulroy/anti-slop) `6d53855` (our vendored base, #308) → `c44ef22` (v0.1.2+) against this repo and adopts what pays for itself:

- **New rules vendored** (`tools/oxlint/anti-slop/`, enabled at `error`): `no-array-filter-map`, `no-reduce-accumulator-copy` (paired with native `oxc/no-accumulating-spread`), `no-widen-then-assert`. Copied from upstream, `oxfmt`'d, one `typeof` swapped for the local `isString` guard so the plugin passes its own lint.
- **4 call sites** rewritten from `filter().map()` / `map().filter()` to a single `flatMap` (docs index, prompts list, skills reconcile, core extensions-install). Behavior unchanged.
- **1 justified suppression** in `shared/lexical-type-parameters.ts`: ESTree node interfaces have no index signature, so the generic child-walk needs a widen-then-assert (upstream spells it `as unknown as`, which our `no-chained-type-assertions` bans).
- **`UPSTREAM.md`** beside the plugin: base/reviewed revisions, local deviations to preserve on future updates, and what was intentionally not vendored.

## Evaluated and skipped (recorded in `UPSTREAM.md`)

| Upstream change | Measured on crust | Why skipped |
|---|---|---|
| Aug-31 semantic fixes to the 10 existing rules | 0 new findings | Not worth a 3-way merge into customized rules (Bun `mock.module`, `allowInBoundaryFunctions`, …) |
| `require-readable-spacing` | 3533 autofix edits / 234 files | `oxfmt` owns formatting |
| `no-shape-in-symbol-names` | 158 hits | `CommandShape`/`CommandShapeAt`/`_types.shape` are public documented API |
| `no-conditional-empty-object-spread` | 22 hits / 9 files | `...(cond ? { k } : {})` is the accepted idiom here |
| `no-reflect-apply` / `no-reflect-get` | 0 | Already covered by `eslint/no-restricted-properties` |
| Effect rules | — | No Effect dependency |

## Validation

- `node --test tools/oxlint/anti-slop/rules/*.test.ts` — 13 pass (10 existing + 3 new)
- `bun run check` ✅ · `bun run check:types` ✅ (25 tasks) · `bun run test` ✅ (26 tasks)

No changeset: tooling only, no end-user behavior change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chenxin-yan/crust/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

